### PR TITLE
Fix deep traversal

### DIFF
--- a/src/Field_Many.php
+++ b/src/Field_Many.php
@@ -5,6 +5,8 @@
 namespace atk4\data;
 
 /**
- * Obsolete. Left for compatibility
+ * Obsolete. Left for compatibility.
  */
-class Field_Many extends Relation_Many {}
+class Field_Many extends Relation_Many
+{
+}

--- a/src/Field_One.php
+++ b/src/Field_One.php
@@ -5,6 +5,8 @@
 namespace atk4\data;
 
 /**
- * Obsolete. Left for compatibility
+ * Obsolete. Left for compatibility.
  */
-class Field_One extends Relation_One {}
+class Field_One extends Relation_One
+{
+}

--- a/src/Field_One_SQL.php
+++ b/src/Field_One_SQL.php
@@ -5,6 +5,8 @@
 namespace atk4\data;
 
 /**
- * Obsolete. Left for compatibility
+ * Obsolete. Left for compatibility.
  */
-class Field_One_SQL extends Relation_One_SQL {}
+class Field_One_SQL extends Relation_One_SQL
+{
+}

--- a/src/Field_SQL_One.php
+++ b/src/Field_SQL_One.php
@@ -7,6 +7,6 @@ namespace atk4\data;
 /**
  * Obsolete. Left for compatibility.
  */
-class Field_One_SQL extends Relation_One_SQL
+class Field_SQL_One extends Relation_SQL_One
 {
 }

--- a/src/Model.php
+++ b/src/Model.php
@@ -1293,7 +1293,7 @@ class Model implements \ArrayAccess, \IteratorAggregate
      */
     public function ref($link, $defaults = [])
     {
-        return $this->getElement('#ref_'.$link)->ref($defaults);
+        return $this->getRef($link)->ref($defaults);
     }
 
     /**
@@ -1306,7 +1306,7 @@ class Model implements \ArrayAccess, \IteratorAggregate
      */
     public function refLink($link, $defaults = [])
     {
-        return $this->getElement('#ref_'.$link)->refLink($defaults);
+        return $this->getRef($link)->refLink($defaults);
     }
 
     /**

--- a/src/Model.php
+++ b/src/Model.php
@@ -586,7 +586,7 @@ class Model implements \ArrayAccess, \IteratorAggregate
      *  ->addCondition('my_field', 'in', [$value1, $value2]);
      *
      * Second argument could be '=', '>', '<', '>=', '<=', '!=' or 'in'.
-     * Those conditons are still supported by most of persistence drivers.
+     * Those conditions are still supported by most of persistence drivers.
      *
      * There are also vendor-specific expression support:
      *  ->addCondition('my_field', $expr);
@@ -1047,7 +1047,7 @@ class Model implements \ArrayAccess, \IteratorAggregate
     }
 
     /**
-     * Even more faster method to add adda, does not modify your
+     * Even more faster method to add data, does not modify your
      * current record and will not return anything.
      *
      * Will be further optimized in the future.

--- a/src/Persistence.php
+++ b/src/Persistence.php
@@ -42,7 +42,7 @@ class Persistence
                 return new Persistence_SQL($dsn, $user, $password, $args);
             default:
                 throw new Exception([
-                    'Unable to determine pesistence driver from DSN',
+                    'Unable to determine persistence driver from DSN',
                     'dsn' => $dsn,
                 ]);
         }

--- a/src/Persistence_Array.php
+++ b/src/Persistence_Array.php
@@ -5,7 +5,7 @@
 namespace atk4\data;
 
 /**
- * Implements persistance driver that can save data into array and load
+ * Implements persistence driver that can save data into array and load
  * from array. This basic driver only offers the load/save support based
  * around ID, you can't use conditions, order or limit.
  */

--- a/src/Relation_Many.php
+++ b/src/Relation_Many.php
@@ -73,7 +73,7 @@ class Relation_Many
     }
 
     /**
-     * Will use either foreign_alias or create #join_<table>.
+     * Will use #ref_<link>.
      *
      * @return string
      */
@@ -99,6 +99,7 @@ class Relation_Many
      */
     protected function getModel($defaults = [])
     {
+        // set table_alias
         if (!isset($defaults['table_alias'])) {
             if (!$this->table_alias) {
                 $this->table_alias = $this->link;
@@ -108,6 +109,7 @@ class Relation_Many
             $defaults['table_alias'] = $this->table_alias;
         }
 
+        // if model is Closure, then call it and return model
         if (is_object($this->model) && $this->model instanceof \Closure) {
             $c = $this->model;
 
@@ -119,6 +121,7 @@ class Relation_Many
             return $c;
         }
 
+        // if model is set, then return clone of this model
         if (is_object($this->model)) {
             if ($this->model->persistence || !$this->owner->persistence) {
                 return clone $this->model;
@@ -129,8 +132,6 @@ class Relation_Many
         }
 
         // last effort - try to add model
-        $p = $this->owner->persistence;
-
         if (is_array($this->model)) {
             $model = $this->model[0];
             $md = $this->model;
@@ -140,6 +141,8 @@ class Relation_Many
         } else {
             $model = $this->model;
         }
+
+        $p = $this->owner->persistence;
 
         return $p->add($p->normalizeClassName($model, 'Model'), $defaults);
     }
@@ -179,9 +182,7 @@ class Relation_Many
     }
 
     /**
-     * Adding field into join will automatically associate that field
-     * with this join. That means it won't be loaded from $table but
-     * form the join instead.
+     * Returns referenced model with condition set.
      *
      * @param array $defaults Properties
      *
@@ -213,9 +214,8 @@ class Relation_Many
     }
 
     /**
-     * Adding field into join will automatically associate that field
-     * with this join. That means it won't be loaded from $table, but
-     * form the join instead.
+     * Adds field as expression to owner model.
+     * Used in aggregate strategy.
      *
      * @param string $n        Field name
      * @param array  $defaults Properties

--- a/src/Relation_One.php
+++ b/src/Relation_One.php
@@ -139,6 +139,7 @@ class Relation_One
      */
     public function getModel($defaults = [])
     {
+        // set table_alias
         if (!isset($defaults['table_alias'])) {
             if (!$this->table_alias) {
                 $this->table_alias = $this->link;
@@ -150,6 +151,8 @@ class Relation_One
             }
             $defaults['table_alias'] = $this->table_alias;
         }
+
+        // if model is Closure, then call it and return model
         if (is_object($this->model) && $this->model instanceof \Closure) {
             $c = $this->model;
 
@@ -161,6 +164,7 @@ class Relation_One
             return $c;
         }
 
+        // if model is set, then return clone of this model
         if (is_object($this->model)) {
             $c = clone $this->model;
             if (!$this->model->persistence && $this->owner->persistence) {
@@ -171,8 +175,6 @@ class Relation_One
         }
 
         // last effort - try to add model
-        $p = $this->owner->persistence;
-
         if (is_array($this->model)) {
             $model = $this->model[0];
             $md = $this->model;
@@ -182,6 +184,8 @@ class Relation_One
         } else {
             $model = $this->model;
         }
+
+        $p = $this->owner->persistence;
 
         return $p->add($p->normalizeClassName($model, 'Model'), $defaults);
     }
@@ -199,9 +203,7 @@ class Relation_One
     }
 
     /**
-     * Adding field into join will automatically associate that field
-     * with this join. That means it won't be loaded from $table but
-     * form the join instead.
+     * Returns referenced model with condition set.
      *
      * @param array $defaults Properties
      *

--- a/src/Relation_One.php
+++ b/src/Relation_One.php
@@ -223,7 +223,6 @@ class Relation_One
 
         // if owner model is loaded, then try to load referenced model
         if ($this->owner->loaded()) {
-
             if ($this->their_field) {
                 if ($this->owner[$this->our_field]) {
                     $m->tryLoadBy($this->their_field, $this->owner[$this->our_field]);

--- a/src/Relation_SQL_One.php
+++ b/src/Relation_SQL_One.php
@@ -51,7 +51,7 @@ class Relation_SQL_One extends Relation_One
     }
 
     /**
-     * Creates model that can be used for generating sub-query acitons.
+     * Creates model that can be used for generating sub-query actions.
      *
      * @return Model
      */

--- a/tests/RelationSQLTest.php
+++ b/tests/RelationSQLTest.php
@@ -145,7 +145,7 @@ class RelationSQLTest extends SQLTestCase
         $o->addCondition('amount', '<', 9);
 
         $this->assertEquals(
-            'select `id`,`name` from `user`',
+            'select `id`,`name` from `user` where `id` in (select `user_id` from `order` where `amount` > :a and `amount` < :b)',
             $o->ref('user_id')->action('select')->render()
         );
     }


### PR DESCRIPTION
**Fixes deep traversal for hasOne.**

If owner model is loaded, then it simply loads referenced model (like before).
But if owner model is not loaded and we use Persistence_SQL, then we add condition with subselect to referenced model.

Previously:
```
$order->unload()->addCondition('amount', '>', 5);
$order->ref('user_id')->action('select')->render();
// select `id`,`name` from `user` - WITHOUT conditions
```

Now:
```
$order->unload()->addCondition('amount', '>', 5);
$order->ref('user_id')->action('select')->render();
// select `id`,`name` from `user` where `id` in (select `user_id` from `order` where `amount` > :a)
```

**Also**
* fixes Field_One_SQL -> Field_SQL_One class/file name
* multiple fixes in comments
