### PR TITLE
Implement export() for Array and CSV persistences

### DIFF
--- a/src/Persistence_Array.php
+++ b/src/Persistence_Array.php
@@ -253,4 +253,21 @@ class Persistence_Array extends Persistence
     {
         return $this->data[$m->table];
     }
+
+    /**
+     * Export all DataSet.
+     *
+     * @param Model      $m
+     * @param array|null $fields
+     *
+     * @return array
+     */
+    public function export(Model $m, $fields = null)
+    {
+        $keys = $fields ? array_flip($fields) : null;
+
+        return array_map(function ($r) use ($m, $keys) {
+            return $this->typecastLoadRow($m, $keys ? array_intersect_key($r, $keys) : $r);
+        }, $this->data[$m->table]);
+    }
 }

--- a/tests/CSVTest.php
+++ b/tests/CSVTest.php
@@ -131,4 +131,31 @@ class CSVTest extends \atk4\core\PHPUnit_AgileTestCase
             file_get_contents($this->file)
         );
     }
+
+    /**
+     * Test export.
+     */
+    public function testExport()
+    {
+        $data = [
+                ['name' => 'John', 'surname' => 'Smith'],
+                ['name' => 'Sarah', 'surname' => 'Jones'],
+            ];
+        $this->setDB($data);
+
+        $p = new Persistence_CSV($this->file);
+        $m = new Model($p);
+        $m->addField('name');
+        $m->addField('surname');
+
+        $this->assertEquals([
+            ['id' => 1, 'name' => 'John', 'surname' => 'Smith'],
+            ['id' => 2, 'name' => 'Sarah', 'surname' => 'Jones'],
+        ],$m->export());
+
+        $this->assertEquals([
+            ['surname' => 'Smith'],
+            ['surname' => 'Jones'],
+        ],$m->export(['surname']));
+    }
 }

--- a/tests/CSVTest.php
+++ b/tests/CSVTest.php
@@ -151,11 +151,11 @@ class CSVTest extends \atk4\core\PHPUnit_AgileTestCase
         $this->assertEquals([
             ['id' => 1, 'name' => 'John', 'surname' => 'Smith'],
             ['id' => 2, 'name' => 'Sarah', 'surname' => 'Jones'],
-        ],$m->export());
+        ], $m->export());
 
         $this->assertEquals([
             ['surname' => 'Smith'],
             ['surname' => 'Jones'],
-        ],$m->export(['surname']));
+        ], $m->export(['surname']));
     }
 }

--- a/tests/PersistentArrayTest.php
+++ b/tests/PersistentArrayTest.php
@@ -290,4 +290,30 @@ class PersistentArrayTest extends \atk4\core\PHPUnit_AgileTestCase
         $m = new Model(new Persistence());
         $m->export();
     }
+
+    /**
+     * Test export.
+     */
+    public function testExport()
+    {
+        $a = [
+            1 => ['name' => 'John', 'surname' => 'Smith'],
+            2 => ['name' => 'Sarah', 'surname' => 'Jones'],
+        ];
+
+        $p = new Persistence_Array($a);
+        $m = new Model($p);
+        $m->addField('name');
+        $m->addField('surname');
+
+        $this->assertEquals([
+            1 => ['name' => 'John', 'surname' => 'Smith'],
+            2 => ['name' => 'Sarah', 'surname' => 'Jones'],
+        ],$m->export());
+
+        $this->assertEquals([
+            1 => ['surname' => 'Smith'],
+            2 => ['surname' => 'Jones'],
+        ],$m->export(['surname']));
+    }
 }

--- a/tests/PersistentArrayTest.php
+++ b/tests/PersistentArrayTest.php
@@ -309,11 +309,11 @@ class PersistentArrayTest extends \atk4\core\PHPUnit_AgileTestCase
         $this->assertEquals([
             1 => ['name' => 'John', 'surname' => 'Smith'],
             2 => ['name' => 'Sarah', 'surname' => 'Jones'],
-        ],$m->export());
+        ], $m->export());
 
         $this->assertEquals([
             1 => ['surname' => 'Smith'],
             2 => ['surname' => 'Jones'],
-        ],$m->export(['surname']));
+        ], $m->export(['surname']));
     }
 }

--- a/tests/PersistentSQLTest.php
+++ b/tests/PersistentSQLTest.php
@@ -176,4 +176,31 @@ class PersistentSQLTest extends \atk4\schema\PHPUnit_SchemaTestCase
         $m->load($ids[1]);
         $this->assertEquals('Smith', $m['surname']);
     }
+
+    /**
+     * Test export.
+     */
+    public function testExport()
+    {
+        $a = [
+            'user' => [
+                1 => ['name' => 'John', 'surname' => 'Smith'],
+                2 => ['name' => 'Sarah', 'surname' => 'Jones'],
+            ], ];
+        $this->setDB($a);
+
+        $m = new Model($this->db, 'user');
+        $m->addField('name');
+        $m->addField('surname');
+
+        $this->assertEquals([
+            ['id' => 1, 'name' => 'John', 'surname' => 'Smith'],
+            ['id' => 2, 'name' => 'Sarah', 'surname' => 'Jones'],
+        ],$m->export());
+
+        $this->assertEquals([
+            ['surname' => 'Smith'],
+            ['surname' => 'Jones'],
+        ],$m->export(['surname']));
+    }
 }

--- a/tests/PersistentSQLTest.php
+++ b/tests/PersistentSQLTest.php
@@ -196,11 +196,11 @@ class PersistentSQLTest extends \atk4\schema\PHPUnit_SchemaTestCase
         $this->assertEquals([
             ['id' => 1, 'name' => 'John', 'surname' => 'Smith'],
             ['id' => 2, 'name' => 'Sarah', 'surname' => 'Jones'],
-        ],$m->export());
+        ], $m->export());
 
         $this->assertEquals([
             ['surname' => 'Smith'],
             ['surname' => 'Jones'],
-        ],$m->export(['surname']));
+        ], $m->export(['surname']));
     }
 }


### PR DESCRIPTION
* Implement `export()` for Array and CSV persistences.
* fix #312
* add tests