### PR TITLE
Fix incompatible type matching

### DIFF
--- a/src/Field.php
+++ b/src/Field.php
@@ -152,7 +152,7 @@ class Field
 
         // only string type fields can use empty string as legit value, for all
         // other field types empty value is the same as no-value, nothing or null
-        if ($f->type != 'string' && $value === '') {
+        if ($f->type && $f->type != 'string' && $value === '') {
             return;
         }
 

--- a/src/Model.php
+++ b/src/Model.php
@@ -498,7 +498,7 @@ class Model implements \ArrayAccess, \IteratorAggregate
 
         $current_value = array_key_exists($field, $this->data) ? $this->data[$field] : $original_value;
 
-        if ($value === $current_value || 
+        if ($value === $current_value ||
             (is_string($value) && is_numeric($current_value) && $value == $current_value) ||
             (is_numeric($value) && is_string($current_value) && $value == $current_value)
         ) {

--- a/src/Model.php
+++ b/src/Model.php
@@ -498,9 +498,9 @@ class Model implements \ArrayAccess, \IteratorAggregate
 
         $current_value = array_key_exists($field, $this->data) ? $this->data[$field] : $original_value;
 
-        if ($value === $current_value ||
-            (is_string($value) && is_int($current_value) && $value == $current_value) ||
-            (is_int($value) && is_string($current_value) && $value == $current_value)
+        if ($value === $current_value || 
+            (is_string($value) && is_numeric($current_value) && $value == $current_value) ||
+            (is_numeric($value) && is_string($current_value) && $value == $current_value)
         ) {
             // do nothing, value unchanged
             return $this;
@@ -529,7 +529,11 @@ class Model implements \ArrayAccess, \IteratorAggregate
             }
         }
 
-        if (array_key_exists($field, $this->dirty) && $this->dirty[$field] == $value) {
+        if (array_key_exists($field, $this->dirty) && (
+            $this->dirty[$field] === $value ||
+            (is_string($value) && is_numeric($this->dirty[$field]) && $value == $this->dirty[$field]) ||
+            (is_numeric($value) && is_string($this->dirty[$field]) && $value == $this->dirty[$field])
+        )) {
             unset($this->dirty[$field]);
         } elseif (!array_key_exists($field, $this->dirty)) {
             $this->dirty[$field] =

--- a/src/Model.php
+++ b/src/Model.php
@@ -498,7 +498,7 @@ class Model implements \ArrayAccess, \IteratorAggregate
 
         $current_value = array_key_exists($field, $this->data) ? $this->data[$field] : $original_value;
 
-        if ($value === $current_value || 
+        if ($value === $current_value ||
             (is_string($value) && is_int($current_value) && $value == $current_value) ||
             (is_int($value) && is_string($current_value) && $value == $current_value)
         ) {

--- a/src/Model.php
+++ b/src/Model.php
@@ -498,7 +498,10 @@ class Model implements \ArrayAccess, \IteratorAggregate
 
         $current_value = array_key_exists($field, $this->data) ? $this->data[$field] : $original_value;
 
-        if ($value == $current_value) {
+        if ($value === $current_value || 
+            (is_string($value) && is_int($current_value) && $value == $current_value) ||
+            (is_int($value) && is_string($current_value) && $value == $current_value)
+        ) {
             // do nothing, value unchanged
             return $this;
         }

--- a/tests/BusinessModelTest.php
+++ b/tests/BusinessModelTest.php
@@ -104,6 +104,9 @@ class BusinessModelTest extends TestCase
         $m = new Model();
         $m->addField('name');
         $m->data = ['name' => 5];
+        $m['name'] = 5;
+        $this->assertEquals([], $m->dirty);
+
         $m['name'] = 10;
         $this->assertEquals(['name' => 5], $m->dirty);
 
@@ -112,6 +115,16 @@ class BusinessModelTest extends TestCase
 
 
         $m['name'] = 5;
+        $this->assertEquals([], $m->dirty);
+
+        $m['name'] = '5';
+        $this->assertEquals([], $m->dirty);
+
+        $m['name'] = '5.0';
+        $this->assertEquals([], $m->dirty);
+
+        $m->data = ['name' => ''];
+        $m['name'] = '';
         $this->assertEquals([], $m->dirty);
 
         // now with defaults
@@ -281,6 +294,23 @@ class BusinessModelTest extends TestCase
         $c['name'] = '  jo hn ';
         $this->assertEquals(['name' => 'jo hn'], $c->data);
         $this->assertEquals('jo hn123', $c['name']);
+    }
+
+    public function testNormalize()
+    {
+        $m = new Model();
+        $m->addField('name', ['type'=>'string']);
+        $m->addField('age', ['type'=>'int']);
+        $m->addField('data');
+
+        $m['name'] = '';
+        $this->assertSame('', $m['name']);
+
+        $m['age'] = '';
+        $this->assertSame(null, $m['age']);
+
+        $m['data'] = '';
+        $this->assertSame('', $m['data']);
     }
 
     public function testExampleFromDoc()

--- a/tests/BusinessModelTest.php
+++ b/tests/BusinessModelTest.php
@@ -299,8 +299,8 @@ class BusinessModelTest extends TestCase
     public function testNormalize()
     {
         $m = new Model();
-        $m->addField('name', ['type'=>'string']);
-        $m->addField('age', ['type'=>'int']);
+        $m->addField('name', ['type' => 'string']);
+        $m->addField('age', ['type' => 'int']);
         $m->addField('data');
 
         $m['name'] = '';

--- a/tests/BusinessModelTest.php
+++ b/tests/BusinessModelTest.php
@@ -120,11 +120,32 @@ class BusinessModelTest extends TestCase
         $m['name'] = '5';
         $this->assertEquals([], $m->dirty);
 
+        $m['name'] = '6';
+        $this->assertNotEquals([], $m->dirty);
+        $m['name'] = '5';
+        $this->assertEquals([], $m->dirty);
+
         $m['name'] = '5.0';
         $this->assertEquals([], $m->dirty);
 
         $m->data = ['name' => ''];
         $m['name'] = '';
+        $this->assertEquals([], $m->dirty);
+
+        $m->data = ['name' => '5'];
+        $m['name'] = 5;
+        $this->assertEquals([], $m->dirty);
+        $m['name'] = 6;
+        $this->assertNotEquals([], $m->dirty);
+        $m['name'] = 5;
+        $this->assertEquals([], $m->dirty);
+
+        $m->data = ['name' => 4.28];
+        $m['name'] = '4.28';
+        $this->assertEquals([], $m->dirty);
+        $m['name'] = '5.28';
+        $this->assertNotEquals([], $m->dirty);
+        $m['name'] = '4.28';
         $this->assertEquals([], $m->dirty);
 
         // now with defaults


### PR DESCRIPTION
Currently, if the field value is "4" and you change it to 4 (int) then this makes field dirty. To avoid this, hotfix was added: 33377f7f52f017581cf566c21bc1f9488af089cc

Unfortunately this resulted in some bad side-effects (not found by tests) reported here: https://github.com/atk4/data/pull/184#commitcomment-19325848

This PR is properly addressing the issue, by using strict comparison unless we are dealing with stringified numbers. Also it adds several tests, so if there are more test-cases that are affected, then please add.

The original problem was caused because hasOne('blah', ); will use non-integer fields even for persistence SQL where `id` fields use int() by default. Still, we can't be fully sure about that and without typecasting SQL response comes back as string. 