### PR TITLE
Feature/save load persistence

### DIFF
--- a/src/Model.php
+++ b/src/Model.php
@@ -964,7 +964,7 @@ class Model implements \ArrayAccess, \IteratorAggregate
     {
         $m = $this->newInstance($class, $options);
 
-        foreach ($this->data as $field=>$value) {
+        foreach ($this->data as $field=> $value) {
             if ($value !== null && $value !== $this->getElement($field)->default) {
 
                 // Copying only non-default value
@@ -1192,7 +1192,6 @@ class Model implements \ArrayAccess, \IteratorAggregate
 
     public function save($data = [], Persistence $to_persistence = null)
     {
-
         if (!$to_persistence) {
             $to_persistence = $this->persistence;
         }

--- a/tests/PersistentArrayTest.php
+++ b/tests/PersistentArrayTest.php
@@ -44,23 +44,26 @@ class PersistentArrayTest extends \PHPUnit_Framework_TestCase
 
     public function testSaveAs()
     {
-        $this->markTestSkipped('TODO: see #146');
+        //$this->markTestSkipped('TODO: see #146');
         $a = [
-            'user' => [
+            'person' => [
                 1 => ['name' => 'John', 'surname' => 'Smith', 'gender' => 'M'],
                 2 => ['name' => 'Sarah', 'surname' => 'Jones', 'gender' => 'F'],
             ],
         ];
 
         $p = new Persistence_Array($a);
-        $m = new Model_Male($p, 'user');
+
+        $m = new Model_Male($p);
         $m->load(1);
         $m->saveAs(new Model_Female());
+        $m->delete();
+
 
         $this->assertEquals([
-            'user' => [
-                1 => ['name' => 'John', 'surname' => 'Smith', 'gender' => 'F'],
+            'person' => [
                 2 => ['name' => 'Sarah', 'surname' => 'Jones', 'gender' => 'F'],
+                3 => ['name' => 'John', 'surname' => 'Smith', 'gender' => 'F', 'id'=>3],
             ],
         ], $a);
     }

--- a/tests/PersistentArrayTest.php
+++ b/tests/PersistentArrayTest.php
@@ -59,7 +59,6 @@ class PersistentArrayTest extends \PHPUnit_Framework_TestCase
         $m->saveAs(new Model_Female());
         $m->delete();
 
-
         $this->assertEquals([
             'person' => [
                 2 => ['name' => 'Sarah', 'surname' => 'Jones', 'gender' => 'F'],


### PR DESCRIPTION
This PR implements a functionality necessary for Agile UI. This allows model data to be loaded from alternative persistence:

``` php
$model->load(3, $persistence_B);
```

Test script is provided for load/save. Other forms of load / save are not included and are considered unnecessary. This functionality can be used to also store content of regular models into cache or load from cache.

Additionally this PR fixes 'saveAs' method.