### PR TITLE
Save id value after insert to id_field

### DIFF
--- a/src/Field.php
+++ b/src/Field.php
@@ -252,7 +252,7 @@ class Field
             // other field types empty value is the same as no-value, nothing or null
             if ($f->type && $f->type != 'string' && $value === '') {
                 if ($this->required && empty($value)) {
-                    throw new ValidationException([$this->name => 'Must not be a empty']);
+                    throw new ValidationException([$this->name => 'Must not be empty']);
                 }
 
                 return;

--- a/src/Model.php
+++ b/src/Model.php
@@ -919,7 +919,11 @@ class Model implements \ArrayAccess, \IteratorAggregate
             }
 
             foreach (array_reverse($field) as $o) {
-                $this->setOrder($o);
+                if (is_array($o)) {
+                    $this->setOrder(...$o);
+                } else {
+                    $this->setOrder($o);
+                }
             }
 
             return $this;

--- a/tests/PersistentSQLTest.php
+++ b/tests/PersistentSQLTest.php
@@ -110,7 +110,7 @@ class PersistentSQLTest extends \atk4\schema\PHPUnit_SchemaTestCase
         $this->setDB($a);
 
         $m = new Model($this->db, 'user');
-        $m->reload_after_save=false;
+        $m->reload_after_save = false;
         $m->addField('name');
         $m->addField('surname');
 

--- a/tests/PersistentSQLTest.php
+++ b/tests/PersistentSQLTest.php
@@ -110,17 +110,17 @@ class PersistentSQLTest extends \atk4\schema\PHPUnit_SchemaTestCase
         $this->setDB($a);
 
         $m = new Model($this->db, 'user');
-        $m->reload_after_save = false;
         $m->addField('name');
         $m->addField('surname');
 
-        $m->save(['name'=>'John', 'surname'=>'Smith']);
-
-        $this->assertEquals('John', $m['name']);
-
-        $this->assertEquals('Smith', $m['surname']);
-        $this->assertNotEmpty($m->id);
-        $this->assertNotEmpty($m[$m->id_field]);
+        // insert new record, model id field 
+        $m->reload_after_save = false;
+        $m->save(['name'=>'Jane', 'surname'=>'Doe']);
+        $this->assertEquals('Jane', $m['name']);
+        $this->assertEquals('Doe', $m['surname']);
+        $this->assertEquals(3, $m->id);
+        // id field value is set with new id value even if reload_after_save = false
+        $this->assertEquals(3, $m[$m->id_field]);
     }
 
     public function testModelInsertRows()

--- a/tests/PersistentSQLTest.php
+++ b/tests/PersistentSQLTest.php
@@ -113,7 +113,7 @@ class PersistentSQLTest extends \atk4\schema\PHPUnit_SchemaTestCase
         $m->addField('name');
         $m->addField('surname');
 
-        // insert new record, model id field 
+        // insert new record, model id field
         $m->reload_after_save = false;
         $m->save(['name'=>'Jane', 'surname'=>'Doe']);
         $this->assertEquals('Jane', $m['name']);

--- a/tests/PersistentSQLTest.php
+++ b/tests/PersistentSQLTest.php
@@ -99,6 +99,30 @@ class PersistentSQLTest extends \atk4\schema\PHPUnit_SchemaTestCase
         $this->assertEquals('Jones', $m->load($ms[1])['surname']);
     }
 
+    public function testModelSaveNoReload()
+    {
+        $a = [
+            'user' => [
+                1 => ['name' => 'John', 'surname' => 'Smith'],
+                2 => ['name' => 'Sarah', 'surname' => 'Jones'],
+            ],
+        ];
+        $this->setDB($a);
+
+        $m = new Model($this->db, 'user');
+        $m->reload_after_save=false;
+        $m->addField('name');
+        $m->addField('surname');
+
+        $m->save(['name'=>'John', 'surname'=>'Smith']);
+
+        $this->assertEquals('John', $m['name']);
+
+        $this->assertEquals('Smith', $m['surname']);
+        $this->assertNotEmpty($m->id);
+        $this->assertNotEmpty($m[$m->id_field]);
+    }
+
     public function testModelInsertRows()
     {
         $a = [


### PR DESCRIPTION
fixes #365. Now, Model->get('id') will always return the id (which is known at that point, just only set to $this->id until now), in the afterInsert hook as well as anywhere after if reload_after_save is set to false.

Romans: added test-case