### PR TITLE
Feature/implement or conditions

### DIFF
--- a/docs/conditions.rst
+++ b/docs/conditions.rst
@@ -84,6 +84,32 @@ Normally, however, you would use a different fields::
 
 You can have as many conditions as you like.
 
+Adding OR Conditions
+--------------------
+
+In Agile Data all conditions are additive. This is done for security - no matter what
+condition you are adding, it will not allow you to circumvent previously added condition.
+
+You can, however, add condition that contains multiple clauses joined with OR operator::
+
+    $m->addCondition([
+        ['name', 'John'],
+        ['surname', 'Smith']
+    ]);
+
+This will add condition that will match against records with either name=John OR surname=Smith.
+If you are building multiple conditions against the same field, you can use this format::
+
+    $m->addCondition('name', ['John', 'Joe']);
+
+For all other cases you can implement them with :php:meth:`Model::expr`::
+
+    $m->addCondition($m->expr("(day([birth_date]) = day([registration_date]) or day([birth_date]) = [])", 10));
+
+This rather unusual condition will show user records who have registered on same date when they were born OR if
+they were born on 10th. (This is really silly condition, please don't judge, if you have a better example, I'd love
+to hear).
+
 Defining your classes
 ---------------------
 

--- a/src/Model.php
+++ b/src/Model.php
@@ -703,11 +703,34 @@ class Model implements \ArrayAccess, \IteratorAggregate
     public function addCondition($field, $operator = null, $value = null)
     {
         if (is_array($field)) {
-            array_map(function ($a) {
-                call_user_func_array([$this, 'addCondition'], $a);
-            }, $field);
+            $this->conditions[] = [$field];
 
             return $this;
+
+            /*
+            $or = $this->persistence->orExpr();
+
+            foreach ($field as list($field, $operator, $value)) {
+
+                if (is_string($field)) {
+                    $f = $this->hasElement($field);
+                    if (!$f) {
+                        throw new Exception([
+                            'Field does not exist',
+                            'model' => $this,
+                            'field' => $field,
+                        ]);
+                    }
+                } elseif ($field instanceof Field) {
+                    $f = $field;
+                }
+
+                $or->where($f, $operator, $value);
+            }
+
+
+            return $this;
+            */
         }
 
         $f = null;

--- a/src/Persistence_SQL.php
+++ b/src/Persistence_SQL.php
@@ -323,6 +323,16 @@ class Persistence_SQL extends Persistence
             // parameter inside where()
 
             if (count($cond) == 1) {
+
+                // OR conditions
+                if (is_array($cond[0])) {
+                    foreach ($cond[0] as &$row) {
+                        if (is_string($row[0])) {
+                            $row[0] = $m->getElement($row[0]);
+                        }
+                    }
+                }
+
                 $q->where($cond[0]);
                 continue;
             }

--- a/tests/ConditionTest.php
+++ b/tests/ConditionTest.php
@@ -20,9 +20,6 @@ class ConditionTest extends TestCase
         $m->addCondition('last_name', 'Smith');
     }
 
-    /**
-     *
-     */
     public function testBasicDiscrimination()
     {
         $m = new Model();
@@ -43,8 +40,6 @@ class ConditionTest extends TestCase
         $this->assertEquals(3, count($m->conditions));
     }
 
-    /**
-     */
     public function testEditableAfterCondition()
     {
         $m = new Model();
@@ -56,8 +51,6 @@ class ConditionTest extends TestCase
         $this->assertEquals(false, $m->getElement('gender')->isEditable());
     }
 
-    /**
-     */
     public function testEditableHasOne()
     {
         $gender = new Model();

--- a/tests/ConditionTest.php
+++ b/tests/ConditionTest.php
@@ -20,6 +20,9 @@ class ConditionTest extends TestCase
         $m->addCondition('last_name', 'Smith');
     }
 
+    /**
+     *
+     */
     public function testBasicDiscrimination()
     {
         $m = new Model();
@@ -37,9 +40,11 @@ class ConditionTest extends TestCase
         $this->assertEquals(2, count($m->conditions));
 
         $m->addCondition([['gender', 'F'], ['foo', 'bar']]);
-        $this->assertEquals(4, count($m->conditions));
+        $this->assertEquals(3, count($m->conditions));
     }
 
+    /**
+     */
     public function testEditableAfterCondition()
     {
         $m = new Model();
@@ -51,6 +56,8 @@ class ConditionTest extends TestCase
         $this->assertEquals(false, $m->getElement('gender')->isEditable());
     }
 
+    /**
+     */
     public function testEditableHasOne()
     {
         $gender = new Model();

--- a/tests/ReferenceSQLTest.php
+++ b/tests/ReferenceSQLTest.php
@@ -14,8 +14,6 @@ use atk4\data\Persistence_SQL;
  */
 class ReferenceSQLTest extends SQLTestCase
 {
-    /**
-     */
     public function testBasic()
     {
         $a = [
@@ -78,8 +76,6 @@ class ReferenceSQLTest extends SQLTestCase
         );
     }
 
-    /**
-     */
     public function testBasic2()
     {
         $a = [
@@ -109,8 +105,6 @@ class ReferenceSQLTest extends SQLTestCase
         $this->assertEquals('Pound', $cc['name']);
     }
 
-    /**
-     */
     public function testLink2()
     {
         $db = new Persistence_SQL($this->db->connection);
@@ -167,7 +161,7 @@ class ReferenceSQLTest extends SQLTestCase
     }
 
     /**
-     * Tests OR conditions
+     * Tests OR conditions.
      */
     public function testOrConditions()
     {
@@ -190,14 +184,14 @@ class ReferenceSQLTest extends SQLTestCase
 
         $u->addCondition([
             ['name', 'John'],
-            ['name', 'Peter']
+            ['name', 'Peter'],
         ]);
 
         $this->assertEquals(2, $u->action('count')->getOne());
 
         $u->addCondition([
             ['name', 'Peter'],
-            ['name', 'Joe']
+            ['name', 'Joe'],
         ]);
         $this->assertEquals(1, $u->action('count')->getOne());
     }

--- a/tests/ReferenceSQLTest.php
+++ b/tests/ReferenceSQLTest.php
@@ -14,6 +14,8 @@ use atk4\data\Persistence_SQL;
  */
 class ReferenceSQLTest extends SQLTestCase
 {
+    /**
+     */
     public function testBasic()
     {
         $a = [
@@ -76,6 +78,8 @@ class ReferenceSQLTest extends SQLTestCase
         );
     }
 
+    /**
+     */
     public function testBasic2()
     {
         $a = [
@@ -105,6 +109,8 @@ class ReferenceSQLTest extends SQLTestCase
         $this->assertEquals('Pound', $cc['name']);
     }
 
+    /**
+     */
     public function testLink2()
     {
         $db = new Persistence_SQL($this->db->connection);
@@ -158,6 +164,42 @@ class ReferenceSQLTest extends SQLTestCase
             'select `id`,`name` from `user` where `id` in (select `user_id` from `order` where `amount` > :a and `amount` < :b)',
             $o->ref('user_id')->action('select')->render()
         );
+    }
+
+    /**
+     * Tests OR conditions
+     */
+    public function testOrConditions()
+    {
+        $a = [
+            'user' => [
+                1 => ['id' => 1, 'name' => 'John'],
+                2 => ['id' => 2, 'name' => 'Peter'],
+                3 => ['id' => 3, 'name' => 'Joe'],
+            ], 'order' => [
+                ['amount' => '20', 'user_id' => 1],
+                ['amount' => '15', 'user_id' => 2],
+                ['amount' => '5', 'user_id' => 1],
+                ['amount' => '3', 'user_id' => 1],
+                ['amount' => '8', 'user_id' => 3],
+            ], ];
+        $this->setDB($a);
+
+        $db = new Persistence_SQL($this->db->connection);
+        $u = (new Model($db, 'user'))->addFields(['name']);
+
+        $u->addCondition([
+            ['name', 'John'],
+            ['name', 'Peter']
+        ]);
+
+        $this->assertEquals(2, $u->action('count')->getOne());
+
+        $u->addCondition([
+            ['name', 'Peter'],
+            ['name', 'Joe']
+        ]);
+        $this->assertEquals(1, $u->action('count')->getOne());
     }
 
     /**


### PR DESCRIPTION
This PR implements OR conditions consistently with DSQL implementation: http://dsql.readthedocs.io/en/develop/queries.html#setting-where-and-having-clauses

Added documentation, test-scripts cleaned up files a little:

``` php
$m->addCondition([
    ['name', 'John'],       // or
    ['surname', 'Smith']
]);
```
