### PR TITLE
Implement 'required' property

### DIFF
--- a/src/Field.php
+++ b/src/Field.php
@@ -221,9 +221,15 @@ class Field
             if (!$this->owner->strict_types) {
                 return $value;
             }
+
             if ($value === null) {
+                if ($this->required) {
+                    throw new Exception('may not be null');
+                }
+
                 return;
             }
+
             $f = $this;
 
             // only string type fields can use empty string as legit value, for all

--- a/src/Field.php
+++ b/src/Field.php
@@ -231,14 +231,14 @@ class Field
             // other field types empty value is the same as no-value, nothing or null
             if ($f->type && $f->type != 'string' && $value === '') {
                 if ($this->required && empty($value)) {
-                    throw new Exception('may not be a zero');
+                    throw new Exception('may not be a empty');
                 }
 
                 return;
             }
 
             switch ($f->type) {
-            case null:
+            case null: // loose comparison, but is OK here
                 if ($this->required && empty($value)) {
                     throw new Exception('must not be empty');
                 }

--- a/src/Field.php
+++ b/src/Field.php
@@ -256,7 +256,7 @@ class Field
                 // we clear out thousand separator, but will change to
                 // http://php.net/manual/en/numberformatter.parse.php
                 // in the future with the introduction of locale
-                $value = str_replace(',', '', $value);
+                $value = preg_replace('/[^0-9.-]/', '', $value);
                 if (!is_numeric($value)) {
                     throw new Exception('must be numeric');
                 }
@@ -276,7 +276,7 @@ class Field
                 }
                 break;
             case 'money':
-                $value = str_replace(',', '', $value);
+                $value = preg_replace('/[^0-9.-]/', '', $value);
                 if (!is_numeric($value)) {
                     throw new Exception('must be numeric');
                 }

--- a/src/Field.php
+++ b/src/Field.php
@@ -106,7 +106,7 @@ class Field
     public $ui = [];
 
     /**
-     * Mandatory field must not be null. The value must be set, even if 
+     * Mandatory field must not be null. The value must be set, even if
      * it's an empty value.
      *
      * Can contain error message for UI.
@@ -208,7 +208,7 @@ class Field
      * Depending on the type of a current field, this will perform
      * some normalization for strict types. This method must also make
      * sure that $f->required is respected when setting the value, e.g.
-     * you can't set value to '' if type=string and required=true
+     * you can't set value to '' if type=string and required=true.
      *
      * @param mixed $value
      *
@@ -219,7 +219,6 @@ class Field
     public function normalize($value)
     {
         try {
-
             if (!$this->owner->strict_types) {
                 return $value;
             }
@@ -234,6 +233,7 @@ class Field
                 if ($this->required && empty($value)) {
                     throw new Exception('may not be a zero');
                 }
+
                 return;
             }
 
@@ -253,10 +253,10 @@ class Field
                 }
                 break;
             case 'integer':
-                // we clear out thousand separator, but will change to 
+                // we clear out thousand separator, but will change to
                 // http://php.net/manual/en/numberformatter.parse.php
                 // in the future with the introduction of locale
-                $value = str_replace(',','',$value);
+                $value = str_replace(',', '', $value);
                 if (!is_numeric($value)) {
                     throw new Exception('must be numeric');
                 }
@@ -266,7 +266,7 @@ class Field
                 }
                 break;
             case 'float':
-                $value = str_replace(',','',$value);
+                $value = str_replace(',', '', $value);
                 if (!is_numeric($value)) {
                     throw new Exception('must be numeric');
                 }
@@ -276,7 +276,7 @@ class Field
                 }
                 break;
             case 'money':
-                $value = str_replace(',','',$value);
+                $value = str_replace(',', '', $value);
                 if (!is_numeric($value)) {
                     throw new Exception('must be numeric');
                 }

--- a/src/Field.php
+++ b/src/Field.php
@@ -116,8 +116,7 @@ class Field
     public $mandatory = false;
 
     /**
-     * Required field must have non-empty value. A null value can still be
-     * used.
+     * Required field must have non-empty value. A null value is considered empty too.
      *
      * Can contain error message for UI.
      *

--- a/src/Persistence.php
+++ b/src/Persistence.php
@@ -260,9 +260,6 @@ class Persistence
             return $t($value, $f, $this);
         }
 
-        // normalize value
-        $value = $f->normalize($value);
-
         // we respect null values
         if ($value === null) {
             return;

--- a/src/Persistence_SQL.php
+++ b/src/Persistence_SQL.php
@@ -463,7 +463,7 @@ class Persistence_SQL extends Persistence
                 $v = new $dt_class('@'.$v);
             } elseif (is_string($v)) {
                 // ! symbol in date format is essential here to remove time part of DateTime - don't remove, this is not a bug
-                $format = ['date' => '+!Y-m-d', 'datetime' => 'Y-m-d H:i:s', 'time' => 'H:i:s'];
+                $format = ['date' => '+!Y-m-d', 'datetime' => '+!Y-m-d H:i:s', 'time' => '+!H:i:s'];
                 $format = $f->persist_format ?: $format[$f->type];
 
                 // datetime only - set from persisting timezone

--- a/tests/FieldTest.php
+++ b/tests/FieldTest.php
@@ -61,6 +61,17 @@ class FieldTest extends SQLTestCase
     /**
      * @expectedException Exception
      */
+    public function testRequired1_1()
+    {
+        $m = new Model();
+        $m->addField('foo', ['required' => true]);
+        $m['foo'] = null;
+        unset($m['foo']);
+    }
+
+    /**
+     * @expectedException Exception
+     */
     public function testMandatory2()
     {
         $db = new Persistence_SQL($this->db->connection);

--- a/tests/FieldTest.php
+++ b/tests/FieldTest.php
@@ -43,6 +43,17 @@ class FieldTest extends SQLTestCase
         $m->addField('foo', ['mandatory' => true]);
         $m['foo'] = 'abc';
         $m['foo'] = null;
+        $m['foo'] = '';
+        unset($m['foo']);
+    }
+
+    public function testRequired1()
+    {
+        $m = new Model();
+        $m->addField('foo', ['required' => true]);
+        $m['foo'] = 'abc';
+        $m['foo'] = null;
+        $m['foo'] = '';
         unset($m['foo']);
     }
 
@@ -62,6 +73,24 @@ class FieldTest extends SQLTestCase
         $m->addField('name', ['mandatory' => true]);
         $m->addField('surname');
         $m->insert(['surname' => 'qq']);
+    }
+
+    /**
+     * @expectedException Exception
+     */
+    public function testRequired2()
+    {
+        $db = new Persistence_SQL($this->db->connection);
+        $a = [
+            'user' => [
+                1 => ['id' => 1, 'name' => 'John', 'surname' => 'Smith'],
+            ], ];
+        $this->setDB($a);
+
+        $m = new Model($db, 'user');
+        $m->addField('name', ['required' => true]);
+        $m->addField('surname');
+        $m->insert(['surname' => 'qq', 'name'=>'']);
     }
 
     /**

--- a/tests/FieldTest.php
+++ b/tests/FieldTest.php
@@ -47,12 +47,13 @@ class FieldTest extends SQLTestCase
         unset($m['foo']);
     }
 
+    /**
+     * @expectedException Exception
+     */
     public function testRequired1()
     {
         $m = new Model();
         $m->addField('foo', ['required' => true]);
-        $m['foo'] = 'abc';
-        $m['foo'] = null;
         $m['foo'] = '';
         unset($m['foo']);
     }

--- a/tests/PersistentArrayTest.php
+++ b/tests/PersistentArrayTest.php
@@ -182,7 +182,7 @@ class PersistentArrayTest extends \PHPUnit_Framework_TestCase
 
         $output = '';
 
-        foreach($m as $row) {
+        foreach ($m as $row) {
             $output .= $row['name'];
         }
 

--- a/tests/TypecastingTest.php
+++ b/tests/TypecastingTest.php
@@ -75,7 +75,7 @@ class TypecastingTest extends SQLTestCase
         $this->assertSame(8.20, $m['money']);
         $this->assertEquals(new \DateTime('2013-02-20'), $m['date']);
         $this->assertEquals(new \DateTime('2013-02-20 20:00:12 UTC'), $m['datetime']);
-        $this->assertEquals(new \DateTime('12:00:50'), $m['time']);
+        $this->assertEquals(new \DateTime('1970-01-01 12:00:50'), $m['time']);
         $this->assertSame(2940, $m['integer']);
         $this->assertEquals([1, 2, 3], $m['array']);
         $this->assertSame(8.202343, $m['float']);
@@ -388,7 +388,7 @@ class TypecastingTest extends SQLTestCase
         $this->assertEquals('22:52:01', $db->typecastSaveField($t, $s));
         $this->assertEquals(new \DateTime('Monday, 15-Aug-05 22:52:01 UTC'), $db->typecastLoadField($dt, '2005-08-16 00:52:01'));
         $this->assertEquals(new \DateTime('Monday, 15-Aug-05'), $db->typecastLoadField($d, '2005-08-15'));
-        $this->assertEquals(new \DateTime('22:52:01'), $db->typecastLoadField($t, '22:52:01'));
+        $this->assertEquals(new \DateTime('1970-01-01 22:52:01'), $db->typecastLoadField($t, '22:52:01'));
 
         date_default_timezone_set('Asia/Tokyo');
 
@@ -398,7 +398,7 @@ class TypecastingTest extends SQLTestCase
         $this->assertEquals('22:52:01', $db->typecastSaveField($t, $s));
         $this->assertEquals(new \DateTime('Monday, 15-Aug-05 22:52:01 UTC'), $db->typecastLoadField($dt, '2005-08-16 00:52:01'));
         $this->assertEquals(new \DateTime('Monday, 15-Aug-05'), $db->typecastLoadField($d, '2005-08-15'));
-        $this->assertEquals(new \DateTime('22:52:01'), $db->typecastLoadField($t, '22:52:01'));
+        $this->assertEquals(new \DateTime('1970-01-01 22:52:01'), $db->typecastLoadField($t, '22:52:01'));
 
         date_default_timezone_set('America/Los_Angeles');
 
@@ -408,7 +408,7 @@ class TypecastingTest extends SQLTestCase
         $this->assertEquals('22:52:01', $db->typecastSaveField($t, $s));
         $this->assertEquals(new \DateTime('Monday, 15-Aug-05 22:52:01 America/Los_Angeles'), $db->typecastLoadField($dt, '2005-08-16 07:52:01'));
         $this->assertEquals(new \DateTime('Monday, 15-Aug-05'), $db->typecastLoadField($d, '2005-08-15'));
-        $this->assertEquals(new \DateTime('22:52:01'), $db->typecastLoadField($t, '22:52:01'));
+        $this->assertEquals(new \DateTime('1970-01-01 22:52:01'), $db->typecastLoadField($t, '22:52:01'));
     }
 
     public function testTimestamp()


### PR DESCRIPTION
 - Added new "required" property
 - Required is also mandatory
 - Numeric/float/money values are normalized better by taking out all non-essential characters (e.g. currency symbol)
 - Field exceptions cleaned up
 - Removed double-normalize when saving row to DB, resolves #223 
 - Loading 'time' from DB will properly reset "date" on the DateTime instead of using current date.
