### PR TITLE
Allow non-scalar value on serialize field

### DIFF
--- a/src/Field.php
+++ b/src/Field.php
@@ -261,7 +261,7 @@ class Field implements Expressionable
             }
 
             // validate scalar values
-            if (in_array($f->type, ['string', 'text', 'integer', 'money', 'float']) && !is_scalar($value)) {
+            if (in_array($f->type, ['string', 'text', 'integer', 'money', 'float']) && !$this->serialize && !is_scalar($value)) {
                 throw new ValidationException([$this->name => 'Must use scalar value']);
             }
 


### PR DESCRIPTION
If a field has a serialization like "json", "serialize" set, it may have non-scalar values. At least I store serialized values in fields of 'type' => 'text'.
This PR adds an additional condition in normalize()'s check for scalar values. If $this->serialize is set, value does not need to be scalar as its made scalar by serialization on save.