### PR TITLE
Action field, fx and fx0 generate nice aliases

### DIFF
--- a/src/Persistence_SQL.php
+++ b/src/Persistence_SQL.php
@@ -599,7 +599,6 @@ class Persistence_SQL extends Persistence
                     $expr = "coalesce($fx([]), 0)";
                 }
 
-
                 if (isset($args['alias'])) {
                     $q->reset('field')->field($q->expr($expr, [$field]), $args['alias']);
                 } elseif ($field instanceof Field_SQL_Expression) {

--- a/src/Persistence_SQL.php
+++ b/src/Persistence_SQL.php
@@ -569,6 +569,8 @@ class Persistence_SQL extends Persistence
                 $m->hook('initSelectQuery', [$q, $type]);
                 if (isset($args['alias'])) {
                     $q->reset('field')->field($field, $args['alias']);
+                } elseif ($field instanceof Field_SQL_Expression) {
+                    $q->reset('field')->field($field, $field->short_name);
                 } else {
                     $q->reset('field')->field($field);
                 }
@@ -597,8 +599,11 @@ class Persistence_SQL extends Persistence
                     $expr = "coalesce($fx([]), 0)";
                 }
 
+
                 if (isset($args['alias'])) {
                     $q->reset('field')->field($q->expr($expr, [$field]), $args['alias']);
+                } elseif ($field instanceof Field_SQL_Expression) {
+                    $q->reset('field')->field($field, $fx.'_'.$field->short_name);
                 } else {
                     $q->reset('field')->field($q->expr($expr, [$field]));
                 }

--- a/tests/ExpressionSQLTest.php
+++ b/tests/ExpressionSQLTest.php
@@ -196,4 +196,32 @@ class ExpressionSQLTest extends SQLTestCase
 
         $this->assertEquals(null, $m->unload()->save(['a' => 4, 'b' => 5])->get('sum'));
     }
+
+    public function testExpressionActionAlias()
+    {
+        $db = new Persistence_SQL($this->db->connection);
+        $m = new Model($db, false);
+        $m->addExpression('x', '2+3');
+
+        // use alias as array key if it is set
+        $q = $m->action('field', ['x','alias'=>'foo']);
+        $this->assertEquals([0=>['foo'=>5]], $q->get());
+
+        // if alias is not set, then use field name as key
+        $q = $m->action('field', ['x']);
+        $this->assertEquals([0=>['x'=>5]], $q->get());
+
+        // FX actions
+        $q = $m->action('fx', ['sum','x', 'alias'=>'foo']);
+        $this->assertEquals([0=>['foo'=>5]], $q->get());
+
+        $q = $m->action('fx', ['sum','x']);
+        $this->assertEquals([0=>['sum_x'=>5]], $q->get());
+
+        $q = $m->action('fx0', ['sum','x', 'alias'=>'foo']);
+        $this->assertEquals([0=>['foo'=>5]], $q->get());
+
+        $q = $m->action('fx0', ['sum','x']);
+        $this->assertEquals([0=>['sum_x'=>5]], $q->get());
+    }
 }

--- a/tests/ExpressionSQLTest.php
+++ b/tests/ExpressionSQLTest.php
@@ -204,7 +204,7 @@ class ExpressionSQLTest extends SQLTestCase
         $m->addExpression('x', '2+3');
 
         // use alias as array key if it is set
-        $q = $m->action('field', ['x','alias'=>'foo']);
+        $q = $m->action('field', ['x', 'alias'=>'foo']);
         $this->assertEquals([0=>['foo'=>5]], $q->get());
 
         // if alias is not set, then use field name as key
@@ -212,16 +212,16 @@ class ExpressionSQLTest extends SQLTestCase
         $this->assertEquals([0=>['x'=>5]], $q->get());
 
         // FX actions
-        $q = $m->action('fx', ['sum','x', 'alias'=>'foo']);
+        $q = $m->action('fx', ['sum', 'x', 'alias'=>'foo']);
         $this->assertEquals([0=>['foo'=>5]], $q->get());
 
-        $q = $m->action('fx', ['sum','x']);
+        $q = $m->action('fx', ['sum', 'x']);
         $this->assertEquals([0=>['sum_x'=>5]], $q->get());
 
-        $q = $m->action('fx0', ['sum','x', 'alias'=>'foo']);
+        $q = $m->action('fx0', ['sum', 'x', 'alias'=>'foo']);
         $this->assertEquals([0=>['foo'=>5]], $q->get());
 
-        $q = $m->action('fx0', ['sum','x']);
+        $q = $m->action('fx0', ['sum', 'x']);
         $this->assertEquals([0=>['sum_x'=>5]], $q->get());
     }
 }


### PR DESCRIPTION
action() field, fx and fx0 on model Expression field now generate nice aliases automatically.

* field - model field name
* fx - fx_fieldname, for example, sum_x
* fx0 - fx_fieldname, for example, sum_x

see test cases for examples

fix #190