### PR TITLE
Allow NonSQL fields to be queried from SQL database

### DIFF
--- a/src/Persistence_SQL.php
+++ b/src/Persistence_SQL.php
@@ -215,7 +215,7 @@ class Persistence_SQL extends Persistence
      */
     public function initField($q, $field)
     {
-        if ($field->useAlias()) {
+        if ($field instanceof Field_SQL && $field->useAlias()) {
             $q->field($field, $field->short_name);
         } else {
             $q->field($field);
@@ -258,13 +258,13 @@ class Persistence_SQL extends Persistence
                 if ($f_object instanceof Field && $f_object->never_persist) {
                     continue;
                 }
-                if ($f_object instanceof Field_SQL && $f_object->system && !isset($added_fields[$field])) {
+                if ($f_object instanceof Field && $f_object->system && !isset($added_fields[$field])) {
                     $this->initField($q, $f_object);
                 }
             }
         } else {
             foreach ($m->elements as $field => $f_object) {
-                if ($f_object instanceof Field_SQL) {
+                if ($f_object instanceof Field) {
                     if ($f_object->never_persist) {
                         continue;
                     }

--- a/src/Persistence_SQL.php
+++ b/src/Persistence_SQL.php
@@ -217,8 +217,10 @@ class Persistence_SQL extends Persistence
     {
         if ($field instanceof Field_SQL && $field->useAlias()) {
             $q->field($field, $field->short_name);
-        } else {
+        } elseif ($field instanceof Field_SQL) {
             $q->field($field);
+        } else {
+            $q->field($field->short_name);
         }
     }
 

--- a/tests/RandomTest.php
+++ b/tests/RandomTest.php
@@ -298,4 +298,24 @@ class RandomSQLTests extends SQLTestCase
         $m->hasOne('Person', 'atk4/data/tests/Model_Person');
         $person = $m->ref('Person');
     }
+
+    public function testNonSQLFieldClass()
+    {
+        $db = new Persistence_SQL($this->db->connection);
+        $a = [
+            'rate' => [
+                ['dat' => '18/12/12', 'bid' => 3.4, 'ask' => 9.4, 'x1'=>'y1', 'x2'=>'y2'],
+            ],
+        ];
+        $this->setDB($a);
+
+        $m = new Model_Rate($db);
+        $m->addField('x1', new \atk4\data\Field_SQL());
+        $m->addField('x2', new \atk4\data\Field());
+        $m->load(1);
+
+        $this->assertEquals(3.4, $m['bid']);
+        $this->assertEquals('y1', $m['x1']);
+        $this->assertEquals('y2', $m['x2']);
+    }
 }


### PR DESCRIPTION
Using "extends Field" for new cross-persistence fields currently does not work with Persistence_SQL. This adds support for loading those fields.