### PR TITLE
implement Array persistence traversal, conditions and actions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ phpunit-mysql-local.xml
 /vendor
 .DS_Store
 /.idea
+atk-test*.csv

--- a/src/Action/Iterator.php
+++ b/src/Action/Iterator.php
@@ -92,7 +92,7 @@ class Iterator
      */
     public function limit($cnt, $shift = 0)
     {
-        $data = array_slice($this->get(), $shift, $cnt, TRUE);
+        $data = array_slice($this->get(), $shift, $cnt, true);
 
         // put data back in generator
         $this->generator = new \ArrayIterator($data);

--- a/src/Action/Iterator.php
+++ b/src/Action/Iterator.php
@@ -11,12 +11,12 @@ use Guzzle\Iterator\FilterIterator;
 class Iterator
 {
     /**
-     * @var array
+     * @var \ArrayIterator
      */
     public $generator;
 
     /**
-     * Array_ constructor.
+     * Iterator constructor.
      *
      * @param $generator
      */
@@ -66,13 +66,20 @@ class Iterator
     }
 
     /**
-     * @return array get all data inside array
+     * Return all data inside array.
+     *
+     * @return array
      */
     public function get()
     {
         return iterator_to_array($this->generator, true);
     }
 
+    /**
+     * Return one row of data.
+     *
+     * @return array
+     */
     public function getRow()
     {
         $row = $this->generator->current();
@@ -81,6 +88,11 @@ class Iterator
         return $row;
     }
 
+    /**
+     * Return one value from one row of data.
+     *
+     * @return mixed
+     */
     public function getOne()
     {
         $data = $this->getRow();

--- a/src/Action/Iterator.php
+++ b/src/Action/Iterator.php
@@ -1,0 +1,92 @@
+<?php
+
+
+namespace atk4\data\Action;
+
+
+use Guzzle\Iterator\FilterIterator;
+
+/**
+ * Class Array_ is returned by $model->action(). Compatible with DSQL to a certain point as it implements
+ * specific actions such as getOne() or get().
+ *
+ * @package atk4\data\Action
+ */
+class Iterator
+{
+    /**
+     * @var array
+     */
+    public $generator;
+
+    /**
+     * Array_ constructor.
+     *
+     * @param $generator
+     */
+    function __construct(array $generator)
+    {
+        $this->generator = new \ArrayIterator($generator);
+    }
+
+    /**
+     * Applies FilterIterator making sure that values of $field equal to $value
+     *
+     * @param $field
+     * @param $value
+     *
+     * @return $this
+     */
+    function where($field, $value) {
+        $this->generator = new \CallbackFilterIterator($this->generator, function($row) use ($field, $value) {
+
+            // skip row. does not have field at all
+            if (!isset($row[$field])) {
+                return false;
+            }
+
+            // has row and it matches
+            if ($row[$field] == $value) {
+                return true;
+            }
+
+            return false;
+        });
+
+        return $this;
+    }
+
+    /**
+     * Counts number of rows and replaces our generator with just a single number
+     *
+     * @return $this
+     */
+    function count()
+    {
+        $this->generator = new \ArrayIterator([[iterator_count($this->generator)]]);
+
+        return $this;
+    }
+
+
+    /**
+     * @return array get all data inside array
+     */
+    function get()
+    {
+        return iterator_to_array($this->generator, true);
+    }
+
+    function getRow(){
+
+        $row = $this->generator->current();
+        $this->generator->next();
+
+        return $row;
+    }
+
+    function getOne(){
+        $data = $this->getRow();
+        return array_shift($data);
+    }
+}

--- a/src/Action/Iterator.php
+++ b/src/Action/Iterator.php
@@ -1,16 +1,12 @@
 <?php
 
-
 namespace atk4\data\Action;
-
 
 use Guzzle\Iterator\FilterIterator;
 
 /**
  * Class Array_ is returned by $model->action(). Compatible with DSQL to a certain point as it implements
  * specific actions such as getOne() or get().
- *
- * @package atk4\data\Action
  */
 class Iterator
 {
@@ -24,21 +20,22 @@ class Iterator
      *
      * @param $generator
      */
-    function __construct(array $generator)
+    public function __construct(array $generator)
     {
         $this->generator = new \ArrayIterator($generator);
     }
 
     /**
-     * Applies FilterIterator making sure that values of $field equal to $value
+     * Applies FilterIterator making sure that values of $field equal to $value.
      *
      * @param $field
      * @param $value
      *
      * @return $this
      */
-    function where($field, $value) {
-        $this->generator = new \CallbackFilterIterator($this->generator, function($row) use ($field, $value) {
+    public function where($field, $value)
+    {
+        $this->generator = new \CallbackFilterIterator($this->generator, function ($row) use ($field, $value) {
 
             // skip row. does not have field at all
             if (!isset($row[$field])) {
@@ -57,36 +54,37 @@ class Iterator
     }
 
     /**
-     * Counts number of rows and replaces our generator with just a single number
+     * Counts number of rows and replaces our generator with just a single number.
      *
      * @return $this
      */
-    function count()
+    public function count()
     {
         $this->generator = new \ArrayIterator([[iterator_count($this->generator)]]);
 
         return $this;
     }
 
-
     /**
      * @return array get all data inside array
      */
-    function get()
+    public function get()
     {
         return iterator_to_array($this->generator, true);
     }
 
-    function getRow(){
-
+    public function getRow()
+    {
         $row = $this->generator->current();
         $this->generator->next();
 
         return $row;
     }
 
-    function getOne(){
+    public function getOne()
+    {
         $data = $this->getRow();
+
         return array_shift($data);
     }
 }

--- a/src/Action/Iterator.php
+++ b/src/Action/Iterator.php
@@ -18,18 +18,18 @@ class Iterator
     /**
      * Iterator constructor.
      *
-     * @param $generator
+     * @param array $data
      */
-    public function __construct(array $generator)
+    public function __construct(array $data)
     {
-        $this->generator = new \ArrayIterator($generator);
+        $this->generator = new \ArrayIterator($data);
     }
 
     /**
      * Applies FilterIterator making sure that values of $field equal to $value.
      *
-     * @param $field
-     * @param $value
+     * @param string $field
+     * @param string $value
      *
      * @return $this
      */
@@ -49,6 +49,53 @@ class Iterator
 
             return false;
         });
+
+        return $this;
+    }
+
+    /**
+     * Applies sorting on Iterator.
+     *
+     * @param array $fields
+     *
+     * @return $this
+     */
+    public function order($fields)
+    {
+        $data = $this->get();
+
+        // prepare arguments for array_multisort()
+        $args = [];
+        foreach ($fields as list($field, $desc)) {
+            $args[] = array_column($data, $field);
+            $args[] = $desc ? SORT_DESC : SORT_ASC;
+            //$args[] = SORT_STRING; // SORT_STRING | SORT_NUMERIC | SORT_REGULAR
+        }
+        $args[] = &$data;
+
+        // call sorting
+        call_user_func_array('array_multisort', $args);
+
+        // put data back in generator
+        $this->generator = new \ArrayIterator(array_pop($args));
+
+        return $this;
+    }
+
+    /**
+     * Limit Iterator.
+     *
+     * @param int $cnt
+     * @param int $shift
+     *
+     * @return $this
+     */
+    public function limit($cnt, $shift = 0)
+    {
+        $data = array_slice($this->get(), $shift, $cnt, TRUE);
+
+        // put data back in generator
+        $this->generator = new \ArrayIterator($data);
 
         return $this;
     }

--- a/src/Persistence_Array.php
+++ b/src/Persistence_Array.php
@@ -266,6 +266,7 @@ class Persistence_Array extends Persistence
     {
         $action = $this->initAction($m, $fields);
         $this->applyConditions($m, $action);
+
         return $action->get();
     }
 
@@ -277,7 +278,6 @@ class Persistence_Array extends Persistence
      */
     public function initAction(Model $m, $fields = null)
     {
-
         $keys = $fields ? array_flip($fields) : null;
 
         $data = array_map(function ($r) use ($m, $keys) {
@@ -309,10 +309,9 @@ class Persistence_Array extends Persistence
             // parameter inside where()
 
             if (count($cond) == 1) {
-
                 throw new Exception([
                     'Condition not acceptable for Array persistence',
-                    'condition'=>$cond
+                    'condition'=> $cond,
                 ]);
                 /*
                 // OR conditions
@@ -337,11 +336,11 @@ class Persistence_Array extends Persistence
                 if ($cond[0] instanceof Field) {
                     $cond[1] = $this->typecastSaveField($cond[0], $cond[1]);
                 }
-                $q->where(is_string($cond[0]) ? $cond[0]: $cond[0]->short_name, $cond[1]);
+                $q->where(is_string($cond[0]) ? $cond[0] : $cond[0]->short_name, $cond[1]);
             } else {
                 throw new Exception([
                     'Condition not acceptable for Array persistence',
-                    'condition'=>$cond
+                    'condition'=> $cond,
                 ]);
 
                 /*
@@ -355,7 +354,7 @@ class Persistence_Array extends Persistence
     }
 
     /**
-     * Various actions possible here, mostly for compatibility for SQLs
+     * Various actions possible here, mostly for compatibility for SQLs.
      *
      * @param Model  $m
      * @param string $type
@@ -402,8 +401,5 @@ class Persistence_Array extends Persistence
                     'type' => $type,
                 ]);
         }
-
     }
-
-
 }

--- a/src/Persistence_Array.php
+++ b/src/Persistence_Array.php
@@ -264,10 +264,146 @@ class Persistence_Array extends Persistence
      */
     public function export(Model $m, $fields = null)
     {
+        $action = $this->initAction($m, $fields);
+        $this->applyConditions($m, $action);
+        return $action->get();
+    }
+
+    /**
+     * @param Model $m
+     * @param array $fields
+     *
+     * @return Action\Iterator
+     */
+    public function initAction(Model $m, $fields = null)
+    {
+
         $keys = $fields ? array_flip($fields) : null;
 
-        return array_map(function ($r) use ($m, $keys) {
+        $data = array_map(function ($r) use ($m, $keys) {
             return $this->typecastLoadRow($m, $keys ? array_intersect_key($r, $keys) : $r);
         }, $this->data[$m->table]);
+
+        return new Action\Iterator($data);
     }
+
+    /**
+     * Will apply conditions defined inside $m onto query $q.
+     *
+     * @param Model            $m
+     * @param \atk4\dsql\Query $q
+     *
+     * @return \atk4\dsql\Query
+     */
+    public function applyConditions(Model $m, Action\Iterator $q)
+    {
+        if (!isset($m->conditions)) {
+            // no conditions are set in the model
+            return $q;
+        }
+
+        foreach ($m->conditions as $cond) {
+
+            // Options here are:
+            // count($cond) == 1, we will pass the only
+            // parameter inside where()
+
+            if (count($cond) == 1) {
+
+                throw new Exception([
+                    'Condition not acceptable for Array persistence',
+                    'condition'=>$cond
+                ]);
+                /*
+                // OR conditions
+                if (is_array($cond[0])) {
+                    foreach ($cond[0] as &$row) {
+                        if (is_string($row[0])) {
+                            $row[0] = $m->getElement($row[0]);
+                        }
+                    }
+                }
+
+                $q->where($cond[0]);
+                continue;
+                */
+            }
+
+            if (is_string($cond[0])) {
+                $cond[0] = $m->getElement($cond[0]);
+            }
+
+            if (count($cond) == 2) {
+                if ($cond[0] instanceof Field) {
+                    $cond[1] = $this->typecastSaveField($cond[0], $cond[1]);
+                }
+                $q->where(is_string($cond[0]) ? $cond[0]: $cond[0]->short_name, $cond[1]);
+            } else {
+                throw new Exception([
+                    'Condition not acceptable for Array persistence',
+                    'condition'=>$cond
+                ]);
+
+                /*
+                if ($cond[0] instanceof Field) {
+                    $cond[2] = $this->typecastSaveField($cond[0], $cond[2]);
+                }
+                $q->where($cond[0], $cond[1], $cond[2]);
+                */
+            }
+        }
+    }
+
+    /**
+     * Various actions possible here, mostly for compatibility for SQLs
+     *
+     * @param Model  $m
+     * @param string $type
+     * @param array  $args
+     *
+     * @return \atk4\dsql\Query,Iterator\Action
+     */
+    public function action($m, $type, $args = [])
+    {
+        if (!is_array($args)) {
+            throw new Exception([
+                '$args must be an array',
+                'args' => $args,
+            ]);
+        }
+
+        $action = $this->initAction($m);
+
+        $this->applyConditions($m, $action);
+
+        switch ($type) {
+            case 'select':
+
+                return $action;
+
+            case 'count':
+
+                return $action->count();
+
+            case 'field':
+
+                $field = is_string($args[0]) ? $m->getElement($args[0]) : $args[0];
+
+                return $action->filterField($field->short_name);
+
+            case 'fx':
+            case 'fx0':
+
+                return $action->aggregate($field->short_name, $fx);
+
+            default:
+                throw new Exception([
+                    'Unsupported action mode',
+                    'type' => $type,
+                ]);
+        }
+
+    }
+
+
 }

--- a/src/Persistence_Array.php
+++ b/src/Persistence_Array.php
@@ -271,6 +271,8 @@ class Persistence_Array extends Persistence
     }
 
     /**
+     * Typecast data and return Iterator of data array.
+     *
      * @param Model $m
      * @param array $fields
      *
@@ -290,10 +292,10 @@ class Persistence_Array extends Persistence
     /**
      * Will apply conditions defined inside $m onto query $q.
      *
-     * @param Model            $m
-     * @param \atk4\dsql\Query $q
+     * @param Model           $m
+     * @param Action\Iterator $q
      *
-     * @return \atk4\dsql\Query
+     * @return Action\Iterator
      */
     public function applyConditions(Model $m, Action\Iterator $q)
     {
@@ -311,7 +313,7 @@ class Persistence_Array extends Persistence
             if (count($cond) == 1) {
                 throw new Exception([
                     'Condition not acceptable for Array persistence',
-                    'condition'=> $cond,
+                    'condition' => $cond,
                 ]);
                 /*
                 // OR conditions
@@ -354,7 +356,7 @@ class Persistence_Array extends Persistence
     }
 
     /**
-     * Various actions possible here, mostly for compatibility for SQLs.
+     * Various actions possible here, mostly for compatibility with SQLs.
      *
      * @param Model  $m
      * @param string $type
@@ -384,6 +386,7 @@ class Persistence_Array extends Persistence
 
                 return $action->count();
 
+            /* These are not implemented yet
             case 'field':
 
                 $field = is_string($args[0]) ? $m->getElement($args[0]) : $args[0];
@@ -394,6 +397,7 @@ class Persistence_Array extends Persistence
             case 'fx0':
 
                 return $action->aggregate($field->short_name, $fx);
+            */
 
             default:
                 throw new Exception([

--- a/tests/PersistentArrayTest.php
+++ b/tests/PersistentArrayTest.php
@@ -317,15 +317,68 @@ class PersistentArrayTest extends \atk4\core\PHPUnit_AgileTestCase
         $m->addField('surname');
 
         $this->assertEquals(4, $m->action('count')->getOne());
+        $this->assertEquals($a['data'], $m->export());
+
         $m->addCondition('name', 'Sarah');
         $this->assertEquals(3, $m->action('count')->getOne());
+
         $m->addCondition('surname', 'Smith');
-
-        $this->assertEquals([4=>['name'=>'Sarah', 'surname'=>'Smith']], $m->export());
-
         $this->assertEquals(1, $m->action('count')->getOne());
+        $this->assertEquals([4=>['name'=>'Sarah', 'surname'=>'Smith']], $m->export());
+        $this->assertEquals([4=>['name'=>'Sarah', 'surname'=>'Smith']], $m->action('select')->get());
+
         $m->addCondition('surname', 'Siiiith');
         $this->assertEquals(0, $m->action('count')->getOne());
+    }
+
+    /**
+     * @expectedException Exception
+     */
+    public function testUnsupportedAction()
+    {
+        $a = [1=>['name'=>'John']];
+        $p = new Persistence_Array($a);
+        $m = new Model($p);
+        $m->addField('name');
+        $m->action('foo');
+    }
+
+    /**
+     * @expectedException Exception
+     */
+    public function testBadActionArgs()
+    {
+        $a = [1=>['name'=>'John']];
+        $p = new Persistence_Array($a);
+        $m = new Model($p);
+        $m->addField('name');
+        $m->action('select', 'foo'); // args should be array
+    }
+
+    /**
+     * @expectedException Exception
+     */
+    public function testUnsupportedCondition1()
+    {
+        $a = [1=>['name'=>'John']];
+        $p = new Persistence_Array($a);
+        $m = new Model($p);
+        $m->addField('name');
+        $m->addCondition('name');
+        $m->export();
+    }
+
+    /**
+     * @expectedException Exception
+     */
+    public function testUnsupportedCondition2()
+    {
+        $a = [1=>['name'=>'John']];
+        $p = new Persistence_Array($a);
+        $m = new Model($p);
+        $m->addField('name');
+        $m->addCondition('name', '<>', 'John');
+        $m->export();
     }
 
     public function testHasOne()

--- a/tests/PersistentArrayTest.php
+++ b/tests/PersistentArrayTest.php
@@ -349,11 +349,11 @@ class PersistentArrayTest extends \atk4\core\PHPUnit_AgileTestCase
         $d = $this->_getRows($m, ['f1']);
         $this->assertEquals([
             ['f1'=>'A'],
-            ['f1'=>'A'],
-            ['f1'=>'C'],
-            ['f1'=>'D'],
-            ['f1'=>'D'],
-            ['f1'=>'E'],
+            ['f1'=> 'A'],
+            ['f1'=> 'C'],
+            ['f1'=> 'D'],
+            ['f1'=> 'D'],
+            ['f1'=> 'E'],
         ], $d);
         $this->assertEquals($d, array_values($m->export(['f1']))); // array_values to get rid of keys
 
@@ -367,11 +367,11 @@ class PersistentArrayTest extends \atk4\core\PHPUnit_AgileTestCase
         $d = $this->_getRows($m, ['f1']);
         $this->assertEquals([
             ['f1'=>'E'],
-            ['f1'=>'D'],
-            ['f1'=>'D'],
-            ['f1'=>'C'],
-            ['f1'=>'A'],
-            ['f1'=>'A'],
+            ['f1'=> 'D'],
+            ['f1'=> 'D'],
+            ['f1'=> 'C'],
+            ['f1'=> 'A'],
+            ['f1'=> 'A'],
         ], $d);
         $this->assertEquals($d, array_values($m->export(['f1']))); // array_values to get rid of keys
 
@@ -387,11 +387,11 @@ class PersistentArrayTest extends \atk4\core\PHPUnit_AgileTestCase
         $d = $this->_getRows($m, ['f1', 'f2', 'id']);
         $this->assertEquals([
             ['f1'=>'E', 'f2'=>'A', 'id'=>5],
-            ['f1'=>'D', 'f2'=>'C', 'id'=>3],
-            ['f1'=>'D', 'f2'=>'A', 'id'=>2],
-            ['f1'=>'C', 'f2'=>'A', 'id'=>6],
-            ['f1'=>'A', 'f2'=>'C', 'id'=>4],
-            ['f1'=>'A', 'f2'=>'B', 'id'=>1],
+            ['f1'=> 'D', 'f2'=>'C', 'id'=>3],
+            ['f1'=> 'D', 'f2'=>'A', 'id'=>2],
+            ['f1'=> 'C', 'f2'=>'A', 'id'=>6],
+            ['f1'=> 'A', 'f2'=>'C', 'id'=>4],
+            ['f1'=> 'A', 'f2'=>'B', 'id'=>1],
         ], $d);
         $this->assertEquals($d, array_values($m->export(['f1', 'f2', 'id']))); // array_values to get rid of keys
     }
@@ -423,7 +423,7 @@ class PersistentArrayTest extends \atk4\core\PHPUnit_AgileTestCase
             ['f1' => 'E'],
         ], array_values($m->export()));
 
-        $m->setLimit(2,1);
+        $m->setLimit(2, 1);
         $this->assertEquals(2, $m->action('count')->getOne());
         $this->assertEquals([
             ['f1' => 'D'],

--- a/tests/PersistentArrayTest.php
+++ b/tests/PersistentArrayTest.php
@@ -316,4 +316,38 @@ class PersistentArrayTest extends \atk4\core\PHPUnit_AgileTestCase
             2 => ['surname' => 'Jones'],
         ], $m->export(['surname']));
     }
+
+    public function testHasOne()
+    {
+        $a = [
+            'user' => [
+                1 => ['name' => 'John', 'surname' => 'Smith', 'country_id'=>1],
+                2 => ['name' => 'Sarah', 'surname' => 'Jones', 'country_id'=>2],
+            ],
+            'country'=>[
+                1 => ['name' => 'Latvia'],
+                2 => ['name' => 'UK'],
+            ]
+        ];
+
+        $p = new Persistence_Array($a);
+
+
+        $user = new Model($p, 'user');
+        $user->addField('name');
+        $user->addField('surname');
+
+        $country = new Model();
+        $country->table='country';
+        $country->addField('name');
+
+        $user->hasOne('country_id', $country);
+
+        $user->load(1);
+        $this->assertEquals('Latvia', $user->ref('country_id')['name']);
+
+        $user->load(2);
+        $this->assertEquals('UK', $user->ref('country_id')['name']);
+
+    }
 }

--- a/tests/PersistentArrayTest.php
+++ b/tests/PersistentArrayTest.php
@@ -328,7 +328,6 @@ class PersistentArrayTest extends \atk4\core\PHPUnit_AgileTestCase
         $this->assertEquals(0, $m->action('count')->getOne());
     }
 
-
     public function testHasOne()
     {
         $a = [
@@ -369,21 +368,19 @@ class PersistentArrayTest extends \atk4\core\PHPUnit_AgileTestCase
                 2 => ['name' => 'Sarah', 'surname' => 'Jones', 'country_id'=>2],
                 3 => ['name' => 'Janis', 'surname' => 'Berzins', 'country_id'=>1],
             ],
-            'country'=>[
+            'country'=> [
                 1 => ['name' => 'Latvia'],
                 2 => ['name' => 'UK'],
-            ]
+            ],
         ];
 
         $p = new Persistence_Array($a);
-
-
 
         $country = new Model($p, 'country');
         $country->addField('name');
 
         $user = new Model();
-        $user->table='user';
+        $user->table = 'user';
         $user->addField('name');
         $user->addField('surname');
 
@@ -394,6 +391,6 @@ class PersistentArrayTest extends \atk4\core\PHPUnit_AgileTestCase
         $this->assertEquals(2, $country->ref('Users')->action('count')->getOne());
 
         $country->load(2);
-        $this->assertEquals(1 , $country->ref('Users')->action('count')->getOne());
+        $this->assertEquals(1, $country->ref('Users')->action('count')->getOne());
     }
 }


### PR DESCRIPTION
Array persistence currently does not support even basic conditions or actions. I have implemented those and now array persistence models can also be traversed.

``` php
$user = new User($array_persistence);
$user->addCondition('name', 'foo');
echo $user->action('count')->getOne();  // 123
```

 - [ ] TODO - look for inconsistency in documentation
 - [x] TODO - check if Grid now works ok with paginator