### PR TITLE
Add test for a Callback type

### DIFF
--- a/tests/FieldHereditaryTest.php
+++ b/tests/FieldHereditaryTest.php
@@ -2,9 +2,6 @@
 
 namespace atk4\data\tests;
 
-use atk4\data\Model;
-use atk4\data\Persistence_SQL;
-
 class FieldHereditaryTest extends \atk4\schema\PHPUnit_SchemaTestCase
 {
     public function testDirty1()
@@ -13,11 +10,12 @@ class FieldHereditaryTest extends \atk4\schema\PHPUnit_SchemaTestCase
 
         // default title field
         $m = new \atk4\data\Model($p);
-        $m->addField('caps', ['Callback', function($m){ return strtoupper($m['name']); }]);
+        $m->addField('caps', ['Callback', function ($m) {
+            return strtoupper($m['name']);
+        }]);
 
         $m->load(1);
         $this->assertEquals('world', $m['name']);
         $this->assertEquals('WORLD', $m['caps']);
     }
 }
-    

--- a/tests/FieldHereditaryTest.php
+++ b/tests/FieldHereditaryTest.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace atk4\data\tests;
+
+use atk4\data\Model;
+use atk4\data\Persistence_SQL;
+
+class FieldHereditaryTest extends \atk4\schema\PHPUnit_SchemaTestCase
+{
+    public function testDirty1()
+    {
+        $p = new \atk4\data\Persistence_Static(['hello', 'world']);
+
+        // default title field
+        $m = new \atk4\data\Model($p);
+        $m->addField('caps', ['Callback', function($m){ return strtoupper($m['name']); }]);
+
+        $m->load(1);
+        $this->assertEquals('world', $m['name']);
+        $this->assertEquals('WORLD', $m['caps']);
+    }
+}
+    


### PR DESCRIPTION
Implementation of Field type Callback. Well, not really implementation, because it's already implemented, but rather some clean-ups and finishing (see ticket #310). Simple use:

``` php
$app->add('name_in_caps', ['Callback', function($m){ return strtoupper($m['name']); }]);
```

 - [ ] Add documentation (possibly to be done in #316)