### PR TITLE
Feature/use seed instead of class

### DIFF
--- a/docs/fields.rst
+++ b/docs/fields.rst
@@ -11,7 +11,7 @@ Agile Data, to distinguish it from object properties. Fields inside a model
 normally have a corresponding instance of Field class.
 
 See :php:meth:`Model::addField()` on how fields are added. By default,
-persistence sets the property _default_class_addField which should correspond
+persistence sets the property _default_seed_addField which should correspond
 to a field object that has enough capabilities for performing field-specific
 mapping into persistence-logic.
 

--- a/src/Field.php
+++ b/src/Field.php
@@ -199,6 +199,7 @@ class Field
      */
     public function __construct($defaults = [])
     {
+
         if (!is_array($defaults)) {
             throw new Exception(['Field requires array for defaults', 'arg' => $defaults]);
         }

--- a/src/Field_SQL_Expression.php
+++ b/src/Field_SQL_Expression.php
@@ -30,6 +30,16 @@ class Field_SQL_Expression extends Field_SQL
     public $read_only = true;
 
     /**
+     * Specifies how to aggregate this
+     */
+    public $aggregate = null;
+
+    /**
+     * Specifies which field to use
+     */
+    public $field = null;
+
+    /**
      * Initialization.
      */
     public function init()

--- a/src/Field_SQL_Expression.php
+++ b/src/Field_SQL_Expression.php
@@ -30,12 +30,12 @@ class Field_SQL_Expression extends Field_SQL
     public $read_only = true;
 
     /**
-     * Specifies how to aggregate this
+     * Specifies how to aggregate this.
      */
     public $aggregate = null;
 
     /**
-     * Specifies which field to use
+     * Specifies which field to use.
      */
     public $field = null;
 

--- a/src/Join.php
+++ b/src/Join.php
@@ -6,6 +6,7 @@ namespace atk4\data;
 
 use atk4\core\InitializerTrait;
 use atk4\core\TrackableTrait;
+use atk4\core\DIContainerTrait;
 
 /**
  * Class description?
@@ -16,6 +17,7 @@ class Join
     use InitializerTrait {
         init as _init;
     }
+    use DIContainerTrait;
 
     /**
      * Name of the table (or collection) that can be used to retrieve data from.
@@ -124,15 +126,11 @@ class Join
      *
      * @param array $defaults
      */
-    public function __construct($defaults = [])
+    public function __construct($foreign_table = null)
     {
-        if (isset($defaults[0])) {
-            $this->foreign_table = $defaults[0];
-            unset($defaults[0]);
-        }
 
-        foreach ($defaults as $key => $val) {
-            $this->$key = $val;
+        if (isset($foreign_table)) {
+            $this->foreign_table = $foreign_table;
         }
     }
 

--- a/src/Join.php
+++ b/src/Join.php
@@ -4,9 +4,9 @@
 
 namespace atk4\data;
 
+use atk4\core\DIContainerTrait;
 use atk4\core\InitializerTrait;
 use atk4\core\TrackableTrait;
-use atk4\core\DIContainerTrait;
 
 /**
  * Class description?
@@ -128,7 +128,6 @@ class Join
      */
     public function __construct($foreign_table = null)
     {
-
         if (isset($foreign_table)) {
             $this->foreign_table = $foreign_table;
         }

--- a/src/Model.php
+++ b/src/Model.php
@@ -26,35 +26,35 @@ class Model implements \ArrayAccess, \IteratorAggregate
      *
      * @var string
      */
-    public $_default_class_addField = ['\atk4\data\Field'];
+    public $_default_seed_addField = ['\atk4\data\Field'];
 
     /**
      * The class used by hasOne() method.
      *
      * @var string
      */
-    public $_default_class_hasOne = ['\atk4\data\Reference_One'];
+    public $_default_seed_hasOne = ['\atk4\data\Reference_One'];
 
     /**
      * The class used by hasMany() method.
      *
      * @var string
      */
-    public $_default_class_hasMany = ['\atk4\data\Reference_Many'];
+    public $_default_seed_hasMany = ['\atk4\data\Reference_Many'];
 
     /**
      * The class used by addField() method.
      *
      * @var string
      */
-    public $_default_class_addExpression = ['\atk4\data\Field_Callback'];
+    public $_default_seed_addExpression = ['\atk4\data\Field_Callback'];
 
     /**
      * The class used by join() method.
      *
      * @var string
      */
-    public $_default_class_join = ['\atk4\data\Join'];
+    public $_default_seed_join = ['\atk4\data\Join'];
 
     /**
      * Contains name of table, session key, collection or file where this
@@ -258,31 +258,25 @@ class Model implements \ArrayAccess, \IteratorAggregate
      * The second use actually calls add() but is preferred usage because:
      *  - it's shorter
      *  - type hinting will work;
+     *  - you can also override table
      *
      * @param Persistence|array $persistence
-     * @param array             $defaults
+     * @param string            $table
      */
-    public function __construct($persistence = null, $defaults = [])
+    public function __construct($persistence = null, $table = null)
     {
-        // persistence is optional
-        if (is_array($persistence)) {
-            $defaults = $persistence;
+        if (is_string($persistence)) {
+            $table = $persistence;
             $persistence = null;
         }
 
-        if (is_string($defaults) || $defaults === false) {
-            $defaults = ['table' => $defaults];
-        }
 
-        if (isset($defaults[0])) {
-            $defaults['table'] = $defaults[0];
-            unset($defaults[0]);
+        if ($table) {
+            $this->table = $table;
         }
-
-        $this->setDefaults($defaults);
 
         if ($persistence) {
-            $persistence->add($this, $defaults);
+            $persistence->add($this);
         }
     }
 
@@ -348,7 +342,9 @@ class Model implements \ArrayAccess, \IteratorAggregate
      */
     public function addField($name, $defaults = [])
     {
-        $field = $this->factory([$this->_default_class_addField], $defaults, 'Field'); 
+        var_dump($this->_default_seed_addField);
+        var_dump($x = $this->mergeSeeds($this->_default_seed_addField, $defaults), null, 'Field'); 
+        $field = $this->factory($x = $this->mergeSeeds($this->_default_seed_addField, $defaults), null, 'Field'); 
         $this->add($field, $name);
 
         return $field;
@@ -1592,7 +1588,7 @@ class Model implements \ArrayAccess, \IteratorAggregate
 
         $defaults[0] = $foreign_table;
 
-        $c = $this->_default_class_join;
+        $c = $this->_default_seed_join;
 
         return $this->add(new $c($defaults));
     }
@@ -1668,7 +1664,7 @@ class Model implements \ArrayAccess, \IteratorAggregate
      */
     public function hasOne($link, $defaults = [])
     {
-        return $this->_hasReference($this->_default_class_hasOne, $link, $defaults);
+        return $this->_hasReference($this->_default_seed_hasOne, $link, $defaults);
     }
 
     /**
@@ -1681,7 +1677,7 @@ class Model implements \ArrayAccess, \IteratorAggregate
      */
     public function hasMany($link, $defaults = [])
     {
-        return $this->_hasReference($this->_default_class_hasMany, $link, $defaults);
+        return $this->_hasReference($this->_default_seed_hasMany, $link, $defaults);
     }
 
     /**
@@ -1785,7 +1781,7 @@ class Model implements \ArrayAccess, \IteratorAggregate
             unset($defaults[0]);
         }
 
-        $c = $this->_default_class_addExpression;
+        $c = $this->_default_seed_addExpression;
 
         return $this->add(new $c($defaults), $name);
     }

--- a/src/Model.php
+++ b/src/Model.php
@@ -1637,7 +1637,7 @@ class Model implements \ArrayAccess, \IteratorAggregate
     protected function _hasReference($c, $link, $defaults = [])
     {
         if (!is_array($defaults)) {
-            $defaults = ['model' => $defaults ?: 'Model\\'.$link];
+            $defaults = ['model' => $defaults ?: 'Model_'.$link];
         } elseif (isset($defaults[0])) {
             $defaults['model'] = $defaults[0];
             unset($defaults[0]);

--- a/src/Model.php
+++ b/src/Model.php
@@ -263,7 +263,7 @@ class Model implements \ArrayAccess, \IteratorAggregate
      * @param Persistence|array $persistence
      * @param string|array      $defaults
      */
-    public function __construct($persistence = null, $defaults = null)
+    public function __construct($persistence = null, $defaults = [])
     {
         if (is_string($persistence) || is_array($persistence)) {
             $defaults = $persistence;

--- a/src/Model.php
+++ b/src/Model.php
@@ -261,18 +261,28 @@ class Model implements \ArrayAccess, \IteratorAggregate
      *  - you can also override table
      *
      * @param Persistence|array $persistence
-     * @param string            $table
+     * @param string            $defaults
      */
-    public function __construct($persistence = null, $table = null)
+    public function __construct($persistence = null, $defaults = null)
     {
-        if (is_string($persistence)) {
-            $table = $persistence;
+        if (is_string($persistence) || is_array($persistence)) {
+            $defaults = $persistence;
             $persistence = null;
         }
 
+        if (is_string($defaults) || $defaults === false) {
+            $defaults = ['table' => $defaults];
+        }
 
-        if ($table) {
-            $this->table = $table;
+        if (isset($defaults[0])) {
+             $defaults['table'] = $defaults[0];
+             unset($defaults[0]);
+         }
+
+        $this->setDefaults($defaults);
+
+        if (is_array($persistence)) {
+            throw new Exception(['$persistence must not be array', 'persistence'=>$persistence]);
         }
 
         if ($persistence) {
@@ -342,8 +352,6 @@ class Model implements \ArrayAccess, \IteratorAggregate
      */
     public function addField($name, $defaults = [])
     {
-        var_dump($this->_default_seed_addField);
-        var_dump($x = $this->mergeSeeds($this->_default_seed_addField, $defaults), null, 'Field'); 
         $field = $this->factory($x = $this->mergeSeeds($this->_default_seed_addField, $defaults), null, 'Field'); 
         $this->add($field, $name);
 
@@ -1590,7 +1598,7 @@ class Model implements \ArrayAccess, \IteratorAggregate
 
         $c = $this->_default_seed_join;
 
-        return $this->add(new $c($defaults));
+        return $this->add($this->factory($c, $defaults));
     }
 
     /**
@@ -1629,7 +1637,7 @@ class Model implements \ArrayAccess, \IteratorAggregate
     protected function _hasReference($c, $link, $defaults = [])
     {
         if (!is_array($defaults)) {
-            $defaults = ['model' => $defaults ?: 'Model_'.$link];
+            $defaults = ['model' => $defaults ?: 'Model\\'.$link];
         } elseif (isset($defaults[0])) {
             $defaults['model'] = $defaults[0];
             unset($defaults[0]);
@@ -1637,7 +1645,7 @@ class Model implements \ArrayAccess, \IteratorAggregate
 
         $defaults[0] = $link;
 
-        return $this->add(new $c($defaults));
+        return $this->add($this->factory($c, $defaults));
     }
 
     /**
@@ -1783,7 +1791,7 @@ class Model implements \ArrayAccess, \IteratorAggregate
 
         $c = $this->_default_seed_addExpression;
 
-        return $this->add(new $c($defaults), $name);
+        return $this->add($this->factory($c, $defaults), $name);
     }
 
     // }}}

--- a/src/Model.php
+++ b/src/Model.php
@@ -17,6 +17,7 @@ class Model implements \ArrayAccess, \IteratorAggregate
     }
     use \atk4\core\NameTrait;
     use \atk4\core\DIContainerTrait;
+    use \atk4\core\FactoryTrait;
 
     // {{{ Properties of the class
 
@@ -25,35 +26,35 @@ class Model implements \ArrayAccess, \IteratorAggregate
      *
      * @var string
      */
-    public $_default_class_addField = 'atk4\data\Field';
+    public $_default_class_addField = ['\atk4\data\Field'];
 
     /**
      * The class used by hasOne() method.
      *
      * @var string
      */
-    public $_default_class_hasOne = 'atk4\data\Reference_One';
+    public $_default_class_hasOne = ['\atk4\data\Reference_One'];
 
     /**
      * The class used by hasMany() method.
      *
      * @var string
      */
-    public $_default_class_hasMany = 'atk4\data\Reference_Many';
+    public $_default_class_hasMany = ['\atk4\data\Reference_Many'];
 
     /**
      * The class used by addField() method.
      *
      * @var string
      */
-    public $_default_class_addExpression = 'atk4\data\Field_Callback';
+    public $_default_class_addExpression = ['\atk4\data\Field_Callback'];
 
     /**
      * The class used by join() method.
      *
      * @var string
      */
-    public $_default_class_join = 'atk4\data\Join';
+    public $_default_class_join = ['\atk4\data\Join'];
 
     /**
      * Contains name of table, session key, collection or file where this
@@ -347,8 +348,7 @@ class Model implements \ArrayAccess, \IteratorAggregate
      */
     public function addField($name, $defaults = [])
     {
-        $c = $this->_default_class_addField;
-        $field = new $c($defaults);
+        $field = $this->factory([$this->_default_class_addField], $defaults, 'Field'); 
         $this->add($field, $name);
 
         return $field;

--- a/src/Model.php
+++ b/src/Model.php
@@ -352,7 +352,7 @@ class Model implements \ArrayAccess, \IteratorAggregate
      */
     public function addField($name, $defaults = [])
     {
-        $field = $this->factory($x = $this->mergeSeeds($this->_default_seed_addField, $defaults), null, 'Field');
+        $field = $this->factory($this->mergeSeeds($this->_default_seed_addField, $defaults), null, 'Field');
         $this->add($field, $name);
 
         return $field;

--- a/src/Model.php
+++ b/src/Model.php
@@ -275,9 +275,9 @@ class Model implements \ArrayAccess, \IteratorAggregate
         }
 
         if (isset($defaults[0])) {
-             $defaults['table'] = $defaults[0];
-             unset($defaults[0]);
-         }
+            $defaults['table'] = $defaults[0];
+            unset($defaults[0]);
+        }
 
         $this->setDefaults($defaults);
 
@@ -352,7 +352,7 @@ class Model implements \ArrayAccess, \IteratorAggregate
      */
     public function addField($name, $defaults = [])
     {
-        $field = $this->factory($x = $this->mergeSeeds($this->_default_seed_addField, $defaults), null, 'Field'); 
+        $field = $this->factory($x = $this->mergeSeeds($this->_default_seed_addField, $defaults), null, 'Field');
         $this->add($field, $name);
 
         return $field;

--- a/src/Model.php
+++ b/src/Model.php
@@ -258,10 +258,10 @@ class Model implements \ArrayAccess, \IteratorAggregate
      * The second use actually calls add() but is preferred usage because:
      *  - it's shorter
      *  - type hinting will work;
-     *  - you can also override table
+     *  - you can specify string for a table
      *
      * @param Persistence|array $persistence
-     * @param string            $defaults
+     * @param string|array      $defaults
      */
     public function __construct($persistence = null, $defaults = null)
     {

--- a/src/Persistence.php
+++ b/src/Persistence.php
@@ -99,11 +99,10 @@ class Persistence
             ]);
         }
 
-        //$m->setDefaults($defaults);
         $m->persistence = $this;
         $m->persistence_data = [];
         $this->initPersistence($m);
-        $m = $this->_add($m); //, $defaults);
+        $m = $this->_add($m);
 
         $this->hook('afterAdd', [$m]);
 

--- a/src/Persistence.php
+++ b/src/Persistence.php
@@ -80,10 +80,12 @@ class Persistence
      */
     public function add($m, $defaults = [])
     {
+        /*
         if (isset($defaults[0])) {
             $m->table = $defaults[0];
             unset($defaults[0]);
         }
+         */
 
         $m = $this->factory($m, $defaults);
 
@@ -97,11 +99,11 @@ class Persistence
             ]);
         }
 
-        $m->setDefaults($defaults);
+        //$m->setDefaults($defaults);
         $m->persistence = $this;
         $m->persistence_data = [];
         $this->initPersistence($m);
-        $m = $this->_add($m, $defaults);
+        $m = $this->_add($m);//, $defaults);
 
         $this->hook('afterAdd', [$m]);
 

--- a/src/Persistence_Array.php
+++ b/src/Persistence_Array.php
@@ -44,7 +44,7 @@ class Persistence_Array extends Persistence
         }
 
         $defaults = array_merge([
-            '_default_class_join' => 'atk4\data\Join_Array',
+            '_default_seed_join' => 'atk4\data\Join_Array',
         ], $defaults);
 
         $m = parent::add($m, $defaults);

--- a/src/Persistence_SQL.php
+++ b/src/Persistence_SQL.php
@@ -21,35 +21,35 @@ class Persistence_SQL extends Persistence
      *
      * @var string
      */
-    public $_default_class_addField = ['\atk4\data\Field_SQL'];
+    public $_default_seed_addField = ['\atk4\data\Field_SQL'];
 
     /**
      * Default class when adding hasOne field.
      *
      * @var string
      */
-    public $_default_class_hasOne = ['\atk4\data\Reference_SQL_One'];
+    public $_default_seed_hasOne = ['\atk4\data\Reference_SQL_One'];
 
     /**
      * Default class when adding hasMany field.
      *
      * @var string
      */
-    public $_default_class_hasMany = null; //'atk4\data\Reference_Many';
+    public $_default_seed_hasMany = null; //'atk4\data\Reference_Many';
 
     /**
      * Default class when adding Expression field.
      *
      * @var string
      */
-    public $_default_class_addExpression = ['\atk4\data\Field_SQL_Expression'];
+    public $_default_seed_addExpression = ['\atk4\data\Field_SQL_Expression'];
 
     /**
      * Default class when adding join.
      *
      * @var string
      */
-    public $_default_class_join = ['\atk4\data\Join_SQL'];
+    public $_default_seed_join = ['\atk4\data\Join_SQL'];
 
     /**
      * Constructor.
@@ -120,11 +120,11 @@ class Persistence_SQL extends Persistence
         // Use our own classes for fields, references and expressions unless
         // $defaults specify them otherwise.
         $defaults = array_merge([
-            '_default_class_addField'      => $this->_default_class_addField,
-            '_default_class_hasOne'        => $this->_default_class_hasOne,
-            '_default_class_hasMany'       => $this->_default_class_hasMany,
-            '_default_class_addExpression' => $this->_default_class_addExpression,
-            '_default_class_join'          => $this->_default_class_join,
+            '_default_seed_addField'      => $this->_default_seed_addField,
+            '_default_seed_hasOne'        => $this->_default_seed_hasOne,
+            '_default_seed_hasMany'       => $this->_default_seed_hasMany,
+            '_default_seed_addExpression' => $this->_default_seed_addExpression,
+            '_default_seed_join'          => $this->_default_seed_join,
         ], $defaults);
 
         $m = parent::add($m, $defaults);

--- a/src/Persistence_SQL.php
+++ b/src/Persistence_SQL.php
@@ -21,14 +21,14 @@ class Persistence_SQL extends Persistence
      *
      * @var string
      */
-    public $_default_class_addField = 'atk4\data\Field_SQL';
+    public $_default_class_addField = ['\atk4\data\Field_SQL'];
 
     /**
      * Default class when adding hasOne field.
      *
      * @var string
      */
-    public $_default_class_hasOne = 'atk4\data\Reference_SQL_One';
+    public $_default_class_hasOne = ['\atk4\data\Reference_SQL_One'];
 
     /**
      * Default class when adding hasMany field.
@@ -42,14 +42,14 @@ class Persistence_SQL extends Persistence
      *
      * @var string
      */
-    public $_default_class_addExpression = 'atk4\data\Field_SQL_Expression';
+    public $_default_class_addExpression = ['\atk4\data\Field_SQL_Expression'];
 
     /**
      * Default class when adding join.
      *
      * @var string
      */
-    public $_default_class_join = 'atk4\data\Join_SQL';
+    public $_default_class_join = ['\atk4\data\Join_SQL'];
 
     /**
      * Constructor.

--- a/src/Reference.php
+++ b/src/Reference.php
@@ -17,6 +17,7 @@ class Reference
         init as _init;
     }
     use \atk4\core\TrackableTrait;
+    use \atk4\core\DIContainerTrait;
 
     /**
      * Use this alias for related entity by default. This can help you
@@ -67,24 +68,13 @@ class Reference
      *
      * @param array $defaults
      */
-    public function __construct($defaults = [])
+    public function __construct($link)
     {
-        if (isset($defaults[0])) {
-            $this->link = $defaults[0];
-            unset($defaults[0]);
-        }
+        $this->link = $link;
 
-        foreach ($defaults as $key => $val) {
-            if (is_array($val)) {
-                $this->$key = array_merge(isset($this->$key) && is_array($this->$key) ? $this->$key : [], $val);
-            } else {
-                $this->$key = $val;
-            }
-        }
-
-        if (!$this->model) {
-            $this->model = $this->link;
-        }
+        //if (!$this->model) {
+            //$this->model = $this->link;
+        //}
     }
 
     /**

--- a/src/Reference.php
+++ b/src/Reference.php
@@ -71,10 +71,6 @@ class Reference
     public function __construct($link)
     {
         $this->link = $link;
-
-        //if (!$this->model) {
-            //$this->model = $this->link;
-        //}
     }
 
     /**

--- a/src/Reference.php
+++ b/src/Reference.php
@@ -66,7 +66,7 @@ class Reference
     /**
      * Default constructor. Will copy argument into properties.
      *
-     * @param array $defaults
+     * @param string $link a short_name component
      */
     public function __construct($link)
     {

--- a/src/Reference_SQL_One.php
+++ b/src/Reference_SQL_One.php
@@ -30,6 +30,7 @@ class Reference_SQL_One extends Reference_One
                 ]);
             }
             $field = $defaults[0];
+            unset($defaults[0]);
         } else {
             $defaults = [];
         }


### PR DESCRIPTION
Currently Model uses _default_class_addField. This was OK in the early days but now we have a very solid implementation of factory(). This allows us to replace class names with seeds for consistency and increased flexibility.

There will also be a lot of simplifications, general removal of setDefaults(). There shouldn't be any impact other than cleaning up code, because class names are only redefined in persistences.