### PR TITLE
Fix #460 - add is_update to beforeSave hook

### DIFF
--- a/src/Model.php
+++ b/src/Model.php
@@ -1735,11 +1735,12 @@ class Model implements ArrayAccess, IteratorAggregate
             if (($errors = $this->validate('save')) !== []) {
                 throw new ValidationException($errors, $this);
             }
-            if ($this->hook('beforeSave') === false) {
+
+            $is_update = $this->loaded();
+            if ($this->hook('beforeSave', [$is_update]) === false) {
                 return $this;
             }
 
-            $is_update = $this->loaded();
             if ($is_update) {
                 $data = [];
                 $dirty_join = false;

--- a/tests/ModelHooksTest.php
+++ b/tests/ModelHooksTest.php
@@ -19,60 +19,54 @@ class ModelHooksTest extends \atk4\schema\PHPUnit_SchemaTestCase
 
         $a = [
             'user' => [
-                1 => ['name' => 'John', 'gender' => 'M']
+                1 => ['name' => 'John', 'gender' => 'M'],
             ],
         ];
 
         $this->setDB($a);
 
-        $db      = new Persistence\SQL($this->db->connection);
+        $db = new Persistence\SQL($this->db->connection);
 
         $this->m = new Model($db, 'user');
         $this->m->addFields(['name', 'gender']);
     }
 
-    /**
-     *
-     */
     public function testBeforeSaveIsUpdate()
     {
         $this->m->addHook(
             'beforeSave', function ($m, $is_update) {
-            if ($is_update) {
-                $m->set('name', 'UpdatedModel');
-            } else {
-                $m->set('name', 'InsertedModel');
-            }
-        });
+                if ($is_update) {
+                    $m->set('name', 'UpdatedModel');
+                } else {
+                    $m->set('name', 'InsertedModel');
+                }
+            });
 
         $this->m->save();
         $this->assertEquals('InsertedModel', $this->m->get('name'));
 
         $this->m->save([
-            'gender' => 'trigger_save_with_changed_data'
+            'gender' => 'trigger_save_with_changed_data',
         ]);
         $this->assertEquals('UpdatedModel', $this->m->get('name'));
     }
 
-    /**
-     *
-     */
     public function testAfterSaveIsUpdate()
     {
         $this->m->addHook(
             'afterSave', function ($m, $is_update) {
-            if ($is_update) {
-                $m->set('name', 'UpdatedModel');
-            } else {
-                $m->set('name', 'InsertedModel');
-            }
-        });
+                if ($is_update) {
+                    $m->set('name', 'UpdatedModel');
+                } else {
+                    $m->set('name', 'InsertedModel');
+                }
+            });
 
         $this->m->save();
         $this->assertEquals('InsertedModel', $this->m->get('name'));
 
         $this->m->save([
-            'gender' => 'trigger_save_with_changed_data'
+            'gender' => 'trigger_save_with_changed_data',
         ]);
         $this->assertEquals('UpdatedModel', $this->m->get('name'));
     }

--- a/tests/ModelHooksTest.php
+++ b/tests/ModelHooksTest.php
@@ -2,56 +2,78 @@
 
 namespace atk4\data\tests;
 
-use atk4\data\Field;
 use atk4\data\Model;
 use atk4\data\Persistence;
 
 /**
  * @coversDefaultClass \atk4\data\Model
  */
-class ModelHooksTest extends \atk4\core\PHPUnit_AgileTestCase
+class ModelHooksTest extends \atk4\schema\PHPUnit_SchemaTestCase
 {
 
-    /**
-     *
-     */
-    public function testBeforeSaveIsUpdate() {
-        $model = new Model($this->db);
-        $model->addHook('beforeSave', function($m, $is_update) {
-            if($is_update) {
-                $m->title = 'UpdatedModel';
-            }
-            else {
-                $m->title = 'InsertedModel';
-            }
-        });
+    public $m;
 
-        $model->save();
-        $this->assertEquals('InsertedModel', $model->title);
+    public function setUp()
+    {
+        parent::setUp();
 
-        $model->save();
-        $this->assertEquals('UpdatedModel', $model->title);
+        $a = [
+            'user' => [
+                1 => ['name' => 'John', 'gender' => 'M']
+            ],
+        ];
+
+        $this->setDB($a);
+
+        $db      = new Persistence\SQL($this->db->connection);
+
+        $this->m = new Model($db, 'user');
+        $this->m->addFields(['name', 'gender']);
     }
 
+    /**
+     *
+     */
+    public function testBeforeSaveIsUpdate()
+    {
+        $this->m->addHook(
+            'beforeSave', function ($m, $is_update) {
+            if ($is_update) {
+                $m->set('name', 'UpdatedModel');
+            } else {
+                $m->set('name', 'InsertedModel');
+            }
+        });
+
+        $this->m->save();
+        $this->assertEquals('InsertedModel', $this->m->get('name'));
+
+        $this->m->save([
+            'gender' => 'trigger_save_with_changed_data'
+        ]);
+        $this->assertEquals('UpdatedModel', $this->m->get('name'));
+    }
 
     /**
      *
      */
-    public function testAfterSaveIsUpdate() {
-        $model = new Model($this->db);
-        $model->addHook('afterSave', function($m, $is_update) {
-            if($is_update) {
-                $m->title = 'UpdatedModel';
-            }
-            else {
-                $m->title = 'InsertedModel';
+    public function testAfterSaveIsUpdate()
+    {
+        $this->m->addHook(
+            'afterSave', function ($m, $is_update) {
+            if ($is_update) {
+                $m->set('name', 'UpdatedModel');
+            } else {
+                $m->set('name', 'InsertedModel');
             }
         });
 
-        $model->save();
-        $this->assertEquals('InsertedModel', $model->title);
+        $this->m->save();
+        $this->assertEquals('InsertedModel', $this->m->get('name'));
 
-        $model->save();
-        $this->assertEquals('UpdatedModel', $model->title);
+        $this->m->save([
+            'gender' => 'trigger_save_with_changed_data'
+        ]);
+        $this->assertEquals('UpdatedModel', $this->m->get('name'));
     }
 }

--- a/tests/ModelHooksTest.php
+++ b/tests/ModelHooksTest.php
@@ -10,7 +10,6 @@ use atk4\data\Persistence;
  */
 class ModelHooksTest extends \atk4\schema\PHPUnit_SchemaTestCase
 {
-
     public $m;
 
     public function setUp()

--- a/tests/ModelHooksTest.php
+++ b/tests/ModelHooksTest.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace atk4\data\tests;
+
+use atk4\data\Field;
+use atk4\data\Model;
+use atk4\data\Persistence;
+
+/**
+ * @coversDefaultClass \atk4\data\Model
+ */
+class ModelHooksTest extends \atk4\core\PHPUnit_AgileTestCase
+{
+
+    /**
+     *
+     */
+    public function testBeforeSaveIsUpdate() {
+        $model = new Model($this->db);
+        $model->addHook('beforeSave', function($m, $is_update) {
+            if($is_update) {
+                $m->title = 'UpdatedModel';
+            }
+            else {
+                $m->title = 'InsertedModel';
+            }
+        });
+
+        $model->save();
+        $this->assertEquals('InsertedModel', $model->title);
+
+        $model->save();
+        $this->assertEquals('UpdatedModel', $model->title);
+    }
+
+
+    /**
+     *
+     */
+    public function testAfterSaveIsUpdate() {
+        $model = new Model($this->db);
+        $model->addHook('afterSave', function($m, $is_update) {
+            if($is_update) {
+                $m->title = 'UpdatedModel';
+            }
+            else {
+                $m->title = 'InsertedModel';
+            }
+        });
+
+        $model->save();
+        $this->assertEquals('InsertedModel', $model->title);
+
+        $model->save();
+        $this->assertEquals('UpdatedModel', $model->title);
+    }
+}


### PR DESCRIPTION
This fixes #460. Code author is @PhilippGrashoff, credit goes to him.

> add second parameter is_update to beforeSave hook to be in line with afterSave hook. Also added a new Test Class for all Model hook related things.
> Fixes #456