### PR TITLE
Don't hardcode "id" - use owner model $id_field property

### DIFF
--- a/src/Join.php
+++ b/src/Join.php
@@ -194,11 +194,11 @@ class Join
         } else {
             $this->reverse = false;
             if (!$this->master_field) {
-                $this->master_field = $this->foreign_table.'_id';
+                $this->master_field = $this->foreign_table.'_'.$this->owner->id_field;
             }
 
             if (!$this->foreign_field) {
-                $this->foreign_field = 'id';
+                $this->foreign_field = $this->owner->id_field;
             }
         }
 

--- a/src/Reference.php
+++ b/src/Reference.php
@@ -105,7 +105,7 @@ class Reference
         if (!isset($defaults['table_alias'])) {
             if (!$this->table_alias) {
                 $this->table_alias = $this->link;
-                $this->table_alias = preg_replace('/_id/', '', $this->table_alias);
+                $this->table_alias = preg_replace('/_'.$this->owner->id_field.'/', '', $this->table_alias);
                 $this->table_alias = preg_replace('/([a-zA-Z])[a-zA-Z]*[^a-zA-Z]*/', '\1', $this->table_alias);
                 if (isset($this->owner->table_alias)) {
                     $this->table_alias = $this->owner->table_alias.'_'.$this->table_alias;

--- a/src/Reference_Many.php
+++ b/src/Reference_Many.php
@@ -54,7 +54,7 @@ class Reference_Many extends Reference
     {
         return $this->getModel($defaults)
             ->addCondition(
-                $this->their_field ?: ($this->owner->table.'_id'),
+                $this->their_field ?: ($this->owner->table.'_'.$this->owner->id_field),
                 $this->getOurValue()
             );
     }
@@ -70,7 +70,7 @@ class Reference_Many extends Reference
     {
         return $this->getModel($defaults)
             ->addCondition(
-                $this->their_field ?: ($this->owner->table.'_id'),
+                $this->their_field ?: ($this->owner->table.'_'.$this->owner->id_field),
                 $this->referenceOurValue()
             );
     }

--- a/src/Reference_SQL_One.php
+++ b/src/Reference_SQL_One.php
@@ -147,7 +147,7 @@ class Reference_SQL_One extends Reference_One
             ]);
         }
 
-        $field = isset($defaults['field']) ? $defaults['field'] : str_replace('_id', '', $this->link);
+        $field = isset($defaults['field']) ? $defaults['field'] : str_replace('_'.$this->owner->id_field, '', $this->link);
         $ex = $this->owner->addExpression($field, array_merge_recursive(
             [
                 function ($m) {


### PR DESCRIPTION
Currently we hard-code "id" field in Join and References, but we can be smarter I guess and use owner model $id_field property instead.