### PR TITLE
Save id value after insert to id_field

### DIFF
--- a/src/Model.php
+++ b/src/Model.php
@@ -1463,6 +1463,7 @@ class Model implements \ArrayAccess, \IteratorAggregate
 
                     $this->dirty = [];
                 } elseif ($this->id) {
+                    $this->set($this->id_field, $this->id);
                     $this->hook('afterInsert', [$this->id]);
 
                     if ($this->reload_after_save !== false) {


### PR DESCRIPTION
fixes #365. Now, Model->get('id') will always return the id (which is known at that point, just only set to $this->id until now), in the afterInsert hook as well as anywhere after if reload_after_save is set to false.