### PR TITLE
Feature/yet another fix for dirtiness

### DIFF
--- a/src/Model.php
+++ b/src/Model.php
@@ -497,7 +497,7 @@ class Model implements \ArrayAccess, \IteratorAggregate
 
         $current_value = array_key_exists($field, $this->data) ? $this->data[$field] : $original_value;
 
-        if ($value === $current_value) {
+        if (gettype($value) == gettype($current_value) && $value == $current_value) {
             // do nothing, value unchanged
             return $this;
         }

--- a/src/Model.php
+++ b/src/Model.php
@@ -529,7 +529,7 @@ class Model implements \ArrayAccess, \IteratorAggregate
         }
 
         if (array_key_exists($field, $this->dirty) && (
-            $this->dirty[$field] === $value
+            gettype($this->dirty[$field]) == gettype($value) && $this->dirty[$field] == $value
         )) {
             unset($this->dirty[$field]);
         } elseif (!array_key_exists($field, $this->dirty)) {

--- a/src/Persistence.php
+++ b/src/Persistence.php
@@ -290,7 +290,7 @@ class Persistence
 
         // only string type fields can use empty string as legit value, for all
         // other field types empty value is the same as no-value, nothing or null
-        if ($f->type != 'string' && $value === '') {
+        if ($f->type && $f->type != 'string' && $value === '') {
             return;
         }
 

--- a/src/Persistence_SQL.php
+++ b/src/Persistence_SQL.php
@@ -458,6 +458,9 @@ class Persistence_SQL extends Persistence
                 // datetime only - set from persisting timezone
                 if ($f->type == 'datetime' && isset($f->persist_timezone)) {
                     $v = $dt_class::createFromFormat($format, $v, new $tz_class($f->persist_timezone));
+                    if ($v === false) {
+                        throw new Exception(['Incorrectly formatted datetime', 'format'=>$format, 'value'=>$value, 'field'=>$f]);
+                    }
                     $v->setTimeZone(new $tz_class(date_default_timezone_get()));
                 } else {
                     $v = $dt_class::createFromFormat($format, $v);

--- a/src/Persistence_SQL.php
+++ b/src/Persistence_SQL.php
@@ -464,6 +464,9 @@ class Persistence_SQL extends Persistence
                     $v->setTimeZone(new $tz_class(date_default_timezone_get()));
                 } else {
                     $v = $dt_class::createFromFormat($format, $v);
+                    if ($v === false) {
+                        throw new Exception(['Incorrectly formatted date/time', 'format' => $format, 'value' => $value, 'field' => $f]);
+                    }
                 }
 
                 // need to cast here because DateTime::createFromFormat returns DateTime object not $dt_class

--- a/src/Persistence_SQL.php
+++ b/src/Persistence_SQL.php
@@ -459,7 +459,7 @@ class Persistence_SQL extends Persistence
                 if ($f->type == 'datetime' && isset($f->persist_timezone)) {
                     $v = $dt_class::createFromFormat($format, $v, new $tz_class($f->persist_timezone));
                     if ($v === false) {
-                        throw new Exception(['Incorrectly formatted datetime', 'format'=>$format, 'value'=>$value, 'field'=>$f]);
+                        throw new Exception(['Incorrectly formatted datetime', 'format' => $format, 'value' => $value, 'field' => $f]);
                     }
                     $v->setTimeZone(new $tz_class(date_default_timezone_get()));
                 } else {

--- a/tests/TypecastingTest.php
+++ b/tests/TypecastingTest.php
@@ -338,4 +338,45 @@ class TypecastingTest extends SQLTestCase
         // must respect 'actual'
         $this->assertNotNull($m['ts']);
     }
+
+    public function testDirtyTimestamp()
+    {
+        $sql_time = '2016-10-25 11:44:08';
+
+        $a = [
+            'types' => [
+                [
+                    'date'     => $sql_time,
+                ],
+            ], ];
+        $this->setDB($a);
+        $db = new Persistence_SQL($this->db->connection);
+
+        $m = new Model($db, ['table' => 'types']);
+        $m->addField('ts', ['actual' => 'date', 'type' => 'datetime']);
+        $m->loadAny();
+        $m['ts'] = clone $m['ts'];
+
+        $this->assertFalse($m->isDirty('ts'));
+    }
+    function testTimestampSave()
+    {
+
+        $a = [
+            'types' => [
+                [
+                    'date'     => 'foobar'
+                ],
+            ], ];
+        $this->setDB($a);
+        $db = new Persistence_SQL($this->db->connection);
+
+        $m = new Model($db, ['table' => 'types']);
+        $m->addField('ts', ['actual'=>'date', 'type' => 'date']);
+        $m->loadAny();
+        $m['ts'] = new \DateTime();
+        $m->save();
+
+        $this->assertEquals(['types'=>[1=>['id'=>1, 'date'=>'2016-11-01']]], $this->getDB());
+    }
 }

--- a/tests/TypecastingTest.php
+++ b/tests/TypecastingTest.php
@@ -467,4 +467,44 @@ class TypecastingTest extends SQLTestCase
         // stores valid date.
         $this->assertEquals(['types' => [1 => ['id' => 1, 'date' => '2012-03-01']]], $this->getDB());
     }
+
+    function testIntegerSave()
+    {
+        $db = new Persistence_SQL($this->db->connection);
+
+        $m = new Model($db, ['table' => 'types']);
+        $m->addField('i', ['type' => 'integer']);
+
+        $m->data['i'] = 1;
+        $this->assertSame([], $m->dirty);
+
+        $m['i'] = '1';
+        $this->assertSame([], $m->dirty);
+
+        $m['i'] = '2';
+        $this->assertSame(['i'=>1], $m->dirty);
+
+        $m['i'] = '1';
+        $this->assertSame([], $m->dirty);
+
+        // same test without type integer
+        $m = new Model($db, ['table' => 'types']);
+        $m->addField('i');
+
+        $m->data['i'] = 1;
+        $this->assertSame([], $m->dirty);
+
+        $m['i'] = '1';
+        $this->assertSame(1, $m->dirty['i']);
+
+        $m['i'] = '2';
+        $this->assertSame(1, $m->dirty['i']);
+
+
+        $m['i'] = '1';
+        $this->assertSame(1, $m->dirty['i']);
+
+        $m['i'] = 1;
+        $this->assertSame([], $m->dirty);
+    }
 }

--- a/tests/TypecastingTest.php
+++ b/tests/TypecastingTest.php
@@ -136,6 +136,7 @@ class TypecastingTest extends SQLTestCase
                     'money'    => '',
                     'float'    => '',
                     'array'    => '',
+                    'object'   => '',
                 ],
             ],
         ];
@@ -152,37 +153,40 @@ class TypecastingTest extends SQLTestCase
         $m->addField('datetime', ['type' => 'datetime']);
         $m->addField('time', ['type' => 'time']);
         $m->addField('boolean', ['type' => 'boolean']);
+        $m->addField('integer', ['type' => 'integer']);
         $m->addField('money', ['type' => 'money']);
         $m->addField('float', ['type' => 'float']);
-        $m->addField('integer', ['type' => 'integer']);
         $m->addField('array', ['type' => 'array']);
+        $m->addField('object', ['type' => 'object']);
         $m->load(1);
 
         // Only
         $this->assertSame('', $m['string']);
         $this->assertSame('', $m['notype']);
-        $this->assertSame(null, $m['boolean']);
-        $this->assertSame(null, $m['money']);
         $this->assertSame(null, $m['date']);
         $this->assertSame(null, $m['datetime']);
         $this->assertSame(null, $m['time']);
+        $this->assertSame(null, $m['boolean']);
         $this->assertSame(null, $m['integer']);
-        $this->assertSame(null, $m['array']);
+        $this->assertSame(null, $m['money']);
         $this->assertSame(null, $m['float']);
+        $this->assertSame(null, $m['array']);
+        $this->assertSame(null, $m['object']);
 
         unset($v['id']);
         $m->set($v);
 
         $this->assertSame('', $m['string']);
         $this->assertSame('', $m['notype']);
-        $this->assertSame(null, $m['boolean']);
-        $this->assertSame(null, $m['money']);
         $this->assertSame(null, $m['date']);
         $this->assertSame(null, $m['datetime']);
         $this->assertSame(null, $m['time']);
+        $this->assertSame(null, $m['boolean']);
         $this->assertSame(null, $m['integer']);
-        $this->assertSame(null, $m['array']);
+        $this->assertSame(null, $m['money']);
         $this->assertSame(null, $m['float']);
+        $this->assertSame(null, $m['array']);
+        $this->assertSame(null, $m['object']);
         $this->assertEquals([], $m->dirty);
 
         $m->save();
@@ -202,6 +206,7 @@ class TypecastingTest extends SQLTestCase
                     'money'    => null,
                     'float'    => null,
                     'array'    => null,
+                    'object'   => null,
         ];
 
         $this->assertEquals($a, $this->getDB());

--- a/tests/TypecastingTest.php
+++ b/tests/TypecastingTest.php
@@ -468,7 +468,7 @@ class TypecastingTest extends SQLTestCase
         $this->assertEquals(['types' => [1 => ['id' => 1, 'date' => '2012-03-01']]], $this->getDB());
     }
 
-    function testIntegerSave()
+    public function testIntegerSave()
     {
         $db = new Persistence_SQL($this->db->connection);
 
@@ -482,7 +482,7 @@ class TypecastingTest extends SQLTestCase
         $this->assertSame([], $m->dirty);
 
         $m['i'] = '2';
-        $this->assertSame(['i'=>1], $m->dirty);
+        $this->assertSame(['i' => 1], $m->dirty);
 
         $m['i'] = '1';
         $this->assertSame([], $m->dirty);

--- a/tests/TypecastingTest.php
+++ b/tests/TypecastingTest.php
@@ -124,7 +124,7 @@ class TypecastingTest extends SQLTestCase
     {
         $a = [
             'types' => [
-                1=> $v = [
+                1 => $v = [
                     'id'       => 1,
                     'string'   => '',
                     'notype'   => '',
@@ -158,7 +158,7 @@ class TypecastingTest extends SQLTestCase
         $m->addField('array', ['type' => 'array']);
         $m->load(1);
 
-        // Only 
+        // Only
         $this->assertSame('', $m['string']);
         $this->assertSame('', $m['notype']);
         $this->assertSame(null, $m['boolean']);
@@ -446,25 +446,25 @@ class TypecastingTest extends SQLTestCase
 
         $this->assertFalse($m->isDirty('ts'));
     }
-    function testTimestampSave()
-    {
 
+    public function testTimestampSave()
+    {
         $a = [
             'types' => [
                 [
-                    'date'     => 'foobar'
+                    'date'     => 'foobar',
                 ],
             ], ];
         $this->setDB($a);
         $db = new Persistence_SQL($this->db->connection);
 
         $m = new Model($db, ['table' => 'types']);
-        $m->addField('ts', ['actual'=>'date', 'type' => 'date']);
+        $m->addField('ts', ['actual' => 'date', 'type' => 'date']);
         $m->loadAny();
         $m['ts'] = new \DateTime('2012-02-30');
         $m->save();
 
         // stores valid date.
-        $this->assertEquals(['types'=>[1=>['id'=>1, 'date'=>'2012-03-01']]], $this->getDB());
+        $this->assertEquals(['types' => [1 => ['id' => 1, 'date' => '2012-03-01']]], $this->getDB());
     }
 }

--- a/tests/TypecastingTest.php
+++ b/tests/TypecastingTest.php
@@ -473,7 +473,7 @@ class TypecastingTest extends SQLTestCase
         $a = [
             'types' => [
                 [
-                    'date'     => 'foobar',
+                    'date'     => '',
                 ],
             ], ];
         $this->setDB($a);

--- a/tests/TypecastingTest.php
+++ b/tests/TypecastingTest.php
@@ -426,6 +426,9 @@ class TypecastingTest extends SQLTestCase
         $this->assertNotNull($m['ts']);
     }
 
+    /**
+     * @expectedException Exception
+     */
     public function testBadTimestamp()
     {
         $sql_time = '20blah16-10-25 11:44:08';
@@ -442,9 +445,6 @@ class TypecastingTest extends SQLTestCase
         $m = new Model($db, ['table' => 'types']);
         $m->addField('ts', ['actual' => 'date', 'type' => 'datetime']);
         $m->loadAny();
-
-        // must respect 'actual'
-        $this->assertNull($m['ts']);
     }
 
     public function testDirtyTimestamp()

--- a/tests/TypecastingTest.php
+++ b/tests/TypecastingTest.php
@@ -359,24 +359,24 @@ class TypecastingTest extends SQLTestCase
 
         $this->assertFalse($m->isDirty('ts'));
     }
-    function testTimestampSave()
-    {
 
+    public function testTimestampSave()
+    {
         $a = [
             'types' => [
                 [
-                    'date'     => 'foobar'
+                    'date'     => 'foobar',
                 ],
             ], ];
         $this->setDB($a);
         $db = new Persistence_SQL($this->db->connection);
 
         $m = new Model($db, ['table' => 'types']);
-        $m->addField('ts', ['actual'=>'date', 'type' => 'date']);
+        $m->addField('ts', ['actual' => 'date', 'type' => 'date']);
         $m->loadAny();
         $m['ts'] = new \DateTime();
         $m->save();
 
-        $this->assertEquals(['types'=>[1=>['id'=>1, 'date'=>'2016-11-01']]], $this->getDB());
+        $this->assertEquals(['types' => [1 => ['id' => 1, 'date' => '2016-11-01']]], $this->getDB());
     }
 }

--- a/tests/TypecastingTest.php
+++ b/tests/TypecastingTest.php
@@ -120,6 +120,93 @@ class TypecastingTest extends SQLTestCase
         $this->assertEquals($first, $duplicate);
     }
 
+    public function testEmptyValues()
+    {
+        $a = [
+            'types' => [
+                1=> $v = [
+                    'id'       => 1,
+                    'string'   => '',
+                    'notype'   => '',
+                    'date'     => '',
+                    'datetime' => '',
+                    'time'     => '',
+                    'boolean'  => '',
+                    'integer'  => '',
+                    'money'    => '',
+                    'float'    => '',
+                    'array'    => '',
+                ],
+            ],
+        ];
+        $this->setDB($a);
+
+        date_default_timezone_set('Asia/Seoul');
+
+        $db = new Persistence_SQL($this->db->connection);
+
+        $m = new Model($db, ['table' => 'types']);
+        $m->addField('string', ['type' => 'string']);
+        $m->addField('notype');
+        $m->addField('date', ['type' => 'date']);
+        $m->addField('datetime', ['type' => 'datetime']);
+        $m->addField('time', ['type' => 'time']);
+        $m->addField('boolean', ['type' => 'boolean']);
+        $m->addField('money', ['type' => 'money']);
+        $m->addField('float', ['type' => 'float']);
+        $m->addField('integer', ['type' => 'integer']);
+        $m->addField('array', ['type' => 'array']);
+        $m->load(1);
+
+        // Only 
+        $this->assertSame('', $m['string']);
+        $this->assertSame('', $m['notype']);
+        $this->assertSame(null, $m['boolean']);
+        $this->assertSame(null, $m['money']);
+        $this->assertSame(null, $m['date']);
+        $this->assertSame(null, $m['datetime']);
+        $this->assertSame(null, $m['time']);
+        $this->assertSame(null, $m['integer']);
+        $this->assertSame(null, $m['array']);
+        $this->assertSame(null, $m['float']);
+
+        unset($v['id']);
+        $m->set($v);
+
+        $this->assertSame('', $m['string']);
+        $this->assertSame('', $m['notype']);
+        $this->assertSame(null, $m['boolean']);
+        $this->assertSame(null, $m['money']);
+        $this->assertSame(null, $m['date']);
+        $this->assertSame(null, $m['datetime']);
+        $this->assertSame(null, $m['time']);
+        $this->assertSame(null, $m['integer']);
+        $this->assertSame(null, $m['array']);
+        $this->assertSame(null, $m['float']);
+        $this->assertEquals([], $m->dirty);
+
+        $m->save();
+        $this->assertEquals($a, $this->getDB());
+
+        $m->duplicate()->save();
+
+        $a['types'][2] = [
+                    'id'       => 2,
+                    'string'   => '',
+                    'notype'   => '',
+                    'date'     => null,
+                    'datetime' => null,
+                    'time'     => null,
+                    'boolean'  => null,
+                    'integer'  => null,
+                    'money'    => null,
+                    'float'    => null,
+                    'array'    => null,
+        ];
+
+        $this->assertEquals($a, $this->getDB());
+    }
+
     public function testTypeCustom1()
     {
         $a = [
@@ -359,24 +446,25 @@ class TypecastingTest extends SQLTestCase
 
         $this->assertFalse($m->isDirty('ts'));
     }
-
-    public function testTimestampSave()
+    function testTimestampSave()
     {
+
         $a = [
             'types' => [
                 [
-                    'date'     => 'foobar',
+                    'date'     => 'foobar'
                 ],
             ], ];
         $this->setDB($a);
         $db = new Persistence_SQL($this->db->connection);
 
         $m = new Model($db, ['table' => 'types']);
-        $m->addField('ts', ['actual' => 'date', 'type' => 'date']);
+        $m->addField('ts', ['actual'=>'date', 'type' => 'date']);
         $m->loadAny();
-        $m['ts'] = new \DateTime();
+        $m['ts'] = new \DateTime('2012-02-30');
         $m->save();
 
-        $this->assertEquals(['types' => [1 => ['id' => 1, 'date' => '2016-11-01']]], $this->getDB());
+        // stores valid date.
+        $this->assertEquals(['types'=>[1=>['id'=>1, 'date'=>'2012-03-01']]], $this->getDB());
     }
 }

--- a/tests/TypecastingTest.php
+++ b/tests/TypecastingTest.php
@@ -426,6 +426,27 @@ class TypecastingTest extends SQLTestCase
         $this->assertNotNull($m['ts']);
     }
 
+    public function testBadTimestamp()
+    {
+        $sql_time = '20blah16-10-25 11:44:08';
+
+        $a = [
+            'types' => [
+                [
+                    'date'     => $sql_time,
+                ],
+            ], ];
+        $this->setDB($a);
+        $db = new Persistence_SQL($this->db->connection);
+
+        $m = new Model($db, ['table' => 'types']);
+        $m->addField('ts', ['actual' => 'date', 'type' => 'datetime']);
+        $m->loadAny();
+
+        // must respect 'actual'
+        $this->assertNull($m['ts']);
+    }
+
     public function testDirtyTimestamp()
     {
         $sql_time = '2016-10-25 11:44:08';


### PR DESCRIPTION
In my latest update i have changed to use '===' to compare types for dirtiness and cleaned up no-type handling. Still it's not a perfect way, and objects are never equal:

    $a['date'] = clone $a['date'];

This results in dirty field, and it shouldn't be.

This fix addresses this by comparing types first and if types match, use loose comparison. I think it's the best way to compare values. 