### PR TITLE
Feature/extend setorder even more

### DIFF
--- a/tests/LimitOrderTest.php
+++ b/tests/LimitOrderTest.php
@@ -99,7 +99,7 @@ class LimitOrderTest extends \atk4\schema\PHPUnit_SchemaTestCase
 
         // pass parameters as array elements [field,order]
         $i = clone $ii;
-        $i->setOrder([ ['net', 'desc'], ['vat'] ]);
+        $i->setOrder([['net', 'desc'], ['vat']]);
         $i->onlyFields(['net', 'vat']);
         $this->assertEquals([
             ['net' => 15, 'vat' => 4],


### PR DESCRIPTION
This PR extends https://github.com/atk4/data/pull/364 even more.

* adds test cases
* adds support for `setOrder(['net'=>true, 'vat'=>false, 'gross'])` and adds test cases for them.