### PR TITLE
Fix typo and setOrder() with array args

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,12 +14,12 @@
     ],
     "require": {
         "php": ">=5.6.0",
-        "atk4/dsql": "^1.2",
-        "atk4/core": "^1.3"
+        "atk4/dsql": "dev-develop",
+        "atk4/core": "dev-develop"
     },
     "require-dev": {
         "phpunit/phpunit": "<6",
-        "atk4/schema": "*",
+        "atk4/schema": "dev-develop",
         "codeclimate/php-test-reporter": "*"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -14,12 +14,12 @@
     ],
     "require": {
         "php": ">=5.6.0",
-        "atk4/dsql": "dev-develop",
-        "atk4/core": "dev-develop"
+        "atk4/dsql": "^1.2",
+        "atk4/core": "^1.3"
     },
     "require-dev": {
         "phpunit/phpunit": "<6",
-        "atk4/schema": "dev-develop",
+        "atk4/schema": "*",
         "codeclimate/php-test-reporter": "*"
     },
     "autoload": {

--- a/src/Field.php
+++ b/src/Field.php
@@ -252,7 +252,7 @@ class Field
             // other field types empty value is the same as no-value, nothing or null
             if ($f->type && $f->type != 'string' && $value === '') {
                 if ($this->required && empty($value)) {
-                    throw new ValidationException([$this->name => 'Must not be a empty']);
+                    throw new ValidationException([$this->name => 'Must not be empty']);
                 }
 
                 return;

--- a/src/Model.php
+++ b/src/Model.php
@@ -919,7 +919,11 @@ class Model implements \ArrayAccess, \IteratorAggregate
             }
 
             foreach (array_reverse($field) as $o) {
-                $this->setOrder($o);
+                if (is_array($o)) {
+                    $this->setOrder(...$o);
+                } else {
+                    $this->setOrder($o);
+                }
             }
 
             return $this;


### PR DESCRIPTION
- Fix Typo

- Extend `Model::setOrder()` method to support array args like to set multiple ordering columns with ordering direction (like the method accepts with single column via the 2nd arg):

```
$model->setOrder([['name', false], ['age', true]]);
```