### PR TITLE
Fix Email Field Validation -  Add Require ext-intl

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,8 @@
     "require": {
         "php": ">=7.2.0",
         "atk4/dsql": "dev-develop as 1.2.5",
-        "atk4/core": "dev-develop"
+        "atk4/core": "dev-develop",
+        "ext-intl": "*"
     },
     "require-dev": {
         "atk4/schema": "dev-develop",


### PR DESCRIPTION
If not present the extension will throw error `function idn_to_ascii not exists` without that extension ph-intl

called here : 

used here : 
https://github.com/atk4/data/blob/0036a94d140c3474c696bb622a861325802abb27/src/Field/Email.php#L73

https://github.com/atk4/data/blob/0036a94d140c3474c696bb622a861325802abb27/src/Field/Email.php#L78

Solutions : 
- add to require in composer ( merge this PR )
- use another method to avoid addiction of required

