### PR TITLE
if model don't have id_field, then don't yield this->id

### DIFF
--- a/src/Model.php
+++ b/src/Model.php
@@ -1446,7 +1446,11 @@ class Model implements \ArrayAccess, \IteratorAggregate
             //     if ($m['date'] < $m->date_from) $m->breakHook(false);
             // })
             if ($this->hook('afterLoad') !== false) {
-                yield $this->id => $this;
+                if ($this->id_field) {
+                    yield $this->id => $this;
+                } else {
+                    yield $this;
+                }
             }
         }
 


### PR DESCRIPTION
if model don't have id_field, then it's useless to yield $model->id as a key.