### PR TITLE
Only call \DateTime::format if its an instance

### DIFF
--- a/src/Field.php
+++ b/src/Field.php
@@ -407,11 +407,11 @@ class Field implements Expressionable
                 case 'boolean':
                     throw new Exception(['Use Field\Boolean for type=boolean', 'this'=>$this]);
                 case 'date':
-                    return $v instanceof \DateTimeInterface ? $v->format('Y-m-d') : '';
+                    return $v instanceof \DateTimeInterface ? $v->format('Y-m-d') : (string) $v;
                 case 'datetime':
-                    return $v instanceof \DateTimeInterface ? $v->format('c') : ''; // ISO 8601 format 2004-02-12T15:19:21+00:00
+                    return $v instanceof \DateTimeInterface ? $v->format('c') : (string) $v; // ISO 8601 format 2004-02-12T15:19:21+00:00
                 case 'time':
-                    return $v instanceof \DateTimeInterface ? $v->format('H:i:s') : '';
+                    return $v instanceof \DateTimeInterface ? $v->format('H:i:s') : (string) $v;
                 case 'array':
                     return json_encode($v); // todo use Persistence->jsonEncode() instead
                 case 'object':

--- a/src/Field.php
+++ b/src/Field.php
@@ -407,11 +407,11 @@ class Field implements Expressionable
                 case 'boolean':
                     throw new Exception(['Use Field\Boolean for type=boolean', 'this'=>$this]);
                 case 'date':
-                    return $v->format('Y-m-d');
+                    return $v instanceof \DateTimeInterface ? $v->format('Y-m-d') : '';
                 case 'datetime':
-                    return $v->format('c'); // ISO 8601 format 2004-02-12T15:19:21+00:00
+                    return $v instanceof \DateTimeInterface ? $v->format('c') : ''; // ISO 8601 format 2004-02-12T15:19:21+00:00
                 case 'time':
-                    return $v->format('H:i:s');
+                    return $v instanceof \DateTimeInterface ? $v->format('H:i:s') : '';
                 case 'array':
                     return json_encode($v); // todo use Persistence->jsonEncode() instead
                 case 'object':

--- a/tests/FieldTest.php
+++ b/tests/FieldTest.php
@@ -846,8 +846,8 @@ class FieldTest extends \atk4\schema\PHPUnit_SchemaTestCase
         $this->expectExceptionMessage('not supported');
         $model->getFields('foo');
     }
-    
-    public function testDateTimeFieldsToString() 
+
+    public function testDateTimeFieldsToString()
     {
         $model = new Model();
         $model->addField('date', ['type' => 'date']);

--- a/tests/FieldTest.php
+++ b/tests/FieldTest.php
@@ -847,10 +847,11 @@ class FieldTest extends \atk4\schema\PHPUnit_SchemaTestCase
         $model->getFields('foo');
     }
     
-    public function testDateTimeFieldsToString() {
+    public function testDateTimeFieldsToString() 
+    {
         $model = new Model();
-        $model->addField('date',     ['type' => 'date']);
-        $model->addField('time',     ['type' => 'time']);
+        $model->addField('date', ['type' => 'date']);
+        $model->addField('time', ['type' => 'time']);
         $model->addField('datetime', ['type' => 'datetime']);
 
         $this->assertEquals('', $model->getField('date')->toString());

--- a/tests/FieldTest.php
+++ b/tests/FieldTest.php
@@ -846,4 +846,24 @@ class FieldTest extends \atk4\schema\PHPUnit_SchemaTestCase
         $this->expectExceptionMessage('not supported');
         $model->getFields('foo');
     }
+    
+    public function testDateTimeFieldsToString() {
+        $model = new Model();
+        $model->addField('date',     ['type' => 'date']);
+        $model->addField('time',     ['type' => 'time']);
+        $model->addField('datetime', ['type' => 'datetime']);
+
+        $this->assertEquals('', $model->getField('date')->toString());
+        $this->assertEquals('', $model->getField('time')->toString());
+        $this->assertEquals('', $model->getField('datetime')->toString());
+
+        $current_date = new \DateTime();
+        $model->set('date', $current_date);
+        $model->set('time', $current_date);
+        $model->set('datetime', $current_date);
+
+        $this->assertEquals($current_date->format('Y-m-d'), $model->getField('date')->toString());
+        $this->assertEquals($current_date->format('H:i:s'), $model->getField('time')->toString());
+        $this->assertEquals($current_date->format('c'), $model->getField('datetime')->toString());
+    }
 }


### PR DESCRIPTION
The value could be null. In this case this error is thrown:
``Error: Call to a member function format() on null``