### PR TITLE
initialize expression field only if it is not already initialized

### DIFF
--- a/src/Field_SQL_Expression.php
+++ b/src/Field_SQL_Expression.php
@@ -34,7 +34,9 @@ class Field_SQL_Expression extends Field_SQL
      */
     public function init()
     {
-        $this->_init();
+        if (!$this->_initialized) {
+            $this->_init();
+        }
 
         if ($this->owner->reload_after_save === null) {
             $this->owner->reload_after_save = true;


### PR DESCRIPTION
If we move already initialized expression field to another model, then this failed (initialized twice).

See GroupModel->addField() methods `return $this->add($this->master_model->getElement($name))` and it failed if field is expression in master model (which was already initialized).