### PR TITLE
Implements DeepCopy->transformData()

### DIFF
--- a/src/Util/DeepCopy.php
+++ b/src/Util/DeepCopy.php
@@ -45,9 +45,9 @@ class DeepCopy
     /**
      * @var array contains array similar to references but containing list of callback methods to transform fields/values:
      *            e.g. ['Invoices'=>['Lines'=>function($data){
-     *                  $data['exchanged_amount'] = $data['amount'] * getExRate($data['date'], $data['currency']);
-     *                  return $data;
-     *              }]]
+     *            $data['exchanged_amount'] = $data['amount'] * getExRate($data['date'], $data['currency']);
+     *            return $data;
+     *            }]]
      */
     protected $transforms = [];
 


### PR DESCRIPTION
Implements `transformData()` method for DeepCopy.

Usage example:
```
->transformData(
    [function($data){ // for Client entity
        $data['name'] => $data['last_name'].' '.$data['first_name'];
        unset($data['first_name'], $data['last_name']);
        return $data;
    }],
    'Invoices' => ['Lines'=>function($data){ // for nested Client->Invoices->Lines hasMany entity
            $data['exchanged_amount'] = $data['amount'] * getExRate($data['date'], $data['currency']);
            return $data;
        }]
);
```
