### PR TITLE
Added implementation for safe handling of ReadOnly models and Models without ID

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -15,6 +15,7 @@ engines:
     - 80ef7f404dd4f054ca51d9ee12d9e9dd # we exit from toStrign() because it can't throw exceptions
     - ae61f5e0cda0328c140f3b7298dbb8af # don't complain about call to static connection, as it's a fallback
     - e71149b967391adfaf3347a53d3c0023 # don't complain about $junk used in foreach when we only need keys
+    - 26d65d6b7bfd58eba544a4669b552401 # Model::save can be longer than 100 lines
     checks:
       CyclomaticComplexity:            # because we solve complex stuff
         enabled: false

--- a/src/Persistence_SQL.php
+++ b/src/Persistence_SQL.php
@@ -691,7 +691,6 @@ class Persistence_SQL extends Persistence
                     'Model uses "id_field" but it wasn\'t available in the database',
                     'model'       => $m,
                     'id_field'    => $m->id_field,
-                    'id'          => $id,
                     'data'        => $data,
                 ]);
             }

--- a/tests/ModelWithoutIDTest.php
+++ b/tests/ModelWithoutIDTest.php
@@ -1,0 +1,135 @@
+<?php
+
+namespace atk4\data\tests;
+
+use atk4\data\Model;
+use atk4\data\Persistence_SQL;
+
+/**
+ * @coversDefaultClass \atk4\data\Model
+ *
+ * Tests cases when model have to work with data that does not have ID field
+ */
+class ModelWithoutIDTest extends SQLTestCase
+{
+    public $m;
+
+    public function setUp()
+    {
+        parent::setUp();
+        $a = [
+            'user' => [
+                1 => ['id' => 1, 'name' => 'John', 'gender' => 'M'],
+                2 => ['id' => 2, 'name' => 'Sue', 'gender' => 'F'],
+            ], ];
+        $this->setDB($a);
+
+        $db = new Persistence_SQL($this->db->connection);
+        $this->m = new Model($db, ['user', 'id_field'=>false]);
+
+        $this->m->addFields(['name', 'gender']);
+    }
+
+    /**
+     * Basic operation should work just fine on model without ID
+     */
+    function testBasic() {
+        $this->m->tryLoadAny();
+        $this->assertEquals('John', $this->m['name']);
+
+        $this->m->setOrder('name desc');
+        $this->m->tryLoadAny();
+        $this->assertEquals('Sue', $this->m['name']);
+
+        $n = [];
+        foreach($this->m as $row){
+            $n[] = $row['name'];
+            $this->assertNull($row->id);
+        }
+        $this->assertEquals(['Sue', 'John'], $n);
+    } 
+
+    /**
+     * @expectedException Exception
+     */
+    function testFail1()
+    {
+        $this->m->load(1);
+    }
+
+    /**
+     * Inserting into model without ID should be OK
+     */
+    function testInsert()
+    {
+        $this->m->insert(['name'=>'Joe']);
+        $this->assertEquals(3, $this->m->action('count')->getOne());
+    }
+
+    /**
+     * Since no ID is set, a new record will be created if saving is attempted.
+     */
+    function testSave1()
+    {
+        $this->m->tryLoadAny();
+        $this->m->saveAndUnload();
+
+        $this->assertEquals(3, $this->m->action('count')->getOne());
+    }
+
+    /**
+     * Calling save will always create new record.
+     */
+    function testSave2()
+    {
+        $this->m->tryLoadAny();
+        $this->m->save();
+
+        $this->assertEquals(3, $this->m->action('count')->getOne());
+    }
+
+    /**
+     * Conditions should work fine
+     */
+    function testLoadBy()
+    {
+        $this->m->loadBy('name', 'Sue');
+        $this->assertEquals('Sue', $this->m['name']);
+    }
+
+    function testLoadCondition()
+    {
+        $this->m->addCondition('name', 'Sue');
+        $this->m->loadAny();
+        $this->assertEquals('Sue', $this->m['name']);
+    }
+
+    /**
+     * @expectedException Exception
+     */
+    function testFailDelete1()
+    {
+        $this->m->delete(4);
+    }
+    /**
+     * Additional checks are done if ID is manually set
+     *
+     * @expectedException Exception
+     */
+    function testFailDelete2()
+    {
+        $this->m->id=4;
+        $this->m->delete();
+    }
+    /**
+     * Additional checks are done if ID is manually set
+     *
+     * @expectedException Exception
+     */
+    function testFailUpdate()
+    {
+        $this->m->id=1;
+        $this->m['name'] = 'foo';
+        $this->m->saveAndUnload();
+    }
+}

--- a/tests/ReadOnlyModeTest.php
+++ b/tests/ReadOnlyModeTest.php
@@ -1,0 +1,115 @@
+<?php
+
+namespace atk4\data\tests;
+
+use atk4\data\Model;
+use atk4\data\Persistence_SQL;
+
+/**
+ * @coversDefaultClass \atk4\data\Model
+ *
+ * Tests cases when model have to work with data that does not have ID field
+ */
+class ReadOnlyModeTest extends SQLTestCase
+{
+    public $m;
+
+    public function setUp()
+    {
+        parent::setUp();
+        $a = [
+            'user' => [
+                1 => ['id' => 1, 'name' => 'John', 'gender' => 'M'],
+                2 => ['id' => 2, 'name' => 'Sue', 'gender' => 'F'],
+            ], ];
+        $this->setDB($a);
+
+        $db = new Persistence_SQL($this->db->connection);
+        $this->m = new Model($db, ['user', 'read_only'=>true]);
+
+        $this->m->addFields(['name', 'gender']);
+    }
+
+    /**
+     * Basic operation should work just fine on model without ID
+     */
+    function testBasic() {
+        $this->m->tryLoadAny();
+        $this->assertEquals('John', $this->m['name']);
+
+        $this->m->setOrder('name desc');
+        $this->m->tryLoadAny();
+        $this->assertEquals('Sue', $this->m['name']);
+
+        $n = [];
+        foreach($this->m as $row){
+            $n[] = $row['name'];
+        }
+        $this->assertEquals(['Sue', 'John'], $n);
+    } 
+
+    /**
+     * Read only model can be loaded just fine
+     */
+    function testLoad()
+    {
+        $this->m->load(1);
+    }
+
+    /**
+     * Model cannot be saved 
+     *
+     * @expectedException Exception
+     */
+    function testLoadSave()
+    {
+        $this->m->load(1);
+        $this->m['name']='X';
+        $this->m->save();
+    }
+
+    /**
+     * Insert should fail too
+     *
+     * @expectedException Exception
+     */
+    function testInsert()
+    {
+        $this->m->insert(['name'=>'Joe']);
+    }
+
+    /**
+     * Different attempt that should also fail
+     *
+     * @expectedException Exception
+     */
+    function testSave1()
+    {
+        $this->m->tryLoadAny();
+        $this->m->saveAndUnload();
+    }
+
+    /**
+     * Conditions should work fine
+     */
+    function testLoadBy()
+    {
+        $this->m->loadBy('name', 'Sue');
+        $this->assertEquals('Sue', $this->m['name']);
+    }
+
+    function testLoadCondition()
+    {
+        $this->m->addCondition('name', 'Sue');
+        $this->m->loadAny();
+        $this->assertEquals('Sue', $this->m['name']);
+    }
+
+    /**
+     * @expectedException Exception
+     */
+    function testFailDelete1()
+    {
+        $this->m->delete(1);
+    }
+}


### PR DESCRIPTION
## Add tests for model without ID
In some cases the model will be used with data that does not have ID field defined. Although technically model would have worked previously, the code wasn't fully tested.


## Add implementation for read_only
Model can be $m->read_only = true, in which case save/delete/insert operations will fail.


 