### PR TITLE
Add implementation for refModel()

### DIFF
--- a/docs/advanced.rst
+++ b/docs/advanced.rst
@@ -495,19 +495,19 @@ layer to load or save anything. Next I need a beforeSave handler::
 
     $this->addHook('beforeSave', function($m) {
         if(isset($m['client_code']) && !isset($m['client_id'])) {
-            $cl = $this->getRef('client_id')->getModel();
+            $cl = $this->refModel('client_id');
             $cl->addCondition('code',$m['client_code']);
             $m['client_id'] = $cl->action('field',['id']);
         }
 
         if(isset($m['client_name']) && !isset($m['client_id'])) {
-            $cl = $this->getRef('client_id')->getModel();
+            $cl = $this->refModel('client_id');
             $cl->addCondition('name', 'like', $m['client_name']);
             $m['client_id'] = $cl->action('field',['id']);
         }
 
         if(isset($m['category']) && !isset($m['category_id'])) {
-            $c = $this->getRef('category_id')->getModel();
+            $c = $this->refModel('category_id');
             $c->addCondition($c->title_field, 'like', $m['category']);
             $m['category_id'] = $c->action('field',['id']);
         }
@@ -526,7 +526,7 @@ You might wonder, with the lookup like that, how the default values will work?
 What if the user-specified entry is not found? Lets look at the code::
 
     if(isset($m['category']) && !isset($m['category_id'])) {
-        $c = $this->getRef('category_id')->getModel();
+        $c = $this->refModel('category_id');
         $c->addCondition($c->title_field, 'like', $m['category']);
         $m['category_id'] = $c->action('field',['id']);
     }
@@ -535,7 +535,7 @@ So if category with a name is not found, then sub-query will return "NULL".
 If you wish to use a different value instead, you can create an expression::
 
     if(isset($m['category']) && !isset($m['category_id'])) {
-        $c = $this->getRef('category_id')->getModel();
+        $c = $this->refModel('category_id');
         $c->addCondition($c->title_field, 'like', $m['category']);
         $m['category_id'] = $this->expr('coalesce([],[])',[
             $c->action('field',['id']),
@@ -548,7 +548,7 @@ as a lookup query::
 
     $this->hasOne('category_id','Model_Category');
     $this->getElement('category_id')->default =
-        $this->getRef('category_id')->getModel()->addCondition('name','Other')
+        $this->refModel('category_id')->addCondition('name','Other')
             ->action('field',['id']);
 
 

--- a/docs/model.rst
+++ b/docs/model.rst
@@ -207,9 +207,7 @@ array:
     Contains list of modified fields since last loading and their original
     values.
 
-
 Full example::
-
 
     $m = new Model_User($db, 'user');
 

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -498,9 +498,9 @@ object which will in turn figure out what to do.
 Additionally you can call :php:meth:`Model::addField()` on the reference model
 that will bring one or several fields from related model into your current model.
 
-Finally this reference object contains method getModel() which will produce a
-(possibly) fresh copy of related entity and will either adjust it's DataSet or
-set the active record.
+Finally this reference object contains method :php:meth:`Reference::getModel()`
+which will produce a (possibly) fresh copy of related entity and will either
+adjust it's DataSet or set the active record.
 
 Actions
 =======

--- a/docs/references.rst
+++ b/docs/references.rst
@@ -86,7 +86,7 @@ ref() you will get a fresh copy.
 If you are worried about performance you can keep 2 models in memory::
 
     $order = new Order($db);
-    $client = $order->getRef('client_id')->getModel();
+    $client = $order->refModel('client_id');
 
     foreach($order as $o) {
         $client->load($o['client_id']);
@@ -192,8 +192,8 @@ keep making your query bigger and bigger::
     change them, you will receive exception.
 
 
-hasMany / refLink
-=================
+hasMany / refLink / refModel
+============================
 
 .. php:method:: refLink($link)
 
@@ -223,6 +223,11 @@ then it now makes sense for generating expression:
         (select sum(amount) from `order` where user_id = `user`.id) sum_amount
     from user
     where is_vip = 1
+
+.. php:method:: refModel($link)
+
+There are many situations when you need to get referenced model instead of reference itself.
+In such case refModel() comes in as handy shortcut of doing `$model->refLink($link)->getModel()`.
 
 hasOne reference
 ================
@@ -383,19 +388,25 @@ No condition will be applied by default so it's all up to you::
 Reference Discovery
 ===================
 
-You can call getRefs() to fetch all the references of a model::
+You can call :php:meth:`Model::getRefs()` to fetch all the references of a model::
 
     $refs = $model->getRefs();
     $ref = $refs['owner_id'];
 
-or if you know the reference you'd like to fetch, you can use getRef()::
+or if you know the reference you'd like to fetch, you can use :php:meth:`Model::getRef()`::
 
     $ref = $model->getRef('owner_id');
 
-While ref() returns a related model, getRef() gives you the reference object itself so that you
-could perform some changes on it, such as import more fields with addField().
+While :php:meth:`Model::ref()` returns a related model, :php:meth:`Model::getRef()`
+gives you the reference object itself so that you could perform some changes on it,
+such as import more fields with :php:meth:`Model::addField()`.
 
-You can also use hasRef() to check if particular reference exists in model::
+Or you can use :php:meth:`Model::refModel()` which will simply return referenced model
+and you can do fancy things with it.
+
+    $ref_model = $model->refModel('owner_id');
+
+You can also use :php:meth:`Model::hasRef()` to check if particular reference exists in model::
 
     $ref = $model->hasRef('owner_id');
 
@@ -406,9 +417,9 @@ When operating with data-sets you can define references that use deep traversal:
 
     echo $o->load(1)->ref('user_id')->ref('address_id')['address_1'];
 
-The above example will actually perform 3 load operations, because as I have explained above,
-ref() loads related model when called on a loaded model. To perform a single query instead,
-you can use::
+The above example will actually perform 3 load operations, because as I have
+explained above, :php:meth:`Model::ref()` loads related model when called on
+a loaded model. To perform a single query instead, you can use::
 
     echo $o->withID(1)->ref('user_id')->ref('address_id')->loadAny()['address_1'];
 
@@ -445,8 +456,9 @@ if you want::
     $item->hasMany('parent_item_id', [new Model_Item(), 'table_alias'=>'mypi'])
         ->addField('parent', 'name');
 
-Additionally you can pass table_alias as second argument into ref() or refLink(). This can
-help you in creating a recursive models that relate to itself. Here is example::
+Additionally you can pass table_alias as second argument into :php:meth:`Model::ref()` or
+:php:meth:`Model::refLink()`. This can help you in creating a recursive models that relate
+to itself. Here is example::
 
     class Model_Item3 extends \atk4\data\Model {
         public $table='item';

--- a/src/Model.php
+++ b/src/Model.php
@@ -1569,7 +1569,7 @@ class Model implements \ArrayAccess, \IteratorAggregate
     }
 
     /**
-     * Return related model
+     * Return related model.
      *
      * @param string $link
      * @param array  $defaults

--- a/src/Model.php
+++ b/src/Model.php
@@ -1569,6 +1569,19 @@ class Model implements \ArrayAccess, \IteratorAggregate
     }
 
     /**
+     * Return related model
+     *
+     * @param string $link
+     * @param array  $defaults
+     *
+     * @return Model
+     */
+    public function refModel($link, $defaults = [])
+    {
+        return $this->getRef($link)->refModel($defaults);
+    }
+
+    /**
      * Returns model that can be used for generating sub-query actions.
      *
      * @param string $link

--- a/src/Reference.php
+++ b/src/Reference.php
@@ -167,13 +167,28 @@ class Reference
     }
 
     /**
-     * Returns referenced model without any extra conditions.
+     * Returns referenced model without any extra conditions. However other
+     * relationship types may override this to imply conditions.
      *
      * @param array $defaults Properties
      *
      * @return Model
      */
     public function ref($defaults = [])
+    {
+        return $this->getModel($defaults);
+    }
+
+    /**
+     * Returns referenced model without any extra conditions. Ever when extended
+     * must always respond with Model that does not look into current record
+     * or scope.
+     *
+     * @param array $defaults Properties
+     *
+     * @return Model
+     */
+    public function refModel($defaults = [])
     {
         return $this->getModel($defaults);
     }

--- a/src/Reference_SQL_One.php
+++ b/src/Reference_SQL_One.php
@@ -149,6 +149,7 @@ class Reference_SQL_One extends Reference_One
             ]
         ));
 
+        // Will try to execute last
         $this->owner->addHook('beforeSave', function ($m) use ($field) {
             if ($m->isDirty($field) && !$m->isDirty($this->link)) {
                 $mm = $m->getRef($this->link)->getModel();
@@ -156,7 +157,7 @@ class Reference_SQL_One extends Reference_One
                 $mm->addCondition($mm->title_field, $m[$field]);
                 $m[$this->link] = $mm->action('field', [$mm->id_field]);
             }
-        });
+        }, null, 20);
 
         return $ex;
     }


### PR DESCRIPTION
A small PR adding refModel(). This method is handy when you simply want to fetch the model from a reference, without it doing any additional conditioning.

