### PR TITLE
Feature/json persistence

### DIFF
--- a/src/Action/Iterator.php
+++ b/src/Action/Iterator.php
@@ -1,0 +1,92 @@
+<?php
+
+
+namespace atk4\data\Action;
+
+
+use Guzzle\Iterator\FilterIterator;
+
+/**
+ * Class Array_ is returned by $model->action(). Compatible with DSQL to a certain point as it implements
+ * specific actions such as getOne() or get().
+ *
+ * @package atk4\data\Action
+ */
+class Iterator
+{
+    /**
+     * @var array
+     */
+    public $generator;
+
+    /**
+     * Array_ constructor.
+     *
+     * @param $generator
+     */
+    function __construct(array $generator)
+    {
+        $this->generator = new \ArrayIterator($generator);
+    }
+
+    /**
+     * Applies FilterIterator making sure that values of $field equal to $value
+     *
+     * @param $field
+     * @param $value
+     *
+     * @return $this
+     */
+    function where($field, $value) {
+        $this->generator = new \CallbackFilterIterator($this->generator, function($row) use ($field, $value) {
+
+            // skip row. does not have field at all
+            if (!isset($row[$field])) {
+                return false;
+            }
+
+            // has row and it matches
+            if ($row[$field] == $value) {
+                return true;
+            }
+
+            return false;
+        });
+
+        return $this;
+    }
+
+    /**
+     * Counts number of rows and replaces our generator with just a single number
+     *
+     * @return $this
+     */
+    function count()
+    {
+        $this->generator = new \ArrayIterator([[iterator_count($this->generator)]]);
+
+        return $this;
+    }
+
+
+    /**
+     * @return array get all data inside array
+     */
+    function get()
+    {
+        return iterator_to_array($this->generator, true);
+    }
+
+    function getRow(){
+
+        $row = $this->generator->current();
+        $this->generator->next();
+
+        return $row;
+    }
+
+    function getOne(){
+        $data = $this->getRow();
+        return array_shift($data);
+    }
+}

--- a/src/Action/Iterator.php
+++ b/src/Action/Iterator.php
@@ -1,16 +1,12 @@
 <?php
 
-
 namespace atk4\data\Action;
-
 
 use Guzzle\Iterator\FilterIterator;
 
 /**
  * Class Array_ is returned by $model->action(). Compatible with DSQL to a certain point as it implements
  * specific actions such as getOne() or get().
- *
- * @package atk4\data\Action
  */
 class Iterator
 {
@@ -24,21 +20,22 @@ class Iterator
      *
      * @param $generator
      */
-    function __construct(array $generator)
+    public function __construct(array $generator)
     {
         $this->generator = new \ArrayIterator($generator);
     }
 
     /**
-     * Applies FilterIterator making sure that values of $field equal to $value
+     * Applies FilterIterator making sure that values of $field equal to $value.
      *
      * @param $field
      * @param $value
      *
      * @return $this
      */
-    function where($field, $value) {
-        $this->generator = new \CallbackFilterIterator($this->generator, function($row) use ($field, $value) {
+    public function where($field, $value)
+    {
+        $this->generator = new \CallbackFilterIterator($this->generator, function ($row) use ($field, $value) {
 
             // skip row. does not have field at all
             if (!isset($row[$field])) {
@@ -57,36 +54,37 @@ class Iterator
     }
 
     /**
-     * Counts number of rows and replaces our generator with just a single number
+     * Counts number of rows and replaces our generator with just a single number.
      *
      * @return $this
      */
-    function count()
+    public function count()
     {
         $this->generator = new \ArrayIterator([[iterator_count($this->generator)]]);
 
         return $this;
     }
 
-
     /**
      * @return array get all data inside array
      */
-    function get()
+    public function get()
     {
         return iterator_to_array($this->generator, true);
     }
 
-    function getRow(){
-
+    public function getRow()
+    {
         $row = $this->generator->current();
         $this->generator->next();
 
         return $row;
     }
 
-    function getOne(){
+    public function getOne()
+    {
         $data = $this->getRow();
+
         return array_shift($data);
     }
 }

--- a/src/Persistence_Array.php
+++ b/src/Persistence_Array.php
@@ -266,6 +266,7 @@ class Persistence_Array extends Persistence
     {
         $action = $this->initAction($m, $fields);
         $this->applyConditions($m, $action);
+
         return $action->get();
     }
 
@@ -277,7 +278,6 @@ class Persistence_Array extends Persistence
      */
     public function initAction(Model $m, $fields = null)
     {
-
         $keys = $fields ? array_flip($fields) : null;
 
         $data = array_map(function ($r) use ($m, $keys) {
@@ -309,10 +309,9 @@ class Persistence_Array extends Persistence
             // parameter inside where()
 
             if (count($cond) == 1) {
-
                 throw new Exception([
                     'Condition not acceptable for Array persistence',
-                    'condition'=>$cond
+                    'condition'=> $cond,
                 ]);
                 /*
                 // OR conditions
@@ -337,11 +336,11 @@ class Persistence_Array extends Persistence
                 if ($cond[0] instanceof Field) {
                     $cond[1] = $this->typecastSaveField($cond[0], $cond[1]);
                 }
-                $q->where(is_string($cond[0]) ? $cond[0]: $cond[0]->short_name, $cond[1]);
+                $q->where(is_string($cond[0]) ? $cond[0] : $cond[0]->short_name, $cond[1]);
             } else {
                 throw new Exception([
                     'Condition not acceptable for Array persistence',
-                    'condition'=>$cond
+                    'condition'=> $cond,
                 ]);
 
                 /*
@@ -355,7 +354,7 @@ class Persistence_Array extends Persistence
     }
 
     /**
-     * Various actions possible here, mostly for compatibility for SQLs
+     * Various actions possible here, mostly for compatibility for SQLs.
      *
      * @param Model  $m
      * @param string $type
@@ -402,8 +401,5 @@ class Persistence_Array extends Persistence
                     'type' => $type,
                 ]);
         }
-
     }
-
-
 }

--- a/src/Persistence_Array.php
+++ b/src/Persistence_Array.php
@@ -264,10 +264,146 @@ class Persistence_Array extends Persistence
      */
     public function export(Model $m, $fields = null)
     {
+        $action = $this->initAction($m, $fields);
+        $this->applyConditions($m, $action);
+        return $action->get();
+    }
+
+    /**
+     * @param Model $m
+     * @param array $fields
+     *
+     * @return Action\Iterator
+     */
+    public function initAction(Model $m, $fields = null)
+    {
+
         $keys = $fields ? array_flip($fields) : null;
 
-        return array_map(function ($r) use ($m, $keys) {
+        $data = array_map(function ($r) use ($m, $keys) {
             return $this->typecastLoadRow($m, $keys ? array_intersect_key($r, $keys) : $r);
         }, $this->data[$m->table]);
+
+        return new Action\Iterator($data);
     }
+
+    /**
+     * Will apply conditions defined inside $m onto query $q.
+     *
+     * @param Model            $m
+     * @param \atk4\dsql\Query $q
+     *
+     * @return \atk4\dsql\Query
+     */
+    public function applyConditions(Model $m, Action\Iterator $q)
+    {
+        if (!isset($m->conditions)) {
+            // no conditions are set in the model
+            return $q;
+        }
+
+        foreach ($m->conditions as $cond) {
+
+            // Options here are:
+            // count($cond) == 1, we will pass the only
+            // parameter inside where()
+
+            if (count($cond) == 1) {
+
+                throw new Exception([
+                    'Condition not acceptable for Array persistence',
+                    'condition'=>$cond
+                ]);
+                /*
+                // OR conditions
+                if (is_array($cond[0])) {
+                    foreach ($cond[0] as &$row) {
+                        if (is_string($row[0])) {
+                            $row[0] = $m->getElement($row[0]);
+                        }
+                    }
+                }
+
+                $q->where($cond[0]);
+                continue;
+                */
+            }
+
+            if (is_string($cond[0])) {
+                $cond[0] = $m->getElement($cond[0]);
+            }
+
+            if (count($cond) == 2) {
+                if ($cond[0] instanceof Field) {
+                    $cond[1] = $this->typecastSaveField($cond[0], $cond[1]);
+                }
+                $q->where(is_string($cond[0]) ? $cond[0]: $cond[0]->short_name, $cond[1]);
+            } else {
+                throw new Exception([
+                    'Condition not acceptable for Array persistence',
+                    'condition'=>$cond
+                ]);
+
+                /*
+                if ($cond[0] instanceof Field) {
+                    $cond[2] = $this->typecastSaveField($cond[0], $cond[2]);
+                }
+                $q->where($cond[0], $cond[1], $cond[2]);
+                */
+            }
+        }
+    }
+
+    /**
+     * Various actions possible here, mostly for compatibility for SQLs
+     *
+     * @param Model  $m
+     * @param string $type
+     * @param array  $args
+     *
+     * @return \atk4\dsql\Query,Iterator\Action
+     */
+    public function action($m, $type, $args = [])
+    {
+        if (!is_array($args)) {
+            throw new Exception([
+                '$args must be an array',
+                'args' => $args,
+            ]);
+        }
+
+        $action = $this->initAction($m);
+
+        $this->applyConditions($m, $action);
+
+        switch ($type) {
+            case 'select':
+
+                return $action;
+
+            case 'count':
+
+                return $action->count();
+
+            case 'field':
+
+                $field = is_string($args[0]) ? $m->getElement($args[0]) : $args[0];
+
+                return $action->filterField($field->short_name);
+
+            case 'fx':
+            case 'fx0':
+
+                return $action->aggregate($field->short_name, $fx);
+
+            default:
+                throw new Exception([
+                    'Unsupported action mode',
+                    'type' => $type,
+                ]);
+        }
+
+    }
+
+
 }

--- a/src/Persistence_JSON.php
+++ b/src/Persistence_JSON.php
@@ -1,15 +1,12 @@
 <?php
 
-
 namespace atk4\data;
-
 
 class Persistence_JSON extends Persistence
 {
-
     /**
      * @var array Contains decoded JSON data. If model specifies table, then it is loaded from a specific
-     * route, e.g. $table='user/blah/abc' will load $data['user']['blah']['abc']
+     *            route, e.g. $table='user/blah/abc' will load $data['user']['blah']['abc']
      *
      * Table route can include ID numbers for record traversal 'user/23/Roles'
      */
@@ -28,11 +25,12 @@ class Persistence_JSON extends Persistence
     /**
      * Associate model with the data driver.
      *
-     * @param Model|string $m Model which will use this persistence
-     * @param array $defaults Properties
+     * @param Model|string $m        Model which will use this persistence
+     * @param array        $defaults Properties
+     *
+     * @throws Exception
      *
      * @return Model
-     * @throws Exception
      */
     public function add($m, $defaults = [])
     {
@@ -56,34 +54,33 @@ class Persistence_JSON extends Persistence
     {
         $path_array = explode('/', $path);
 
-        $cur =& $this->data;
+        $cur = &$this->data;
 
-        foreach($path_array as $node) {
+        foreach ($path_array as $node) {
             if (!isset($cur[$node])) {
                 throw new Exception([
                     'Path not found in JSON',
-                    'path'=>$path
+                    'path'=> $path,
                 ]);
             }
 
-            $cur =& $cur[$node];
+            $cur = &$cur[$node];
         }
-
     }
 
     /**
      * Loads model and returns data record.
      *
-     * @param Model $m
-     * @param mixed $id
+     * @param Model  $m
+     * @param mixed  $id
      * @param string $table
      *
-     * @return array|false
      * @throws Exception
+     *
+     * @return array|false
      */
     public function load(Model $m, $id, $table = null)
     {
-
         if (isset($m->table) && !isset($this->data[$m->table])) {
             throw new Exception([
                 'Table was not found in the array data source',
@@ -123,6 +120,4 @@ class Persistence_JSON extends Persistence
 
         return $this->typecastLoadRow($m, $this->data[$table][$id]);
     }
-
-
 }

--- a/src/Persistence_JSON.php
+++ b/src/Persistence_JSON.php
@@ -1,0 +1,128 @@
+<?php
+
+
+namespace atk4\data;
+
+
+class Persistence_JSON extends Persistence
+{
+
+    /**
+     * @var array Contains decoded JSON data. If model specifies table, then it is loaded from a specific
+     * route, e.g. $table='user/blah/abc' will load $data['user']['blah']['abc']
+     *
+     * Table route can include ID numbers for record traversal 'user/23/Roles'
+     */
+    public $data;
+
+    /**
+     * Decode and store $json as associative array.
+     *
+     * @param $json
+     */
+    public function __construct($json)
+    {
+        $this->data = json_decode($json, true);
+    }
+
+    /**
+     * Associate model with the data driver.
+     *
+     * @param Model|string $m Model which will use this persistence
+     * @param array $defaults Properties
+     *
+     * @return Model
+     * @throws Exception
+     */
+    public function add($m, $defaults = [])
+    {
+        if (isset($defaults[0])) {
+            $m->table = $defaults[0];
+            unset($defaults[0]);
+        }
+
+        $m = parent::add($m, $defaults);
+
+        return $m;
+    }
+
+    /**
+     * When specified a path, such as 'foo/bar/baz', this will locate a specific spot inside $this->data
+     * and return reference to it.
+     *
+     * @param $path
+     */
+    public function getDataRef($path)
+    {
+        $path_array = explode('/', $path);
+
+        $cur =& $this->data;
+
+        foreach($path_array as $node) {
+            if (!isset($cur[$node])) {
+                throw new Exception([
+                    'Path not found in JSON',
+                    'path'=>$path
+                ]);
+            }
+
+            $cur =& $cur[$node];
+        }
+
+    }
+
+    /**
+     * Loads model and returns data record.
+     *
+     * @param Model $m
+     * @param mixed $id
+     * @param string $table
+     *
+     * @return array|false
+     * @throws Exception
+     */
+    public function load(Model $m, $id, $table = null)
+    {
+
+        if (isset($m->table) && !isset($this->data[$m->table])) {
+            throw new Exception([
+                'Table was not found in the array data source',
+                'table' => $m->table,
+            ]);
+        }
+
+        if (!isset($this->data[$table ?: $m->table][$id])) {
+            throw new Exception([
+                'Record with specified ID was not found',
+                'id' => $id,
+            ], 404);
+        }
+
+        return $this->tryLoad($m, $id, $table);
+    }
+
+    /**
+     * Tries to load model and return data record.
+     * Doesn't throw exception if model can't be loaded.
+     *
+     * @param Model  $m
+     * @param mixed  $id
+     * @param string $table
+     *
+     * @return array|false
+     */
+    public function tryLoad(Model $m, $id, $table = null)
+    {
+        if (!isset($table)) {
+            $table = $m->table;
+        }
+
+        if (!isset($this->data[$table][$id])) {
+            return false; // no record with such id in table
+        }
+
+        return $this->typecastLoadRow($m, $this->data[$table][$id]);
+    }
+
+
+}

--- a/tests/PersistentArrayTest.php
+++ b/tests/PersistentArrayTest.php
@@ -324,21 +324,20 @@ class PersistentArrayTest extends \atk4\core\PHPUnit_AgileTestCase
                 1 => ['name' => 'John', 'surname' => 'Smith', 'country_id'=>1],
                 2 => ['name' => 'Sarah', 'surname' => 'Jones', 'country_id'=>2],
             ],
-            'country'=>[
+            'country'=> [
                 1 => ['name' => 'Latvia'],
                 2 => ['name' => 'UK'],
-            ]
+            ],
         ];
 
         $p = new Persistence_Array($a);
-
 
         $user = new Model($p, 'user');
         $user->addField('name');
         $user->addField('surname');
 
         $country = new Model();
-        $country->table='country';
+        $country->table = 'country';
         $country->addField('name');
 
         $user->hasOne('country_id', $country);
@@ -348,6 +347,5 @@ class PersistentArrayTest extends \atk4\core\PHPUnit_AgileTestCase
 
         $user->load(2);
         $this->assertEquals('UK', $user->ref('country_id')['name']);
-
     }
 }

--- a/tests/PersistentArrayTest.php
+++ b/tests/PersistentArrayTest.php
@@ -316,4 +316,38 @@ class PersistentArrayTest extends \atk4\core\PHPUnit_AgileTestCase
             2 => ['surname' => 'Jones'],
         ], $m->export(['surname']));
     }
+
+    public function testHasOne()
+    {
+        $a = [
+            'user' => [
+                1 => ['name' => 'John', 'surname' => 'Smith', 'country_id'=>1],
+                2 => ['name' => 'Sarah', 'surname' => 'Jones', 'country_id'=>2],
+            ],
+            'country'=>[
+                1 => ['name' => 'Latvia'],
+                2 => ['name' => 'UK'],
+            ]
+        ];
+
+        $p = new Persistence_Array($a);
+
+
+        $user = new Model($p, 'user');
+        $user->addField('name');
+        $user->addField('surname');
+
+        $country = new Model();
+        $country->table='country';
+        $country->addField('name');
+
+        $user->hasOne('country_id', $country);
+
+        $user->load(1);
+        $this->assertEquals('Latvia', $user->ref('country_id')['name']);
+
+        $user->load(2);
+        $this->assertEquals('UK', $user->ref('country_id')['name']);
+
+    }
 }

--- a/tests/PersistentArrayTest.php
+++ b/tests/PersistentArrayTest.php
@@ -328,7 +328,6 @@ class PersistentArrayTest extends \atk4\core\PHPUnit_AgileTestCase
         $this->assertEquals(0, $m->action('count')->getOne());
     }
 
-
     public function testHasOne()
     {
         $a = [
@@ -369,21 +368,19 @@ class PersistentArrayTest extends \atk4\core\PHPUnit_AgileTestCase
                 2 => ['name' => 'Sarah', 'surname' => 'Jones', 'country_id'=>2],
                 3 => ['name' => 'Janis', 'surname' => 'Berzins', 'country_id'=>1],
             ],
-            'country'=>[
+            'country'=> [
                 1 => ['name' => 'Latvia'],
                 2 => ['name' => 'UK'],
-            ]
+            ],
         ];
 
         $p = new Persistence_Array($a);
-
-
 
         $country = new Model($p, 'country');
         $country->addField('name');
 
         $user = new Model();
-        $user->table='user';
+        $user->table = 'user';
         $user->addField('name');
         $user->addField('surname');
 
@@ -394,6 +391,6 @@ class PersistentArrayTest extends \atk4\core\PHPUnit_AgileTestCase
         $this->assertEquals(2, $country->ref('Users')->action('count')->getOne());
 
         $country->load(2);
-        $this->assertEquals(1 , $country->ref('Users')->action('count')->getOne());
+        $this->assertEquals(1, $country->ref('Users')->action('count')->getOne());
     }
 }

--- a/tests/PersistentJSONTest.php
+++ b/tests/PersistentJSONTest.php
@@ -323,7 +323,6 @@ class PersistentJSONTest extends \atk4\core\PHPUnit_AgileTestCase
         $this->assertEquals(0, $m->action('count')->getOne());
     }
 
-
     public function testHasOne()
     {
         $a = [
@@ -364,21 +363,19 @@ class PersistentJSONTest extends \atk4\core\PHPUnit_AgileTestCase
                 2 => ['name' => 'Sarah', 'surname' => 'Jones', 'country_id'=>2],
                 3 => ['name' => 'Janis', 'surname' => 'Berzins', 'country_id'=>1],
             ],
-            'country'=>[
+            'country'=> [
                 1 => ['name' => 'Latvia'],
                 2 => ['name' => 'UK'],
-            ]
+            ],
         ];
 
         $p = new Persistence_Array($a);
-
-
 
         $country = new Model($p, 'country');
         $country->addField('name');
 
         $user = new Model();
-        $user->table='user';
+        $user->table = 'user';
         $user->addField('name');
         $user->addField('surname');
 
@@ -389,6 +386,6 @@ class PersistentJSONTest extends \atk4\core\PHPUnit_AgileTestCase
         $this->assertEquals(2, $country->ref('Users')->action('count')->getOne());
 
         $country->load(2);
-        $this->assertEquals(1 , $country->ref('Users')->action('count')->getOne());
+        $this->assertEquals(1, $country->ref('Users')->action('count')->getOne());
     }
 }

--- a/tests/PersistentJSONTest.php
+++ b/tests/PersistentJSONTest.php
@@ -1,0 +1,394 @@
+<?php
+
+namespace atk4\data\tests;
+
+use atk4\data\Model;
+use atk4\data\Persistence;
+use atk4\data\Persistence_Array;
+use atk4\data\Persistence_JSON;
+use atk4\data\tests\Model\Female as Female;
+use atk4\data\tests\Model\Male as Male;
+
+/**
+ * @coversDefaultClass \atk4\data\Model
+ */
+class PersistentJSONTest extends \atk4\core\PHPUnit_AgileTestCase
+{
+    /**
+     * Test constructor.
+     */
+    public function testLoadJSON()
+    {
+        $a = "[['id':1, 'name':'John', 'surname':'Smith'], ['id': 2, 'name':'Sarah', 'surname':'Jones'] ]";
+        $p = new Persistence_JSON($a);
+        $m = new Model($p, 'user');
+        $m->addField('name');
+        $m->addField('surname');
+
+        $m->load(1);
+        $this->assertEquals('John', $m['name']);
+
+        $m->unload();
+        $this->assertFalse($m->loaded());
+
+        $m->tryLoadAny();
+        $this->assertTrue($m->loaded());
+
+        $m->load(2);
+        $this->assertEquals('Jones', $m['surname']);
+        $m['surname'] = 'Smith';
+        $m->save();
+
+        $m->load(1);
+        $this->assertEquals('John', $m['name']);
+
+        $m->load(2);
+        $this->assertEquals('Smith', $m['surname']);
+    }
+
+    public function testSaveAs()
+    {
+        //$this->markTestSkipped('TODO: see #146');
+        $a = [
+            'person' => [
+                1 => ['name' => 'John', 'surname' => 'Smith', 'gender' => 'M'],
+                2 => ['name' => 'Sarah', 'surname' => 'Jones', 'gender' => 'F'],
+            ],
+        ];
+
+        $p = new Persistence_Array($a);
+
+        $m = new Male($p);
+        $m->load(1);
+        $m->saveAs(new Female());
+        $m->delete();
+
+        $this->assertEquals([
+            'person' => [
+                2 => ['name' => 'Sarah', 'surname' => 'Jones', 'gender' => 'F'],
+                3 => ['name' => 'John', 'surname' => 'Smith', 'gender' => 'F', 'id'=>3],
+            ],
+        ], $a);
+    }
+
+    public function testSaveAndUnload()
+    {
+        $a = [
+            'user' => [
+                1 => ['name' => 'John', 'surname' => 'Smith', 'gender' => 'M'],
+                2 => ['name' => 'Sarah', 'surname' => 'Jones', 'gender' => 'F'],
+            ],
+        ];
+
+        $p = new Persistence_Array($a);
+        $m = new Male($p, 'user');
+
+        $m->load(1);
+        $this->assertTrue($m->loaded());
+        $m['gender'] = 'F';
+        $m->saveAndUnload();
+        $this->assertFalse($m->loaded());
+
+        $m = new Female($p, 'user');
+        $m->load(1);
+        $this->assertTrue($m->loaded());
+
+        $this->assertEquals([
+            'user' => [
+                1 => ['name' => 'John', 'surname' => 'Smith', 'gender' => 'F'],
+                2 => ['name' => 'Sarah', 'surname' => 'Jones', 'gender' => 'F'],
+            ],
+        ], $a);
+    }
+
+    public function testUpdateArray()
+    {
+        $a = [
+            'user' => [
+                1 => ['name' => 'John', 'surname' => 'Smith'],
+                2 => ['name' => 'Sarah', 'surname' => 'Jones'],
+            ],
+        ];
+
+        $p = new Persistence_Array($a);
+        $m = new Model($p, 'user');
+        $m->addField('name');
+        $m->addField('surname');
+
+        $m->load(1);
+        $m['name'] = 'Peter';
+        $m->save();
+
+        $m->load(2);
+        $m['surname'] = 'Smith';
+        $m->save();
+        $m['surname'] = 'QQ';
+        $m->save();
+
+        $this->assertEquals([
+            'user' => [
+                1 => ['name' => 'Peter', 'surname' => 'Smith'],
+                2 => ['name' => 'Sarah', 'surname' => 'QQ'],
+            ],
+        ], $a);
+
+        $m->unload();
+        $m->set(['name' => 'Foo', 'surname' => 'Bar']);
+        $m->save();
+
+        $this->assertEquals([
+            'user' => [
+                1 => ['name' => 'Peter', 'surname' => 'Smith'],
+                2 => ['name' => 'Sarah', 'surname' => 'QQ'],
+                3 => ['name' => 'Foo', 'surname' => 'Bar', 'id' => 3],
+            ],
+        ], $a);
+    }
+
+    public function testInsert()
+    {
+        $a = [
+            'user' => [
+                1 => ['name' => 'John', 'surname' => 'Smith'],
+                2 => ['name' => 'Sarah', 'surname' => 'Jones'],
+            ],
+        ];
+
+        $p = new Persistence_Array($a);
+        $m = new Model($p, 'user');
+        $m->addField('name');
+        $m->addField('surname');
+
+        $m->insert(['name' => 'Foo', 'surname' => 'Bar']);
+
+        $this->assertEquals([
+            'user' => [
+                1 => ['name' => 'John', 'surname' => 'Smith'],
+                2 => ['name' => 'Sarah', 'surname' => 'Jones'],
+                3 => ['name' => 'Foo', 'surname' => 'Bar', 'id' => 3],
+            ],
+        ], $a);
+    }
+
+    public function testIterator()
+    {
+        $a = [
+            'user' => [
+                1 => ['name' => 'John', 'surname' => 'Smith'],
+                2 => ['name' => 'Sarah', 'surname' => 'Jones'],
+            ],
+        ];
+
+        $p = new Persistence_Array($a);
+        $m = new Model($p, 'user');
+        $m->addField('name');
+        $m->addField('surname');
+
+        $output = '';
+
+        foreach ($m as $row) {
+            $output .= $row['name'];
+        }
+
+        $this->assertEquals('JohnSarah', $output);
+    }
+
+    /**
+     * Test short format.
+     */
+    public function testShortFormat()
+    {
+        $a = [
+            1 => ['name' => 'John', 'surname' => 'Smith'],
+            2 => ['name' => 'Sarah', 'surname' => 'Jones'],
+        ];
+
+        $p = new Persistence_Array($a);
+        $m = new Model($p);
+        $m->addField('name');
+        $m->addField('surname');
+
+        $m->load(1);
+        $this->assertEquals('John', $m['name']);
+
+        $m->load(2);
+        $this->assertEquals('Jones', $m['surname']);
+        $m['surname'] = 'Smith';
+        $m->save();
+
+        $m->load(1);
+        $this->assertEquals('John', $m['name']);
+
+        $m->load(2);
+        $this->assertEquals('Smith', $m['surname']);
+    }
+
+    /**
+     * Some persistences don't support tryLoad() method.
+     *
+     * @expectedException Exception
+     */
+    public function testTryLoadNotSupportedException()
+    {
+        $m = new Model(new Persistence());
+        $m->tryLoad(1);
+    }
+
+    /**
+     * Some persistences don't support loadAny() method.
+     *
+     * @expectedException Exception
+     */
+    public function testLoadAnyNotSupportedException()
+    {
+        $m = new Model(new Persistence());
+        $m->loadAny();
+    }
+
+    /**
+     * Some persistences don't support tryLoadAny() method.
+     *
+     * @expectedException Exception
+     */
+    public function testTryLoadAnyNotSupportedException()
+    {
+        $m = new Model(new Persistence());
+        $m->tryLoadAny();
+    }
+
+    /**
+     * Test export.
+     */
+    public function testExport()
+    {
+        $a = [
+            1 => ['name' => 'John', 'surname' => 'Smith'],
+            2 => ['name' => 'Sarah', 'surname' => 'Jones'],
+        ];
+
+        $p = new Persistence_Array($a);
+        $m = new Model($p);
+        $m->addField('name');
+        $m->addField('surname');
+
+        $this->assertEquals([
+            1 => ['name' => 'John', 'surname' => 'Smith'],
+            2 => ['name' => 'Sarah', 'surname' => 'Jones'],
+        ], $m->export());
+
+        $this->assertEquals([
+            1 => ['surname' => 'Smith'],
+            2 => ['surname' => 'Jones'],
+        ], $m->export(['surname']));
+    }
+
+    public function testCount()
+    {
+        $a = [
+            1 => ['name' => 'John', 'surname' => 'Smith'],
+            2 => ['name' => 'Sarah', 'surname' => 'Jones'],
+        ];
+
+        $p = new Persistence_Array($a);
+        $m = new Model($p);
+        $m->addField('name');
+        $m->addField('surname');
+
+        $this->assertEquals(2, $m->action('count')->getOne());
+    }
+
+    public function testCondition()
+    {
+        $a = [
+            1 => ['name' => 'John', 'surname' => 'Smith'],
+            2 => ['name' => 'Sarah', 'surname' => 'QQ'],
+            3 => ['name' => 'Sarah', 'surname' => 'XX'],
+            4 => ['name' => 'Sarah', 'surname' => 'Smith'],
+        ];
+
+        $p = new Persistence_Array($a);
+        $m = new Model($p);
+        $m->addField('name');
+        $m->addField('surname');
+
+        $this->assertEquals(4, $m->action('count')->getOne());
+        $m->addCondition('name', 'Sarah');
+        $this->assertEquals(3, $m->action('count')->getOne());
+        $m->addCondition('surname', 'Smith');
+
+        $this->assertEquals([4=>['name'=>'Sarah', 'surname'=>'Smith']], $m->export());
+
+        $this->assertEquals(1, $m->action('count')->getOne());
+        $m->addCondition('surname', 'Siiiith');
+        $this->assertEquals(0, $m->action('count')->getOne());
+    }
+
+
+    public function testHasOne()
+    {
+        $a = [
+            'user' => [
+                1 => ['name' => 'John', 'surname' => 'Smith', 'country_id'=>1],
+                2 => ['name' => 'Sarah', 'surname' => 'Jones', 'country_id'=>2],
+            ],
+            'country'=> [
+                1 => ['name' => 'Latvia'],
+                2 => ['name' => 'UK'],
+            ],
+        ];
+
+        $p = new Persistence_Array($a);
+
+        $user = new Model($p, 'user');
+        $user->addField('name');
+        $user->addField('surname');
+
+        $country = new Model();
+        $country->table = 'country';
+        $country->addField('name');
+
+        $user->hasOne('country_id', $country);
+
+        $user->load(1);
+        $this->assertEquals('Latvia', $user->ref('country_id')['name']);
+
+        $user->load(2);
+        $this->assertEquals('UK', $user->ref('country_id')['name']);
+    }
+
+    public function testHasMany()
+    {
+        $a = [
+            'user' => [
+                1 => ['name' => 'John', 'surname' => 'Smith', 'country_id'=>1],
+                2 => ['name' => 'Sarah', 'surname' => 'Jones', 'country_id'=>2],
+                3 => ['name' => 'Janis', 'surname' => 'Berzins', 'country_id'=>1],
+            ],
+            'country'=>[
+                1 => ['name' => 'Latvia'],
+                2 => ['name' => 'UK'],
+            ]
+        ];
+
+        $p = new Persistence_Array($a);
+
+
+
+        $country = new Model($p, 'country');
+        $country->addField('name');
+
+        $user = new Model();
+        $user->table='user';
+        $user->addField('name');
+        $user->addField('surname');
+
+        $country->hasMany('Users', $user);
+        $user->hasOne('country_id', $country);
+
+        $country->load(1);
+        $this->assertEquals(2, $country->ref('Users')->action('count')->getOne());
+
+        $country->load(2);
+        $this->assertEquals(1 , $country->ref('Users')->action('count')->getOne());
+    }
+}


### PR DESCRIPTION
Depends on #377 

Implementation of JSON persistence to be used by RestAPI JSON endpoint persistence later. Simple use:

``` php
$json = "[['id':1, 'name':'John', 'surname':'Smith'], ['id': 2, 'name':'Sarah', 'surname':'Jones'] ]";
$p = new Persistence_JSON($json);
$m = new User($p);

$m->load(1);
echo $m['name']; // John
```

Things to look out for:

 - [ ] basic operation, loading saving etc.
 - [ ] export data from persistence back as JSON string
 - [ ] possibly add hook, so we could store modified JSON and save it
 - [ ] initialize from decoded JSON (if the field is already unserialized by ATK Data)
 - [ ] table can specify JSON path ('Users/34/Roles')
 - [ ] as an option - look into JSONPath '$.authors'

------------

 - [ ] iterate through elements (each)
 - [ ] support array or associative storage
 - [ ] support for "id" fields inside record
 - [ ] support for custom id_field
 - [ ] adding and removing records
 - [ ] autogeneration of ID
 - [ ] support UUID for randomly generated IDs

---------------

 - [ ] support conditions
 - [ ] support limit
 - [ ] reference traversal

k




 - Documentation: [docs/file.rst](docs/file.rst)
 - Demo: [demos/file.php](demos/file.php)

p.s. set label "in review" and assign reviewers if PR is complete. Otherwise set "work in progress" label.
