### PR TITLE
Feature/add static persistence

### DIFF
--- a/docs/fields.rst
+++ b/docs/fields.rst
@@ -2,13 +2,18 @@
 
 .. _Fields:
 
-======
-Fields
-======
+.. php:namespace:: atk4\data
 
-Field represents a model `property` which we do refer to as field throughout
-Agile Data, to distinguish it from object properties. Fields inside a model
-normally have a corresponding instance of Field class.
+.. php:class:: Field
+
+
+=====
+Field
+=====
+
+Field represents a model `property` that can hold informaiton about your entity.
+In Agile Data we call it a Field, to distinguish it from object properties. Fields
+inside a model normally have a corresponding instance of Field class.
 
 See :php:meth:`Model::addField()` on how fields are added. By default,
 persistence sets the property _default_seed_addField which should correspond

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -17,6 +17,7 @@ Contents:
     fields
     conditions
     sql
+    static
     references
     expressions
     joins

--- a/docs/static.rst
+++ b/docs/static.rst
@@ -1,0 +1,55 @@
+
+.. _SQL:
+
+==================
+Static Persistence
+==================
+
+.. php:class:: Persistence_Static
+
+Static Persistence extends :php:class:`Persistence_Array` to implement a user-friendly way of
+specifying data through an array.
+
+Usage
+=====
+
+This is most useful when working with "sample" code, where you want to see your results quick::
+
+    $htmltable->setModel(new Model(new Persistence_Static([
+        ['VAT_rate'=>'12.0%', 'VAT'=>'36.00', 'Net'=>'300.00'],
+        ['VAT_rate'=>'10.0%', 'VAT'=>'52.00', 'Net'=>'520.00'],
+    ])));
+    
+Lets unwrap the example:
+
+.. php:method:: __construct
+
+Constructor accepts array as an argument, but the array could be in various forms::
+
+ - can be array of strings ['one', 'two']
+ - can be array of hashes. First hash will be examined to pick up fields
+ - can be array of arrays. Will name columns as 'field1', 'field2', 'field3'.
+
+If you are using any fields without keys (numeric keys) it's important that all your
+records have same number of elements. 
+
+Static Persistence will also make attempt to deduce a "title" field and will set it
+automatically for the model. If you have a field with key "name" then it will be used.
+Alternative it will check key "title".
+
+If neither are present you can still manually specify title field for your model.
+
+Finally, static persistence (unlike :php:class:Persistence_Array) will automatically
+populate fields for the model and will even attempt to deduce field types.
+
+Currently it recognizes dates, and booleans, other fields will appear as-is.
+
+
+
+Saving Records
+--------------
+
+Models that you specify against static persistence will not be marked as "Read Only" 
+(:php:attr:`Model::read_only`), and you will be allowed to save data back. The data
+will only be stored inside persistence object and will be discarded at the end of
+your PHP script.

--- a/docs/static.rst
+++ b/docs/static.rst
@@ -42,7 +42,8 @@ If neither are present you can still manually specify title field for your model
 Finally, static persistence (unlike :php:class:Persistence_Array) will automatically
 populate fields for the model and will even attempt to deduce field types.
 
-Currently it recognizes dates, and booleans, other fields will appear as-is.
+Currently it recognizes integer, date, boolean, float, array and object types.
+Other fields will appear as-is.
 
 
 

--- a/src/Persistence_Array.php
+++ b/src/Persistence_Array.php
@@ -59,7 +59,7 @@ class Persistence_Array extends Persistence
         // and put all persistence data in there
         if (!$m->table) {
             $m->table = 'data'; // fake table name 'data'
-            if (!isset($this->data['data']) || count($this->data) != 1) {
+            if (!isset($this->data[$m->table]) || count($this->data) != 1) {
                 $this->data = [$m->table => $this->data];
             }
         }

--- a/src/Persistence_Array.php
+++ b/src/Persistence_Array.php
@@ -59,7 +59,9 @@ class Persistence_Array extends Persistence
         // and put all persistence data in there
         if (!$m->table) {
             $m->table = 'data'; // fake table name 'data'
-            $this->data = [$m->table => $this->data];
+            if (!isset($this->data['data']) || count($this->data) != 1) {
+                $this->data = [$m->table => $this->data];
+            }
         }
 
         // if there is no such table in persistence, then create empty one

--- a/src/Persistence_Static.php
+++ b/src/Persistence_Static.php
@@ -1,0 +1,38 @@
+<?php
+
+// vim:ts=4:sw=4:et:fdm=marker:fdl=0
+
+namespace atk4\data;
+
+/**
+ * Implements a very basic array-access pattern:
+ *
+ * $m = new Model(Persistence_Static(['hello', 'world']));
+ * $m->load(1);
+ *
+ * echo $m['name'];  // world
+ */
+class Persistence_Static extends Persistence_Array
+{
+    /**
+     * Constructor. Can pass array of data in parameters.
+     *
+     * @param array &$data
+     */
+    public function __construct($data = null)
+    {
+        $data2 = [];
+        if ($data) foreach($data as $id=>$name) {
+            $data2[$id] = ['id'=>$id, 'name'=>$name];
+        }
+
+        $this->addHook('afterAdd', function($p, $m) {
+            if (!$m->hasElement($m->title_field)) {
+                $m->addField($m->title_field);
+            }
+        });
+
+        // convert array
+        parent::__construct($data2);
+    }
+}

--- a/src/Persistence_Static.php
+++ b/src/Persistence_Static.php
@@ -16,11 +16,15 @@ class Persistence_Static extends Persistence_Array
 {
     /**
      * This will be the title for the model.
+     *
+     * @var string
      */
     public $titleForModel = null;
 
     /**
      * Populate the following fields for the model.
+     *
+     * @var array
      */
     public $fieldsForModel = [];
 
@@ -63,23 +67,30 @@ class Persistence_Static extends Persistence_Array
         $must_override = false;
 
         foreach ($row1 as $key=>$value) {
-            // if title is not set, use first key
 
             // id information present, use it instead
             if ($key == 'id') {
                 $must_override = true;
             }
 
+            // try to detect type of field by its value
             if (is_int($value)) {
                 $def_types[] = ['type'=>'int'];
             } elseif ($value instanceof \DateTime) {
                 $def_types[] = ['type'=>'datetime'];
             } elseif (is_bool($value)) {
                 $def_types[] = ['type'=>'boolean'];
+            } elseif (is_float($value)) {
+                $def_types[] = ['type'=>'float'];
+            } elseif (is_array($value)) {
+                $def_types[] = ['type'=>'array'];
+            } elseif (is_object($value)) {
+                $def_types[] = ['type'=>'object'];
             } else {
                 $def_types[] = [];
             }
 
+            // if title is not set, use first key
             if (!$this->titleForModel) {
                 if (is_int($key)) {
                     $key_override[] = 'name';
@@ -117,7 +128,14 @@ class Persistence_Static extends Persistence_Array
         parent::__construct($data);
     }
 
-    public function afterAdd($p, $m, $arg = null)
+    /**
+     * Automatically adds missing model fields.
+     * Called from AfterAdd hook.
+     *
+     * @param Persistence_Static $p
+     * @param Model              $m
+     */
+    public function afterAdd($p, $m)
     {
         if ($p->titleForModel) {
             $m->title_field = $p->titleForModel;

--- a/src/Persistence_Static.php
+++ b/src/Persistence_Static.php
@@ -5,7 +5,7 @@
 namespace atk4\data;
 
 /**
- * Implements a very basic array-access pattern:
+ * Implements a very basic array-access pattern:.
  *
  * $m = new Model(Persistence_Static(['hello', 'world']));
  * $m->load(1);
@@ -22,11 +22,13 @@ class Persistence_Static extends Persistence_Array
     public function __construct($data = null)
     {
         $data2 = [];
-        if ($data) foreach($data as $id=>$name) {
-            $data2[$id] = ['id'=>$id, 'name'=>$name];
+        if ($data) {
+            foreach ($data as $id=>$name) {
+                $data2[$id] = ['id'=>$id, 'name'=>$name];
+            }
         }
 
-        $this->addHook('afterAdd', function($p, $m) {
+        $this->addHook('afterAdd', function ($p, $m) {
             if (!$m->hasElement($m->title_field)) {
                 $m->addField($m->title_field);
             }

--- a/src/Persistence_Static.php
+++ b/src/Persistence_Static.php
@@ -17,17 +17,16 @@ class Persistence_Static extends Persistence_Array
     /**
      * Constructor. Can pass array of data in parameters.
      *
-     * @param array &$data
+     * @param array $data
      */
     public function __construct($data = null)
     {
-        $data2 = [];
-        if ($data) {
-            foreach ($data as $id=>$name) {
-                $data2[$id] = ['id'=>$id, 'name'=>$name];
-            }
-        }
+        // nomalize data array
+        $data = array_map(function ($id, $name) {
+            return ['id' => $id, 'name' => $name];
+        }, array_keys($data), $data);        
 
+        // automatically add title_field in model when it is added in persistence
         $this->addHook('afterAdd', function ($p, $m) {
             if (!$m->hasElement($m->title_field)) {
                 $m->addField($m->title_field);
@@ -35,6 +34,6 @@ class Persistence_Static extends Persistence_Array
         });
 
         // convert array
-        parent::__construct($data2);
+        parent::__construct($data);
     }
 }

--- a/src/Persistence_Static.php
+++ b/src/Persistence_Static.php
@@ -22,9 +22,9 @@ class Persistence_Static extends Persistence_Array
     public function __construct($data = null)
     {
         // nomalize data array
-        $data = array_map(function ($id, $name) {
-            return ['id' => $id, 'name' => $name];
-        }, array_keys($data), $data);
+        array_walk($data, function (&$name, $id) {
+            $name = ['id' => $id, 'name' => $name];
+        });
 
         // automatically add title_field in model when it is added in persistence
         $this->addHook('afterAdd', function ($p, $m) {

--- a/src/Persistence_Static.php
+++ b/src/Persistence_Static.php
@@ -14,14 +14,13 @@ namespace atk4\data;
  */
 class Persistence_Static extends Persistence_Array
 {
-
     /**
-     * This will be the title for the model
+     * This will be the title for the model.
      */
     public $titleForModel = null;
 
     /**
-     * Populate the following fields for the model
+     * Populate the following fields for the model.
      */
     public $fieldsForModel = [];
 
@@ -32,7 +31,6 @@ class Persistence_Static extends Persistence_Array
      */
     public function __construct($data = null)
     {
-
         if (!is_array($data)) {
             throw new Exception(['Static data should be array of strings or array of hashes', 'data'=>$data]);
         }
@@ -44,15 +42,15 @@ class Persistence_Static extends Persistence_Array
 
         if (is_string($row1)) {
             // We are dealing with array of strings. Convert it into array of hashes
-            array_walk($data, function(&$str, $key) {
+            array_walk($data, function (&$str, $key) {
                 $str = ['id'=>$key, 'name'=>$str];
             });
 
             $this->titleForModel = 'name';
             $this->fieldsForModel = ['name'=>[]];
+
             return parent::__construct($data);
         }
-
 
         if (isset($row1['name'])) {
             $this->titleForModel = 'name';
@@ -64,9 +62,8 @@ class Persistence_Static extends Persistence_Array
         $def_types = [];
         $must_override = false;
 
-        foreach($row1 as $key=>$value) {
+        foreach ($row1 as $key=>$value) {
             // if title is not set, use first key
-
 
             // id information present, use it instead
             if ($key == 'id') {
@@ -82,7 +79,6 @@ class Persistence_Static extends Persistence_Array
             } else {
                 $def_types[] = [];
             }
-
 
             if (!$this->titleForModel) {
                 if (is_int($key)) {
@@ -107,7 +103,7 @@ class Persistence_Static extends Persistence_Array
         if ($must_override) {
             $data2 = [];
 
-            foreach($data as $key=>$row) {
+            foreach ($data as $key=>$row) {
                 $row = array_combine($key_override, $row);
                 if (isset($row['id'])) {
                     $key = $row['id'];
@@ -121,7 +117,8 @@ class Persistence_Static extends Persistence_Array
         parent::__construct($data);
     }
 
-    function afterAdd($p, $m, $arg = null) {
+    public function afterAdd($p, $m, $arg = null)
+    {
         if ($p->titleForModel) {
             $m->title_field = $p->titleForModel;
         }

--- a/src/Persistence_Static.php
+++ b/src/Persistence_Static.php
@@ -24,7 +24,7 @@ class Persistence_Static extends Persistence_Array
         // nomalize data array
         $data = array_map(function ($id, $name) {
             return ['id' => $id, 'name' => $name];
-        }, array_keys($data), $data);        
+        }, array_keys($data), $data);
 
         // automatically add title_field in model when it is added in persistence
         $this->addHook('afterAdd', function ($p, $m) {

--- a/src/Persistence_Static.php
+++ b/src/Persistence_Static.php
@@ -14,26 +14,125 @@ namespace atk4\data;
  */
 class Persistence_Static extends Persistence_Array
 {
+
+    /**
+     * This will be the title for the model
+     */
+    public $titleForModel = null;
+
+    /**
+     * Populate the following fields for the model
+     */
+    public $fieldsForModel = [];
+
     /**
      * Constructor. Can pass array of data in parameters.
      *
-     * @param array $data
+     * @param array $data Static data in one of supported formats
      */
     public function __construct($data = null)
     {
-        // nomalize data array
-        array_walk($data, function (&$name, $id) {
-            $name = ['id' => $id, 'name' => $name];
-        });
 
-        // automatically add title_field in model when it is added in persistence
-        $this->addHook('afterAdd', function ($p, $m) {
-            if (!$m->hasElement($m->title_field)) {
-                $m->addField($m->title_field);
+        if (!is_array($data)) {
+            throw new Exception(['Static data should be array of strings or array of hashes', 'data'=>$data]);
+        }
+
+        // chomp off first row, we will use it to deduct fields
+        $row1 = reset($data);
+
+        $this->addHook('afterAdd', [$this, 'afterAdd']);
+
+        if (is_string($row1)) {
+            // We are dealing with array of strings. Convert it into array of hashes
+            array_walk($data, function(&$str, $key) {
+                $str = ['id'=>$key, 'name'=>$str];
+            });
+
+            $this->titleForModel = 'name';
+            $this->fieldsForModel = ['name'=>[]];
+            return parent::__construct($data);
+        }
+
+
+        if (isset($row1['name'])) {
+            $this->titleForModel = 'name';
+        } elseif (isset($row1['title'])) {
+            $this->titleForModel = 'title';
+        }
+
+        $key_override = [];
+        $def_types = [];
+        $must_override = false;
+
+        foreach($row1 as $key=>$value) {
+            // if title is not set, use first key
+
+
+            // id information present, use it instead
+            if ($key == 'id') {
+                $must_override = true;
             }
-        });
 
-        // convert array
+            if (is_int($value)) {
+                $def_types[] = ['type'=>'int'];
+            } elseif ($value instanceof \DateTime) {
+                $def_types[] = ['type'=>'datetime'];
+            } elseif (is_bool($value)) {
+                $def_types[] = ['type'=>'boolean'];
+            } else {
+                $def_types[] = [];
+            }
+
+
+            if (!$this->titleForModel) {
+                if (is_int($key)) {
+                    $key_override[] = 'name';
+                    $this->titleForModel = 'name';
+                    $must_override = true;
+                    continue;
+                } else {
+                    $this->titleForModel = $key;
+                }
+            }
+
+            if (is_int($key)) {
+                $key_override[] = 'field'.$key;
+                $must_override = true;
+                continue;
+            }
+
+            $key_override[] = $key;
+        }
+
+        if ($must_override) {
+            $data2 = [];
+
+            foreach($data as $key=>$row) {
+                $row = array_combine($key_override, $row);
+                if (isset($row['id'])) {
+                    $key = $row['id'];
+                }
+                $data2[$key] = $row;
+            }
+            $data = $data2;
+        }
+
+        $this->fieldsForModel = array_combine($key_override, $def_types);
         parent::__construct($data);
+    }
+
+    function afterAdd($p, $m, $arg = null) {
+        if ($p->titleForModel) {
+            $m->title_field = $p->titleForModel;
+        }
+
+        foreach ($this->fieldsForModel as $field=>$def) {
+            if ($m->hasElement($field)) {
+                continue;
+            }
+
+            // add new field
+            $m->addField($field, $def);
+        }
     }
 }

--- a/src/Persistence_Static.php
+++ b/src/Persistence_Static.php
@@ -75,7 +75,7 @@ class Persistence_Static extends Persistence_Array
 
             // try to detect type of field by its value
             if (is_int($value)) {
-                $def_types[] = ['type'=>'int'];
+                $def_types[] = ['type'=>'integer'];
             } elseif ($value instanceof \DateTime) {
                 $def_types[] = ['type'=>'datetime'];
             } elseif (is_bool($value)) {

--- a/tests/StaticPersistenceTest.php
+++ b/tests/StaticPersistenceTest.php
@@ -109,15 +109,17 @@ class StaticPersistenceTest extends TestCase
         ]]);
         $m = new \atk4\data\Model($p);
 
-        $this->assertEquals('string', $m->getElement('name')->type);
         $this->assertEquals('integer', $m->getElement('test_int')->type);
         $this->assertEquals('float', $m->getElement('test_float')->type);
         $this->assertEquals('datetime', $m->getElement('test_date')->type);
         $this->assertEquals('array', $m->getElement('test_array')->type);
         $this->assertEquals('object', $m->getElement('test_object')->type);
-        $this->assertEquals('string', $m->getElement('test_str_1')->type);
-        $this->assertEquals('string', $m->getElement('test_str_2')->type);
-        $this->assertEquals('string', $m->getElement('test_str_3')->type);
+        
+        // string is default type, so it is null
+        $this->assertNull($m->getElement('name')->type);
+        $this->assertNull($m->getElement('test_str_1')->type);
+        $this->assertNull($m->getElement('test_str_2')->type);
+        $this->assertNull($m->getElement('test_str_3')->type);
     }
 }
 

--- a/tests/StaticPersistenceTest.php
+++ b/tests/StaticPersistenceTest.php
@@ -13,10 +13,15 @@ class StaticPersistenceTest extends TestCase
     public function testBasicStatic()
     {
         $p = new \atk4\data\Persistence_Static(['hello', 'world']);
+
+        // default title field
         $m = new \atk4\data\Model($p);
-
         $m->load(1);
-
         $this->assertEquals('world', $m['name']);
+
+        // custom title field
+        $m = new \atk4\data\Model($p, ['title_field' => 'foo']);
+        $m->load(1);
+        $this->assertEquals('world', $m['name']); // still 'name' here not 'foo'
     }
 }

--- a/tests/StaticPersistenceTest.php
+++ b/tests/StaticPersistenceTest.php
@@ -19,9 +19,87 @@ class StaticPersistenceTest extends TestCase
         $m->load(1);
         $this->assertEquals('world', $m['name']);
 
-        // custom title field
-        $m = new \atk4\data\Model($p, ['title_field' => 'foo']);
+        // custom title field and try loading from same static twice
+        $m = new \atk4\data\Model($p);//, ['title_field' => 'foo']);
         $m->load(1);
         $this->assertEquals('world', $m['name']); // still 'name' here not 'foo'
+    }
+
+    public function testArrayOfArrays()
+    {
+        $p = new \atk4\data\Persistence_Static([['hello', 'xx', true], ['world', 'xy', false]]);
+        $m = new \atk4\data\Model($p);
+
+        $m->load(1);
+
+        $this->assertEquals('world', $m['name']);
+        $this->assertEquals('xy', $m['field1']);
+        $this->assertEquals(false, $m['field2']);
+    }
+
+    public function testArrayOfHashes()
+    {
+        $p = new \atk4\data\Persistence_Static([['foo'=>'hello'], ['foo'=>'world']]);
+        $m = new \atk4\data\Model($p);
+
+        $m->load(1);
+
+        $this->assertEquals('world', $m['foo']);
+    }
+
+    public function testIDArg()
+    {
+        $p = new \atk4\data\Persistence_Static([['id'=>20, 'foo'=>'hello'], ['id'=>21, 'foo'=>'world']]);
+        $m = new \atk4\data\Model($p);
+
+        $m->load(21);
+
+        $this->assertEquals('world', $m['foo']);
+    }
+
+    public function testIDKey()
+    {
+        $p = new \atk4\data\Persistence_Static([20=>['foo'=>'hello'], 21=>['foo'=>'world']]);
+        $m = new \atk4\data\Model($p);
+
+        $m->load(21);
+
+        $this->assertEquals('world', $m['foo']);
+    }
+
+    public function testCustomField()
+    {
+        $p = new \atk4\data\Persistence_Static([['foo'=>'hello'], ['foo'=>'world']]);
+        $m = new StaticPersistenceModel($p);
+
+        $this->assertEquals('custom field', $m->getElement('foo')->caption);
+
+        $p = new \atk4\data\Persistence_Static([['foo'=>'hello', 'bar'=>'world']]);
+        $m = new StaticPersistenceModel($p);
+        $this->assertEquals('foo', $m->title_field);
+    }
+
+    public function testTitleOrName()
+    {
+        $p = new \atk4\data\Persistence_Static([['foo'=>'hello', 'bar'=>'world']]);
+        $m = new \atk4\data\Model($p);
+        $this->assertEquals('foo', $m->title_field);
+
+        $p = new \atk4\data\Persistence_Static([['foo'=>'hello', 'name'=>'x']]);
+        $m = new \atk4\data\Model($p);
+        $this->assertEquals('name', $m->title_field);
+
+        $p = new \atk4\data\Persistence_Static([['foo'=>'hello', 'title'=>'x']]);
+        $m = new \atk4\data\Model($p);
+        $this->assertEquals('title', $m->title_field);
+    }
+}
+
+class StaticPersistenceModel extends \atk4\data\Model {
+    public $title_field='foo';
+    function init() {
+        parent::init();
+
+        $this->addField('foo', ['caption'=>'custom field']);
     }
 }

--- a/tests/StaticPersistenceTest.php
+++ b/tests/StaticPersistenceTest.php
@@ -93,22 +93,22 @@ class StaticPersistenceTest extends TestCase
         $m = new \atk4\data\Model($p);
         $this->assertEquals('title', $m->title_field);
     }
-    
+
     public function testFieldTypes()
     {
         $p = new \atk4\data\Persistence_Static([[
-            'name' => 'hello',
+            'name'        => 'hello',
             'test_int'    => 123,
             'test_float'  => 123.45,
             'test_date'   => new \DateTime(),
-            'test_array'  => ['a','b','c'],
+            'test_array'  => ['a', 'b', 'c'],
             'test_object' => new \DateInterval('P1Y'),
             'test_str_1'  => 'abc',
             'test_str_2'  => '123',
             'test_str_3'  => '123.45',
         ]]);
         $m = new \atk4\data\Model($p);
-        
+
         $this->assertEquals('string', $m->getElement('name')->type);
         $this->assertEquals('integer', $m->getElement('test_int')->type);
         $this->assertEquals('float', $m->getElement('test_float')->type);

--- a/tests/StaticPersistenceTest.php
+++ b/tests/StaticPersistenceTest.php
@@ -12,7 +12,6 @@ class StaticPersistenceTest extends TestCase
      */
     public function testBasicStatic()
     {
-
         $p = new \atk4\data\Persistence_Static(['hello', 'world']);
         $m = new \atk4\data\Model($p);
 

--- a/tests/StaticPersistenceTest.php
+++ b/tests/StaticPersistenceTest.php
@@ -114,7 +114,7 @@ class StaticPersistenceTest extends TestCase
         $this->assertEquals('datetime', $m->getElement('test_date')->type);
         $this->assertEquals('array', $m->getElement('test_array')->type);
         $this->assertEquals('object', $m->getElement('test_object')->type);
-        
+
         // string is default type, so it is null
         $this->assertNull($m->getElement('name')->type);
         $this->assertNull($m->getElement('test_str_1')->type);

--- a/tests/StaticPersistenceTest.php
+++ b/tests/StaticPersistenceTest.php
@@ -93,6 +93,32 @@ class StaticPersistenceTest extends TestCase
         $m = new \atk4\data\Model($p);
         $this->assertEquals('title', $m->title_field);
     }
+    
+    public function testFieldTypes()
+    {
+        $p = new \atk4\data\Persistence_Static([[
+            'name' => 'hello',
+            'test_int'    => 123,
+            'test_float'  => 123.45,
+            'test_date'   => new \DateTime(),
+            'test_array'  => ['a','b','c'],
+            'test_object' => new \DateInterval('P1Y'),
+            'test_str_1'  => 'abc',
+            'test_str_2'  => '123',
+            'test_str_3'  => '123.45',
+        ]]);
+        $m = new \atk4\data\Model($p);
+        
+        $this->assertEquals('string', $m->getElement('name')->type);
+        $this->assertEquals('integer', $m->getElement('test_int')->type);
+        $this->assertEquals('float', $m->getElement('test_float')->type);
+        $this->assertEquals('datetime', $m->getElement('test_date')->type);
+        $this->assertEquals('array', $m->getElement('test_array')->type);
+        $this->assertEquals('object', $m->getElement('test_object')->type);
+        $this->assertEquals('string', $m->getElement('test_str_1')->type);
+        $this->assertEquals('string', $m->getElement('test_str_2')->type);
+        $this->assertEquals('string', $m->getElement('test_str_3')->type);
+    }
 }
 
 class StaticPersistenceModel extends \atk4\data\Model

--- a/tests/StaticPersistenceTest.php
+++ b/tests/StaticPersistenceTest.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace atk4\data\tests;
+
+/**
+ * @coversDefaultClass \atk4\data\Model
+ */
+class StaticPersistenceTest extends TestCase
+{
+    /**
+     * Test constructor.
+     */
+    public function testBasicStatic()
+    {
+
+        $p = new \atk4\data\Persistence_Static(['hello', 'world']);
+        $m = new \atk4\data\Model($p);
+
+        $m->load(1);
+
+        $this->assertEquals('world', $m['name']);
+    }
+}

--- a/tests/StaticPersistenceTest.php
+++ b/tests/StaticPersistenceTest.php
@@ -20,7 +20,7 @@ class StaticPersistenceTest extends TestCase
         $this->assertEquals('world', $m['name']);
 
         // custom title field and try loading from same static twice
-        $m = new \atk4\data\Model($p);//, ['title_field' => 'foo']);
+        $m = new \atk4\data\Model($p); //, ['title_field' => 'foo']);
         $m->load(1);
         $this->assertEquals('world', $m['name']); // still 'name' here not 'foo'
     }
@@ -95,9 +95,12 @@ class StaticPersistenceTest extends TestCase
     }
 }
 
-class StaticPersistenceModel extends \atk4\data\Model {
-    public $title_field='foo';
-    function init() {
+class StaticPersistenceModel extends \atk4\data\Model
+{
+    public $title_field = 'foo';
+
+    public function init()
+    {
         parent::init();
 
         $this->addField('foo', ['caption'=>'custom field']);


### PR DESCRIPTION
Implementation of Static Persistence. This is handy when you need a one-liner for creating a model. Simple use:

``` php
$m = new Model(Persistence_Static(['female', 'male']));

// model can be used anywhere, such as in a table
$table->setModel($m);
```

The other use-case if you have associative array like this:

``` php
$m = new Model(Persistence_Static([
    ['icon'=>'map marker', 'title'=>'Krolewskie Jadlo', 'descr'=>'An excellent polish restaurant, quick delivery and hearty, filling meals'],
    ['icon'=> 'map marker', 'title'=>'Xian Famous Foods', 'descr'=>'A taste of Shaanxi\'s delicious culinary traditions, with delights like spicy cold noodles and lamb burgers.'],
    ['icon'=> 'check', 'title'=>'Sapporo Haru', 'descr'=>'Greenpoint\'s best choice for quick and delicious sushi'],
]);
```

Static persistence will do few things:

- [x] Unlike "Array" no need to pass array by reference.
- [x] Will support either array of strings or array of hashes.
- [x] Will also support "array of arrays".
- [x] If you supply "id" column, will use that, otherwise will use key (0, 1, etc)
- [x] Will use first record from your hash to identify columns
- [x] If column is missing in your model, will add it with `addColumn()`
- [x] Will use value to determine type (string, int, date)
- [x] If column is named "title" or "name" will be used as a title column.
- [x] if no "title" or "name" column exist, will use first column as a title.

--------

 - Documentation: [docs/static.rst](docs/file.rst)
 - Demo: above

