### PR TITLE
Make model use AppScopeTrait thus inheriting $app property from the persistence

### DIFF
--- a/src/Model.php
+++ b/src/Model.php
@@ -18,6 +18,7 @@ class Model implements \ArrayAccess, \IteratorAggregate
     use \atk4\core\NameTrait;
     use \atk4\core\DIContainerTrait;
     use \atk4\core\FactoryTrait;
+    use \atk4\core\AppScopeTrait;
 
     // {{{ Properties of the class
 


### PR DESCRIPTION
Persistence implements appscope trait so it can belong to an application. Model, however, does not. 

With this change, model will automatically inherit $app property from persistence when created.