### PR TITLE
Feature/id default type

### DIFF
--- a/src/Model.php
+++ b/src/Model.php
@@ -844,7 +844,7 @@ class Model implements \ArrayAccess, \IteratorAggregate
         }
 
         $this->data = $this->persistence->load($this, $id);
-        if(is_null($this->id)) {
+        if (is_null($this->id)) {
             $this->id = $id;
         }
         $this->hook('afterLoad');

--- a/src/Model.php
+++ b/src/Model.php
@@ -844,7 +844,9 @@ class Model implements \ArrayAccess, \IteratorAggregate
         }
 
         $this->data = $this->persistence->load($this, $id);
-        $this->id = $id;
+        if(is_null($this->id)) {
+            $this->id = $id;
+        }
         $this->hook('afterLoad');
 
         return $this;

--- a/src/Model.php
+++ b/src/Model.php
@@ -304,7 +304,6 @@ class Model implements \ArrayAccess, \IteratorAggregate
         if ($this->id_field) {
             $this->addField($this->id_field, [
                 'system'    => true,
-                'type'      => 'integer',
             ]);
         }
     }

--- a/src/Persistence_Array.php
+++ b/src/Persistence_Array.php
@@ -49,7 +49,7 @@ class Persistence_Array extends Persistence
 
         $m = parent::add($m, $defaults);
 
-        if($f = $m->hasElement($m->id_field)) {
+        if ($f = $m->hasElement($m->id_field)) {
             if (!$f->type) {
                 $f->type = 'integer';
             }

--- a/src/Persistence_Array.php
+++ b/src/Persistence_Array.php
@@ -47,7 +47,15 @@ class Persistence_Array extends Persistence
             '_default_class_join' => 'atk4\data\Join_Array',
         ], $defaults);
 
-        return parent::add($m, $defaults);
+        $m = parent::add($m, $defaults);
+
+        if($f = $m->hasElement($m->id_field)) {
+            if (!$f->type) {
+                $f->type = 'integer';
+            }
+        }
+
+        return $m;
     }
 
     /**

--- a/src/Persistence_SQL.php
+++ b/src/Persistence_SQL.php
@@ -892,12 +892,7 @@ class Persistence_SQL extends Persistence
         $data = $this->typecastSaveRow($m, $data);
 
         // only apply fields that has been modified
-        $cnt = 0;
-        foreach ($data as $field => $value) {
-            $f = $m->getElement($field);
-            $update->set($f->actual ?: $f->short_name, $value);
-            $cnt++;
-        }
+        $update->set($data);
         $update->where($m->getElement($m->id_field), $id);
 
 
@@ -905,7 +900,7 @@ class Persistence_SQL extends Persistence
 
         try {
             $m->hook('beforeUpdateQuery', [$update]);
-            if ($cnt) {
+            if ($data) {
                 $st = $update->execute();
             }
         } catch (\PDOException $e) {

--- a/src/Persistence_SQL.php
+++ b/src/Persistence_SQL.php
@@ -143,7 +143,7 @@ class Persistence_SQL extends Persistence
             $m->addExpression('id', '1');
         } else {
             // SQL databases use ID of int by default
-            $m->getElement('id')->type = 'integer';
+            //$m->getElement('id')->type = 'integer';
         }
 
         return $m;

--- a/tests/FieldTest.php
+++ b/tests/FieldTest.php
@@ -317,6 +317,16 @@ class FieldTest extends SQLTestCase
                 2 => ['id' => 2, 'name' => 'Peter', 'surname' => 'qq'],
             ], ];
         $this->assertEquals($a, $this->getDB());
+
+        $m['first_name'] = 'Scott';
+        $m->save();
+
+        $a = [
+            'user' => [
+                1 => ['id' => 1, 'name' => 'Scott', 'surname' => 'Smith'],
+                2 => ['id' => 2, 'name' => 'Peter', 'surname' => 'qq'],
+            ], ];
+        $this->assertEquals($a, $this->getDB());
     }
 
     public function testSystem1()

--- a/tests/TypecastingTest.php
+++ b/tests/TypecastingTest.php
@@ -163,8 +163,8 @@ class TypecastingTest extends SQLTestCase
         $m->load(1);
 
         $this->assertSame('hello world', $m['rot13']);
-        $this->assertSame(1, $m->id);
-        $this->assertSame(1, $m['id']);
+        $this->assertSame('1', $m->id);
+        $this->assertSame('1', $m['id']);
         $this->assertEquals('2013-02-21 05:00:12', (string) $m['datetime']);
         $this->assertEquals('2013-02-20', (string) $m['date']);
         $this->assertEquals('12:00:50', (string) $m['time']);


### PR DESCRIPTION
As per documentation, we use undefined type to preserve value of the field.

Persistence_SQL currently uses 'integer' as default type and the same thing is with global persistence. It's safer not to set any type, because this way we will preserve the original type of id, INT or HASH.

Another effect of this is that hasOne() which defines fields without type by default now won't update "123" to 123 and consider it dirty. 