### PR TITLE
Although we have added PostgreSQL, persistence does not recognize it

### DIFF
--- a/src/Persistence.php
+++ b/src/Persistence.php
@@ -56,6 +56,7 @@ class Persistence
                     $dsn .= ';charset=utf8';
                 }
 
+            case 'pgsql':
             case 'dumper':
             case 'counter':
             case 'sqlite':


### PR DESCRIPTION
Although DSQL now supports PostgreSQL (https://github.com/atk4/dsql/pull/130), connect method wasn't able to recognize it and associate it with dsql.

``` php
$app->dbConnect('pgsql://...');
```

This PR fixes it.