### PR TITLE
Few fixes

### DIFF
--- a/src/Field.php
+++ b/src/Field.php
@@ -146,14 +146,14 @@ class Field
             return $value;
         }
         if ($value === null) {
-            return null;
+            return;
         }
         $f = $this;
 
         // only string type fields can use empty string as legit value, for all
         // other field types empty value is the same as no-value, nothing or null
         if ($f->type != 'string' && $value === '') {
-            return null;
+            return;
         }
 
         switch ($f->type) {

--- a/src/Field.php
+++ b/src/Field.php
@@ -167,6 +167,8 @@ class Field
                 } elseif (isset($f->enum[1]) && $value === $f->enum[1]) {
                     $value = true;
                 }
+            } elseif (is_numeric($value)) {
+                $value = (bool) $value;
             }
             if (!is_bool($value)) {
                 throw new Exception('Field value must be a boolean');

--- a/src/Field.php
+++ b/src/Field.php
@@ -146,13 +146,19 @@ class Field
             return $value;
         }
         if ($value === null) {
-            return;
+            return null;
         }
         $f = $this;
 
+        // only string type fields can use empty string as legit value, for all
+        // other field types empty value is the same as no-value, nothing or null
+        if ($f->type != 'string' && $value === '') {
+            return null;
+        }
+
         switch ($f->type) {
         case 'string':
-            if (!is_string($value) && !is_numeric($value)) {
+            if (!is_scalar($value)) {
                 throw new Exception('Field value must be a string');
             }
             $value = trim($value);

--- a/src/Persistence_SQL.php
+++ b/src/Persistence_SQL.php
@@ -429,6 +429,16 @@ class Persistence_SQL extends Persistence
             return $callback($value, $f, $this);
         }
 
+        if ($value === null) {
+            return null;
+        }
+
+        // only string type fields can use empty string as legit value, for all
+        // other field types empty value is the same as no-value, nothing or null
+        if ($f->type != 'string' && $value === '') {
+            return null;
+        }
+
         switch ($f->type) {
         case 'boolean':
 
@@ -490,6 +500,16 @@ class Persistence_SQL extends Persistence
         // Support for callback: (28, ['age', [persistence_object]])
         if ($callback = $f->saveCallback) {
             return $callback($value, $f, $this);
+        }
+
+        if ($value === null) {
+            return null;
+        }
+
+        // only string type fields can use empty string as legit value, for all
+        // other field types empty value is the same as no-value, nothing or null
+        if ($f->type != 'string' && $value === '') {
+            return null;
         }
 
         // Manually handle remaining types

--- a/src/Persistence_SQL.php
+++ b/src/Persistence_SQL.php
@@ -430,13 +430,13 @@ class Persistence_SQL extends Persistence
         }
 
         if ($value === null) {
-            return null;
+            return;
         }
 
         // only string type fields can use empty string as legit value, for all
         // other field types empty value is the same as no-value, nothing or null
         if ($f->type != 'string' && $value === '') {
-            return null;
+            return;
         }
 
         switch ($f->type) {
@@ -503,13 +503,13 @@ class Persistence_SQL extends Persistence
         }
 
         if ($value === null) {
-            return null;
+            return;
         }
 
         // only string type fields can use empty string as legit value, for all
         // other field types empty value is the same as no-value, nothing or null
         if ($f->type != 'string' && $value === '') {
-            return null;
+            return;
         }
 
         // Manually handle remaining types

--- a/src/Reference_One.php
+++ b/src/Reference_One.php
@@ -144,6 +144,7 @@ class Reference_One
             $this->our_field = $this->link;
         }
         if (!$this->owner->hasElement($this->our_field)) {
+            // @todo
             // Imants: proper way would be to get actual field type of id field of related model,
             // but if we try to do so here, then we end up in infinite loop :(
             //$m = $this->getModel();

--- a/src/Reference_SQL_One.php
+++ b/src/Reference_SQL_One.php
@@ -16,18 +16,22 @@ class Reference_SQL_One extends Reference_One
      *
      * @param string|Field $field
      * @param string|null  $their_field
+     * @param array $defaults Properties
      *
      * @return Field_SQL_Expression
      */
-    public function addField($field, $their_field = null)
+    public function addField($field, $their_field = null, $defaults = [])
     {
         if ($their_field === null) {
             $their_field = $field;
         }
 
-        return $this->owner->addExpression($field, function ($m) use ($their_field) {
-            return $m->refLink($this->link)->action('field', [$their_field]);
-        });
+        return $this->owner->addExpression($field, array_merge([
+            function ($m) use ($their_field) {
+                return $m->refLink($this->link)->action('field', [$their_field]);
+            }],
+            $defaults
+        ));
     }
 
     /**

--- a/src/Reference_SQL_One.php
+++ b/src/Reference_SQL_One.php
@@ -16,7 +16,7 @@ class Reference_SQL_One extends Reference_One
      *
      * @param string|Field $field
      * @param string|null  $their_field
-     * @param array        $defaults Properties
+     * @param array        $defaults    Properties
      *
      * @return Field_SQL_Expression
      */

--- a/src/Reference_SQL_One.php
+++ b/src/Reference_SQL_One.php
@@ -16,7 +16,7 @@ class Reference_SQL_One extends Reference_One
      *
      * @param string|Field $field
      * @param string|null  $their_field
-     * @param array $defaults Properties
+     * @param array        $defaults Properties
      *
      * @return Field_SQL_Expression
      */
@@ -29,7 +29,7 @@ class Reference_SQL_One extends Reference_One
         return $this->owner->addExpression($field, array_merge([
             function ($m) use ($their_field) {
                 return $m->refLink($this->link)->action('field', [$their_field]);
-            }],
+            }, ],
             $defaults
         ));
     }
@@ -94,7 +94,7 @@ class Reference_SQL_One extends Reference_One
                     return $mm->action('field', [$mm->title_field]);
                 },
                 'type' => 'string',
-                'ui' => ['editable' => false, 'visible' => true],
+                'ui'   => ['editable' => false, 'visible' => true],
             ],
             $defaults,
             [

--- a/src/Reference_SQL_One.php
+++ b/src/Reference_SQL_One.php
@@ -89,6 +89,7 @@ class Reference_SQL_One extends Reference_One
 
                     return $mm->action('field', [$mm->title_field]);
                 },
+                'type' => 'string',
                 'ui' => ['editable' => false, 'visible' => true],
             ],
             $defaults,


### PR DESCRIPTION
* set field type to 'string' for addTitle generated field
* boolean fields should normalize integers to boolean otherwise we always need to set enum [0,1] even if we just want to use/store 0|1. This is also needed to be compatible with atk4 toolkit form fields
* fixing empty string and null value issue once and for all (I hope) !!!
* Reference_SQL_One->addField now allows to pass additional properties to field object