### PR TITLE
adds afterSaveTransaction and afterDeleteTransaction hooks

### DIFF
--- a/src/Model.php
+++ b/src/Model.php
@@ -1167,7 +1167,7 @@ class Model implements \ArrayAccess, \IteratorAggregate
             $this->set($data);
         }
 
-        return $this->atomic(function () use ($data) {
+        $a = $this->atomic(function () use ($data) {
             if ($this->hook('beforeSave') === false) {
                 return $this;
             }
@@ -1248,6 +1248,10 @@ class Model implements \ArrayAccess, \IteratorAggregate
 
             return $this;
         });
+
+        $this->hook('afterSaveTransaction', [$a]);
+
+        return $a;
     }
 
     /**
@@ -1374,7 +1378,7 @@ class Model implements \ArrayAccess, \IteratorAggregate
             $id = null;
         }
 
-        return $this->atomic(function () use ($id) {
+        $a = $this->atomic(function () use ($id) {
             if ($id) {
                 $c = clone $this;
                 $c->load($id)->delete();
@@ -1393,6 +1397,10 @@ class Model implements \ArrayAccess, \IteratorAggregate
                 throw new Exception(['No active record is set, unable to delete.']);
             }
         });
+
+        $this->hook('afterDeleteTransaction', [$a]);
+
+        return $a;
     }
 
     /**


### PR DESCRIPTION
Sometime it is useful to have hook which executes after model save/delete is commited.
For example, if you need to execute some action after model inserts a record, but this action relies on data inserted in afterSave hook.

Not-tested example - just to give you idea:
```
$order->addHook('afterInsert', function ($m) {
    // automatically create new invoice when new order is inserted
    // this executes in same $order->save() transaction
    $order->ref('Invoice')->set([$some_data])->save();

    // and now we also want to get any unpaid invoice and do something with that
    $total = $order->ref('UnpaidInvoice')->loadAny()->get('total');
    // here ref() will add condition on id of invoice which we created few lines above
    // and loadAny() will not find this record, because it's not yet commited.
    $m->set('total', $total)->save();
});
```

so last action should be done after save is commited, but previously we couldn't hook in that spot.