### PR TITLE
Minor refactor in insert() and save()

### DIFF
--- a/src/Field_Many.php
+++ b/src/Field_Many.php
@@ -179,7 +179,7 @@ class Field_Many
 
         $field = isset($defaults['field']) ? $defaults['field'] : $n;
 
-        return $this->owner->addExpression($n, function ($m) use ($defaults, $field) {
+        return $this->owner->addExpression($n, function () use ($defaults, $field) {
             return $this->refLink()->action('fx', [$defaults['aggregate'], $field]);
         });
     }

--- a/src/Field_Many.php
+++ b/src/Field_Many.php
@@ -84,7 +84,7 @@ class Field_Many
         if (is_object($this->model) && $this->model instanceof \Closure) {
             $c = $this->model;
 
-            $c = $c($this->owner, $this);
+            $c = $c($this->owner, $this, $defaults);
             if (!$c->persistence && $this->owner->persistence) {
                 $c = $this->owner->persistence->add($c, $defaults);
             }

--- a/src/Model.php
+++ b/src/Model.php
@@ -768,7 +768,7 @@ class Model implements \ArrayAccess, \IteratorAggregate
         $m = clone $this;
         $this->_rawInsert($m, $row);
 
-        return $m;
+        return $m->id;
     }
 
     /**

--- a/src/Model.php
+++ b/src/Model.php
@@ -660,10 +660,14 @@ class Model implements \ArrayAccess, \IteratorAggregate
         return $this;
     }
 
-    public function save()
+    public function save($data = [])
     {
         if (!$this->persistence) {
             throw new Exception(['Model is not associated with any database']);
+        }
+
+        if($data) {
+            $this->set($data);
         }
 
         if ($this->hook('beforeSave') === false) {
@@ -706,6 +710,7 @@ class Model implements \ArrayAccess, \IteratorAggregate
 
             //$this->hook('beforeUpdate', array(&$source));
         } else {
+            $data = [];
             foreach ($this->get() as $name => $value) {
                 $field = $this->hasElement($name);
                 if (!$field) {

--- a/src/Model.php
+++ b/src/Model.php
@@ -754,16 +754,8 @@ class Model implements \ArrayAccess, \IteratorAggregate
     protected function _rawInsert($m, $row)
     {
         $m->unload();
-        if (!is_array($row)) {
-            $m->set($this->title_field, $row);
-        } else {
-            if (isset($row[0]) && $this->title_field) {
-                $row[$this->title_field] = $row[0];
-                unset($row[0]);
-            }
-            $m->set($row);
-        }
-        $m->save();
+        $m->save($row);
+        $m->data[$m->id_field] = $m->id;
     }
 
     /**

--- a/src/Model.php
+++ b/src/Model.php
@@ -254,7 +254,7 @@ class Model implements \ArrayAccess, \IteratorAggregate
             $field = $field->short_name;
         }
 
-        if (!is_string($field)) {
+        if (!is_string($field) || is_numeric($field)) {
             throw new Exception([
                 'Incorect specification of field name',
                 'arg' => $field,

--- a/src/Model.php
+++ b/src/Model.php
@@ -277,20 +277,22 @@ class Model implements \ArrayAccess, \IteratorAggregate
 
     public function set($field, $value = null)
     {
-        // set(['foo'=>'bar']) will call itself as set('foo', 'bar');
         if (func_num_args() == 1) {
             if (is_array($field)) {
                 foreach ($field as $key => $value) {
-                    $this->set($key, $value);
+                    if($key === "0" || $key === 0) {
+                        $this->set($value);
+                    }else{
+                        $this->set($key, $value);
+                    }
                 }
 
                 return $this;
+            }else{
+                $value = $field;
+                $field = $this->title_field;
             }
 
-            throw new Exception([
-                'Single argument set() requires an array argument',
-                'arg' => $field,
-            ]);
         }
 
         $field = $this->normalizeFieldName($field);

--- a/src/Model.php
+++ b/src/Model.php
@@ -254,7 +254,7 @@ class Model implements \ArrayAccess, \IteratorAggregate
             $field = $field->short_name;
         }
 
-        if (!is_string($field) || is_numeric($field)) {
+        if (!is_string($field) || $field === "" || is_numeric($field[0])) {
             throw new Exception([
                 'Incorect specification of field name',
                 'arg' => $field,

--- a/src/Persistence.php
+++ b/src/Persistence.php
@@ -21,6 +21,7 @@ class Persistence
         switch (strtolower(isset($args['driver']) ?: $driver)) {
             case 'mysql':
             case 'dumper':
+            case 'counter':
             case 'sqlite':
                 return new Persistence_SQL($dsn, $user, $password, $args);
             default:

--- a/tests/BusinessModelTest.php
+++ b/tests/BusinessModelTest.php
@@ -144,7 +144,7 @@ class BusinessModelTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * Sets title field
+     * Sets title field.
      */
     public function testSetTitle()
     {

--- a/tests/BusinessModelTest.php
+++ b/tests/BusinessModelTest.php
@@ -206,6 +206,17 @@ class BusinessModelTest extends TestCase
 
     /**
      * @expectedException Exception
+     *
+     * fields can't be numeric
+     */
+    public function testException2d()
+    {
+        $m = new Model();
+        $m->set(['foo','bar']);
+    }
+
+    /**
+     * @expectedException Exception
      */
     public function testException3()
     {

--- a/tests/BusinessModelTest.php
+++ b/tests/BusinessModelTest.php
@@ -156,7 +156,7 @@ class BusinessModelTest extends \PHPUnit_Framework_TestCase
         $m->set(['bar']);
         $this->assertEquals($m['name'], 'bar');
 
-        $m->set(['name'=>'baz']);
+        $m->set(['name' => 'baz']);
         $this->assertEquals($m['name'], 'baz');
     }
 

--- a/tests/BusinessModelTest.php
+++ b/tests/BusinessModelTest.php
@@ -184,6 +184,28 @@ class BusinessModelTest extends TestCase
 
     /**
      * @expectedException Exception
+     *
+     * fields can't be numeric
+     */
+    public function testException2b()
+    {
+        $m = new Model();
+        $m->set("3b", 'foo');
+    }
+
+    /**
+     * @expectedException Exception
+     *
+     * fields can't be numeric
+     */
+    public function testException2c()
+    {
+        $m = new Model();
+        $m->set("", 'foo');
+    }
+
+    /**
+     * @expectedException Exception
      */
     public function testException3()
     {

--- a/tests/BusinessModelTest.php
+++ b/tests/BusinessModelTest.php
@@ -144,12 +144,25 @@ class BusinessModelTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
+     * Sets title field
+     */
+    public function testSetTitle()
+    {
+        $m = new Model();
+        $m->addField('name');
+        $m->set('foo');
+        $this->assertEquals($m['name'], 'foo');
+    }
+
+    /**
      * @expectedException Exception
+     *
+     * fields can't be numeric
      */
     public function testException2()
     {
         $m = new Model();
-        $m->set('foo');
+        $m->set(0, 'foo');
     }
 
     /**

--- a/tests/BusinessModelTest.php
+++ b/tests/BusinessModelTest.php
@@ -152,6 +152,12 @@ class BusinessModelTest extends \PHPUnit_Framework_TestCase
         $m->addField('name');
         $m->set('foo');
         $this->assertEquals($m['name'], 'foo');
+
+        $m->set(['bar']);
+        $this->assertEquals($m['name'], 'bar');
+
+        $m->set(['name'=>'baz']);
+        $this->assertEquals($m['name'], 'baz');
     }
 
     /**

--- a/tests/BusinessModelTest.php
+++ b/tests/BusinessModelTest.php
@@ -9,7 +9,7 @@ use atk4\data\Persistence;
 /**
  * @coversDefaultClass \atk4\data\Model
  */
-class BusinessModelTest extends \PHPUnit_Framework_TestCase
+class BusinessModelTest extends TestCase
 {
     /**
      * Test constructor.
@@ -169,6 +169,17 @@ class BusinessModelTest extends \PHPUnit_Framework_TestCase
     {
         $m = new Model();
         $m->set(0, 'foo');
+    }
+
+    /**
+     * @expectedException Exception
+     *
+     * fields can't be numeric
+     */
+    public function testException2a()
+    {
+        $m = new Model();
+        $m->set("3", 'foo');
     }
 
     /**

--- a/tests/BusinessModelTest.php
+++ b/tests/BusinessModelTest.php
@@ -212,7 +212,7 @@ class BusinessModelTest extends TestCase
     public function testException2d()
     {
         $m = new Model();
-        $m->set(['foo','bar']);
+        $m->set(['foo', 'bar']);
     }
 
     /**

--- a/tests/PersistentSQLTest.php
+++ b/tests/PersistentSQLTest.php
@@ -113,9 +113,9 @@ class PersistentSQLTest extends TestCase
             $ms[] = $m->insert($row);
         }
 
-        $this->assertEquals('John', $ms[0]['name']);
+        $this->assertEquals('John', $m->load($ms[0])['name']);
 
-        $this->assertEquals('Jones', $ms[1]['surname']);
+        $this->assertEquals('Jones', $m->load($ms[1])['surname']);
     }
 
     public function testModelInsertRows()


### PR DESCRIPTION
This PR changes slightly how `save()` and `insert()` work.

With a more dynamic nature of the Agile Data creating data takes requires a lot of flexibility. There are three ways to add data currently:

 - import([[data], [data], ..]);   // returns $this
 - insert([data]);  // returns clone of $this
 - save();  // save current record. Returns $this

The problems are:

 - return of insert() is not very usable.
 - save() requires to call set().

Proposal:

 - make insert() return ID instead of clone. (often ID is good enough!)
 - allow save([data]) which will combine set with save. 




