### PR TITLE
Feature/json unserialize error check (compatible with php 7.3)

### DIFF
--- a/src/Model.php
+++ b/src/Model.php
@@ -1987,8 +1987,8 @@ class Model implements \ArrayAccess, \IteratorAggregate
     /**
      * Add expression field.
      *
-     * @param string $name
-     * @param string|array  $expression
+     * @param string       $name
+     * @param string|array $expression
      *
      * @return Field_Callback
      */

--- a/src/Persistence.php
+++ b/src/Persistence.php
@@ -429,14 +429,14 @@ class Persistence
         case 'serialize':
             return unserialize($value);
         case 'json':
-            if(!defined('JSON_THROW_ON_ERROR')){
+            if (!defined('JSON_THROW_ON_ERROR')) {
                 define('JSON_THROW_ON_ERROR', 0);
             }
             $res = json_decode($value, $f->type == 'array', 512, JSON_THROW_ON_ERROR);
             if (json_last_error() !== JSON_ERROR_NONE) {
                 throw new \Exception(json_last_error_msg());
-
             }
+
             return $res;
         case 'base64':
             return base64_decode($value);

--- a/src/Persistence.php
+++ b/src/Persistence.php
@@ -429,14 +429,15 @@ class Persistence
         case 'serialize':
             return unserialize($value);
         case 'json':
-            switch ($f->type) {
-            case 'array':
-                return json_decode($value, true);
-            case 'object':
-                return json_decode($value, false);
+            if(!defined('JSON_THROW_ON_ERROR')){
+                define('JSON_THROW_ON_ERROR', 0);
             }
+            $res = json_decode($value, $f->type == 'array', 512, JSON_THROW_ON_ERROR);
+            if (json_last_error() !== JSON_ERROR_NONE) {
+                throw new \Exception(json_last_error_msg());
 
-            return json_decode($value, true);
+            }
+            return $res;
         case 'base64':
             return base64_decode($value);
         }


### PR DESCRIPTION
You can set field to be serialized with json:

``` php
$this->addField('tags', ['serialize'=>'json']);
```

This is quite handy - you can store values in SQL and have them accessible as array or object in your code.

However, when loading data it is incorrectly formatted, then the value is being reset to null silently. That's because json_decode() does not complain about errors.

This is [addressed in 7.3](https://laravel-news.com/php-7-3-json-error-handling). This PR adds support for that and backward compatibility for versions prior to 7.3.

Incorrectly formatted json with now throw exception preventing you from loosing value.
