### PR TITLE
Significantly improve flexibility of aggregates

### DIFF
--- a/docs/references.rst
+++ b/docs/references.rst
@@ -184,12 +184,59 @@ keep making your query bigger and bigger::
             ['total_gross', 'aggregate'=>'sum'],
         ]);
 
-.. important::
-    Imported fields will preserve format of the field the reference. In the example,
-    if 'Invoice_line' field total_vat has type `money` then it will also be used
-    for a sum. Aggregate fields are always declared read-only, and if you try to
-    change them, you will receive exception.
+Imported fields will preserve format of the field they reference. In the example,
+if 'Invoice_line' field total_vat has type `money` then it will also be used
+for a sum. 
 
+You can also specify a type yourself::
+
+    ->addField('paid_amount', ['aggregate'=>'sum', 'field'=>'amount', 'type'=>'money']);
+
+Aggregate fields are always declared read-only, and if you try to
+change them (`$m['paid_amount'] = 123;`), you will receive exception.
+
+Available Aggregation Functions
+-------------------------------
+
+The mathematical aggregates such as sum, avg, min, max and count will automatically
+default to 0 if no respective rows were provided. The default SQL behaviour is to
+return NULL, but this does go well with the cascading formulas::
+
+    coalesce(sum([field]), 0);
+
+For other functions, such as 'group_concat' no coalesce will be used, so the empty
+string will be the result. When you specify `'aggregate'=>'count'` field defaults
+to '*'.
+
+Aggregate Expressions
+---------------------
+
+Sometimes you want to use a more complex formula, and you may do so by specifying
+expression into 'aggregate'::
+
+    ->addField('len', ['expr' => 'sum(length([name]))']),
+
+You can reference fields by using square brackets here. Also you may pass `args`
+containing your optional arguments::
+
+    ->addField('len', [
+        'expr' => 'sum(if([date] = [exp_date], 1, 0))', 
+        'args'=>['exp_date'=>'2003-03-04]
+        ]),
+
+Alternatively you may also specify either 'aggregate'::
+
+    $book->hasMany('Pages', new Page())
+        ->addField('page_list', [
+            'aggregate'=>$book->refModel('Pages')->expr('group_concat([number], [])', ['-'])
+        ]);
+
+
+or 'field'::
+
+    ->addField('paid_amount', ['aggregate'=>'count', 'field'=>new \atk4\dsql\Expression('*')]);
+
+.. note:: as of 1.3.4 count's field defaults to `*` - no need to specify explicitly.
 
 hasMany / refLink / refModel
 ============================

--- a/docs/references.rst
+++ b/docs/references.rst
@@ -198,15 +198,17 @@ change them (`$m['paid_amount'] = 123;`), you will receive exception.
 Available Aggregation Functions
 -------------------------------
 
-The mathematical aggregates such as sum, avg, min, max and count will automatically
+The mathematical aggregate `sum` will automatically
 default to 0 if no respective rows were provided. The default SQL behaviour is to
 return NULL, but this does go well with the cascading formulas::
 
     coalesce(sum([field]), 0);
 
-For other functions, such as 'group_concat' no coalesce will be used, so the empty
-string will be the result. When you specify `'aggregate'=>'count'` field defaults
-to '*'.
+For other functions, such as `min`, `max`, `avg` and non mathematical aggregates such
+as `group_concat` no zero-coalesce will be used. Expect that result could be zero or
+null.
+
+When you specify `'aggregate'=>'count'` field defaults.
 
 Aggregate Expressions
 ---------------------

--- a/src/Reference_Many.php
+++ b/src/Reference_Many.php
@@ -100,6 +100,7 @@ class Reference_Many extends Reference
         if (isset($defaults['expr'])) {
             $cb = function () use ($defaults, $field) {
                 $r = $this->refLink();
+
                 return $r->action('field', [$r->expr(
                     $defaults['expr'],
                     isset($defaults['args']) ? $defaults['args'] : null
@@ -114,7 +115,7 @@ class Reference_Many extends Reference
             $cb = function () use ($defaults, $field) {
                 return $this->refLink()->action('count', ['alias'=>$field]);
             };
-        } elseif (in_array($defaults['aggregate'], ['sum','avg','min','max','count'])) {
+        } elseif (in_array($defaults['aggregate'], ['sum', 'avg', 'min', 'max', 'count'])) {
             $cb = function () use ($defaults, $field_n) {
                 return $this->refLink()->action('fx0', [$defaults['aggregate'], $field_n]);
             };

--- a/src/Reference_Many.php
+++ b/src/Reference_Many.php
@@ -127,12 +127,6 @@ class Reference_Many extends Reference
 
         $e = $this->owner->addExpression($n, array_merge([$cb], $defaults));
 
-        if (isset($defaults['type'])) {
-            $e->type = $defaults['type'];
-        } else {
-            $e->type = $this->guessFieldType($field);
-        }
-
         return $e;
     }
 

--- a/src/Reference_Many.php
+++ b/src/Reference_Many.php
@@ -86,22 +86,45 @@ class Reference_Many extends Reference
      */
     public function addField($n, $defaults = [])
     {
-        if (!isset($defaults['aggregate'])) {
+        if (!isset($defaults['aggregate']) && !isset($defaults['expr'])) {
             throw new Exception([
-                '"aggregate" strategy should be defined for oneToMany field',
+                '"aggregate" strategy (or "expr") should be defined for oneToMany field',
                 'field'    => $n,
                 'defaults' => $defaults,
             ]);
         }
 
-        $field = isset($defaults['field']) ? $defaults['field'] : $n;
+        $field_n = isset($defaults['field']) ? $defaults['field'] : $n;
+        $field = isset($defaults['field']) ? $defaults['field'] : null;
 
-        $e = $this->owner->addExpression($n, array_merge([
-            function () use ($defaults, $field) {
-                return $this->refLink()->action('fx0', [$defaults['aggregate'], $field]);
-            }, ],
-            $defaults
-        ));
+        if (isset($defaults['expr'])) {
+            $cb = function () use ($defaults, $field) {
+                $r = $this->refLink();
+                return $r->action('field', [$r->expr(
+                    $defaults['expr'],
+                    isset($defaults['args']) ? $defaults['args'] : null
+                ), 'alias'=>$field]);
+            };
+            unset($defaults['args']);
+        } elseif (is_object($defaults['aggregate'])) {
+            $cb = function () use ($defaults, $field) {
+                return $this->refLink()->action('field', [$defaults['aggregate'], 'alias'=>$field]);
+            };
+        } elseif ($defaults['aggregate'] == 'count' && !isset($defaults['field'])) {
+            $cb = function () use ($defaults, $field) {
+                return $this->refLink()->action('count', ['alias'=>$field]);
+            };
+        } elseif (in_array($defaults['aggregate'], ['sum','avg','min','max','count'])) {
+            $cb = function () use ($defaults, $field_n) {
+                return $this->refLink()->action('fx0', [$defaults['aggregate'], $field_n]);
+            };
+        } else {
+            $cb = function () use ($defaults, $field_n) {
+                return $this->refLink()->action('fx', [$defaults['aggregate'], $field_n]);
+            };
+        }
+
+        $e = $this->owner->addExpression($n, array_merge([$cb], $defaults));
 
         if (isset($defaults['type'])) {
             $e->type = $defaults['type'];

--- a/tests/ReferenceSQLTest.php
+++ b/tests/ReferenceSQLTest.php
@@ -301,10 +301,10 @@ class ReferenceSQLTest extends \atk4\schema\PHPUnit_SchemaTestCase
         $db = new Persistence_SQL($this->db->connection);
         $i = (new Model($db, 'invoice'))->addFields(['ref_no']);
         $l = (new Model($db, 'invoice_line'))->addFields([
-            'invoice_id', 
+            'invoice_id',
             ['total_net', 'type'=>'money'],
             ['total_vat', 'type'=>'money'],
-            ['total_gross', 'type'=>'money']
+            ['total_gross', 'type'=>'money'],
         ]);
         $i->hasMany('line', $l)
             ->addFields([
@@ -319,7 +319,6 @@ class ReferenceSQLTest extends \atk4\schema\PHPUnit_SchemaTestCase
 
         // type was not set and is not inherited
         $this->assertEquals(null, $i->getElement('total_net')->type);
-
 
         $this->assertEquals(40, $i['total_net']);
         $this->assertEquals(9.2, $i['total_vat']);

--- a/tests/ReferenceSQLTest.php
+++ b/tests/ReferenceSQLTest.php
@@ -356,9 +356,9 @@ class ReferenceSQLTest extends \atk4\schema\PHPUnit_SchemaTestCase
         $i = (new Model($db, 'item'))->addFields(['list_id', 'name', 'code']);
         $l->hasMany('Items', $i)
             ->addFields([
-                ['items_name','aggregate' => 'count', 'field' => 'name'],
-                ['items_code','aggregate' => 'count', 'field' => 'code'], // counts only not-null values
-                ['items_star','aggregate' => 'count'], // no field set, counts all rows with count(*)
+                ['items_name', 'aggregate' => 'count', 'field' => 'name'],
+                ['items_code', 'aggregate' => 'count', 'field' => 'code'], // counts only not-null values
+                ['items_star', 'aggregate' => 'count'], // no field set, counts all rows with count(*)
                 ['items_c',   'aggregate' => 'group_concat', 'field'=>'name'],
                 ['items_c-',  'aggregate' => $i->expr('group_concat([name], [])', ['-'])],
                 ['len',       'aggregate' => $i->expr('sum(length([name]))')],

--- a/tests/ReferenceSQLTest.php
+++ b/tests/ReferenceSQLTest.php
@@ -324,14 +324,13 @@ class ReferenceSQLTest extends \atk4\schema\PHPUnit_SchemaTestCase
         $this->assertEquals($n * ($vat + 1), $i['total_gross']);
 
         $i->ref('line')->import([
-                ['total_net' => null, 'total_vat' => null, 'total_gross' => 1]
+                ['total_net' => null, 'total_vat' => null, 'total_gross' => 1],
             ]);
         $i->reload();
 
         $this->assertEquals($n = 43, $i['total_net']);
         $this->assertEquals($n * $vat, $i['total_vat']);
         $this->assertEquals($n * ($vat + 1) + 1, $i['total_gross']);
-
     }
 
     public function testOtherAggregates()
@@ -346,7 +345,7 @@ class ReferenceSQLTest extends \atk4\schema\PHPUnit_SchemaTestCase
                 ['name' => 'Apple',  'list_id'=>3],
                 ['name' => 'Banana', 'list_id'=>3],
                 ['name' => 'Pork',   'list_id'=>1],
-                ['name' => 'Chicken','list_id'=>1],
+                ['name' => 'Chicken', 'list_id'=>1],
                 ['name' => 'Pear',   'list_id'=>3],
             ], ];
 
@@ -369,8 +368,8 @@ class ReferenceSQLTest extends \atk4\schema\PHPUnit_SchemaTestCase
         $this->assertEquals(2, $l['items']);
         $this->assertEquals('Pork,Chicken', $l['items_c']);
         $this->assertEquals('Pork-Chicken', $l['items_c-']);
-        $this->assertEquals(strlen('Chicken')+strlen('Pork'), $l['len']);
-        $this->assertEquals(strlen('Chicken')+strlen('Pork'), $l['len2']);
+        $this->assertEquals(strlen('Chicken') + strlen('Pork'), $l['len']);
+        $this->assertEquals(strlen('Chicken') + strlen('Pork'), $l['len2']);
         $this->assertEquals(10, $l['chicken5']);
 
         $l->load(2);

--- a/tests/ReferenceSQLTest.php
+++ b/tests/ReferenceSQLTest.php
@@ -300,14 +300,26 @@ class ReferenceSQLTest extends \atk4\schema\PHPUnit_SchemaTestCase
 
         $db = new Persistence_SQL($this->db->connection);
         $i = (new Model($db, 'invoice'))->addFields(['ref_no']);
-        $l = (new Model($db, 'invoice_line'))->addFields(['invoice_id', 'total_net', 'total_vat', 'total_gross']);
+        $l = (new Model($db, 'invoice_line'))->addFields([
+            'invoice_id', 
+            ['total_net', 'type'=>'money'],
+            ['total_vat', 'type'=>'money'],
+            ['total_gross', 'type'=>'money']
+        ]);
         $i->hasMany('line', $l)
             ->addFields([
-                ['total_vat', 'aggregate' => 'sum'],
+                ['total_vat', 'aggregate' => 'sum', 'type'=>'money'],
                 ['total_net', 'aggregate' => 'sum'],
                 ['total_gross', 'aggregate' => 'sum'],
         ]);
         $i->load('1');
+
+        // type was set explicitly
+        $this->assertEquals('money', $i->getElement('total_vat')->type);
+
+        // type was not set and is not inherited
+        $this->assertEquals(null, $i->getElement('total_net')->type);
+
 
         $this->assertEquals(40, $i['total_net']);
         $this->assertEquals(9.2, $i['total_vat']);

--- a/tests/ReferenceSQLTest.php
+++ b/tests/ReferenceSQLTest.php
@@ -322,6 +322,63 @@ class ReferenceSQLTest extends \atk4\schema\PHPUnit_SchemaTestCase
         $this->assertEquals($n = 43, $i['total_net']);
         $this->assertEquals($n * $vat, $i['total_vat']);
         $this->assertEquals($n * ($vat + 1), $i['total_gross']);
+
+        $i->ref('line')->import([
+                ['total_net' => null, 'total_vat' => null, 'total_gross' => 1]
+            ]);
+        $i->reload();
+
+        $this->assertEquals($n = 43, $i['total_net']);
+        $this->assertEquals($n * $vat, $i['total_vat']);
+        $this->assertEquals($n * ($vat + 1) + 1, $i['total_gross']);
+
+    }
+
+    public function testOtherAggregates()
+    {
+        $vat = 0.23;
+        $a = [
+            'list' => [
+                1 => ['id' => 1, 'name' => 'Meat'],
+                2 => ['id' => 2, 'name' => 'Veg'],
+                3 => ['id' => 3, 'name' => 'Fruit'],
+            ], 'item' => [
+                ['name' => 'Apple',  'list_id'=>3],
+                ['name' => 'Banana', 'list_id'=>3],
+                ['name' => 'Pork',   'list_id'=>1],
+                ['name' => 'Chicken','list_id'=>1],
+                ['name' => 'Pear',   'list_id'=>3],
+            ], ];
+
+        $this->setDB($a);
+
+        $db = new Persistence_SQL($this->db->connection);
+        $l = (new Model($db, 'list'))->addFields(['name']);
+        $i = (new Model($db, 'item'))->addFields(['list_id', 'name']);
+        $l->hasMany('Items', $i)
+            ->addFields([
+                ['items',   'aggregate' => 'count', 'field'=>'name'],
+                ['items_c', 'aggregate' => 'group_concat', 'field'=>'name'],
+                ['items_c-', 'aggregate' => $i->expr('group_concat([name], [])', ['-'])],
+                ['len', 'aggregate' => $i->expr('sum(length([name]))')],
+                ['len2', 'expr' => 'sum(length([name]))'],
+                ['chicken5', 'expr' => 'sum([])', 'args'=>['5']],
+        ]);
+        $l->load(1);
+
+        $this->assertEquals(2, $l['items']);
+        $this->assertEquals('Pork,Chicken', $l['items_c']);
+        $this->assertEquals('Pork-Chicken', $l['items_c-']);
+        $this->assertEquals(strlen('Chicken')+strlen('Pork'), $l['len']);
+        $this->assertEquals(strlen('Chicken')+strlen('Pork'), $l['len2']);
+        $this->assertEquals(10, $l['chicken5']);
+
+        $l->load(2);
+        $this->assertEquals(0, $l['items']);
+        $this->assertEquals('', $l['items_c']);
+        $this->assertEquals(null, $l['len']);
+        $this->assertEquals(null, $l['len2']);
+        $this->assertEquals(null, $l['chicken5']);
     }
 
     public function testReferenceHook()


### PR DESCRIPTION
Implementation of better aggregates. New features:

 - 'aggregate'=>'count' will default 'field' to '*', no need to specify through Expression anymore
 - 'aggregate'=>'group_concat' won't replace empty string with 0
 - 'expr'=>'sum([field])' can be used instead of aggregate
 - 'args' can be passed if you are using 'expr'
 - 'aggregate' can now also be expression ('field' will be unused)

Documentation and test-suite updated.