### PR TITLE
Implement isDirty

### DIFF
--- a/src/Model.php
+++ b/src/Model.php
@@ -1214,7 +1214,7 @@ class Model implements \ArrayAccess, \IteratorAggregate
      *
      * @return object
      */
-    protected function _hasSomething($c, $link, $defaults = [])
+    protected function _hasRelation($c, $link, $defaults = [])
     {
         if (!is_array($defaults)) {
             if ($defaults) {
@@ -1242,7 +1242,7 @@ class Model implements \ArrayAccess, \IteratorAggregate
      */
     public function hasOne($link, $defaults = [])
     {
-        return $this->_hasSomething($this->_default_class_hasOne, $link, $defaults);
+        return $this->_hasRelation($this->_default_class_hasOne, $link, $defaults);
     }
 
     /**
@@ -1255,7 +1255,7 @@ class Model implements \ArrayAccess, \IteratorAggregate
      */
     public function hasMany($link, $defaults = [])
     {
-        return $this->_hasSomething($this->_default_class_hasMany, $link, $defaults);
+        return $this->_hasRelation($this->_default_class_hasMany, $link, $defaults);
     }
 
     /**

--- a/src/Model.php
+++ b/src/Model.php
@@ -370,6 +370,30 @@ class Model implements \ArrayAccess, \IteratorAggregate
     }
 
     /**
+     * Will return true if any of the specified fields are dirty.
+     *
+     * @param string|array $field
+     *
+     * @return boolean
+     */
+    function isDirty($fields = [])
+    {
+        if (!is_array($fields)) {
+            $fields = [$fields];
+        }
+
+        foreach ($fields as $field) {
+            $field = $this->normalizeFieldName($field);
+
+            if(isset($this->dirty[$field])) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
      * Set field value.
      *
      * @param string|array $field

--- a/src/Model.php
+++ b/src/Model.php
@@ -1193,6 +1193,9 @@ class Model implements \ArrayAccess, \IteratorAggregate
      */
     public function leftJoin($foreign_table, $defaults = [])
     {
+        if (!is_array($defaults)) {
+            $defaults = ['master_field' => $defaults];
+        }
         $defaults['weak'] = true;
 
         return $this->join($foreign_table, $defaults);

--- a/src/Model.php
+++ b/src/Model.php
@@ -374,9 +374,9 @@ class Model implements \ArrayAccess, \IteratorAggregate
      *
      * @param string|array $field
      *
-     * @return boolean
+     * @return bool
      */
-    function isDirty($fields = [])
+    public function isDirty($fields = [])
     {
         if (!is_array($fields)) {
             $fields = [$fields];
@@ -385,7 +385,7 @@ class Model implements \ArrayAccess, \IteratorAggregate
         foreach ($fields as $field) {
             $field = $this->normalizeFieldName($field);
 
-            if(isset($this->dirty[$field])) {
+            if (isset($this->dirty[$field])) {
                 return true;
             }
         }


### PR DESCRIPTION
Apart from few minor fixes, this PR introduce a new method:

```
if ($m->isDirty(['name','surname'])) {
   $m['full_name'] = $m['name'].' '.$m['surname'];
}
```

When the code above is placed in beforeSave hook, it will only be executed when certain fields have been changed. If your recalculations are expensive, it's pretty handy to rely on "dirty" fields to avoid some complex logic.