### PR TITLE
Aggregate using IFNULL() by default.

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -38,8 +38,6 @@ engines:
         enabled: false
       Design/LongClass:                # because we design carefully what is native and what is extension
         enabled: false
-      Design/LongMethod:               # because we sometime have longer methods than just 100 lines
-        enabled: false
       Controversial/CamelCaseMethodName:    # because we need certain method naming patterns, render_blah for rendering [blah]
         enabled: false
       Controversial/CamelCaseParameterName: #

--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -27,6 +27,8 @@ engines:
         enabled: false
       Design/TooManyMethods:           # because we solve complex stuff
         enabled: false
+      Design/LongMethod:               # because methods are as long as we need them to be
+        enabled: false
       ExcessivePublicCount:            # because Model has too many public methods
         enabled: false
       Design/TooManyFields:            # because we solve complex things

--- a/src/Persistence_SQL.php
+++ b/src/Persistence_SQL.php
@@ -562,7 +562,6 @@ class Persistence_SQL extends Persistence
 
             case 'fx':
             case 'fx0':
-            case 'fx00':
                 if (!isset($args[0], $args[1])) {
                     throw new Exception([
                         'fx action needs 2 arguments, eg: ["sum", "amount"]',

--- a/src/Persistence_SQL.php
+++ b/src/Persistence_SQL.php
@@ -579,8 +579,6 @@ class Persistence_SQL extends Persistence
                     $expr = "$fx([])";
                 } elseif ($type=='fx0') {
                     $expr = "ifnull($fx([]), 0)";
-                } elseif ($type=='fx00') {
-                    $expr = "ifnull($fx(ifnull([], 0)), 0)";
                 } else {
                     throw new Exception(['Bug in Agile Data', 'type'=>$type]);
                 }

--- a/src/Persistence_SQL.php
+++ b/src/Persistence_SQL.php
@@ -576,10 +576,8 @@ class Persistence_SQL extends Persistence
 
                 if ($type == 'fx') {
                     $expr = "$fx([])";
-                } elseif ($type == 'fx0') {
-                    $expr = "ifnull($fx([]), 0)";
                 } else {
-                    throw new Exception(['Bug in Agile Data', 'type'=>$type]);
+                    $expr = "ifnull($fx([]), 0)";
                 }
 
                 if (isset($args['alias'])) {

--- a/src/Persistence_SQL.php
+++ b/src/Persistence_SQL.php
@@ -562,6 +562,7 @@ class Persistence_SQL extends Persistence
 
             case 'fx':
             case 'fx0':
+            case 'fx00':
                 if (!isset($args[0], $args[1])) {
                     throw new Exception([
                         'fx action needs 2 arguments, eg: ["sum", "amount"]',
@@ -574,10 +575,14 @@ class Persistence_SQL extends Persistence
                 $this->initQueryConditions($m, $q);
                 $m->hook('initSelectQuery', [$q, $type]);
 
-                if ($type=='fx0') {
-                    $expr = "ifnull($fx(ifnull([], 0)), 0)";
-                }else{
+                if ($type=='fx') {
                     $expr = "$fx([])";
+                } elseif ($type=='fx0') {
+                    $expr = "ifnull($fx([]), 0)";
+                } elseif ($type=='fx00') {
+                    $expr = "ifnull($fx(ifnull([], 0)), 0)";
+                } else {
+                    throw new Exception(['Bug in Agile Data', 'type'=>$type]);
                 }
 
                 if (isset($args['alias'])) {

--- a/src/Persistence_SQL.php
+++ b/src/Persistence_SQL.php
@@ -577,7 +577,7 @@ class Persistence_SQL extends Persistence
                 if ($type == 'fx') {
                     $expr = "$fx([])";
                 } else {
-                    $expr = "ifnull($fx([]), 0)";
+                    $expr = "coalesce($fx([]), 0)";
                 }
 
                 if (isset($args['alias'])) {

--- a/src/Persistence_SQL.php
+++ b/src/Persistence_SQL.php
@@ -574,9 +574,10 @@ class Persistence_SQL extends Persistence
                 $this->initQueryConditions($m, $q);
                 $m->hook('initSelectQuery', [$q, $type]);
 
-                $expr = "$fx([])";
-                if ($type == 'fx0') {
-                    $expr = "ifnull($expr, 0)";
+                if ($type=='fx0') {
+                    $expr = "ifnull($fx(ifnull([], 0)), 0)";
+                }else{
+                    $expr = "$fx([])";
                 }
 
                 if (isset($args['alias'])) {

--- a/src/Persistence_SQL.php
+++ b/src/Persistence_SQL.php
@@ -561,6 +561,7 @@ class Persistence_SQL extends Persistence
                 return $q;
 
             case 'fx':
+            case 'fx0':
                 if (!isset($args[0], $args[1])) {
                     throw new Exception([
                         'fx action needs 2 arguments, eg: ["sum", "amount"]',
@@ -572,10 +573,16 @@ class Persistence_SQL extends Persistence
                 $field = is_string($args[1]) ? $m->getElement($args[1]) : $args[1];
                 $this->initQueryConditions($m, $q);
                 $m->hook('initSelectQuery', [$q, $type]);
+
+                $expr = "$fx([])";
+                if ($type=='fx0') {
+                    $expr = "ifnull($expr, 0)";
+                }
+
                 if (isset($args['alias'])) {
-                    $q->reset('field')->field($q->expr("$fx([])", [$field]), $args['alias']);
+                    $q->reset('field')->field($q->expr($expr, [$field]), $args['alias']);
                 } else {
-                    $q->reset('field')->field($q->expr("$fx([])", [$field]));
+                    $q->reset('field')->field($q->expr($expr, [$field]));
                 }
 
                 return $q;

--- a/src/Reference_Many.php
+++ b/src/Reference_Many.php
@@ -97,7 +97,7 @@ class Reference_Many extends Reference
         $field = isset($defaults['field']) ? $defaults['field'] : $n;
 
         $e = $this->owner->addExpression($n, function () use ($defaults, $field) {
-            return $this->refLink()->action('fx', [$defaults['aggregate'], $field]);
+            return $this->refLink()->action('fx0', [$defaults['aggregate'], $field]);
         });
 
         if (isset($defaults['type'])) {

--- a/src/Reference_Many.php
+++ b/src/Reference_Many.php
@@ -77,8 +77,7 @@ class Reference_Many extends Reference
 
     /**
      * Adds field as expression to owner model.
-     * Used in aggregate strategy. Specify property 'fx'=>'fx00'
-     * to convert null into zeroes.
+     * Used in aggregate strategy.
      *
      * @param string $n        Field name
      * @param array  $defaults Properties
@@ -98,7 +97,7 @@ class Reference_Many extends Reference
         $field = isset($defaults['field']) ? $defaults['field'] : $n;
 
         $e = $this->owner->addExpression($n, function () use ($defaults, $field) {
-            return $this->refLink()->action(isset($defaults['fx'])?$defaults['fx']:'fx0', [$defaults['aggregate'], $field]);
+            return $this->refLink()->action('fx0', [$defaults['aggregate'], $field]);
         });
 
         if (isset($defaults['type'])) {

--- a/src/Reference_Many.php
+++ b/src/Reference_Many.php
@@ -77,7 +77,8 @@ class Reference_Many extends Reference
 
     /**
      * Adds field as expression to owner model.
-     * Used in aggregate strategy.
+     * Used in aggregate strategy. Specify property 'fx'=>'fx00'
+     * to convert null into zeroes.
      *
      * @param string $n        Field name
      * @param array  $defaults Properties
@@ -97,7 +98,7 @@ class Reference_Many extends Reference
         $field = isset($defaults['field']) ? $defaults['field'] : $n;
 
         $e = $this->owner->addExpression($n, function () use ($defaults, $field) {
-            return $this->refLink()->action('fx0', [$defaults['aggregate'], $field]);
+            return $this->refLink()->action(isset($defaults['fx'])?$defaults['fx']:'fx0', [$defaults['aggregate'], $field]);
         });
 
         if (isset($defaults['type'])) {


### PR DESCRIPTION
When we declare "hasMany" relationship and use aggregation, what happens if no related records exist? SUM() without any values returns null, but that's not what we want.

This PR adds a new action 'fx0' that's identical to 'fx' in all ways, but will wrap expression into "IFNULL([], 0)". This way aggregate functions will always return non-null values and will not break any further calculations.

