### PR TITLE
Feature/dont supply null

### DIFF
--- a/src/Persistence_SQL.php
+++ b/src/Persistence_SQL.php
@@ -766,7 +766,7 @@ class Persistence_SQL extends Persistence
     public function insert(Model $m, $data)
     {
         $insert = $m->action('insert');
-        if ($m->id_field && key_exists($m->id_field, $data) && $data[$m->id_field] === null) {
+        if ($m->id_field && array_key_exists($m->id_field, $data) && $data[$m->id_field] === null) {
             unset($data[$m->id_field]);
         }
         $insert->set($this->typecastSaveRow($m, $data));

--- a/src/Persistence_SQL.php
+++ b/src/Persistence_SQL.php
@@ -766,6 +766,9 @@ class Persistence_SQL extends Persistence
     public function insert(Model $m, $data)
     {
         $insert = $m->action('insert');
+        if ($m->id_field && key_exists($m->id_field, $data) && $data[$m->id_field] === null) {
+            unset($data[$m->id_field]);
+        }
         $insert->set($this->typecastSaveRow($m, $data));
 
         $st = null;


### PR DESCRIPTION
Postgres does not like when you specify (id) values (null) when we insert new record with auto_increment field.

https://github.com/atk4/dsql/issues/128

So I'm removing the field if it's set to "null". You can still override by setting it to Expression('null'); 