### PR TITLE
[1.1] Improve multi-persistence, multi-record and multi-object operations

### DIFF
--- a/docs/advanced.rst
+++ b/docs/advanced.rst
@@ -3,7 +3,7 @@
 Advanced Topics
 ===============
 
-Agile Data allow you to implement various tricks. 
+Agile Data allow you to implement various tricks.
 
 
 Audit Fields
@@ -22,7 +22,7 @@ I will be looking to create the following fields:
 To implement the above, I'll create a new class::
 
     class Controller_Audit {
-        
+
         use \atk4\core\InitializerTrait {
             init as _init;
         }
@@ -33,7 +33,7 @@ To implement the above, I'll create a new class::
 
 TrackableTrait means that I'll be able to add this object inside model
 with ``$model->add(new Controller_Audit())`` and that will automatically
-populate $owner, and $app values (due to AppScopeTrait) as well as 
+populate $owner, and $app values (due to AppScopeTrait) as well as
 execute init() method, which I want to define like this::
 
 
@@ -63,8 +63,8 @@ execute init() method, which I want to define like this::
         });
     }
 
-In order to add your defined behaviour to the model. The first check actually allows you to define
-models that will bypass audit alltogether::
+In order to add your defined behavior to the model. The first check actually allows you to define
+models that will bypass audit altogether::
 
     $u1 = new Model_User($db);   // Model_User::init() includes audit
 
@@ -98,7 +98,7 @@ soft-delete controller for Agile Data (for educational purposes).
 Start by creating a class::
 
     class Controller_SoftDelete {
-        
+
         use \atk4\core\InitializerTrait {
             init as _init;
         }
@@ -175,16 +175,16 @@ The method body is actually defined in our controller. Notice that we have defin
 hooks - beforeSoftDelete and afterSoftDelete that work similarly to beforeDelete and afterDelete.
 
 beforeSoftDelete will allow you to "break" it in certain cases to bypass the rest of method, again,
-this is to maintain conistency with the rest of before* hooks in Agile Data.
+this is to maintain consistency with the rest of before* hooks in Agile Data.
 
-Hooks are called through the model, so your call-back will autamtically receive first argument
+Hooks are called through the model, so your call-back will automatically receive first argument
 $m, and afterSoftDelete will pass second argument - $id of deleted record.
 
 I am then setting reload_after_save value to false, because after I set 'is_deleted' to false,
 $m will no longer be able to load the record - it will fall outside of the DataSet. (We
 might implement a better method for saving records outside of DataSet in the future).
 
-After softDelete active record is unloaded, mimicking behaviour of delete().
+After softDelete active record is unloaded, mimicking behavior of delete().
 
 It's also possible for you to easily look at deleted records and even restore them::
 
@@ -202,7 +202,7 @@ a pretty simple controller. In fact I'm reusing the one from before and just sli
 it::
 
     class Controller_SoftDelete {
-        
+
         use \atk4\core\InitializerTrait {
             init as _init;
         }
@@ -265,7 +265,7 @@ it::
 
 Implementation of this controller is similar to the one above, however instead of creating softDelete()
 it overrides the delete() method through a hook. It will still call 'afterDelete' to mimic the
-behaviour of regular delete() after the record is marked as deleted and unloaded.
+behavior of regular delete() after the record is marked as deleted and unloaded.
 
 You can still access the deleted records::
 
@@ -304,7 +304,7 @@ your model are unique::
             $this->owner->addHook('beforeSave', $this);
         }
 
-        function beforeSave($m) 
+        function beforeSave($m)
         {
             foreach ($this->fields as $field) {
                 if ($m->dirty[$field]) {
@@ -360,7 +360,7 @@ Next we need to define relationship. Inside Model_Invoice add::
         $j->hasOne('invoice_id', 'Model_Invoice');
     }, 'their_field'=>'invoice_id']);
 
-    $this->addHook('beforeDelete',function($m){ 
+    $this->addHook('beforeDelete',function($m){
         $m->ref('InvoicePayment')->action('delete')->execute();
 
         // If you have important per-row hooks in InvoicePayment
@@ -404,7 +404,7 @@ towards a most suitable invoice::
 
         // we are only interested in unpaid invoices
         $invoices->addCondition('amount_due', '>', 0);
-        
+
         // Prioritize older invoices
         $invoices->setOrder('date');
 
@@ -434,7 +434,7 @@ towards a most suitable invoice::
         }
     }
 
-The method here will prioritise oldest invoices unless it finds the one that has a matching
+The method here will prioritize oldest invoices unless it finds the one that has a matching
 reference. Additionally it will allocate your payment towards multiple invoices. Finally
 if invoice is partially paid it will only allocate what is due.
 
@@ -442,7 +442,7 @@ if invoice is partially paid it will only allocate what is due.
 
 Creating Related Entity Lookup
 ==============================
-    
+
 Sometimes when you add a record inside your model you want to specify some related records
 not through ID but through other means. For instance, when adding invoice, I want to make
 it possible to specify 'Category' through the name, not only category_id. First, let me
@@ -469,17 +469,17 @@ this approach will require us to perform 2 extra queries::
 
     $m = new Model_Invoice($db);
     $m->insert([
-        'total'=>20, 
+        'total'=>20,
         'client_id'=>$m->ref('client_id')->loadBy('code', $client_code)->id,
         'category_id'=>$m->ref('category_id')->loadBy('name', $category)->id,
     ]);
 
-The ideal way would be to create some "non-peristable" fields that can be used to make
+The ideal way would be to create some "non-persistable" fields that can be used to make
 things easier::
 
     $m = new Model_Invoice($db);
     $m->insert([
-        'total'=>20, 
+        'total'=>20,
         'client_code'=>$client_code,
         'category'=>$category
     ]);
@@ -488,7 +488,7 @@ Here is how to add them. First you need to create fields::
 
     $this->addField('client_code', ['never_persist'=>true]);
     $this->addField('client_name', ['never_persist'=>true]);
-    $this->addField('clategory', ['never_persist'=>true]);
+    $this->addField('category', ['never_persist'=>true]);
 
 I have declared those fields with never_persist so they will never be used by persistence
 layer to load or save anything. Next I need a beforeSave handler::
@@ -514,7 +514,7 @@ layer to load or save anything. Next I need a beforeSave handler::
     });
 
 Note that isset() here will be true for modified fields only and behaves
-differently from PHP's default behaviour. See documentaiton for Model::isset
+differently from PHP's default behavior. See documentation for Model::isset
 
 This technique allows you to hide the complexity of the lookups and also embed the
 necessary queries inside your "insert" query.
@@ -547,7 +547,7 @@ The beautiful thing about this approach is that default can also be defined
 as a lookup query::
 
     $this->hasOne('category_id','Model_Category');
-    $this->getElement('category_id')->default = 
+    $this->getElement('category_id')->default =
         $this->getRef('category_id')->getModel()->addCondition('name','Other')
             ->action('field',['id']);
 
@@ -559,7 +559,7 @@ In this example I'll be building API that allows me to insert multi-model
 information. Here is usage example::
 
     $invoice->insert([
-        'client'=>'Joe Smith', 
+        'client'=>'Joe Smith',
         'payment'=>[
             'amount'=>15,
             'ref'=>'half upfront',
@@ -582,7 +582,7 @@ section. Add this into your Invoice Model::
 Next both payment and lines need to be added after invoice is actually created,
 so::
 
-    $this->addHook('afterSave', function($m){ 
+    $this->addHook('afterSave', function($m){
         if(isset($m['payment'])) {
             $m->ref('Payment')->insert($m['payment']);
         }
@@ -593,7 +593,7 @@ so::
     });
 
 You should never call save() inside afterSave hook, but if you wish to do some
-further manipulation, you can relad a clone::
+further manipulation, you can reload a clone::
 
     $mm = clone $m;
     $mm->reload();
@@ -637,7 +637,7 @@ Model_Invoice add::
 
     $this->hasOne('client_id', 'Client');
 
-    $this->hasOne('payment_invoice_id', function($m){ 
+    $this->hasOne('payment_invoice_id', function($m){
         return $m->ref('client_id')->ref('Payment');
     });
 
@@ -656,12 +656,12 @@ In this case the payment_invoice_id will be set to ID of any payment by client
         $m['payment_invoice_id'] = $m->ref('payment_invoice_id')->tryLoadAny()->id;
         $m->save();
 
-    });  
+    });
 
 Narrowing Down Existing Relations
 =================================
 
-Aglie Data allow you to define multiple relations between same entities, but
+Agile Data allow you to define multiple relations between same entities, but
 sometimes that can be quite useful. Consider adding this inside your Model_Contact::
 
     $this->hasMany('Invoice', 'Model_Invoice');
@@ -674,5 +674,5 @@ relationship to use different model::
 
     $this->getRef('Invoice')->model = 'Model_Invoice_Sale';
 
-The 'OverdueInvoice' relation will be also propoerly adjusted.
+The 'OverdueInvoice' relation will be also properly adjusted.
 

--- a/docs/conditions.rst
+++ b/docs/conditions.rst
@@ -22,7 +22,7 @@ narrow down set of "loadable" records by introducing a condition::
     $m->addCondition('gender','F');
     $m->load(1);    // exception, user with ID=1 is M
 
-Conditions serve important role and must be used to inteligently restrict
+Conditions serve important role and must be used to intelligently restrict
 logically accessible data for a model before you attempt the loading.
 
 Basic Usage
@@ -86,11 +86,11 @@ You can have as many conditions as you like.
 Defining your classes
 ---------------------
 
-Although I have used in-line additon of the arguments, normally you would want to
+Although I have used in-line addition of the arguments, normally you would want to
 set those conditions inside the init() method of your model::
 
 
-    class Model_Girl extends Model_User 
+    class Model_Girl extends Model_User
     {
         function init()
         {
@@ -102,7 +102,7 @@ set those conditions inside the init() method of your model::
 
 Note that the field 'gender' should be defined inside Model_User::init().
 
-Vendor-dependant logic
+Vendor-dependent logic
 ======================
 
 There are many other ways to set conditions, but you must always check if
@@ -138,7 +138,7 @@ SQL Expression Matching
 
 .. php:method:: expr($expression, $arguments = [])
 
-    Basically is a wrapper to create DSQL Expression, however this will 
+    Basically is a wrapper to create DSQL Expression, however this will
     find any usage of identifiers inside the template that do not have
     a corresponding value inside $arguments and replace it with the
     field::
@@ -152,7 +152,7 @@ Supported by: SQL
 
 Usage::
 
-    $m->addCondition($m->expr('[age] inbetween [min_age] and [max_age]'));
+    $m->addCondition($m->expr('[age] between [min_age] and [max_age]'));
 
 Allow you to define an arbitrary expression using SQL language.
 
@@ -165,7 +165,7 @@ Supported by: SQL
 Usage::
 
     $m->addCondition(
-        $m->expr('[age] inbetween [min_age] and [max_age]'), 
+        $m->expr('[age] between [min_age] and [max_age]'),
         ['min_age'=>10, 'max_age'=>30]
     );
 
@@ -174,9 +174,9 @@ nested and consist of objects as well as actions::
 
 
     $m->addCondition(
-        $m->expr('[age] inbetween [min_age] and [max_age]'), 
+        $m->expr('[age] between [min_age] and [max_age]'),
         [
-            'min_age'=>$m->action('min', ['age']), 
+            'min_age'=>$m->action('min', ['age']),
             'max_age'=>$m->expr('(20 + [])', [20])
         ]
     );
@@ -184,12 +184,12 @@ nested and consist of objects as well as actions::
 This will result in the following condition::
 
     WHERE
-        `age` inbetween 
+        `age` between
             (select min(`age`) from `user`)
-            and 
+            and
             (20 + :a)
 
-where the other 20 is passed through parameter. Refer to 
+where the other 20 is passed through parameter. Refer to
 http://dsql.readthedocs.io/en/develop/expressions.html for full documentation
 on expressions.
 
@@ -212,7 +212,7 @@ Using withID
 .. php:method:: withID($id)
 
 This method is similar to load($id) but instead of loading the specified record, it
-sets condition for ID to match. Technically that saves you on equery if you do not
+sets condition for ID to match. Technically that saves you one query if you do not
 need actual record by are only looking to traverse::
 
     $u = new Model_User($db);

--- a/docs/design.rst
+++ b/docs/design.rst
@@ -50,11 +50,11 @@ The Domain Layer Scope
 =======================
 
 Agile Data is a framework that will allow you to define your Domain objects
-and will map them into database of your choice. 
+and will map them into database of your choice.
 
 You can use Agile Data with SQL (PDO-compatible) vendors, NoSQL (MongoDB)
 or memory Arrays. Support for other database vendors can be added
-through add-ons. 
+through add-ons.
 
 
 The Danger of Raw Queries
@@ -114,7 +114,7 @@ When dealing with Domain logic, you work with a single object.
 When we start developing a new application, we first decide on the Model structure.
 Think what models your application will use and how they are related. Do not
 think in terms of "tables", but rather think in terms of "objects" and properties
-of those objects. 
+of those objects.
 
 All of those model properties are "declared".
 
@@ -140,10 +140,10 @@ A code to declare a model::
 
 Domain Model Methods
 --------------------
- 
+
 Next we need to write down various "functions" your application would have to
 perform and attribute those to individual models. At the same time think
-about object inheritance. 
+about object inheritance.
 
  - User
    - sendPasswordReminder()
@@ -181,10 +181,10 @@ Our next step is to define object fields (or properties). Remember that inherita
    - permission_level
  - Order
    - description, amount, is_paid
-   
+
 Those fields are not just mere "properties", but have more "meta" information behind them and that's why we call them "fields" and not "properties". A typical field contain information about field name, caption, type, validation rules, persistence rules, presentation rules and more. Meta information is optional and it can be used by automated processes (such as presentation or persistence).
 
-For instance, is_paid has a `type('boolean')` which means it will be stored as 1/0 in MySQL, but will use true/false in MongoDB. It will be displayed as a checkbox. Those decisions are made by the framework and will simplify your life, however if you want to do things differently, you will still be able to override default behaviour.
+For instance, is_paid has a `type('boolean')` which means it will be stored as 1/0 in MySQL, but will use true/false in MongoDB. It will be displayed as a checkbox. Those decisions are made by the framework and will simplify your life, however if you want to do things differently, you will still be able to override default behavior.
 
 Code to declare fields::
 
@@ -205,13 +205,13 @@ Code to access field values::
 Domain Model Relationship
 -------------------------
 
-Next - relations. Think how those objects relate to each-other. Think in terms of "specific object" and not database relations. Client has many Orders. Order has one Client. 
+Next - relations. Think how those objects relate to each-other. Think in terms of "specific object" and not database relations. Client has many Orders. Order has one Client.
 
  - User
    - hasMany(Client)
  - Client
    - hasOne(User)
-  
+
 There are no "many-to-many" relationship in Domain Model because relationships
 work from a specific record, but more on that later.
 
@@ -264,7 +264,7 @@ know it's ID::
 Persistence-specific Code
 =========================
 
-Finally, some code may rely on specific features of your persistence layer. 
+Finally, some code may rely on specific features of your persistence layer.
 
 
 Domain Model Expressions
@@ -299,7 +299,7 @@ Code::
 
                 $this->addExpression('is_password_expired')
                     ->set(
-                        '{} < NOW() - INTERVAL 1 MONTH', 
+                        '{} < NOW() - INTERVAL 1 MONTH',
                         [$this->getElement('password_change_date')]
                     );
             }
@@ -312,7 +312,7 @@ Persistence Hooks
 
 Hooks can help you perform operations when object is being persisted::
 
-    
+
     class Model_User extends data\Model {
         function init() {
             parent::init();
@@ -364,7 +364,7 @@ Orders::
     $sum += $order['amount'];
 
 You can iterate over the DataSet::
-    
+
     $sum = 0;
     foreach($db->add('Model_Order') as $order) {
         $sum += $order['amount'];
@@ -380,7 +380,7 @@ At this point, I'll jump ahead a bit and will show you an alternative code::
 
 It will have same effect as the code above, but will perform operation of
 adding up all order amounts inside the database and save you a lot of
-CPU cycles. 
+CPU cycles.
 
 Domain Conditions
 =================
@@ -410,7 +410,7 @@ on user_id. We can't do that, because "query", "table" and "user_id" are persist
 and we must keep them outside of business logic. Other ORM solution give you something like this::
 
     $array_of_orders = $user->orders();
-    
+
 Unfortunately this has practical performance implications and scalability constraints. What
 if your user is having millions of orders? Even with lazy-loading, you will be operating
 with million "id" records.
@@ -421,7 +421,7 @@ Agile Data implements traversal as a simple operation that converts one DataSet 
     $vip_orders = $user_dataset -> refSet('Order');
 
     $sum = $vip_orders->sum('amount')->getOne();
-    
+
 The implementation of refSet is pretty powerful - $user_dataset can address 3 users in
 the database and only 2 of those users are VIP. Typical ORM would require you to fetch all
 VIP records and then perform additional queries to find their orders.
@@ -435,7 +435,7 @@ Domain Model Actions
 --------------------
 
 Persistence layer in Agile Data uses intelligent mapping of your Domain Logic into
-DatabaseVendor-specific operations. 
+DatabaseVendor-specific operations.
 
 To continue my example from above, I'll use a query method to calculate number of orders
 placed by VIP clients::
@@ -453,7 +453,7 @@ While with MongoDB, the query could be different::
 
     $ids = collections.client.find({'is_vip':true}).field('id');
     return collections.order.find({'user_id':$ids}).count();
-    
+
 Finally the code above will work even if you use a simple Array as a data source::
 
     $db = new data\Persistence\Array([
@@ -495,7 +495,7 @@ not violate SRP (Single Responsibility Principle)
 
 Unique Features of Persistence Layer
 ------------------------------------
-More often than not, your application is designed and built with a specific persistence layer in mind. If you are using SQL database, you want to 
+More often than not, your application is designed and built with a specific persistence layer in mind. If you are using SQL database, you want to
 
 
 
@@ -511,5 +511,5 @@ Before we talk "databases", we must outline a few challenges:
  - we should be able to perform basic Unit tests on our domain logic
  - single vs multiple records
  - ..add more..
- 
+
 

--- a/docs/expressions.rst
+++ b/docs/expressions.rst
@@ -30,9 +30,9 @@ Example will calculate "total_gross" by adding up values for "net" and "vat"::
 
 The query using during load() will look like this::
 
-    select 
+    select
         `id`,`total_net`,`total_vat`,
-        (`total_net`+`total_vat`) `total_gross` 
+        (`total_net`+`total_vat`) `total_gross`
     from `invoice`',
 
 Defining Expression
@@ -40,15 +40,15 @@ Defining Expression
 
 The simplest format to define expression is by simply passing a string. The
 argument is executed through Model::expr() which automatically substitutes
-values for the other fields including other expressions. 
+values for the other fields including other expressions.
 
 There are other ways how you can specify expression::
 
-    $m->addExpression('total_gross', 
+    $m->addExpression('total_gross',
         $m->expr('[total_net]+[total_vat] + [fee]', ['fee'=>$fee])
     );
 
-This format allow you to supply additional parametetrs inside expression.
+This format allow you to supply additional parameters inside expression.
 You should always use parameters instead of appending values inside your
 expression string (for safety)
 
@@ -111,7 +111,7 @@ might be out of sync and you might need your SQL to recalculate those expression
 To simplify your life, Agile Data implements smart model reloading. Consider
 the following model::
 
-    class Model_Math extends \atk4\data\Model 
+    class Model_Math extends \atk4\data\Model
     {
         public $table = 'math';
         function init()
@@ -132,12 +132,12 @@ the following model::
 
     echo $m['sum'];
 
-When $m->save() is executed, Agile Data will perform reloading of the model. 
+When $m->save() is executed, Agile Data will perform reloading of the model.
 This is to ensure that expression 'sum' would be re-calculated for the values of
 4 and 6 so the final line will output a desired result - 10;
 
 Reload after save will only be executed if you have defined any expressions
-inside your model, however you can affect this behaviour::
+inside your model, however you can affect this behavior::
 
     $m = new Model_Math($db, ['reload_after_save' => false]);
     $m['a'] = 4;
@@ -159,7 +159,7 @@ is another scenario when your database defines default fields:
 
 Then try the following code::
 
-    class Model_Math extends \atk4\data\Model 
+    class Model_Math extends \atk4\data\Model
     {
         public $table = 'math';
         function init()
@@ -188,5 +188,5 @@ expressions. This time you can explicitly enable reload after save::
     echo $m['a']+$m['b']; // outputs 14
 
 .. note:: If your model is using reload_after_save, but you wish to insert
-    data without additional query - use :php:meth:`Model::insert()` or 
+    data without additional query - use :php:meth:`Model::insert()` or
     :php:meth:`Model::import()`.

--- a/docs/joins.rst
+++ b/docs/joins.rst
@@ -21,7 +21,7 @@ joins::
     $j_contact->addField('county');
     $j_contact->hasOne('Country');
 
-This code will load data from two tables simultaniously and if you do change any of those
+This code will load data from two tables simultaneously and if you do change any of those
 fields they will be update in their respective tables. With SQL the load query would
 look like this::
 
@@ -32,7 +32,7 @@ look like this::
     join contact c on c.id=u.contact_id
     where u.id = $id
 
-If driver is unable to query both tables simultaniously, then it will load one record
+If driver is unable to query both tables simultaneously, then it will load one record
 first, then load other record and will collect fields together::
 
     $user_data = $user->find($id);
@@ -81,7 +81,7 @@ you can even join using existing models::
     $user->weakJoin('country')->importModel('Country');
 
 This will automatically import fields, expressions, relations and conditions from
-'Country' model into $user model and will also re-map field names in process. 
+'Country' model into $user model and will also re-map field names in process.
 
 .. php:method:: weakJoinModel
 
@@ -97,7 +97,7 @@ Join relationship definitions
 -----------------------------
 
 When defining joins, you need to outline two fields that must match. In our
-earlier examples, we the master table was "user" that contained reference to 
+earlier examples, we the master table was "user" that contained reference to
 "contact". The condition would look like this ``user.contact_id=contact.id``.
 In some cases, however, a relation should be reversed::
 
@@ -109,14 +109,14 @@ can optionally define the field in the foreign table. If field is set, we will
 assume that it's a reverse join.
 
 Reverse joins are saved in the opposite order - primary table will be saved
-first and when id of a primary tabel is known, foreign table record is stored
+first and when id of a primary table is known, foreign table record is stored
 and ID is supplied. You can pass option 'master_field' to the join() which
 will specify which field to be used for matching. By default the field is
 calculated like this: foreign_table.'_id'. Here is usage example::
 
     $user->addField('username');
     $j_cc = $user->join('credit_card', [
-        'prefix'=>'cc_', 
+        'prefix'=>'cc_',
         'master_field'=>'default_credit_card_id'
     ]);
     $j_cc->addField('number');  // creates cc_number
@@ -131,7 +131,7 @@ Method Proxying
 ---------------
 
 Once your join is defined, you can call several methods on the join objects, that
-will create fields, other joins or expressions but those would be associated 
+will create fields, other joins or expressions but those would be associated
 with a foreign table.
 
 
@@ -164,12 +164,12 @@ with a foreign table.
 
     same as :php:meth:`Model::containsMany` but the data will be stored in a field inside foreign table.
 
-Create and Delete behaivour
----------------------------
+Create and Delete behavior
+--------------------------
 
 Updating joined records are simple, but when it comes to creation and deletion, there are some
-conditions. First we look at dependency. If master table contains id of a foreign table, then 
-foreign table record must be created first, so that we can store its ID in a master table. If 
+conditions. First we look at dependency. If master table contains id of a foreign table, then
+foreign table record must be created first, so that we can store its ID in a master table. If
 the join is reversed, the master record is created first and then foreign record is inserted
 along with the value of master id.
 
@@ -222,7 +222,7 @@ SQL-specific joins
 
 When your model is associated with SQL-capable driver, then instead of using 'Join' class, the
 'Join_SQL' is used instead. This class is designed to improve loading technique, because
-SQL vendors can query multiple tables simultaniously. 
+SQL vendors can query multiple tables simultaneously.
 
 Vendors that cannot do JOINs will have to implement compatibility by pulling data from
 collections in a correct order.
@@ -230,7 +230,7 @@ collections in a correct order.
 Implementation Details
 ----------------------
 
-- altough some SQL vendors allow update .. join .. syntax, this will not be used. That is done to
+- although some SQL vendors allow update .. join .. syntax, this will not be used. That is done to
   ensure better compatibility.
 - when field has the 'join' option set, trying to convert this field into expression will prefix
   the field properly with the foreign table alias.

--- a/docs/model.rst
+++ b/docs/model.rst
@@ -93,6 +93,12 @@ you create the instance like this::
 
     $m = new Model_User($db, 'user');
 
+.. php:method:: withPersistence($persistence, $id = null, $class = null)
+
+    Creates a duplicate of a current model and associate new copy with a specified
+    persistence. This method is useful for moving model data from one persistence
+    to another.
+
 
 Working with selective fields
 =============================

--- a/docs/model.rst
+++ b/docs/model.rst
@@ -14,7 +14,7 @@ Initialization
 
 Model class implements your Business Model - single entity of your business logic. When
 you plan your business application you should create classes for all your possible
-business entities by extending from "Model" class. 
+business entities by extending from "Model" class.
 
 .. php:method:: init
 
@@ -33,7 +33,7 @@ driver. Use it to define fields of your model::
 
 .. php:method:: addField($name, $defaults)
 
-    Creates a new field objects inside your model (by default the class is 'Field'). 
+    Creates a new field objects inside your model (by default the class is 'Field').
     The fields are implemented on top of Containers from Agile Core.
 
     Second argument to addField() can supply field default properties::
@@ -65,13 +65,13 @@ Populating Data
     amounts of data.
 
     The method will still convert the data needed and operate with joined
-    tables as needed. If you wish to access tables directly, you'll 
+    tables as needed. If you wish to access tables directly, you'll
     have to look into Persistence::insert($m, $data, $table);
 
 Associating Model with Database
 ===============================
 
-Normally you should always associate your model with persistance layer (database) when
+Normally you should always associate your model with persistence layer (database) when
 you create the instance like this::
 
     $m = new Model_User($db);
@@ -83,13 +83,13 @@ you create the instance like this::
 
 .. php:attr:: persistence_data
 
-    Array containing arbitrary data by a specific persistance layer.
+    Array containing arbitrary data by a specific persistence layer.
 
 .. php:attr:: table
 
-    If $table property is set, then your persistance driver will use it as default
-    table / colleciton when loading data. If you omit the table, you should specify
-    it when assoicating model with database::
+    If $table property is set, then your persistence driver will use it as default
+    table / collection when loading data. If you omit the table, you should specify
+    it when associating model with database::
 
     $m = new Model_User($db, 'user');
 
@@ -176,7 +176,7 @@ array:
 
         isset($m['name']); // returns false
         $m['name'] = 'Other Name';
-        isset($m['name']); // returns true 
+        isset($m['name']); // returns true
 
 
 .. php:method:: isDirty
@@ -194,7 +194,7 @@ array:
 .. php:attr:: dirty
 
     Contains list of modified fields since last loading and their original
-    valies.
+    values.
 
 
 Full example::
@@ -218,7 +218,7 @@ Full example::
 
     echo $m['salary'];          // 3000 (changed)
     echo isset($m['salary']);   // true
-    
+
     unset($m['salary']);        // return to original value
 
     echo $m['salary'];          // 2000
@@ -280,7 +280,7 @@ Title Field
     your title field in the header, or inside drop-down.
 
     If you don't have field 'name' but you want some other field to be title, you can specify that in
-    the property. If title_field is not needed, set it to false or point towards a non-existant field.
+    the property. If title_field is not needed, set it to false or point towards a non-existent field.
 
     See: :php:meth::`hasOne::addTitle()`
 
@@ -293,7 +293,7 @@ Hooks
     - beforeInsertQuery [sql only] (query)
     - afterInsertQuery (query, statement)
 
-  - beforeUpdate [only ift update]
+  - beforeUpdate [only if update]
     - beforeUpdateQuery [sql only] (query)
     - afterUpdateQuery (query, statement)
 
@@ -309,7 +309,7 @@ Hooks
 How to verify Updates
 ---------------------
 
-The model is only beind saved if any fields have been changed (dirty).
+The model is only being saved if any fields have been changed (dirty).
 Sometimes it's possible that the record in the database is no longer
 available and your update() may not actually update anything. This
 does not normally generate an error, however if you want to actually
@@ -352,7 +352,7 @@ further execution of other beforeLoad hooks and by specifying
 argument as 'false' it will also prevent call to $persistence
 for actual loading of the data.
 
-Similarly you can prevent deletion if you wish to implement 
-:ref:`soft-delete` or stop insert/modify from occuring.
+Similarly you can prevent deletion if you wish to implement
+:ref:`soft-delete` or stop insert/modify from occurring.
 
 

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -9,7 +9,7 @@ of other ORM, ActiveRecord and QueryBuilder tools could be helpful, but
 you should carefully go through the basics if you want to know how to use
 Agile Data efficiently.
 
-Documentation for Agile Data is organised into chapters where each chapter
+Documentation for Agile Data is organized into chapters where each chapter
 is dedicated to provide full documentation on all functionality of Agile
 Data.
 
@@ -63,7 +63,7 @@ Core Concepts
 
 Business Model (see :ref:`Model`)
     You define business logic inside your own classes that extend :php:class:`Model`.
-    Each class you create represent one business entity. 
+    Each class you create represent one business entity.
 
     Model has 3 major characteristic: Business Logic definition, DataSet mapping
     and Active Record.
@@ -99,9 +99,9 @@ to your data. If you have used ORM, ActiveRecord or QueryBuilders, you will be
 thinking in terms of "Persistence Domain". That means that you think in terms
 of "tables", "fields", "foreign keys" and "group by" operations.
 
-In larger application developers does not necesserily have to know the
+In larger application developers does not necessarily have to know the
 details of your database structure. In fact - structure can often change and
-code that depend on specific field names or types can break. 
+code that depend on specific field names or types can break.
 
 More importantly, if you decide to store some data in different database either
 for caching (memcache), unique features (full-text search) or to handle large
@@ -114,7 +114,7 @@ words - Business Logic is an API you and the rest of your developer team
 can use without concerning about data storage.
 
 Agile Data has a rich set of features to define how Business Domain maps
-into Persistance Domain. It also allows you to perform most actions with
+into Persistence Domain. It also allows you to perform most actions with
 only knowledge of Business Domain, keeping the rest of your application
 independent from your database choice, structure or patterns.
 
@@ -122,7 +122,7 @@ Class vs In-Line definition
 ---------------------------
 Business model entity in Agile Data is represented through PHP object.
 While it is advisable to create each entity in its own class, you do not have
-to do so. 
+to do so.
 
 It might be handy to use in-line definition of a model. Try the following
 inside console::
@@ -140,7 +140,7 @@ Next, exit and create file `src/Model_ContactInfo.php`::
     class Model_ContactInfo extends \atk4\data\Model
     {
         public $table = 'contact_info';
-        function init() 
+        function init()
         {
             parent::init();
 
@@ -172,7 +172,7 @@ Persistence
 
 When you first create model using `new Model` it will just exist as an
 independent container. By passing `$db` as a parameter you are also
-associating your model with that specific persistence. 
+associating your model with that specific persistence.
 
 Once model is associated with one persistence, you cannot re-associate it.
 Method :php:meth:`Model::init()` will be executed only after persistence is
@@ -197,7 +197,7 @@ conditions is your way to specify which records to operate on::
     {
         return json_encode($m->export($fields));
     }
-    
+
     $m = new Model_User($db);
     $m->addCondition('country_id', '2');
 
@@ -222,7 +222,7 @@ stores. You can load / unload records like this::
 
 You can call `$m->loaded()` to see if there is active record and `$m->id`
 will store the ID of active record. You can also un-load the record with
-`$m->unload()`. 
+`$m->unload()`.
 
 By default no records are loaded and if you modify some field and attempt
 to save unloaded model, it will create a new record.
@@ -244,7 +244,7 @@ Other Parameters
 ^^^^^^^^^^^^^^^^
 
 Apart from the main 3 pieces of "state" your Model holds there can also be
-some other paramaters such as:
+some other parameters such as:
 
  - order
  - limit
@@ -256,7 +256,7 @@ You can also define your own parameters like this::
 
     $m->audit
 
-This can be used internally for all sorts of decisions for model behaviour.
+This can be used internally for all sorts of decisions for model behavior.
 
 
 Getting Started
@@ -296,7 +296,7 @@ instances::
 
 .. note:: If you're trying those lines, you will also have to
     create this new table inside your MySQL database::
-    
+
         create table user2 as select * from user:
 
 As I mentioned - :php:meth:`Model::init` is called when model is associated
@@ -326,7 +326,7 @@ initially, avoid using generators.
 
 In practice, :php:meth:`Model::addField()` creates a new 'Field' object and then
 links it up to your model. This object is used to store some information about
-your field, but it also participates in some field-related acitivity.
+your field, but it also participates in some field-related activity.
 
 Table Joins
 -----------
@@ -344,7 +344,7 @@ That means that your business model will contain 'address_1' and 'address_2'
 fields, but when it comes to storing those values, they will be sent
 into a different database table and the records will be automatically linked.
 
-Lets once again load up the console for some excercises::
+Lets once again load up the console for some exercises::
 
     $m = new Model_User($db);
 
@@ -373,7 +373,7 @@ will properly manipulate features of that specific database engine.
 Understanding Persistence
 -------------------------
 
-To make things simple, console has already created persistence 
+To make things simple, console has already created persistence
 inside variable `$db`. Load up `console.php` in your editor to look
 at how persistence is set up::
 
@@ -381,7 +381,7 @@ at how persistence is set up::
 
     // or
 
-    $app->db = new \atk4\data\Persistence_SQL($pdo, $user, $pass); 
+    $app->db = new \atk4\data\Persistence_SQL($pdo, $user, $pass);
 
 There are several Persistence classes that deal with different
 data sources. Lets load up our console and try out a different
@@ -398,7 +398,7 @@ persistence::
     var_dump($a); // shows you stored data
 
 This time our Model_User logic has worked pretty well with Array-only
-peristence logic.
+persistence logic.
 
 .. note:: Persisting into Array or MongoDB are not fully functional as of 1.0
     version. We plan to expand this functionality soon, see our development
@@ -412,7 +412,7 @@ Your application normally uses multiple business entities and they can be relate
 to each-other.
 
 .. warning:: Do not mix-up business model relations with database relations (foreign
-    keys). 
+    keys).
 
 Relations are defined by calling :php:meth:`Model::hasOne()` or
 :php:meth:`Model::hasMany()`. You always specify destination model and you can
@@ -492,7 +492,7 @@ you keep the return value of hasOne() / hasMany() or call :php:meth:`Model::getR
 with the same identifier later on.
 
 Calling :php:meth:`Model::ref()` will proxy into the ref() method of relation
-object which will in turn figure out what to do. 
+object which will in turn figure out what to do.
 
 Additionally you can call :php:meth:`Model::addField()` on the reference model
 that will bring one or several fields from related model into your current model.
@@ -570,7 +570,7 @@ Multi-record actions
 
 Actions also allow you to perform operations on multiple records. This can be very
 handy with some deep traversal to improve query efficiency. Suppose you need to change
-Client/Supplier status to 'suspended' for a specific user. Fire up a concole once
+Client/Supplier status to 'suspended' for a specific user. Fire up a console once
 away::
 
     $m = new Model_User($db);
@@ -585,7 +585,7 @@ away::
 Note that I had to perform 2 updates here, because Agile Data considers Client and
 Supplier as separate models. In our implementation they happened to be in a same
 table, but technically that could also be implemented differently by persistence
-layer. 
+layer.
 
 Advanced Use of Actions
 -----------------------

--- a/docs/relations.rst
+++ b/docs/relations.rst
@@ -7,7 +7,7 @@ Relations
 
 .. php:class:: Model
 
-.. php:method:: ref($link, $defailts = []);
+.. php:method:: ref($link, $details = []);
 
 Models can relate one to another. The logic of traversing relations, however, is
 slightly different to the traditional ORM implementation, because in Agile Data
@@ -36,7 +36,7 @@ also possible::
     $orders_for_vips->loadAny();
 
 Condition on the base model will be carried over to the orders and you will
-only be able to access orders that belong to vip users. The query for loading
+only be able to access orders that belong to VIP users. The query for loading
 order will look like this::
 
     select * from order where user_id in (
@@ -76,7 +76,7 @@ Safety and Performance
 
 When using ref() on hasMany relation, it will always return a fresh clone
 of the model. You can perform actions on the clone and next time you execute
-ref() this will not be impcated. If you performing traversals inside
+ref() this will not be impacted. If you performing traversals inside
 iterations, this can cause performance issues, for this reason you should
 see refLink()
 
@@ -123,7 +123,7 @@ Dealing with NON-ID fields
 
 Sometimes you have to use non-ID relations. For example we might have two models
 describing list of currencies and for each currency we might have historic rates
-available. Both models will relate throug ``currency.code = exchange.currency_code``::
+available. Both models will relate through ``currency.code = exchange.currency_code``::
 
     $c = new Model_Currency();
     $e = new Model_ExchangeRate();
@@ -135,9 +135,9 @@ available. Both models will relate throug ``currency.code = exchange.currency_co
 
 This will produce the following query::
 
-    select * from exchange 
-    where currency_code in 
-        (select code form currency wehre is_convertable=1)
+    select * from exchange
+    where currency_code in
+        (select code form currency where is_convertable=1)
 
 
 Add Aggregate Fields
@@ -191,7 +191,7 @@ The refLink would define a condition on a query like this::
 And it will not be viable on its own, however if you use it inside a sub-query,
 then it now makes sense for generating expression::
 
-    select 
+    select
         (select sum(amount) from `order` where user_id = `user`.id) sum_amount
     from user
     where is_vip = 1
@@ -239,10 +239,10 @@ user model::
 The important point here is that no additional queries are generated in the process and
 the loadAny() will look like this::
 
-    select * from user where id in 
+    select * from user where id in
         (select user_id from order where status = 'failed')
 
-By passing options to hasOne() you can also differenciate field name::
+By passing options to hasOne() you can also differentiate field name::
 
     $o->addField('user_id');
     $o->hasOne('User', [$u, 'our_field'=>'user_id']);
@@ -250,7 +250,7 @@ By passing options to hasOne() you can also differenciate field name::
     $o->load(1)->ref('User')['name'];
 
 You can also use ``their_field`` if you need non-id matching (see example above for hasMany()).
-    
+
 Importing Fields
 ----------------
 
@@ -282,7 +282,7 @@ did above::
             'address_notes'=>['notes', 'type'=>'text']
         ]);
 Above, all ``address_`` fields are copied with the same name, however field 'notes' from Address model
-will be called 'address_notes' inside user model. 
+will be called 'address_notes' inside user model.
 
 Relation Discovery
 ==================
@@ -320,7 +320,7 @@ you can use::
     echo $o->id(1)->ref('user_id/address_id')->loadAny()['address_1'];
 
 Here ``id()`` will only set a condition without actually loading the record and traversal
-will ecapsulate sub-queries resulting in a query like this::
+will encapsulate sub-queries resulting in a query like this::
 
     select * from address where id in
         (select address_id from user where id in
@@ -377,15 +377,15 @@ Loading model like that can produce a pretty sophisticated query
 
     select
         `pp`.`id`,`pp`.`name`,`pp`.`age`,`pp_i`.`parent_item_id`,
-        (select `parent`.`name` 
+        (select `parent`.`name`
          from `item` `parent`
-         left join `item2` as `parent_i` on `parent_i`.`item_id` = `parent`.`id` 
+         left join `item2` as `parent_i` on `parent_i`.`item_id` = `parent`.`id`
          where `parent`.`id` = `pp_i`.`parent_item_id`
          ) `parent_item`,
         (select sum(`child`.`age`) from `item` `child`
-         left join `item2` as `child_i` on `child_i`.`item_id` = `child`.`id` 
+         left join `item2` as `child_i` on `child_i`.`item_id` = `child`.`id`
          where `child_i`.`parent_item_id` = `pp`.`id`
-        ) `child_age`,`pp`.`id` `_i` 
+        ) `child_age`,`pp`.`id` `_i`
     from `item` `pp`left join `item2` as `pp_i` on `pp_i`.`item_id` = `pp`.`id`
 
 Relations with New Records
@@ -431,7 +431,7 @@ next example will traverse into the contact to set it up::
     $m->save();
 
 When entity which you have referenced through ref() is saved, it will automatically populate
-$m['contact_id'] field and the final $m->save() will also store the reference. 
+$m['contact_id'] field and the final $m->save() will also store the reference.
 
 ID setting is implemented through a basic hook. Related model will have afterSave
 hook, which will update address_id field of the $m.

--- a/docs/results.rst
+++ b/docs/results.rst
@@ -35,14 +35,14 @@ each iteration like this::
     }
 
 Additionally model will execute necessary after-load hooks that might trigger some other
-calculation or validations. 
+calculation or validations.
 
 .. note:: changing query parameter during iteration will has no effect until you finish
     iterating.
 
 Keeping models
 --------------
-If you wish to preserve the objects that you have loaded (not recomended as they will
+If you wish to preserve the objects that you have loaded (not recommended as they will
 consume memory), you can do it like this::
 
     $cat = [];
@@ -83,12 +83,12 @@ You can invoke and iterate action (particularly SQL) to fetch the data::
         var_dump($row); // array
     }
 
-This has the identical behaviour to $m->rawIterator();
+This has the identical behavior to $m->rawIterator();
 
 
 Comparison of various ways of fetching
 ======================================
 
 - getIterator - action(select), [ fetches row, set ID/Data, call afterLoad hook, yields model ], unloads data
-- rawIterator - action(select), [ fetches row, yields row ] 
+- rawIterator - action(select), [ fetches row, yields row ]
 - export - action(select), fetches all rows, returns all rows

--- a/src/Model.php
+++ b/src/Model.php
@@ -781,9 +781,11 @@ class Model implements \ArrayAccess, \IteratorAggregate
     }
 
     /**
-     * Keeps the model data, but wipes out the ID
-     * so when you save it next time, ends up as a new
+     * Keeps the model data, but wipes out the ID so
+     * when you save it next time, it ends up as a new
      * record in the database.
+     *
+     * @param mixed|null $new_id
      *
      * @return $this
      */
@@ -806,6 +808,11 @@ class Model implements \ArrayAccess, \IteratorAggregate
      *
      * but will assume that both models are compatible,
      * therefore will not perform any loading.
+     *
+     * @param string $class
+     * @param array $options
+     *
+     * @return Model
      */
     public function saveAs($class, $options = [])
     {
@@ -813,11 +820,14 @@ class Model implements \ArrayAccess, \IteratorAggregate
     }
 
     /**
-     * Store the data into database, but will never attempt
-     * to reload the data. Additioanlly any data
-     * will be unloaded. Use this instead of
-     * save() if you want to squezee a little more
-     * performance out.
+     * Store the data into database, but will never attempt to
+     * reload the data. Additionally any data will be unloaded.
+     * Use this instead of save() if you want to squezee a
+     * little more performance out.
+     *
+     * @param array $data
+     *
+     * @return $this
      */
     public function saveAndUnload($data = [])
     {
@@ -835,8 +845,13 @@ class Model implements \ArrayAccess, \IteratorAggregate
     /**
      * This will cast Model into another class without
      * loosing state of your active record.
+     *
+     * @param string $class
+     * @param array $options
+     *
+     * @return Model
      */
-    public function asModel($class, $options)
+    public function asModel($class, $options = [])
     {
         $m = $this->newInstance($class, $options);
 
@@ -851,29 +866,26 @@ class Model implements \ArrayAccess, \IteratorAggregate
     }
 
     /**
-     * Create new model form the same base class
+     * Create new model from the same base class
      * as $this.
      *
      * @param string $class
+     * @param array $options
      *
-     * @return $this
+     * @return Model
      */
     public function newInstance($class = null, $options = [])
     {
         if ($class === null) {
             $class = get_class($this);
         }
-        if (is_string($class)) {
-            $m = new $class($this->persistence, $options);
-        } elseif (is_object($class)) {
-            $m = $this->persistence->add($class, $options);
-        }
+        $m = $this->persistence->add($class, $options);
 
         return $m;
     }
 
     /**
-     * Create new model form the same base class
+     * Create new model from the same base class
      * as $this. If you omit $id,then when saving
      * a new record will be created with default ID.
      * If you specify $id then it will be used
@@ -890,14 +902,15 @@ class Model implements \ArrayAccess, \IteratorAggregate
      * See https://github.com/atk4/data/issues/111 for
      * use-case examples.
      *
-     * @param string $class
+     * @param Persistence $persistence
      * @param mixed  $id
+     * @param string $class
      *
      * @return $this
      */
     public function withPersistence($persistence, $id = null, string $class = null)
     {
-        if (!$persistence instanceof \atk4\data\Persintence) {
+        if (!$persistence instanceof \atk4\data\Persistence) {
             throw new Exception([
                 'Please supply valid persistence',
                 'arg' => $persistence,

--- a/src/Model.php
+++ b/src/Model.php
@@ -810,7 +810,7 @@ class Model implements \ArrayAccess, \IteratorAggregate
      * therefore will not perform any loading.
      *
      * @param string $class
-     * @param array $options
+     * @param array  $options
      *
      * @return Model
      */
@@ -847,7 +847,7 @@ class Model implements \ArrayAccess, \IteratorAggregate
      * loosing state of your active record.
      *
      * @param string $class
-     * @param array $options
+     * @param array  $options
      *
      * @return Model
      */
@@ -870,7 +870,7 @@ class Model implements \ArrayAccess, \IteratorAggregate
      * as $this.
      *
      * @param string $class
-     * @param array $options
+     * @param array  $options
      *
      * @return Model
      */
@@ -903,8 +903,8 @@ class Model implements \ArrayAccess, \IteratorAggregate
      * use-case examples.
      *
      * @param Persistence $persistence
-     * @param mixed  $id
-     * @param string $class
+     * @param mixed       $id
+     * @param string      $class
      *
      * @return $this
      */

--- a/src/Model.php
+++ b/src/Model.php
@@ -808,7 +808,7 @@ class Model implements \ArrayAccess, \IteratorAggregate
      */
     public function saveAs($class, $options = [])
     {
-        return $this->as($class, $options)->save();
+        return $this->asModel($class, $options)->save();
     }
 
     /**
@@ -834,7 +834,7 @@ class Model implements \ArrayAccess, \IteratorAggregate
      * This will cast Model into another class without
      * loosing state of your active record
      */
-    public function as($class, $options) {
+    public function asModel($class, $options) {
         $m = $this->newInstance($class, $options);
 
         // Warning. If condition is different on both models,

--- a/src/Persistence.php
+++ b/src/Persistence.php
@@ -63,13 +63,15 @@ class Persistence
             unset($defaults[0]);
         }
 
-        if (!is_object($m)) {
-            $m = $this->factory($this->normalizeClassName($m), $defaults);
-        }
+        $m = $this->factory($m, $defaults);
 
         if ($m->persistence) {
+            if ($m->persistence === $this) {
+                return $m;
+            }
+
             throw new Exception([
-                'Model already has conditions or is related to persistence',
+                'Model is already related to another persistence',
             ]);
         }
 

--- a/tests/FolderTest.php
+++ b/tests/FolderTest.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace atk4\data\tests;
+
+use atk4\data\Model;
+use atk4\data\Persistence_SQL;
+
+class Folder extends \atk4\data\Model
+{
+    public $table = 'folder';
+
+    public function init()
+    {
+        parent::init();
+        $this->addField('name');
+
+        $this->hasMany('SubFolder', [new Folder(), 'their_field'=>'parent_id'])
+            ->addField('count', ['aggregate'=>'count', 'field'=>$this->expr('*')]);
+
+        $this->hasOne('parent_id', new Folder())
+            ->addTitle();
+
+        $this->addField('is_deleted', ['type'=>'bool']);
+        $this->addCondition('is_deleted', false);
+    }
+}
+
+
+/**
+ * @coversDefaultClass \atk4\data\Model
+ */
+class FolderTest extends SQLTestCase
+{
+    public function testRate()
+    {
+        $a = [
+            'folder' => [
+                ['parent_id' => 1, 'is_deleted'=>0, 'name'=>'Desktop'],
+                ['parent_id' => 1, 'is_deleted'=>0, 'name'=>'My Documents'],
+                ['parent_id' => 1, 'is_deleted'=>0, 'name'=>'My Videos'],
+                ['parent_id' => 1, 'is_deleted'=>0, 'name'=>'My Projects'],
+                ['parent_id' => 4, 'is_deleted'=>0, 'name'=>'Agile Data'],
+                ['parent_id' => 4, 'is_deleted'=>0, 'name'=>'DSQL'],
+                ['parent_id' => 4, 'is_deleted'=>0, 'name'=>'Agile Toolkit'],
+                ['parent_id' => 4, 'is_deleted'=>1, 'name'=>'test-project'],
+            ], ];
+        $this->setDB($a);
+
+        $db = new Persistence_SQL($this->db->connection);
+        $f = new Folder($db);
+        $f->load(4);
+
+        $this->assertEquals([
+            'id'=>4,
+            'name'=>'My Projects',
+            'count'=>3,
+            'parent_id'=>1,
+            'parent'=>'Desktop',
+            'is_deleted'=>0,
+        ], $f->get());
+    }
+
+}


### PR DESCRIPTION
One of the core features for 1.1 is improved support for multiple permissions as well as improved handling when working with multiple records. This PR adds a lot of functionality on top of existing logic. When reviewing make sure each section has proper documentation and tests.

### newInstance()

Creates a Vanilla copy of your model.

### asModel()

Casts your model into a different class without  reloading.

### saveAs()

Saves your model under a different class.

### saveAndUnload()

Saves your model then unload. Will not try to reload.

### withPersistence()

Returns new instance of your model associated with given persistence (and copy dirty values).



A lot of documentation have been updated to provide various examples how the new features can be used for:

 - creating MemCache for load-by-id caching strategy with SQL write-back.
 - create read/write replica support
 - store active record into different DB every time it is updated
 - implement caching of logged-in user inside session