### PR TITLE
Preserves "Dirty" flags for afterSave hooks.

### DIFF
--- a/src/Model.php
+++ b/src/Model.php
@@ -886,6 +886,8 @@ class Model implements \ArrayAccess, \IteratorAggregate
      *
      * @return $this
      */
+    public $_dirty_after_reload = [];
+
     public function save($data = [])
     {
         if (!$this->persistence) {
@@ -899,6 +901,8 @@ class Model implements \ArrayAccess, \IteratorAggregate
         if ($this->hook('beforeSave') === false) {
             return $this;
         }
+
+        $this->_dirty_after_save = [];
 
         $is_update = $this->loaded();
         if ($is_update) {
@@ -963,7 +967,11 @@ class Model implements \ArrayAccess, \IteratorAggregate
             $this->hook('afterInsert', [$this->id]);
 
             if ($this->reload_after_save !== false) {
+                $d = $this->dirty;
+                $this->dirty = [];
                 $this->reload();
+                $this->_dirty_after_reload = $this->dirty;
+                $this->dirty = $d;
             }
         }
 
@@ -971,7 +979,7 @@ class Model implements \ArrayAccess, \IteratorAggregate
 
 
         if ($this->loaded()) {
-            $this->dirty = [];
+            $this->dirty = $this->_dirty_after_reload;
         }
 
         return $this;

--- a/src/Persistence_SQL.php
+++ b/src/Persistence_SQL.php
@@ -675,7 +675,10 @@ class Persistence_SQL extends Persistence
 
         // if any rows were updated in database, and we had expressions, reload
         if ($m->reload_after_save === true && $st->rowCount()) {
+            $d = $m->dirty;
             $m->reload();
+            $m->_dirty_after_reload = $m->dirty;
+            $m->dirty = $d;
         }
     }
 


### PR DESCRIPTION
when using afterSave hooks you might be interested to look at the dirty fields. Unfortunately using the "reload after save" mechanics will cause it to reload the record which resets dirty fields.

This fix:
 - will memorize dirty fields before reloading (A)
 - will memorize dirty fields after reloading (B)
 - will restore dirty fields A then call hooks.
 - will merge with dirty fields B after hooks.

Goal of this PR:
 - make sure you get all dirty fields inside afterSave hook regardless if "reload after save" is On/Off.
 - if you perform any changes, in afterSave - do not forget those.
 - if afterLoad performs any changes as a part of reloading, keep those in our dirty array


No test-scripts provided for the above cases.

