### PR TITLE
Persistence requires name trait

### DIFF
--- a/src/Model.php
+++ b/src/Model.php
@@ -24,35 +24,35 @@ class Model implements \ArrayAccess, \IteratorAggregate
      *
      * @var string
      */
-    protected $_default_class_addField = 'atk4\data\Field';
+    public $_default_class_addField = 'atk4\data\Field';
 
     /**
      * The class used by hasOne() method.
      *
      * @var string
      */
-    protected $_default_class_hasOne = 'atk4\data\Field_One';
+    public $_default_class_hasOne = 'atk4\data\Field_One';
 
     /**
      * The class used by hasMany() method.
      *
      * @var string
      */
-    protected $_default_class_hasMany = 'atk4\data\Field_Many';
+    public $_default_class_hasMany = 'atk4\data\Field_Many';
 
     /**
      * The class used by addField() method.
      *
      * @var string
      */
-    protected $_default_class_addExpression = 'atk4\data\Field_Callback';
+    public $_default_class_addExpression = 'atk4\data\Field_Callback';
 
     /**
      * The class used by join() method.
      *
      * @var string
      */
-    protected $_default_class_join = 'atk4\data\Join';
+    public $_default_class_join = 'atk4\data\Join';
 
     /**
      * Contains name of table, session key, collection or file where this

--- a/src/Persistence.php
+++ b/src/Persistence.php
@@ -15,6 +15,7 @@ class Persistence
     use \atk4\core\FactoryTrait;
     use \atk4\core\HookTrait;
     use \atk4\core\AppScopeTrait;
+    use \atk4\core\NameTrait;
 
     /**
      * Connects database.


### PR DESCRIPTION
Persistence requires name trait otherwise we can get exception from Container trait _addContainer method which uses $name property in this line:
```
        $element->name = $this->_shorten($this->name.'_'.$element->short_name);
```