### PR TITLE
Added new Email type

### DIFF
--- a/src/Field/Email.php
+++ b/src/Field/Email.php
@@ -72,7 +72,7 @@ class Email extends Field
 
             if ($this->dns_check) {
                 $domain = explode('@', $email)[1];
-                if (!checkdnsrr(idn_to_ascii($domain), 'MX')) {
+                if (!checkdnsrr(idn_to_ascii($domain, 0, INTL_IDNA_VARIANT_UTS46), 'MX')) {
                     throw new ValidationException([$this->name => 'Email domain does not exist']);
                 }
             }

--- a/src/Field/Email.php
+++ b/src/Field/Email.php
@@ -4,8 +4,8 @@
 
 namespace atk4\data\Field;
 
-use atk4\data\ValidationException;
 use atk4\data\Field;
+use atk4\data\ValidationException;
 
 /**
  * Stores valid email(s) as per configuration.
@@ -13,7 +13,7 @@ use atk4\data\Field;
  * Usage:
  *  $user->addField('email', ['Email']);
  *  $user->addField('email_mx_check', ['Email', 'dns_check'=>true]);
- *  $user->addField('email_with_name', ['Email', 'include_names'=>true]);
+ *  *  $user->addField('email_with_name', ['Email', 'include_names'=>true]);
  *  $user->addField('emails', ['Email', 'allow_multiple'=>true, 'separator'=>[',',';']]);
  *
  * Various options can also be combined.
@@ -34,7 +34,7 @@ class Email extends Field
      * @var bool Also allow entry of names in format "Romans <me@example.com>"
      */
     public $include_names = false;
-    
+
     /**
      * @var array Array of allowed separators
      */
@@ -52,7 +52,7 @@ class Email extends Field
     public function normalize($value)
     {
         // split value by any number of separator characters
-        $emails = preg_split("/[".join('',array_map('preg_quote',$this->separator))."]+/", $value, -1, PREG_SPLIT_NO_EMPTY);
+        $emails = preg_split('/['.implode('', array_map('preg_quote', $this->separator)).']+/', $value, -1, PREG_SPLIT_NO_EMPTY);
 
         if (!$this->allow_multiple && count($emails) > 1) {
             throw new ValidationException([$this->name => 'Only a single email can be entered']);

--- a/src/Field/Email.php
+++ b/src/Field/Email.php
@@ -1,21 +1,15 @@
 <?php
 
-
 namespace atk4\data\Field;
-
 
 use atk4\data\Exception;
 use atk4\data\Field;
-use atk4\data\ValidationException;
 
 /**
- * Stores valid email(s) as per configuration
- *
- * @package atk4\data\Field
+ * Stores valid email(s) as per configuration.
  */
 class Email extends Field
 {
-
     /**
      * @var bool Enable lookup for MX record for email addresses stored
      */
@@ -31,18 +25,17 @@ class Email extends Field
      */
     public $include_names = false;
 
-    function normalize($value)
+    public function normalize($value)
     {
 
         // use comma as separator
         $emails = explode(',', $value);
 
-        if (!$this->allow_multiple && count($emails)>1) {
+        if (!$this->allow_multiple && count($emails) > 1) {
             throw new Exception(['Only a single email can be entered', 'email'=>$value]);
         }
 
-        array_map(function($email){
-
+        array_map(function ($email) {
             $email = trim($email);
 
             if ($this->include_names) {
@@ -60,6 +53,6 @@ class Email extends Field
             }
         }, $emails);
 
-        return parent::normalize(join(', ', array_map('trim', $emails)));
+        return parent::normalize(implode(', ', array_map('trim', $emails)));
     }
 }

--- a/src/Field/Email.php
+++ b/src/Field/Email.php
@@ -1,0 +1,65 @@
+<?php
+
+
+namespace atk4\data\Field;
+
+
+use atk4\data\Exception;
+use atk4\data\Field;
+use atk4\data\ValidationException;
+
+/**
+ * Stores valid email(s) as per configuration
+ *
+ * @package atk4\data\Field
+ */
+class Email extends Field
+{
+
+    /**
+     * @var bool Enable lookup for MX record for email addresses stored
+     */
+    public $dns_check = false;
+
+    /**
+     * @var bool Permit entry of multiple email addresses, separated with comma (and extra spaces)
+     */
+    public $allow_multiple = false;
+
+    /**
+     * @var bool Also allow entry of names in format "Romans <me@example.com>"
+     */
+    public $include_names = false;
+
+    function normalize($value)
+    {
+
+        // use comma as separator
+        $emails = explode(',', $value);
+
+        if (!$this->allow_multiple && count($emails)>1) {
+            throw new Exception(['Only a single email can be entered', 'email'=>$value]);
+        }
+
+        array_map(function($email){
+
+            $email = trim($email);
+
+            if ($this->include_names) {
+                $email = preg_replace('/^[^<]*<([^>]*)>/', '\1', $email);
+            }
+
+            if (!filter_var($email, FILTER_VALIDATE_EMAIL)) {
+                throw new Exception(['Email format is invalid', 'email'=>$email]);
+            }
+
+            $domain = explode('@', $email)[1];
+
+            if ($this->dns_check && !checkdnsrr($domain, 'MX')) {
+                throw new Exception(['Email domain does not exist', 'domain'=>$domain]);
+            }
+        }, $emails);
+
+        return parent::normalize(join(', ', array_map('trim', $emails)));
+    }
+}

--- a/src/Field/Email.php
+++ b/src/Field/Email.php
@@ -83,7 +83,7 @@ class Email extends Field
 
         return parent::normalize(implode(', ', $emails));
     }
-    
+
     /**
      * Return translated address.
      *
@@ -91,8 +91,8 @@ class Email extends Field
      *
      * @return string
      */
-     protected function idn_to_ascii($email)
-     {
+    protected function idn_to_ascii($email)
+    {
         return idn_to_ascii($email, IDNA_NONTRANSITIONAL_TO_ASCII, INTL_IDNA_VARIANT_UTS46);
-     }
+    }
 }

--- a/src/Field/Email.php
+++ b/src/Field/Email.php
@@ -67,12 +67,14 @@ class Email extends Field
             }
 
             // should actually run only domain trough idn_to_ascii(), but for validation purpose this way it's fine too
-            if (!filter_var($this->idn_to_ascii($email), FILTER_VALIDATE_EMAIL)) {
+            $p = explode('@', $email);
+            $user = $p[0] ?? null;
+            $domain = $p[1] ?? null;
+            if (!filter_var($user.'@'.$this->idn_to_ascii($domain), FILTER_VALIDATE_EMAIL)) {
                 throw new ValidationException([$this->name => 'Email format is invalid']);
             }
 
             if ($this->dns_check) {
-                $domain = explode('@', $email)[1];
                 if (!checkdnsrr($this->idn_to_ascii($domain), 'MX')) {
                     throw new ValidationException([$this->name => 'Email domain does not exist']);
                 }
@@ -87,12 +89,12 @@ class Email extends Field
     /**
      * Return translated address.
      *
-     * @param string $email
+     * @param string $domain
      *
      * @return string
      */
-    protected function idn_to_ascii($email)
+    protected function idn_to_ascii($domain)
     {
-        return idn_to_ascii($email, IDNA_NONTRANSITIONAL_TO_ASCII, INTL_IDNA_VARIANT_UTS46);
+        return idn_to_ascii($domain, IDNA_NONTRANSITIONAL_TO_ASCII, INTL_IDNA_VARIANT_UTS46);
     }
 }

--- a/tests/FieldTypesTest.php
+++ b/tests/FieldTypesTest.php
@@ -71,7 +71,7 @@ class FieldTypesTest extends \atk4\schema\PHPUnit_SchemaTestCase
 
         $m['email_name'] = 'Romans <me@gmail.com>';
         $m['email_names'] = 'Romans1 <me1@gmail.com>, Romans2 <me2@gmail.com>; Romans3 <me3@gmail.com>';
-        $m['email_idn'] = 'test@täst.de';
+        $m['email_idn'] = 'test@日本レジストリサービス.jp';
 
         $this->expectExceptionMessage('format is invalid');
         $m['email'] = 'Romans <me@gmail.com>';

--- a/tests/FieldTypesTest.php
+++ b/tests/FieldTypesTest.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace atk4\data\tests;
+
+use atk4\core\Exception;
+use atk4\data\Model;
+use atk4\data\Persistence_Static;
+use atk4\data\UserAction;
+
+/**
+ * Test various Field/*
+ */
+class FieldTypesTest extends \atk4\schema\PHPUnit_SchemaTestCase
+{
+    public $pers = null;
+
+    public function setUp()
+    {
+        parent::setUp();
+
+        $this->pers = new Persistence_Static([
+            1 => ['name'=>'John'],
+            2 => ['name'=>'Peter'],
+        ]);
+    }
+
+    public function testEmail1()
+    {
+        $m = new Model($this->pers);
+        $m->addField('email', ['Email']);
+
+        $m['email'] = ' foo@example.com';
+        $m->save();
+
+        // padding removed
+        $this->assertEquals('foo@example.com', $m['email']);
+
+        $this->expectExceptionMessage('format is invalid');
+        $m['email'] = 'qq';
+    }
+
+    public function testEmail2()
+    {
+        $m = new Model($this->pers);
+        $m->addField('email', ['Email']);
+        $m->addField('emails', ['Email', 'allow_multiple'=>true]);
+
+        $m['emails'] = 'bar@exampe.com ,foo@example.com';
+        $this->assertEquals('bar@exampe.com, foo@example.com', $m['emails']);
+
+        $this->expectExceptionMessage('a single email');
+        $m['email'] = 'bar@exampe.com ,foo@example.com';
+    }
+
+    public function testEmail3()
+    {
+        $m = new Model($this->pers);
+        $m->addField('email', ['Email', 'dns_check'=>true]);
+
+        $m['email'] = ' foo@gmail.com';
+
+        $this->expectExceptionMessage('does not exist');
+        $m['email'] = ' foo@lrcanoetuhasnotdusantotehusontehuasntddaontehudnouhtd.com';
+    }
+
+    public function testEmail4()
+    {
+        $m = new Model($this->pers);
+        $m->addField('email_name', ['Email', 'include_names'=>true]);
+        $m->addField('email_names', ['Email', 'include_names'=>true, 'allow_multiple'=>true]);
+        $m->addField('email', ['Email']);
+
+        $m['email_name'] = 'Romans <me@gmail.com>';
+        $m['email_names'] = 'Romans1 <me1@gmail.com>, Romans2 <me2@gmail.com>';
+
+        $this->expectExceptionMessage('format is invalid');
+        $m['email'] = 'Romans <me@gmail.com>';
+    }
+}

--- a/tests/FieldTypesTest.php
+++ b/tests/FieldTypesTest.php
@@ -2,13 +2,11 @@
 
 namespace atk4\data\tests;
 
-use atk4\core\Exception;
 use atk4\data\Model;
 use atk4\data\Persistence_Static;
-use atk4\data\UserAction;
 
 /**
- * Test various Field/*
+ * Test various Field/*.
  */
 class FieldTypesTest extends \atk4\schema\PHPUnit_SchemaTestCase
 {

--- a/tests/FieldTypesTest.php
+++ b/tests/FieldTypesTest.php
@@ -65,7 +65,7 @@ class FieldTypesTest extends \atk4\schema\PHPUnit_SchemaTestCase
     {
         $m = new Model($this->pers);
         $m->addField('email_name', ['Email', 'include_names'=>true]);
-        $m->addField('email_names', ['Email', 'include_names'=>true, 'allow_multiple'=>true, 'separator'=>[',',';']]);
+        $m->addField('email_names', ['Email', 'include_names'=>true, 'allow_multiple'=>true, 'separator'=>[',', ';']]);
         $m->addField('email_idn', ['Email']);
         $m->addField('email', ['Email']);
 

--- a/tests/FieldTypesTest.php
+++ b/tests/FieldTypesTest.php
@@ -6,7 +6,7 @@ use atk4\data\Model;
 use atk4\data\Persistence_Static;
 
 /**
- * Test various Field/*.
+ * Test various Field.
  */
 class FieldTypesTest extends \atk4\schema\PHPUnit_SchemaTestCase
 {
@@ -65,11 +65,13 @@ class FieldTypesTest extends \atk4\schema\PHPUnit_SchemaTestCase
     {
         $m = new Model($this->pers);
         $m->addField('email_name', ['Email', 'include_names'=>true]);
-        $m->addField('email_names', ['Email', 'include_names'=>true, 'allow_multiple'=>true]);
+        $m->addField('email_names', ['Email', 'include_names'=>true, 'allow_multiple'=>true, 'separator'=>[',',';']]);
+        $m->addField('email_idn', ['Email']);
         $m->addField('email', ['Email']);
 
         $m['email_name'] = 'Romans <me@gmail.com>';
-        $m['email_names'] = 'Romans1 <me1@gmail.com>, Romans2 <me2@gmail.com>';
+        $m['email_names'] = 'Romans1 <me1@gmail.com>, Romans2 <me2@gmail.com>; Romans3 <me3@gmail.com>';
+        $m['email_idn'] = 'test@täst.de';
 
         $this->expectExceptionMessage('format is invalid');
         $m['email'] = 'Romans <me@gmail.com>';

--- a/tests/FieldTypesTest.php
+++ b/tests/FieldTypesTest.php
@@ -65,8 +65,8 @@ class FieldTypesTest extends \atk4\schema\PHPUnit_SchemaTestCase
     {
         $m = new Model($this->pers);
         $m->addField('email_name', ['Email', 'include_names'=>true]);
-        $m->addField('email_names', ['Email', 'include_names'=>true, 'allow_multiple'=>true, 'separator'=>[',', ';']]);
-        $m->addField('email_idn', ['Email']);
+        $m->addField('email_names', ['Email', 'include_names'=>true, 'allow_multiple'=>true, 'dns_check'=>true, 'separator'=>[',', ';']]);
+        $m->addField('email_idn', ['Email', 'dns_check'=>true]);
         $m->addField('email', ['Email']);
 
         $m['email_name'] = 'Romans <me@gmail.com>';


### PR DESCRIPTION
Re-implementation of https://github.com/atk4/data/pull/443

Adds new field type `Email` with various options for validation and safe storage of emails:

``` php
$user->addField('email', ['Email']);
$user->addField('email_mx_check', ['Email', 'dns_check'=>true]);
$user->addField('email_with_name', ['Email', 'include_names'=>true]);
$user->addField('emails', ['Email', 'allow_multiple'=>true]);
```

Various options can also be combined. Also will clean up spaces. @acicovic - what do you think ?