### PR TITLE
Fix boolean compatibility

### DIFF
--- a/src/Persistence_SQL.php
+++ b/src/Persistence_SQL.php
@@ -542,11 +542,22 @@ class Persistence_SQL extends Persistence
         // Manually handle remaining types
         switch ($f->type) {
         case 'boolean':
-            if (isset($f->enum) && is_array($f->enum) && isset($f->enum[0]) && isset($f->enum[1])) {
-                $value = $value ? $f->enum[1] : $f->enum[0];
-            } else {
+
+            // if enum is not set, cast value to boolean simply.
+            if (!isset($f->enum) || !$f->enum) {
                 $value = (int) $value;
+                break;
             }
+
+            // if enum is set, first lets see if it matches one of those precisely
+            if ($value === $f->enum[1]) {
+                $value = true;
+            } elseif ($value === $f->enum[0]) {
+                $value = false;
+            }
+
+            // finally, convert into appropriate value
+            $value = $value ? $f->enum[1] : $f->enum[0];
             break;
         case 'date':
         case 'datetime':

--- a/tests/TypecastingTest.php
+++ b/tests/TypecastingTest.php
@@ -279,9 +279,8 @@ class TypecastingTest extends SQLTestCase
         $db = new Persistence_SQL($this->db->connection);
         $m = new Model($db, 'job');
 
-        $f = $m->addField('closed', ['type'=>'boolean','enum'=>['N','Y']]);
+        $f = $m->addField('closed', ['type' => 'boolean', 'enum' => ['N', 'Y']]);
 
         $this->assertEquals('N', $db->typecastSaveField($f, 'N'));
     }
-
 }

--- a/tests/TypecastingTest.php
+++ b/tests/TypecastingTest.php
@@ -273,4 +273,15 @@ class TypecastingTest extends SQLTestCase
 
         $m->addCondition('date', $d)->loadAny();
     }
+
+    public function testTypecastBoolean()
+    {
+        $db = new Persistence_SQL($this->db->connection);
+        $m = new Model($db, 'job');
+
+        $f = $m->addField('closed', ['type'=>'boolean','enum'=>['N','Y']]);
+
+        $this->assertEquals('N', $db->typecastSaveField($f, 'N'));
+    }
+
 }


### PR DESCRIPTION
Previously you could have boolean with values 'Y', 'N'. In Agile Data you can still use it if you define field like this:

```
$this->addField('closed', ['type'=>'boolean', 'enum'=>['N','Y']]);
```

However if you `set('closed', 'N')` it actually stores `Y` in database, because it considers `N` to be a "true" value.

This PR will observe exact matches for boolean fields and then it will correctly store them. Also added new test-script.