### PR TITLE
Feature/normalize date values

### DIFF
--- a/src/Field.php
+++ b/src/Field.php
@@ -357,6 +357,16 @@ class Field
 
                     throw new ValidationException(['must be a '.$f->type, 'class' => $class, 'value type' => gettype($value)]);
                 }
+
+                if ($f->type == 'date') {
+                    // remove time portion from date type value
+                    $value->setTime(0,0,0);
+                }
+                if ($f->type == 'time') {
+                    // remove date portion from date type value
+                    $value->setDate(0,1,1);
+                }
+
                 break;
             case 'array':
                 if (!is_array($value)) {

--- a/src/Field.php
+++ b/src/Field.php
@@ -360,11 +360,11 @@ class Field
 
                 if ($f->type == 'date') {
                     // remove time portion from date type value
-                    $value->setTime(0,0,0);
+                    $value->setTime(0, 0, 0);
                 }
                 if ($f->type == 'time') {
                     // remove date portion from date type value
-                    $value->setDate(0,1,1);
+                    $value->setDate(0, 1, 1);
                 }
 
                 break;


### PR DESCRIPTION
`date` and `time` values should have proper normalization.

If in database they still can be  stored in whatever format, then in detecting dirty values (for audit for example) that's especially important. `date` field should not care about time part of DateTime object and `time` field should not care about date.