### PR TITLE
remove method guessFieldType - it was disabled for some time now

### DIFF
--- a/docs/references.rst
+++ b/docs/references.rst
@@ -674,11 +674,3 @@ References are implemented through several classes:
 
     Returns referenced model WITH conditions. (if possible)
 
-.. php:method:: guessFieldType
-
-    This method implementation is removed due to performance but may be
-    reconsidered. Attempts to initialize related model to find out more
-    about the field that is being referenced during the "definition time".
-
-    Normally this would happen only during query time and if the field is
-    included into query.

--- a/src/Reference.php
+++ b/src/Reference.php
@@ -179,42 +179,6 @@ class Reference
         return $this->getModel($defaults);
     }
 
-    /**
-     * If you have set $their_field property correctly, then calling this method
-     * will traverse into a related model and fetch the type of their field. This
-     * method will be extra careful to avoid any loops.
-     *
-     * @param string $their_field
-     *
-     * @return string|null
-     */
-    public function guessFieldType($their_field = null)
-    {
-        return;
-        if (!is_string($their_field)) {
-            return;
-        }
-
-        // We shouldn't traverse into ourselves recursively
-        $cl = get_class($this->owner).'::'.$this->short_name;
-
-        // see where we shouldn't traverse
-        if (isset($this->owner->_do_not_traverse_into)) {
-            $dnti = $this->owner->_do_not_traverse_into;
-
-            if (isset($dnti[$cl])) {
-                return;
-            }
-        }
-        $dnti[$cl] = true;
-
-        $m = $this->getModel(['_do_not_traverse_into' => $dnti]);
-
-        $f = $m->hasElement($their_field ?: $this->their_field);
-
-        return $f ? $f->type : null;
-    }
-
     // {{{ Debug Methods
 
     /**

--- a/src/Reference_One.php
+++ b/src/Reference_One.php
@@ -161,7 +161,7 @@ class Reference_One extends Reference
 
         if (!$this->owner->hasElement($this->our_field)) {
             $this->owner->addField($this->our_field, [
-                'type'              => $this->type, // $this->guessFieldType(),
+                'type'              => $this->type,
                 'reference'         => $this,
                 'system'            => $this->system,
                 'join'              => $this->join,


### PR DESCRIPTION
cleanup removing $reference->guessFieldType(). It wasn't used and had 'return' on first line.