### PR TITLE
fixed test-suite

### DIFF
--- a/src/Reference.php
+++ b/src/Reference.php
@@ -163,7 +163,7 @@ class Reference
 
         $p = $this->owner->persistence;
 
-        return $p->add($p->normalizeClassName($model, 'Model'), $defaults);
+        return $p->add($model, $defaults);
     }
 
     /**

--- a/tests/RandomTest.php
+++ b/tests/RandomTest.php
@@ -25,7 +25,7 @@ class Model_Item extends \atk4\data\Model
     {
         parent::init();
         $this->addField('name');
-        $this->hasOne('parent_item_id', '\atk4\data\tests\Item')
+        $this->hasOne('parent_item_id', '\atk4\data\tests\Model_Item')
             ->addTitle();
     }
 }
@@ -295,7 +295,7 @@ class RandomSQLTests extends SQLTestCase
         $db = new Persistence_SQL($this->db->connection);
         $m = new Model_Item($db);
 
-        $m->hasOne('Person', 'atk4/data/tests/Person');
+        $m->hasOne('Person', 'atk4/data/tests/Model_Person');
         $person = $m->ref('Person');
     }
 }


### PR DESCRIPTION
The Agile Data will no longer prefix model names with 'Model_' if they specified as string. This pattern is a legacy from ATK4 and documentation suggest to pass second argument to hasOne / hasMany as object. 

If you use string, then it should follow the principles of FactoryTrait described in Agile Core. You will have to refactor your code.

This PR does not change the behaviour (it was changed within the Agile Core) but it simply updates TestSute to respect the new 

OLD:

``` php
class Model_Page extends Model {
}

class Model_Book extends Model {
    function init() {
        parent::init();
        $this->hasMany('Book', 'Page');
    }
}
```

New code should contain:

``` php
$this->hasMany('Book', 'Model_Page');  // full class name
```

or you can use

``` php
$this->hasMany('Book', new Model_Page());  // as documentation suggests
```

To find incorrect usage in your project:

``` shell
grep -RE 'hasMany|hasOne' . | grep -v new
```