### PR TITLE
implement action(field) for array persistence, fix #415

### DIFF
--- a/src/Persistence/Array_.php
+++ b/src/Persistence/Array_.php
@@ -425,27 +425,47 @@ class Array_ extends Persistence
             ]);
         }
 
-        $action = $this->initAction($m, isset($args[0]) ? $args[0] : null);
-
-        $this->applyConditions($m, $action);
-        $this->setLimitOrder($m, $action);
-
         switch ($type) {
             case 'select':
+                $action = $this->initAction($m, isset($args[0]) ? $args[0] : null);
+                $this->applyConditions($m, $action);
+                $this->setLimitOrder($m, $action);
 
                 return $action;
 
             case 'count':
+                $action = $this->initAction($m, isset($args[0]) ? $args[0] : null);
+                $this->applyConditions($m, $action);
+                $this->setLimitOrder($m, $action);
 
                 return $action->count();
 
-            /* These are not implemented yet
             case 'field':
+                if (!isset($args[0])) {
+                    throw new Exception([
+                        'This action requires one argument with field name',
+                        'action' => $type,
+                    ]);
+                }
 
-                $field = is_string($args[0]) ? $m->getField($args[0]) : $args[0];
+                $field = is_string($args[0]) ? $args[0] : $args[0][0];
 
-                return $action->filterField($field->short_name);
+                $action = $this->initAction($m, [$field]);
+                $this->applyConditions($m, $action);
+                $this->setLimitOrder($m, $action);
 
+                // get first record
+                $row = $action->getRow();
+                if ($row) {
+                    if (isset($args['alias']) && array_key_exists($field, $row)) {
+                        $row[$args['alias']] = $row[$field];
+                        unset($row[$field]);
+                    }
+                }
+
+                return $row;
+
+            /* These are not implemented yet
             case 'fx':
             case 'fx0':
 

--- a/tests/PersistentArrayTest.php
+++ b/tests/PersistentArrayTest.php
@@ -303,7 +303,7 @@ class PersistentArrayTest extends \atk4\core\PHPUnit_AgileTestCase
 
         $this->assertEquals(2, $m->action('count')->getOne());
     }
-    
+
     /**
      * Test Model->action('field').
      */
@@ -329,7 +329,7 @@ class PersistentArrayTest extends \atk4\core\PHPUnit_AgileTestCase
         $q = $m->action('field', ['name']);
         $this->assertEquals(['name'=>'John'], $q);
     }
-    
+
     /**
      * Test Model->addCondition operator LIKE.
      */

--- a/tests/PersistentArrayTest.php
+++ b/tests/PersistentArrayTest.php
@@ -289,7 +289,7 @@ class PersistentArrayTest extends \atk4\core\PHPUnit_AgileTestCase
     /**
      * Test Model->action('count').
      */
-    public function testCount()
+    public function testActionCount()
     {
         $a = [
             1 => ['name' => 'John', 'surname' => 'Smith'],
@@ -303,7 +303,33 @@ class PersistentArrayTest extends \atk4\core\PHPUnit_AgileTestCase
 
         $this->assertEquals(2, $m->action('count')->getOne());
     }
+    
+    /**
+     * Test Model->action('field').
+     */
+    public function testActionField()
+    {
+        $a = [
+            1 => ['name' => 'John', 'surname' => 'Smith'],
+            2 => ['name' => 'Sarah', 'surname' => 'Jones'],
+        ];
 
+        $p = new Persistence\Array_($a);
+        $m = new Model($p);
+        $m->addField('name');
+        $m->addField('surname');
+
+        $this->assertEquals(2, $m->action('count')->getOne());
+
+        // use alias as array key if it is set
+        $q = $m->action('field', ['name', 'alias'=>'first_name']);
+        $this->assertEquals(['first_name'=>'John'], $q);
+
+        // if alias is not set, then use field name as key
+        $q = $m->action('field', ['name']);
+        $this->assertEquals(['name'=>'John'], $q);
+    }
+    
     /**
      * Test Model->addCondition operator LIKE.
      */
@@ -356,7 +382,7 @@ class PersistentArrayTest extends \atk4\core\PHPUnit_AgileTestCase
         unset($result);
         $m->unload();
 
-        // case : %str
+        // case : %str%
         $m->conditions = [];
         $m->addCondition('country', 'LIKE', '%a%');
         $result = $m->action('select')->get();


### PR DESCRIPTION
Implements `$model->action(field, ['foo'])` for `Persistence\Array_`.
Adds test case and fix #415.

P.S. Not sure if this implementation is good enough, but it at least works somehow :)