### PR TITLE
Allows static persistence to use empty array

### DIFF
--- a/src/Model.php
+++ b/src/Model.php
@@ -1238,7 +1238,9 @@ class Model implements \ArrayAccess, \IteratorAggregate
         $this->data = $this->persistence->tryLoadAny($this);
         if ($this->data) {
             if ($this->id_field) {
-                $this->id = $this->data[$this->id_field];
+                if (isset($this->data[$this->id_field])) {
+                    $this->id = $this->data[$this->id_field];
+                }
             }
 
             if ($this->hook('afterLoad') === false) {

--- a/src/Persistence_Array.php
+++ b/src/Persistence_Array.php
@@ -123,7 +123,7 @@ class Persistence_Array extends Persistence
     }
 
     /**
-     * Loads first available record
+     * Loads first available record.
      */
     public function tryLoadAny(Model $m, $table = null)
     {
@@ -140,6 +140,7 @@ class Persistence_Array extends Persistence
 
         $res = $this->load($m, $key, $table);
         $m->id = $key;
+
         return $res;
     }
 

--- a/src/Persistence_Array.php
+++ b/src/Persistence_Array.php
@@ -123,6 +123,27 @@ class Persistence_Array extends Persistence
     }
 
     /**
+     * Loads first available record
+     */
+    public function tryLoadAny(Model $m, $table = null)
+    {
+        if (!isset($table)) {
+            $table = $m->table;
+        }
+
+        if (!$this->data[$table]) {
+            return false; // no records at all;
+        }
+
+        reset($this->data[$table]);
+        $key = key($this->data[$table]);
+
+        $res = $this->load($m, $key, $table);
+        $m->id = $key;
+        return $res;
+    }
+
+    /**
      * Inserts record in data array and returns new record ID.
      *
      * @param Model  $m

--- a/src/Persistence_Array.php
+++ b/src/Persistence_Array.php
@@ -79,7 +79,7 @@ class Persistence_Array extends Persistence
      * @param mixed  $id
      * @param string $table
      *
-     * @return array
+     * @return array|false
      */
     public function load(Model $m, $id, $table = null)
     {
@@ -89,6 +89,7 @@ class Persistence_Array extends Persistence
                 'table' => $m->table,
             ]);
         }
+
         if (!isset($this->data[$table ?: $m->table][$id])) {
             throw new Exception([
                 'Record with specified ID was not found',
@@ -107,7 +108,7 @@ class Persistence_Array extends Persistence
      * @param mixed  $id
      * @param string $table
      *
-     * @return array
+     * @return array|false
      */
     public function tryLoad(Model $m, $id, $table = null)
     {
@@ -116,14 +117,20 @@ class Persistence_Array extends Persistence
         }
 
         if (!isset($this->data[$table][$id])) {
-            return false;
+            return false; // no record with such id in table
         }
 
         return $this->typecastLoadRow($m, $this->data[$table][$id]);
     }
 
     /**
-     * Loads first available record.
+     * Tries to load first available record and return data record.
+     * Doesn't throw exception if model can't be loaded or there are no data records.
+     *
+     * @param Model $m
+     * @param mixed $table
+     *
+     * @return array|false
      */
     public function tryLoadAny(Model $m, $table = null)
     {
@@ -132,16 +139,16 @@ class Persistence_Array extends Persistence
         }
 
         if (!$this->data[$table]) {
-            return false; // no records at all;
+            return false; // no records at all in table
         }
 
         reset($this->data[$table]);
         $key = key($this->data[$table]);
 
-        $res = $this->load($m, $key, $table);
+        $row = $this->load($m, $key, $table);
         $m->id = $key;
 
-        return $res;
+        return $row;
     }
 
     /**

--- a/src/Persistence_Static.php
+++ b/src/Persistence_Static.php
@@ -44,7 +44,7 @@ class Persistence_Static extends Persistence_Array
 
         $this->addHook('afterAdd', [$this, 'afterAdd']);
 
-        if (is_string($row1)) {
+        if (!is_array($row1)) {
             // We are dealing with array of strings. Convert it into array of hashes
             array_walk($data, function (&$str, $key) {
                 $str = ['id'=>$key, 'name'=>$str];

--- a/tests/PersistentArrayTest.php
+++ b/tests/PersistentArrayTest.php
@@ -30,6 +30,12 @@ class PersistentArrayTest extends TestCase
         $m->load(1);
         $this->assertEquals('John', $m['name']);
 
+        $m->unload();
+        $this->assertFalse($m->loaded());
+
+        $m->tryLoadAny();
+        $this->assertTrue($m->loaded());
+
         $m->load(2);
         $this->assertEquals('Jones', $m['surname']);
         $m['surname'] = 'Smith';

--- a/tests/StaticPersistenceTest.php
+++ b/tests/StaticPersistenceTest.php
@@ -67,6 +67,16 @@ class StaticPersistenceTest extends TestCase
         $this->assertEquals('world', $m['foo']);
     }
 
+    public function testEmpty()
+    {
+        $p = new \atk4\data\Persistence_Static([]);
+        $m = new \atk4\data\Model($p);
+
+        $m->tryLoadAny();
+
+        $this->assertFalse($m->loaded());
+    }
+
     public function testCustomField()
     {
         $p = new \atk4\data\Persistence_Static([['foo'=>'hello'], ['foo'=>'world']]);


### PR DESCRIPTION
Currently the following code fails:


``` php
$table->setSource([]);
```

The issue is not with the table, but with static persistence. Currently it attempts to load first row and reverse-engineer fields from that, but if there are no rows - error is shown.

This PR fixes this problem and additionally implements `tryLoadAny` for Persistence_Array.

Here I have faced a small problem. "load($id)" would load the record and if successful, the $id will be placed in $model->id.

tryLoadAny does not know ID, it should be coming from the record, but Array specifies "id" as a key, so it's not defined by id_field. I had to add extra check for that.

I hope this does not interfere with SQL.