### PR TITLE
Reference get caption

### DIFF
--- a/src/Reference.php
+++ b/src/Reference.php
@@ -22,7 +22,7 @@ class Reference
 
     /**
      * Owner Model of the reference.
-     * override the hint type definition already present in TrackableTrait
+     * override the hint type definition already present in TrackableTrait.
      *
      * @var Model
      */
@@ -163,6 +163,9 @@ class Reference
      *
      * @param Model $model
      * @param array $defaults
+     *
+     * @throws Exception
+     * @throws \atk4\core\Exception
      *
      * @return Model
      */

--- a/src/Reference.php
+++ b/src/Reference.php
@@ -106,6 +106,8 @@ class Reference
      *
      * @param array $defaults Properties
      *
+     * @throws \atk4\core\Exception
+     *
      * @return Model
      */
     public function getModel($defaults = []) : Model
@@ -126,7 +128,7 @@ class Reference
         // if model is Closure, then call it and return model
         if (is_object($this->model) && $this->model instanceof \Closure) {
             $c = $this->model;
-            $c = $c($this->owner, $this, $defaults);
+            $c = ($c)($this->owner, $this, $defaults);
 
             return $this->addToPersistence($c, $defaults);
         }

--- a/src/Reference.php
+++ b/src/Reference.php
@@ -21,6 +21,14 @@ class Reference
     use \atk4\core\FactoryTrait;
 
     /**
+     * Owner Model of the reference.
+     * override the hint type definition already present in TrackableTrait
+     *
+     * @var Model
+     */
+    public $owner;
+
+    /**
      * Use this alias for related entity by default. This can help you
      * if you create sub-queries or joins to separate this from main
      * table. The table_alias will be uniquely generated.

--- a/src/Reference.php
+++ b/src/Reference.php
@@ -127,8 +127,7 @@ class Reference
 
         // if model is Closure, then call it and return model
         if (is_object($this->model) && $this->model instanceof \Closure) {
-            $c = $this->model;
-            $c = ($c)($this->owner, $this, $defaults);
+            $c = ($this->model)($this->owner, $this, $defaults);
 
             return $this->addToPersistence($c, $defaults);
         }
@@ -205,6 +204,8 @@ class Reference
      *
      * @param array $defaults Properties
      *
+     * @throws \atk4\core\Exception
+     *
      * @return Model
      */
     public function ref($defaults = []) : Model
@@ -218,6 +219,8 @@ class Reference
      * or scope.
      *
      * @param array $defaults Properties
+     *
+     * @throws \atk4\core\Exception
      *
      * @return Model
      */

--- a/src/Reference/HasOne.php
+++ b/src/Reference/HasOne.php
@@ -4,6 +4,7 @@
 
 namespace atk4\data\Reference;
 
+use atk4\core\Exception;
 use atk4\data\Field;
 use atk4\data\Join;
 use atk4\data\Model;
@@ -155,6 +156,8 @@ class HasOne extends Reference
     /**
      * Reference_One will also add a field corresponding
      * to 'our_field' unless it exists of course.
+     *
+     * @throws Exception
      */
     public function init()
     {
@@ -189,6 +192,8 @@ class HasOne extends Reference
 
     /**
      * Returns our field or id field.
+     *
+     * @throws Exception
      *
      * @return Field
      */

--- a/src/Reference/HasOne.php
+++ b/src/Reference/HasOne.php
@@ -237,6 +237,7 @@ class HasOne extends Reference
                     $this->owner[$this->our_field] = $m[$this->their_field];
                 });
         }
+
         if ($this->owner[$this->our_field]) {
             $m->tryLoad($this->owner[$this->our_field]);
         }

--- a/src/Reference/HasOne.php
+++ b/src/Reference/HasOne.php
@@ -207,6 +207,9 @@ class HasOne extends Reference
      *
      * @param array $defaults Properties
      *
+     * @throws Exception
+     * @throws \atk4\data\Exception
+     *
      * @return Model
      */
     public function ref($defaults = []) : Model
@@ -228,18 +231,14 @@ class HasOne extends Reference
                 $m->addHook('afterSave', function ($m) {
                     $this->owner[$this->our_field] = $m[$this->their_field];
                 });
-        } else {
-            if ($this->owner[$this->our_field]) {
-                $m->tryLoad($this->owner[$this->our_field]);
-            }
-
-            return
-                $m->addHook('afterSave', function ($m) {
-                    $this->owner[$this->our_field] = $m->id;
-                });
+        }
+        if ($this->owner[$this->our_field]) {
+            $m->tryLoad($this->owner[$this->our_field]);
         }
 
-        // can not load referenced model or set conditions on it, so we just return it
-        return $m;
+        return
+            $m->addHook('afterSave', function ($m) {
+                $this->owner[$this->our_field] = $m->id;
+            });
     }
 }

--- a/src/Reference/HasOne_SQL.php
+++ b/src/Reference/HasOne_SQL.php
@@ -47,6 +47,10 @@ class HasOne_SQL extends HasOne
             $their_field = $field;
         }
 
+        // if caption is not defined in $defaults -> get it directly from the linked model field $their_field
+        $defaults['caption'] = $defaults['caption'] ?? $this->owner->refModel($this->link)->getField($their_field)->getCaption();
+
+        /** @var Field_SQL_Expression $e */
         $e = $this->owner->addExpression($field, array_merge([
             function (Model $m) use ($their_field) {
                 // remove order if we just select one field from hasOne model

--- a/src/Reference/HasOne_SQL.php
+++ b/src/Reference/HasOne_SQL.php
@@ -20,12 +20,14 @@ class HasOne_SQL extends HasOne
      *
      * Returns Expression in case you want to do something else with it.
      *
-     * @param string|Field|array $field       or [$field, ..defaults]
+     * @param string|Field|array $field or [$field, ..defaults]
      * @param string|null        $their_field
      *
+     * @throws Exception
+     * @throws \atk4\core\Exception
      * @return Field_SQL_Expression
      */
-    public function addField($field, $their_field = null) : Field_SQL_Expression
+    public function addField($field, ?string $their_field = null) : Field_SQL_Expression
     {
         if (is_array($field)) {
             $defaults = $field;
@@ -46,7 +48,7 @@ class HasOne_SQL extends HasOne
         }
 
         $e = $this->owner->addExpression($field, array_merge([
-            function ($m) use ($their_field) {
+            function (Model $m) use ($their_field) {
                 // remove order if we just select one field from hasOne model
                 // that is mandatory for Oracle
                 return $m->refLink($this->link)->action('field', [$their_field])->reset('order');
@@ -58,7 +60,7 @@ class HasOne_SQL extends HasOne
         $e->never_save = true;
 
         // Will try to execute last
-        $this->owner->addHook('beforeSave', function ($m) use ($field, $their_field) {
+        $this->owner->addHook('beforeSave', function (Model $m) use ($field, $their_field) {
             // if title field is changed, but reference ID field (our_field)
             // is not changed, then update reference ID field value
             if ($m->isDirty($field) && !$m->isDirty($this->our_field)) {
@@ -86,6 +88,10 @@ class HasOne_SQL extends HasOne
      * addFields(['from', 'to'], ['type' => 'date']);
      *
      * @param array $fields
+     * @param array $defaults
+     *
+     * @throws Exception
+     * @throws \atk4\core\Exception
      *
      * @return $this
      */
@@ -122,6 +128,8 @@ class HasOne_SQL extends HasOne
      *
      * @param array $defaults Properties
      *
+     * @throws \atk4\core\Exception
+     *
      * @return Model
      */
     public function refLink($defaults = []) : Model
@@ -140,6 +148,9 @@ class HasOne_SQL extends HasOne
      * Navigate to referenced model.
      *
      * @param array $defaults Properties
+     *
+     * @throws Exception
+     * @throws \atk4\core\Exception
      *
      * @return Model
      */
@@ -184,6 +195,9 @@ class HasOne_SQL extends HasOne
      *
      * @param array $defaults Properties
      *
+     * @throws Exception
+     * @throws \atk4\core\Exception
+     *
      * @return Field_SQL_Expression
      */
     public function addTitle($defaults = []) : Field_SQL_Expression
@@ -206,9 +220,10 @@ class HasOne_SQL extends HasOne
             ]);
         }
 
+        /** @var Field_SQL_Expression $ex */
         $ex = $this->owner->addExpression($field, array_merge_recursive(
             [
-                function ($m) {
+                function (Model $m) {
                     $mm = $m->refLink($this->link);
 
                     return $mm->action('field', [$mm->title_field])->reset('order');
@@ -226,7 +241,7 @@ class HasOne_SQL extends HasOne
         ));
 
         // Will try to execute last
-        $this->owner->addHook('beforeSave', function ($m) use ($field) {
+        $this->owner->addHook('beforeSave', function (Model $m) use ($field) {
             // if title field is changed, but reference ID field (our_field)
             // is not changed, then update reference ID field value
             if ($m->isDirty($field) && !$m->isDirty($this->our_field)) {
@@ -253,6 +268,9 @@ class HasOne_SQL extends HasOne
      * This will add expression 'user' equal to ref('user_id')['name'];
      *
      * @param array $defaults Properties
+     *
+     * @throws Exception
+     * @throws \atk4\core\Exception
      *
      * @return $this
      */

--- a/src/Reference/HasOne_SQL.php
+++ b/src/Reference/HasOne_SQL.php
@@ -130,7 +130,7 @@ class HasOne_SQL extends HasOne
 
         $m->addCondition(
             $this->their_field ?: ($m->id_field),
-            $this->referenceOurValue($m)
+            $this->referenceOurValue()
         );
 
         return $m;

--- a/src/Reference/HasOne_SQL.php
+++ b/src/Reference/HasOne_SQL.php
@@ -20,11 +20,12 @@ class HasOne_SQL extends HasOne
      *
      * Returns Expression in case you want to do something else with it.
      *
-     * @param string|Field|array $field or [$field, ..defaults]
+     * @param string|Field|array $field       or [$field, ..defaults]
      * @param string|null        $their_field
      *
      * @throws Exception
      * @throws \atk4\core\Exception
+     *
      * @return Field_SQL_Expression
      */
     public function addField($field, ?string $their_field = null) : Field_SQL_Expression

--- a/tests/ReferenceSQLTest.php
+++ b/tests/ReferenceSQLTest.php
@@ -558,4 +558,47 @@ class ReferenceSQLTest extends \atk4\schema\PHPUnit_SchemaTestCase
         $o->reload();
         $this->assertEquals(3, $o->get('user_id')); // and it's really saved like that
     }
+
+    /**
+     * Tests that if we change hasOne->addTitle() field value then it will also update
+     * link field value when saved.
+     */
+    public function testHasOneReferenceCaption()
+    {
+        $a = [
+            'user'  => [
+                1 => ['id' => 1, 'name' => 'John', 'last_name' => 'Doe'],
+                2 => ['id' => 2, 'name' => 'Peter', 'last_name' => 'Foo'],
+                3 => ['id' => 3, 'name' => 'Goofy', 'last_name' => 'Goo'],
+            ],
+            'order' => [
+                1 => ['id' => 1, 'user_id' => 1],
+                2 => ['id' => 2, 'user_id' => 2],
+                3 => ['id' => 3, 'user_id' => 1],
+            ],
+        ];
+
+        // restore DB
+        $this->setDB($a);
+        $u = (new Model($this->db, ['user', 'title_field'=>'last_name']))->addFields(['name', 'last_name']);
+
+        // Test : Now the caption is null and is generated from field name
+        $this->assertEquals('Last Name',$u->getField('last_name')->getCaption());
+
+        $u->getField('last_name')->caption = 'Surname';
+
+        // Test : Now the caption is not null and the value is returned
+        $this->assertEquals('Surname',$u->getField('last_name')->getCaption());
+
+        $o = (new Model($this->db, 'order'));
+        $order_user_ref = $o->hasOne('my_user', [$u, 'our_field'=>'user_id']);
+        $order_user_ref->addField('user_last_name', 'last_name');
+
+        $referenced_caption = $o->getField('user_last_name')->getCaption();
+
+        // Test : $field->caption for the field 'last_name' is defined in referenced model (User)
+        // When Order add field from Referenced model User
+        // caption will be passed to Order field user_last_name
+        $this->assertEquals('Surname',$referenced_caption);
+    }
 }

--- a/tests/ReferenceSQLTest.php
+++ b/tests/ReferenceSQLTest.php
@@ -583,12 +583,12 @@ class ReferenceSQLTest extends \atk4\schema\PHPUnit_SchemaTestCase
         $u = (new Model($this->db, ['user', 'title_field'=>'last_name']))->addFields(['name', 'last_name']);
 
         // Test : Now the caption is null and is generated from field name
-        $this->assertEquals('Last Name',$u->getField('last_name')->getCaption());
+        $this->assertEquals('Last Name', $u->getField('last_name')->getCaption());
 
         $u->getField('last_name')->caption = 'Surname';
 
         // Test : Now the caption is not null and the value is returned
-        $this->assertEquals('Surname',$u->getField('last_name')->getCaption());
+        $this->assertEquals('Surname', $u->getField('last_name')->getCaption());
 
         $o = (new Model($this->db, 'order'));
         $order_user_ref = $o->hasOne('my_user', [$u, 'our_field'=>'user_id']);
@@ -599,6 +599,6 @@ class ReferenceSQLTest extends \atk4\schema\PHPUnit_SchemaTestCase
         // Test : $field->caption for the field 'last_name' is defined in referenced model (User)
         // When Order add field from Referenced model User
         // caption will be passed to Order field user_last_name
-        $this->assertEquals('Surname',$referenced_caption);
+        $this->assertEquals('Surname', $referenced_caption);
     }
 }


### PR DESCRIPTION
I have this code : 
```php
//Model Measure:
        $this->addField('code', ['type' => 'string', 'caption' => 'U.M.']);

//Model Article : 
        $this->hasOne('spec_measure', Measure::class)
                ->addField('spec_measure_code','code');

//Model ComponentOfArticleBOM
        $this->hasOne('article_id', Article::class)
                ->addField('spec_measure_code');
```
if i call `ComponentOfArticleBOM->getField('spec_measure_code')->caption` i get : "Spec Measure Code"

Everytime we add a field from a relation we have to redefine the caption it. Caption is lost, and if we change it we have to find all occurencies and change by hand.

With this PR i fix it and if i call : `ComponentOfArticleBOM->getField('spec_measure_code')->caption` i get : "U.M."
