### PR TITLE
Model::addField() to use $model->fields property rather than elements (and new Trait)

### DIFF
--- a/src/Model.php
+++ b/src/Model.php
@@ -6,13 +6,13 @@ namespace atk4\data;
 
 use ArrayAccess;
 use atk4\core\AppScopeTrait;
+use atk4\core\CollectionTrait;
 use atk4\core\ContainerTrait;
 use atk4\core\DIContainerTrait;
 use atk4\core\DynamicMethodTrait;
 use atk4\core\FactoryTrait;
 use atk4\core\HookTrait;
 use atk4\core\InitializerTrait;
-use atk4\core\CollectionTrait;
 use atk4\core\NameTrait;
 use atk4\dsql\Query;
 use IteratorAggregate;
@@ -1627,8 +1627,9 @@ class Model implements ArrayAccess, IteratorAggregate
      * @param mixed $field_name
      * @param mixed $value
      *
-     * @return $this
      * @throws \atk4\core\Exception
+     *
+     * @return $this
      */
     public function loadBy(string $field_name, $value)
     {
@@ -1664,10 +1665,11 @@ class Model implements ArrayAccess, IteratorAggregate
      * Will not throw exception if record doesn't exist.
      *
      * @param string $field_name
-     * @param mixed $value
+     * @param mixed  $value
+     *
+     * @throws \atk4\core\Exception
      *
      * @return $this
-     * @throws \atk4\core\Exception
      */
     public function tryLoadBy(string $field_name, $value)
     {

--- a/src/Model.php
+++ b/src/Model.php
@@ -450,6 +450,7 @@ class Model implements ArrayAccess, IteratorAggregate
         if ($obj instanceof Field) {
             throw new Exception(['You should always use addField() for adding fields, not add()']);
         }
+
         return $obj;
     }
 
@@ -516,12 +517,14 @@ class Model implements ArrayAccess, IteratorAggregate
     }
 
     /**
-     * Remove field that was added previously
+     * Remove field that was added previously.
      *
      * @param $name
+     *
      * @throws \atk4\core\Exception
      */
-    public function removeField($name) {
+    public function removeField($name)
+    {
         return $this->_removeFromCollection($name, 'fields');
     }
 

--- a/src/Model.php
+++ b/src/Model.php
@@ -22,7 +22,9 @@ use IteratorAggregate;
  */
 class Model implements ArrayAccess, IteratorAggregate
 {
-    use ContainerTrait;
+    use ContainerTrait {
+        add as _add;
+    }
     use DynamicMethodTrait;
     use HookTrait;
     use InitializerTrait {
@@ -442,6 +444,15 @@ class Model implements ArrayAccess, IteratorAggregate
         return $errors;
     }
 
+    public function add($obj, $args = [])
+    {
+        $obj = $this->_add($obj, $args);
+        if ($obj instanceof Field) {
+            throw new Exception(['You should always use addField() for adding fields, not add()']);
+        }
+        return $obj;
+    }
+
     /**
      * Adds new field into model.
      *
@@ -502,6 +513,16 @@ class Model implements ArrayAccess, IteratorAggregate
         }
 
         return $this;
+    }
+
+    /**
+     * Remove field that was added previously
+     *
+     * @param $name
+     * @throws \atk4\core\Exception
+     */
+    public function removeField($name) {
+        return $this->_removeFromCollection($name, 'fields');
     }
 
     /**
@@ -2435,7 +2456,7 @@ class Model implements ArrayAccess, IteratorAggregate
 
         $this->addField($name, $field);
 
-        return $this->add($field, $name);
+        return $field;
     }
 
     /**

--- a/src/Model.php
+++ b/src/Model.php
@@ -440,7 +440,6 @@ class Model implements ArrayAccess, IteratorAggregate
      */
     public function addField($name, $seed = [])
     {
-
         if ($this->persistence) {
             $field = $this->persistence->fieldFactory($seed);
         } else {
@@ -456,8 +455,9 @@ class Model implements ArrayAccess, IteratorAggregate
      * @param array $fields
      * @param array $defaults
      *
-     * @return $this
      * @throws \atk4\core\Exception
+     *
+     * @return $this
      */
     public function addFields($fields = [], $defaults = [])
     {
@@ -499,13 +499,15 @@ class Model implements ArrayAccess, IteratorAggregate
      *
      * @param string|Field $name
      *
-     * @return Field
      * @throws \atk4\core\Exception
+     *
+     * @return Field
      */
     public function getField($name)
     {
         /** @var Field $field */
         $field = $this->_getFromCollection($name, 'fields');
+
         return $field;
     }
 
@@ -514,8 +516,9 @@ class Model implements ArrayAccess, IteratorAggregate
      *
      * @param array $fields
      *
-     * @return $this
      * @throws \atk4\core\Exception
+     *
+     * @return $this
      */
     public function onlyFields($fields = [])
     {
@@ -542,8 +545,9 @@ class Model implements ArrayAccess, IteratorAggregate
      *
      * @param mixed $field
      *
-     * @return string
      * @throws \atk4\core\Exception
+     *
+     * @return string
      */
     private function normalizeFieldName($field)
     {
@@ -612,7 +616,8 @@ class Model implements ArrayAccess, IteratorAggregate
      *
      * @return array
      */
-    public function getFields(string $filter = null){
+    public function getFields(string $filter = null)
+    {
         return array_filter($this->fields, function ($field, $name) use ($filter) {
 
             // do not return fields outside of "only_fields" scope
@@ -620,13 +625,12 @@ class Model implements ArrayAccess, IteratorAggregate
                 return false;
             }
 
-            switch($filter) {
+            switch ($filter) {
                 case null: return !$field->system;
                 case 'system': return $field->system;
                 case 'editable': return $field->ui['editable'] ?? !$field->system;
                 case 'visible': return $field->ui['visible'] ?? !$field->system;
             }
-
         }, ARRAY_FILTER_USE_BOTH);
     }
 

--- a/src/Model.php
+++ b/src/Model.php
@@ -460,9 +460,9 @@ class Model implements ArrayAccess, IteratorAggregate
     }
 
     /**
-     * Given a field seed, return a feld object.
+     * Given a field seed, return a field object.
      *
-     * @param string $type
+     * @param array $seed
      *
      * @throws \atk4\core\Exception
      *
@@ -470,12 +470,13 @@ class Model implements ArrayAccess, IteratorAggregate
      */
     public function fieldFactory($seed = [])
     {
-        /** @var Field $field */
         $seed = $this->mergeSeeds(
             $seed,
             isset($seed['type']) ? ($this->typeToFieldSeed[$seed['type']] ?? null) : null,
             [Field::class]
         );
+
+        /** @var Field $field */
         $field = $this->factory($seed, null, '\atk4\data\Field');
 
         return $field;
@@ -517,20 +518,23 @@ class Model implements ArrayAccess, IteratorAggregate
     /**
      * Remove field that was added previously.
      *
-     * @param $name
+     * @param string $name
      *
      * @throws \atk4\core\Exception
+     *
+     * @return $this
      */
-    public function removeField($name)
+    public function removeField(string $name)
     {
         $this->_removeFromCollection($name, 'fields');
+
+        return $this;
     }
 
     /**
      * Finds a field with a corresponding name. Returns false if field not found. Similar
      * to hasElement() but with extra checks to make sure it's certainly a field you are
      * getting.
-     *
      *
      * @param string $name
      *
@@ -545,7 +549,7 @@ class Model implements ArrayAccess, IteratorAggregate
      * Same as hasField, but will throw exception if field not found.
      * Similar to getElement().
      *
-     * @param string|Field $name
+     * @param string $name
      *
      * @throws \atk4\core\Exception
      *

--- a/src/Model.php
+++ b/src/Model.php
@@ -450,7 +450,6 @@ class Model implements ArrayAccess, IteratorAggregate
         if ($obj instanceof Field) {
             throw new Exception(['You should always use addField() for adding fields, not add()']);
         }
-
         return $obj;
     }
 
@@ -517,14 +516,12 @@ class Model implements ArrayAccess, IteratorAggregate
     }
 
     /**
-     * Remove field that was added previously.
+     * Remove field that was added previously
      *
      * @param $name
-     *
      * @throws \atk4\core\Exception
      */
-    public function removeField($name)
-    {
+    public function removeField($name) {
         return $this->_removeFromCollection($name, 'fields');
     }
 

--- a/src/Model.php
+++ b/src/Model.php
@@ -445,8 +445,8 @@ class Model implements ArrayAccess, IteratorAggregate
     /**
      * Adds new field into model.
      *
-     * @param string $name
-     * @param array|object  $seed
+     * @param string       $name
+     * @param array|object $seed
      *
      * @throws \atk4\core\Exception
      *
@@ -647,6 +647,7 @@ class Model implements ArrayAccess, IteratorAggregate
         if (!$filter) {
             return $this->fields;
         }
+
         return array_filter($this->fields, function ($field, $name) use ($filter) {
 
             // do not return fields outside of "only_fields" scope
@@ -2433,6 +2434,7 @@ class Model implements ArrayAccess, IteratorAggregate
         $field = $this->factory($c, $expression);
 
         $this->addField($name, $field);
+
         return $this->add($field, $name);
     }
 

--- a/src/Persistence.php
+++ b/src/Persistence.php
@@ -77,18 +77,22 @@ class Persistence
     }
 
     /**
-     * Given a field seed, return a feld object
+     * Given a field seed, return a feld object.
      *
      * @param string $type
+     *
      * @throws \atk4\core\Exception
+     *
      * @return Field
      */
-    public function fieldFactory($seed = []) {
+    public function fieldFactory($seed = [])
+    {
         /** @var Field $field */
         $field = $this->factory($this->mergeSeeds(
             isset($seed['type']) ? ($this->typeToFieldSeed[$seed['type']] ?? null) : null,
             [Field::class]
         ), null, '\atk4\data\Field');
+
         return $field;
     }
 
@@ -99,12 +103,13 @@ class Persistence
     /**
      * Associate model with the data driver.
      *
-     * @param Model|string $m Model which will use this persistence
-     * @param array $defaults Properties
+     * @param Model|string $m        Model which will use this persistence
+     * @param array        $defaults Properties
      *
-     * @return Model
      * @throws Exception
      * @throws \atk4\core\Exception
+     *
+     * @return Model
      */
     public function add($m, $defaults = [])
     {

--- a/src/Persistence.php
+++ b/src/Persistence.php
@@ -88,16 +88,18 @@ class Persistence
     public function fieldFactory($seed = [])
     {
         /** @var Field $field */
-        $field = $this->factory($this->mergeSeeds(
+        $seed = $this->mergeSeeds(
+            $seed,
             isset($seed['type']) ? ($this->typeToFieldSeed[$seed['type']] ?? null) : null,
             [Field::class]
-        ), null, '\atk4\data\Field');
+        );
+        $field = $this->factory($seed, null, '\atk4\data\Field');
 
         return $field;
     }
 
     protected $typeToFieldSeed = [
-        'boolean' => 'Boolean',
+        'boolean' => ['Boolean'],
     ];
 
     /**

--- a/src/Persistence.php
+++ b/src/Persistence.php
@@ -77,32 +77,6 @@ class Persistence
     }
 
     /**
-     * Given a field seed, return a feld object.
-     *
-     * @param string $type
-     *
-     * @throws \atk4\core\Exception
-     *
-     * @return Field
-     */
-    public function fieldFactory($seed = [])
-    {
-        /** @var Field $field */
-        $seed = $this->mergeSeeds(
-            $seed,
-            isset($seed['type']) ? ($this->typeToFieldSeed[$seed['type']] ?? null) : null,
-            [Field::class]
-        );
-        $field = $this->factory($seed, null, '\atk4\data\Field');
-
-        return $field;
-    }
-
-    protected $typeToFieldSeed = [
-        'boolean' => ['Boolean'],
-    ];
-
-    /**
      * Associate model with the data driver.
      *
      * @param Model|string $m        Model which will use this persistence

--- a/src/Persistence.php
+++ b/src/Persistence.php
@@ -77,12 +77,34 @@ class Persistence
     }
 
     /**
+     * Given a field seed, return a feld object
+     *
+     * @param string $type
+     * @throws \atk4\core\Exception
+     * @return Field
+     */
+    public function fieldFactory($seed = []) {
+        /** @var Field $field */
+        $field = $this->factory($this->mergeSeeds(
+            isset($seed['type']) ? ($this->typeToFieldSeed[$seed['type']] ?? null) : null,
+            [Field::class]
+        ), null, '\atk4\data\Field');
+        return $field;
+    }
+
+    protected $typeToFieldSeed = [
+        'boolean' => 'Boolean',
+    ];
+
+    /**
      * Associate model with the data driver.
      *
-     * @param Model|string $m        Model which will use this persistence
-     * @param array        $defaults Properties
+     * @param Model|string $m Model which will use this persistence
+     * @param array $defaults Properties
      *
      * @return Model
+     * @throws Exception
+     * @throws \atk4\core\Exception
      */
     public function add($m, $defaults = [])
     {

--- a/src/Persistence/CSV.php
+++ b/src/Persistence/CSV.php
@@ -188,11 +188,7 @@ class CSV extends Persistence
         $this->openFile('w');
 
         $header = [];
-        foreach ($m->elements as $name=>$field) {
-            if (!$field instanceof Field) {
-                continue;
-            }
-
+        foreach ($m->getFields() as $name=>$field) {
             if ($name == $m->id_field) {
                 continue;
             }

--- a/src/Persistence/SQL.php
+++ b/src/Persistence/SQL.php
@@ -155,7 +155,7 @@ class SQL extends Persistence
 
         // When we work without table, we can't have any IDs
         if ($m->table === false) {
-            $m->getField($m->id_field)->destroy();
+            $m->removeField($m->id_field);
             $m->addExpression($m->id_field, '1');
             //} else {
             // SQL databases use ID of int by default
@@ -241,13 +241,10 @@ class SQL extends Persistence
      */
     public function initField($q, $field)
     {
-        $is_sql_field = ($field instanceof \atk4\data\Field_SQL) || ($field instanceof \atk4\data\Field\Boolean);
-        if ($is_sql_field && $field->useAlias()) {
+        if ($field->useAlias()) {
             $q->field($field, $field->short_name);
-        } elseif ($is_sql_field) {
-            $q->field($field);
         } else {
-            $q->field($field->short_name);
+            $q->field($field);
         }
     }
 

--- a/src/Persistence/SQL.php
+++ b/src/Persistence/SQL.php
@@ -287,24 +287,20 @@ class SQL extends Persistence
             }
 
             // now add system fields, if they were not added
-            foreach ($m->elements as $field => $f_object) {
-                if ($f_object instanceof Field) {
-                    if ($f_object->never_persist) {
-                        continue;
-                    }
-                    if ($f_object->system && !isset($added_fields[$field])) {
-                        $this->initField($q, $f_object);
-                    }
+            foreach ($m->getFields() as $field => $f_object) {
+                if ($f_object->never_persist) {
+                    continue;
+                }
+                if ($f_object->system && !isset($added_fields[$field])) {
+                    $this->initField($q, $f_object);
                 }
             }
         } else {
-            foreach ($m->elements as $field => $f_object) {
-                if ($f_object instanceof Field) {
-                    if ($f_object->never_persist) {
-                        continue;
-                    }
-                    $this->initField($q, $f_object);
+            foreach ($m->getFields() as $field => $f_object) {
+                if ($f_object->never_persist) {
+                    continue;
                 }
+                $this->initField($q, $f_object);
             }
         }
     }

--- a/tests/BusinessModelTest.php
+++ b/tests/BusinessModelTest.php
@@ -24,7 +24,7 @@ class BusinessModelTest extends \atk4\core\PHPUnit_AgileTestCase
         $f = $m->getField('name');
         $this->assertEquals('name', $f->short_name);
 
-        $m->add(new Field(), 'surname');
+        $m->addField('surname', new Field());
         $f = $m->getField('surname');
         $this->assertEquals('surname', $f->short_name);
     }

--- a/tests/ConditionTest.php
+++ b/tests/ConditionTest.php
@@ -10,7 +10,7 @@ use atk4\data\Model;
 class ConditionTest extends \atk4\core\PHPUnit_AgileTestCase
 {
     /**
-     * @expectedException \atk4\data\Exception
+     * @expectedException \atk4\core\Exception
      */
     public function testException1()
     {

--- a/tests/FieldTest.php
+++ b/tests/FieldTest.php
@@ -436,6 +436,7 @@ class FieldTest extends \atk4\schema\PHPUnit_SchemaTestCase
         $m = new Model($db, 'user');
         $m->addField('first_name', ['actual' => 'name']);
         $m->addField('surname');
+        var_dump($m->load(1)->get());
         $m->insert(['first_name' => 'Peter', 'surname' => 'qq']);
         $m->loadBy('first_name', 'John');
         $this->assertEquals('John', $m['first_name']);

--- a/tests/FieldTest.php
+++ b/tests/FieldTest.php
@@ -436,7 +436,6 @@ class FieldTest extends \atk4\schema\PHPUnit_SchemaTestCase
         $m = new Model($db, 'user');
         $m->addField('first_name', ['actual' => 'name']);
         $m->addField('surname');
-        var_dump($m->load(1)->get());
         $m->insert(['first_name' => 'Peter', 'surname' => 'qq']);
         $m->loadBy('first_name', 'John');
         $this->assertEquals('John', $m['first_name']);

--- a/tests/FieldTest.php
+++ b/tests/FieldTest.php
@@ -812,31 +812,33 @@ class FieldTest extends \atk4\schema\PHPUnit_SchemaTestCase
         $this->assertSame('{"foo":"bar","int":123,"rows":["a","b"]}', $m->getField('object')->toString((object) ['foo'=>'bar', 'int'=>123, 'rows'=>['a', 'b']]));
     }
 
-    public function testAddFieldDirectly() {
+    public function testAddFieldDirectly()
+    {
         $this->expectException(Exception::class);
         $model = new Model();
         $model->add(new Field(), 'test');
     }
 
-    public function testGetFields() {
+    public function testGetFields()
+    {
         $model = new Model();
         $model->addField('system', ['system'=>true]);
         $model->addField('editable', ['ui'=>['editable'=>true]]);
-        $model->addField('editable_system', ['ui'=>['editable'=>true],'system'=>true]);
+        $model->addField('editable_system', ['ui'=>['editable'=>true], 'system'=>true]);
         $model->addField('visible', ['ui'=>['visible'=>true]]);
-        $model->addField('visible_system', ['ui'=>['visible'=>true],'system'=>true]);
+        $model->addField('visible_system', ['ui'=>['visible'=>true], 'system'=>true]);
         $model->addField('not_editable', ['ui'=>['editable'=>false]]);
 
-        $this->assertEquals(['system' ,'editable', 'editable_system', 'visible', 'visible_system', 'not_editable'], array_keys($model->getFields()));
-        $this->assertEquals(['system' ,'editable_system', 'visible_system'], array_keys($model->getFields('system')));
+        $this->assertEquals(['system', 'editable', 'editable_system', 'visible', 'visible_system', 'not_editable'], array_keys($model->getFields()));
+        $this->assertEquals(['system', 'editable_system', 'visible_system'], array_keys($model->getFields('system')));
         $this->assertEquals(['editable', 'visible', 'not_editable'], array_keys($model->getFields('not system')));
-        $this->assertEquals(['editable' ,'editable_system', 'visible'], array_keys($model->getFields('editable')));
-        $this->assertEquals(['editable' ,'visible', 'visible_system', 'not_editable'], array_keys($model->getFields('visible')));
+        $this->assertEquals(['editable', 'editable_system', 'visible'], array_keys($model->getFields('editable')));
+        $this->assertEquals(['editable', 'visible', 'visible_system', 'not_editable'], array_keys($model->getFields('visible')));
 
         $model->onlyFields(['system', 'visible', 'not_editable']);
 
         // getFields() is unaffected by only_fields, will always return all fields
-        $this->assertEquals(['system' ,'editable', 'editable_system', 'visible', 'visible_system', 'not_editable'], array_keys($model->getFields()));
+        $this->assertEquals(['system', 'editable', 'editable_system', 'visible', 'visible_system', 'not_editable'], array_keys($model->getFields()));
 
         // only return subset of only_fields
         $this->assertEquals(['visible', 'not_editable'], array_keys($model->getFields('visible')));

--- a/tests/FieldTest.php
+++ b/tests/FieldTest.php
@@ -2,6 +2,8 @@
 
 namespace atk4\data\tests;
 
+use atk4\core\Exception;
+use atk4\data\Field;
 use atk4\data\Model;
 use atk4\data\Persistence;
 
@@ -808,5 +810,38 @@ class FieldTest extends \atk4\schema\PHPUnit_SchemaTestCase
         $this->assertSame('12:23:34', $m->getField('time')->toString(new \DateTime('2019-01-20T12:23:34+00:00')));
         $this->assertSame('{"foo":"bar","int":123,"rows":["a","b"]}', $m->getField('array')->toString(['foo'=>'bar', 'int'=>123, 'rows'=>['a', 'b']]));
         $this->assertSame('{"foo":"bar","int":123,"rows":["a","b"]}', $m->getField('object')->toString((object) ['foo'=>'bar', 'int'=>123, 'rows'=>['a', 'b']]));
+    }
+
+    public function testAddFieldDirectly() {
+        $this->expectException(Exception::class);
+        $model = new Model();
+        $model->add(new Field(), 'test');
+    }
+
+    public function testGetFields() {
+        $model = new Model();
+        $model->addField('system', ['system'=>true]);
+        $model->addField('editable', ['ui'=>['editable'=>true]]);
+        $model->addField('editable_system', ['ui'=>['editable'=>true],'system'=>true]);
+        $model->addField('visible', ['ui'=>['visible'=>true]]);
+        $model->addField('visible_system', ['ui'=>['visible'=>true],'system'=>true]);
+        $model->addField('not_editable', ['ui'=>['editable'=>false]]);
+
+        $this->assertEquals(['system' ,'editable', 'editable_system', 'visible', 'visible_system', 'not_editable'], array_keys($model->getFields()));
+        $this->assertEquals(['system' ,'editable_system', 'visible_system'], array_keys($model->getFields('system')));
+        $this->assertEquals(['editable', 'visible', 'not_editable'], array_keys($model->getFields('not system')));
+        $this->assertEquals(['editable' ,'editable_system', 'visible'], array_keys($model->getFields('editable')));
+        $this->assertEquals(['editable' ,'visible', 'visible_system', 'not_editable'], array_keys($model->getFields('visible')));
+
+        $model->onlyFields(['system', 'visible', 'not_editable']);
+
+        // getFields() is unaffected by only_fields, will always return all fields
+        $this->assertEquals(['system' ,'editable', 'editable_system', 'visible', 'visible_system', 'not_editable'], array_keys($model->getFields()));
+
+        // only return subset of only_fields
+        $this->assertEquals(['visible', 'not_editable'], array_keys($model->getFields('visible')));
+
+        $this->expectExceptionMessage('not supported');
+        $model->getFields('foo');
     }
 }


### PR DESCRIPTION
Implements getFields() and refactors fields in general to use MultiContainerTrait..

Depends on #444 (next is to refactor "references" into separate array)

## Note on type->seed conversion

Previously there was a check - type=boolean -> use Bolean class. I want this to be similar to factories in Table, Form etc. However, i think Persistence should be able to influence which classes are used for types.

Model fields can also be used without persistence and as a result there are some code duplication right now (fieldFactory). 

Please suggest how to resolve that.