### PR TITLE
Feature/line end normalize

### DIFF
--- a/src/Field.php
+++ b/src/Field.php
@@ -265,10 +265,20 @@ class Field
                 }
                 break;
             case 'string':
+                if (!is_scalar($value)) {
+                    throw new ValidationException([$this->name => 'Must be a string']);
+                }
+                // remove all line-ends
+                $value = trim(str_replace(["\r", "\n"], "", $value));
+                if ($this->required && empty($value)) {
+                    throw new ValidationException([$this->name => 'Must not be empty']);
+                }
+                break;
             case 'text':
                 if (!is_scalar($value)) {
                     throw new ValidationException([$this->name => 'Must be a string']);
                 }
+                // normalize line-ends to LF
                 $value = trim(str_replace(["\r\n", "\r"], "\n", $value));
                 if ($this->required && empty($value)) {
                     throw new ValidationException([$this->name => 'Must not be empty']);

--- a/src/Field.php
+++ b/src/Field.php
@@ -257,7 +257,7 @@ class Field
 
                 return;
             }
-            
+
             // validate scalar values
             if (in_array($f->type, ['string', 'text', 'integer', 'money', 'float']) && !is_scalar($value)) {
                 throw new ValidationException([$this->name => 'Must use scalar value']);
@@ -351,6 +351,7 @@ class Field
                     if (is_object($value)) {
                         throw new ValidationException(['must be a '.$f->type, 'class' => $class, 'value class' => get_class($value)]);
                     }
+
                     throw new ValidationException(['must be a '.$f->type, 'class' => $class, 'value type' => gettype($value)]);
                 }
                 break;

--- a/src/Field.php
+++ b/src/Field.php
@@ -257,7 +257,13 @@ class Field
 
                 return;
             }
+            
+            // validate scalar values
+            if (in_array($f->type, ['string', 'text', 'integer', 'money', 'float']) && !is_scalar($value)) {
+                throw new ValidationException([$this->name => 'Must use scalar value']);
+            }
 
+            // normalize
             switch ($f->type) {
             case null: // loose comparison, but is OK here
                 if ($this->required && empty($value)) {
@@ -265,20 +271,14 @@ class Field
                 }
                 break;
             case 'string':
-                if (!is_scalar($value)) {
-                    throw new ValidationException([$this->name => 'Must be a string']);
-                }
-                // remove all line-ends
+                // remove all line-ends and trim
                 $value = trim(str_replace(["\r", "\n"], '', $value));
                 if ($this->required && empty($value)) {
                     throw new ValidationException([$this->name => 'Must not be empty']);
                 }
                 break;
             case 'text':
-                if (!is_scalar($value)) {
-                    throw new ValidationException([$this->name => 'Must be a string']);
-                }
-                // normalize line-ends to LF
+                // normalize line-ends to LF and trim
                 $value = trim(str_replace(["\r\n", "\r"], "\n", $value));
                 if ($this->required && empty($value)) {
                     throw new ValidationException([$this->name => 'Must not be empty']);
@@ -298,7 +298,7 @@ class Field
                 }
                 break;
             case 'float':
-                $value = str_replace(',', '', $value);
+                $value = preg_replace('/[^0-9.-]/', '', $value);
                 if (!is_numeric($value)) {
                     throw new ValidationException([$this->name => 'Must be numeric']);
                 }
@@ -322,9 +322,9 @@ class Field
                     break;
                 }
                 if (isset($f->enum) && is_array($f->enum)) {
-                    if (isset($f->enum[0]) && $value === $f->enum[0]) {
+                    if (isset($f->enum[0]) && strtolower($value) === strtolower($f->enum[0])) {
                         $value = false;
-                    } elseif (isset($f->enum[1]) && $value === $f->enum[1]) {
+                    } elseif (isset($f->enum[1]) && strtolower($value) === strtolower($f->enum[1])) {
                         $value = true;
                     }
                 } elseif (is_numeric($value)) {
@@ -340,7 +340,6 @@ class Field
             case 'date':
             case 'datetime':
             case 'time':
-
                 // we allow http://php.net/manual/en/datetime.formats.relative.php
                 $class = isset($f->dateTimeClass) ? $f->dateTimeClass : 'DateTime';
 
@@ -349,7 +348,10 @@ class Field
                 } elseif (is_string($value)) {
                     $value = new $class($value);
                 } elseif (!$value instanceof $class) {
-                    throw new Exception(['must be a '.$f->type, 'class' => $class, 'value class' => get_class($value)]);
+                    if (is_object($value)) {
+                        throw new ValidationException(['must be a '.$f->type, 'class' => $class, 'value class' => get_class($value)]);
+                    }
+                    throw new ValidationException(['must be a '.$f->type, 'class' => $class, 'value type' => gettype($value)]);
                 }
                 break;
             case 'array':

--- a/src/Field.php
+++ b/src/Field.php
@@ -269,7 +269,7 @@ class Field
                     throw new ValidationException([$this->name => 'Must be a string']);
                 }
                 // remove all line-ends
-                $value = trim(str_replace(["\r", "\n"], "", $value));
+                $value = trim(str_replace(["\r", "\n"], '', $value));
                 if ($this->required && empty($value)) {
                     throw new ValidationException([$this->name => 'Must not be empty']);
                 }

--- a/tests/FieldTest.php
+++ b/tests/FieldTest.php
@@ -531,8 +531,8 @@ class FieldTest extends \atk4\schema\PHPUnit_SchemaTestCase
     public function testNormalize()
     {
         $m = new Model(['strict_types' => true]);
-        
-        // Field types: 'string', 'text', 'integer', 'money', 'float', 'boolean', 
+
+        // Field types: 'string', 'text', 'integer', 'money', 'float', 'boolean',
         //              'date', 'datetime', 'time', 'array', 'object'
         $m->addField('string', ['type' => 'string']);
         $m->addField('text', ['type' => 'text']);
@@ -549,13 +549,13 @@ class FieldTest extends \atk4\schema\PHPUnit_SchemaTestCase
 
         // string
         $m['string'] = "Two\r\nLines  ";
-        $this->assertSame("TwoLines", $m['string']);
+        $this->assertSame('TwoLines', $m['string']);
 
         $m['string'] = "Two\rLines  ";
-        $this->assertSame("TwoLines", $m['string']);
+        $this->assertSame('TwoLines', $m['string']);
 
         $m['string'] = "Two\nLines  ";
-        $this->assertSame("TwoLines", $m['string']);
+        $this->assertSame('TwoLines', $m['string']);
 
         // text
         $m['text'] = "Two\r\nLines  ";
@@ -568,15 +568,15 @@ class FieldTest extends \atk4\schema\PHPUnit_SchemaTestCase
         $this->assertSame("Two\nLines", $m['text']);
 
         // integer, money, float
-        $m['integer'] = "12,345.67676767"; // no digits after dot
+        $m['integer'] = '12,345.67676767'; // no digits after dot
         $this->assertSame(12345, $m['integer']);
 
-        $m['money'] = "12,345.67676767"; // 4 digits after dot
+        $m['money'] = '12,345.67676767'; // 4 digits after dot
         $this->assertSame(12345.6768, $m['money']);
 
-        $m['float'] = "12,345.67676767"; // don't round
+        $m['float'] = '12,345.67676767'; // don't round
         $this->assertSame(12345.67676767, $m['float']);
-        
+
         // boolean
         $m['boolean'] = 0;
         $this->assertSame(false, $m['boolean']);
@@ -618,6 +618,7 @@ class FieldTest extends \atk4\schema\PHPUnit_SchemaTestCase
         $m->addField('foo', ['type' => 'string']);
         $m['foo'] = [];
     }
+
     /**
      * @expectedException \atk4\data\ValidationException
      */
@@ -627,6 +628,7 @@ class FieldTest extends \atk4\schema\PHPUnit_SchemaTestCase
         $m->addField('foo', ['type' => 'text']);
         $m['foo'] = [];
     }
+
     /**
      * @expectedException \atk4\data\ValidationException
      */
@@ -636,6 +638,7 @@ class FieldTest extends \atk4\schema\PHPUnit_SchemaTestCase
         $m->addField('foo', ['type' => 'integer']);
         $m['foo'] = [];
     }
+
     /**
      * @expectedException \atk4\data\ValidationException
      */
@@ -645,6 +648,7 @@ class FieldTest extends \atk4\schema\PHPUnit_SchemaTestCase
         $m->addField('foo', ['type' => 'money']);
         $m['foo'] = [];
     }
+
     /**
      * @expectedException \atk4\data\ValidationException
      */
@@ -654,6 +658,7 @@ class FieldTest extends \atk4\schema\PHPUnit_SchemaTestCase
         $m->addField('foo', ['type' => 'float']);
         $m['foo'] = [];
     }
+
     /**
      * @expectedException \atk4\data\ValidationException
      */
@@ -663,6 +668,7 @@ class FieldTest extends \atk4\schema\PHPUnit_SchemaTestCase
         $m->addField('foo', ['type' => 'date']);
         $m['foo'] = [];
     }
+
     /**
      * @expectedException \atk4\data\ValidationException
      */
@@ -672,6 +678,7 @@ class FieldTest extends \atk4\schema\PHPUnit_SchemaTestCase
         $m->addField('foo', ['type' => 'datetime']);
         $m['foo'] = [];
     }
+
     /**
      * @expectedException \atk4\data\ValidationException
      */
@@ -681,6 +688,7 @@ class FieldTest extends \atk4\schema\PHPUnit_SchemaTestCase
         $m->addField('foo', ['type' => 'time']);
         $m['foo'] = [];
     }
+
     /**
      * @expectedException \atk4\data\ValidationException
      */
@@ -690,6 +698,7 @@ class FieldTest extends \atk4\schema\PHPUnit_SchemaTestCase
         $m->addField('foo', ['type' => 'integer']);
         $m['foo'] = '123---456';
     }
+
     /**
      * @expectedException \atk4\data\ValidationException
      */
@@ -699,6 +708,7 @@ class FieldTest extends \atk4\schema\PHPUnit_SchemaTestCase
         $m->addField('foo', ['type' => 'money']);
         $m['foo'] = '123---456';
     }
+
     /**
      * @expectedException \atk4\data\ValidationException
      */
@@ -708,6 +718,7 @@ class FieldTest extends \atk4\schema\PHPUnit_SchemaTestCase
         $m->addField('foo', ['type' => 'float']);
         $m['foo'] = '123---456';
     }
+
     /**
      * @expectedException \atk4\data\ValidationException
      */
@@ -717,6 +728,7 @@ class FieldTest extends \atk4\schema\PHPUnit_SchemaTestCase
         $m->addField('foo', ['type' => 'array']);
         $m['foo'] = 'ABC';
     }
+
     /**
      * @expectedException \atk4\data\ValidationException
      */


### PR DESCRIPTION
Normalize `type='string'` field value to one-liner (no line breaks).