### PR TITLE
Getters for protected our_field and their_field

### DIFF
--- a/src/Reference.php
+++ b/src/Reference.php
@@ -179,6 +179,20 @@ class Reference
         return $this->getModel($defaults);
     }
 
+    /**
+     * Getter for protected property our_field.
+     */
+    public function getOurField() {
+        return $this->our_field;
+    }
+
+    /**
+     * Getter for protected property their_field.
+     */
+    public function getTheirField() {
+        return $this->their_field;
+    }
+    
     // {{{ Debug Methods
 
     /**


### PR DESCRIPTION
Makes something like this possible:
Model User
```
$this->hasMany('Email', [new Email(), 'their_field' => 'user_id');
```

```
$new_user = $user->newInstance();
//copy all emails
foreach($user->ref('Email') as $e) {
    $new_e = new Email();
    $new_e->set($e->ref('Email')->getTheirField(), $e->get('email');
    $new_e->save();
}
```

This seems related to the deep copy feature currently being inplemented.