### PR TITLE
Fix hasOne field type for typecasting to work correctly

### DIFF
--- a/src/Reference_One.php
+++ b/src/Reference_One.php
@@ -10,6 +10,17 @@ namespace atk4\data;
 class Reference_One extends Reference
 {
     /**
+     * Field type.
+     *
+     * Values are: 'string', 'boolean', 'integer', 'money', 'float',
+     *             'date', 'datetime', 'time', 'array', 'object'.
+     * Can also be set to unspecified type for your own custom handling.
+     *
+     * @var string
+     */
+    public $type = null;
+
+    /**
      * Points to the join if we are part of one.
      *
      * @var Join|null
@@ -126,7 +137,7 @@ class Reference_One extends Reference
 
         if (!$this->owner->hasElement($this->our_field)) {
             $this->owner->addField($this->our_field, [
-                'type'              => null, // $this->guessFieldType(),
+                'type'              => $this->type, // $this->guessFieldType(),
                 //'system'          => true,
                 'join'              => $this->join,
                 'default'           => $this->default,


### PR DESCRIPTION
Without this fix we can not set type of hasOne field and as result typecasting treat hasOne field as type=null always.
This is bad if we want id field to be integer to avoid trying to insert empty string value instead of NULL in id field.

Example,
```
$this->hasOne('contact_id', [
    'Contact',
    'type' => 'integer', // setting this had no effect up till now
]);
```