### PR TITLE
If return false from afterLoad hook then prevent yielding data row

### DIFF
--- a/docs/hooks.rst
+++ b/docs/hooks.rst
@@ -23,6 +23,23 @@ model will perform very weirdly when cloned::
     echo $m['name'];   // Will contain 'John', which it shouldn't
                        // because insert() is not supposed to affect active record
 
+afterLoad hook
+--------------
+You can return false from afterLoad hook to prevent yielding of particular data rows.
+
+Use it like this::
+
+$model->addHook('afterLoad', function ($m) {
+    if ($m['date'] < $m->date_from) {
+        $m->breakHook(false); // will not yield such data row
+    }
+    // otherwise yields data row
+});
+
+Also this approach can be used to prevent data row to be loaded. If you return false
+from afterLoad hook, then record which we just loaded will be instantly unloaded.
+This can be helpful in some cases.
+
 
 More on hooks
 ===========

--- a/src/Model.php
+++ b/src/Model.php
@@ -898,7 +898,10 @@ class Model implements \ArrayAccess, \IteratorAggregate
         if (is_null($this->id)) {
             $this->id = $id;
         }
-        $this->hook('afterLoad');
+
+        if ($this->hook('afterLoad') === false) {
+            $this->unload();
+        }
 
         return $this;
     }
@@ -1099,7 +1102,10 @@ class Model implements \ArrayAccess, \IteratorAggregate
         $this->data = $this->persistence->tryLoad($this, $id);
         if ($this->data) {
             $this->id = $id;
-            $this->hook('afterLoad');
+
+            if ($this->hook('afterLoad') === false) {
+                $this->unload();
+            }
         } else {
             $this->unload();
         }
@@ -1127,7 +1133,10 @@ class Model implements \ArrayAccess, \IteratorAggregate
             if ($this->id_field) {
                 $this->id = $this->data[$this->id_field];
             }
-            $this->hook('afterLoad');
+
+            if ($this->hook('afterLoad') === false) {
+                $this->unload();
+            }
         } else {
             $this->unload();
         }
@@ -1156,7 +1165,10 @@ class Model implements \ArrayAccess, \IteratorAggregate
             if ($this->id_field) {
                 $this->id = $this->data[$this->id_field];
             }
-            $this->hook('afterLoad');
+
+            if ($this->hook('afterLoad') === false) {
+                $this->unload();
+            }
         } else {
             $this->unload();
         }
@@ -1404,9 +1416,17 @@ class Model implements \ArrayAccess, \IteratorAggregate
             if ($this->id_field) {
                 $this->id = isset($data[$this->id_field]) ? $data[$this->id_field] : null;
             }
-            $this->hook('afterLoad');
-            yield $this->id => $this;
+
+            // you can return false in afterLoad hook to prevent to yield this data row
+            // use it like this:
+            // $model->addHook('afterLoad', function ($m) {
+            //     if ($m['date'] < $m->date_from) $m->breakHook(false);
+            // })
+            if ($this->hook('afterLoad') !== false) {
+                yield $this->id => $this;
+            }
         }
+
         $this->unload();
     }
 


### PR DESCRIPTION
Now we can return false from `afterLoad` hook to prevent yielding particular data rows from `getIterator()` or automatically unloading loaded record from `load()`, `tryLoad()`, `loadAny()`, `tryLoadAny()`.

Usage,
```
$model->addHook('afterLoad', function ($m) {
     if ($m['date'] < $m->date_from) $m->breakHook(false);
})
```
