### PR TITLE
implement insert lookups

### DIFF
--- a/src/Reference_SQL_One.php
+++ b/src/Reference_SQL_One.php
@@ -48,6 +48,22 @@ class Reference_SQL_One extends Reference_One
             $defaults
         ));
 
+        $e->read_only = false;
+        $e->never_save = true;
+
+        // Will try to execute last
+        $this->owner->addHook('beforeSave', function ($m) use ($field, $their_field) {
+            // if title field is changed, but reference ID field (our_field)
+            // is not changed, then update reference ID field value
+            if ($m->isDirty($field) && !$m->isDirty($this->our_field)) {
+                $mm = $this->getModel();
+
+                $mm->addCondition($their_field, $m[$field]);
+                $m[$this->our_field] = $mm->action('field', [$mm->id_field]);
+                unset($m[$field]);
+            }
+        }, null, 21);
+
         return $e;
     }
 

--- a/tests/LookupSQLTest.php
+++ b/tests/LookupSQLTest.php
@@ -297,6 +297,29 @@ class LookupSQLTest extends \atk4\schema\PHPUnit_SchemaTestCase
         ], $this->getDB(['country', 'user']));
     }
 
+    public function testImportByLookup()
+    {
+        $c = new LCountry($this->db);
+
+        // Specifying hasMany here will perform input
+        $c->import([
+            ['Canada', 'code'=>'CA'],
+            ['Latvia', 'code'=>'LV'],
+            ['Japan', 'code'=>'JP'],
+            ['Lithuania', 'code'=>'LT', 'is_eu'=>true],
+            ['Russia', 'code'=>'RU'],
+        ]);
+
+        $u = new LUser($this->db);
+
+        $u->import([
+            [ 'name'       => 'Alain', 'country_code'=>'CA'],
+            [ 'name'       => 'Imants', 'country_code'=>'LV'],
+            //[ 'name'       => 'Romans', 'country_code'=>'UK'],  // does not exist
+        ]);
+
+    }
+
     /*
      *
      * TODO - that's left for hasMTM implementation..., to be coming later

--- a/tests/LookupSQLTest.php
+++ b/tests/LookupSQLTest.php
@@ -313,11 +313,10 @@ class LookupSQLTest extends \atk4\schema\PHPUnit_SchemaTestCase
         $u = new LUser($this->db);
 
         $u->import([
-            [ 'name'       => 'Alain', 'country_code'=>'CA'],
-            [ 'name'       => 'Imants', 'country_code'=>'LV'],
+            ['name'       => 'Alain', 'country_code'=>'CA'],
+            ['name'       => 'Imants', 'country_code'=>'LV'],
             //[ 'name'       => 'Romans', 'country_code'=>'UK'],  // does not exist
         ]);
-
     }
 
     /*


### PR DESCRIPTION
Addition to #350 which is not also looking up non-title imported fields during data ingestion.

TODO: we probably need to change this, if values for multiple lookup fields are specified by adding multiple condition for a lookup. While we assume that title field is unique, not all lookups are.

