### PR TITLE
Reference caption implementation

### DIFF
--- a/src/Locale.php
+++ b/src/Locale.php
@@ -16,6 +16,6 @@ class Locale
      */
     public static function getPath()
     {
-        return join(DIRECTORY_SEPARATOR, [__DIR__, '..', 'locale']) . DIRECTORY_SEPARATOR;
+        return implode(DIRECTORY_SEPARATOR, [__DIR__, '..', 'locale']).DIRECTORY_SEPARATOR;
     }
 }

--- a/src/Locale.php
+++ b/src/Locale.php
@@ -16,6 +16,6 @@ class Locale
      */
     public static function getPath()
     {
-        return __DIR__.'/../locale/';
+        return join(DIRECTORY_SEPARATOR, [__DIR__, '..', 'locale']) . DIRECTORY_SEPARATOR;
     }
 }

--- a/src/Model.php
+++ b/src/Model.php
@@ -250,7 +250,7 @@ class Model implements ArrayAccess, IteratorAggregate
 
     /**
      * Caption of the model. Can be used in UI components, for example.
-     * Should be iun plain English and ready for proper localization.
+     * Should be in plain English and ready for proper localization.
      *
      * @var string
      */

--- a/src/Reference.php
+++ b/src/Reference.php
@@ -132,7 +132,7 @@ class Reference
             }
             $defaults['table_alias'] = $this->table_alias;
         }
-        
+
         // if model is Closure, then call it and return model
         if (is_object($this->model) && $this->model instanceof \Closure) {
             $c = ($this->model)($this->owner, $this, $defaults);
@@ -183,7 +183,7 @@ class Reference
         }
 
         // set model caption
-        if ($this->caption !==null) {
+        if ($this->caption !== null) {
             $model->caption = $this->caption;
         }
 

--- a/src/Reference.php
+++ b/src/Reference.php
@@ -73,6 +73,14 @@ class Reference
     protected $their_field = null;
 
     /**
+     * Caption of the reeferenced model. Can be used in UI components, for example.
+     * Should be in plain English and ready for proper localization.
+     *
+     * @var string
+     */
+    public $caption = null;
+
+    /**
      * Default constructor. Will copy argument into properties.
      *
      * @param string $link a short_name component
@@ -124,7 +132,7 @@ class Reference
             }
             $defaults['table_alias'] = $this->table_alias;
         }
-
+        
         // if model is Closure, then call it and return model
         if (is_object($this->model) && $this->model instanceof \Closure) {
             $c = ($this->model)($this->owner, $this, $defaults);
@@ -172,6 +180,11 @@ class Reference
     {
         if (!$model->persistence && $p = $this->getDefaultPersistence($model)) {
             $p->add($model, $defaults);
+        }
+
+        // set model caption
+        if ($this->caption !==null) {
+            $model->caption = $this->caption;
         }
 
         return $model;

--- a/src/Reference/ContainsMany.php
+++ b/src/Reference/ContainsMany.php
@@ -61,8 +61,8 @@ class ContainsMany extends ContainsOne
         // will not use ID field (no, sorry, will have to use it)
         $m = $this->getModel(array_merge($defaults, [
             'contained_in_root_model' => $this->owner->contained_in_root_model ?: $this->owner,
-            //'id_field' => false,
-            'table' => $this->table_alias,
+            //'id_field'              => false,
+            'table'                   => $this->table_alias,
         ]));
 
         // set some hooks for ref_model

--- a/src/Reference/ContainsOne.php
+++ b/src/Reference/ContainsOne.php
@@ -29,6 +29,15 @@ class ContainsOne extends Reference
     public $system = true;
 
     /**
+     * Defines a label to go along with this field. Use getCaption() which
+     * will always return meaningful label (even if caption is null). Set
+     * this property to any string.
+     *
+     * @var string
+     */
+    public $caption = null;
+
+    /**
      * Array with UI flags like editable, visible and hidden.
      *
      * By default hasOne relation ID field should be editable in forms,
@@ -65,6 +74,7 @@ class ContainsOne extends Reference
                 'type'              => $this->type,
                 'reference'         => $this,
                 'system'            => $this->system,
+                'caption'           => $this->caption,
                 'ui'                => $this->ui,
             ]);
         }

--- a/src/Reference/ContainsOne.php
+++ b/src/Reference/ContainsOne.php
@@ -29,15 +29,6 @@ class ContainsOne extends Reference
     public $system = true;
 
     /**
-     * Defines a label to go along with this field. Use getCaption() which
-     * will always return meaningful label (even if caption is null). Set
-     * this property to any string.
-     *
-     * @var string
-     */
-    public $caption = null;
-
-    /**
      * Array with UI flags like editable, visible and hidden.
      *
      * By default hasOne relation ID field should be editable in forms,
@@ -74,7 +65,7 @@ class ContainsOne extends Reference
                 'type'              => $this->type,
                 'reference'         => $this,
                 'system'            => $this->system,
-                'caption'           => $this->caption,
+                'caption'           => $this->caption, // it's ref models caption, but we can use it here for field too
                 'ui'                => $this->ui,
             ]);
         }

--- a/tests/ContainsManyTest.php
+++ b/tests/ContainsManyTest.php
@@ -29,7 +29,7 @@ class Invoice2 extends Model
         $this->addField('amount', ['type' => 'money']);
 
         // will contain many Lines
-        $this->containsMany('lines', Line2::class);
+        $this->containsMany('lines', [Line2::class, 'caption' => 'My Invoice Lines']);
 
         // total_gross - calculated by php callback not by SQL expression
         $this->addCalculatedField('total_gross', function ($m) {
@@ -146,6 +146,19 @@ class ContainsManyTest extends \atk4\schema\PHPUnit_SchemaTestCase
             ['id' => 1, 'ref_no' => 'A1', 'amount' => 123],
             ['id' => 2, 'ref_no' => 'A2', 'amount' => 456],
         ]);
+    }
+
+    /**
+     * Test caption of referenced model.
+     */
+    public function testModelCaption()
+    {
+        $i = new Invoice2($this->db);
+
+        // test caption of containsMany reference
+        $this->assertEquals('My Invoice Lines', $i->getField('lines')->getCaption());
+        $this->assertEquals('My Invoice Lines', $i->refModel('lines')->getModelCaption());
+        $this->assertEquals('My Invoice Lines', $i->ref('lines')->getModelCaption());
     }
 
     /**

--- a/tests/ContainsOneTest.php
+++ b/tests/ContainsOneTest.php
@@ -48,7 +48,7 @@ class Address1 extends Model
         $this->addField('tags', ['type'=>'array', 'default'=>[]]);
 
         // will contain one door code
-        $this->containsOne('door_code', DoorCode1::class);
+        $this->containsOne('door_code', [DoorCode1::class, 'caption' => 'Secret Code']);
     }
 }
 
@@ -111,6 +111,19 @@ class ContainsOneTest extends \atk4\schema\PHPUnit_SchemaTestCase
             ['id' => 1, 'ref_no' => 'A1', 'addr' => null],
             ['id' => 2, 'ref_no' => 'A2', 'addr' => null],
         ]);
+    }
+
+    /**
+     * Test caption of referenced model.
+     */
+    public function testModelCaption()
+    {
+        $a = (new Invoice1($this->db))->ref('addr');
+
+        // test caption of containsOne reference
+        $this->assertEquals('Secret Code', $a->getField('door_code')->getCaption());
+        $this->assertEquals('Secret Code', $a->refModel('door_code')->getModelCaption());
+        $this->assertEquals('Secret Code', $a->ref('door_code')->getModelCaption());
     }
 
     /**

--- a/tests/LocaleTest.php
+++ b/tests/LocaleTest.php
@@ -15,6 +15,7 @@ class LocaleTest extends \PHPUnit_Framework_TestCase
 
     public function testGetPath()
     {
-        $this->assertEquals(dirname(__DIR__).'/src/../locale/', Locale::getPath());
+        $path = join(DIRECTORY_SEPARATOR, [dirname(__DIR__), 'src', '..', 'locale']) . DIRECTORY_SEPARATOR;
+        $this->assertEquals($path, Locale::getPath());
     }
 }

--- a/tests/LocaleTest.php
+++ b/tests/LocaleTest.php
@@ -15,7 +15,7 @@ class LocaleTest extends \PHPUnit_Framework_TestCase
 
     public function testGetPath()
     {
-        $path = join(DIRECTORY_SEPARATOR, [dirname(__DIR__), 'src', '..', 'locale']) . DIRECTORY_SEPARATOR;
+        $path = implode(DIRECTORY_SEPARATOR, [dirname(__DIR__), 'src', '..', 'locale']).DIRECTORY_SEPARATOR;
         $this->assertEquals($path, Locale::getPath());
     }
 }

--- a/tests/ReferenceTest.php
+++ b/tests/ReferenceTest.php
@@ -20,7 +20,7 @@ class ReferenceTest extends \atk4\core\PHPUnit_AgileTestCase
         $order->addField('amount', ['default' => 20]);
         $order->addField('user_id');
 
-        $user->hasMany('Orders', $order);
+        $user->hasMany('Orders', [$order, 'caption' => 'My Orders']);
         $o = $user->ref('Orders');
 
         $this->assertEquals(20, $o['amount']);
@@ -35,6 +35,26 @@ class ReferenceTest extends \atk4\core\PHPUnit_AgileTestCase
         });
 
         $this->assertEquals(100, $user->ref('BigOrders')['amount']);
+    }
+
+    /**
+     * Test caption of referenced model.
+     */
+    public function testModelCaption()
+    {
+        $user = new Model(['table' => 'user']);
+        $user->addField('name');
+        $user->id = 1;
+
+        $order = new Model();
+        $order->addField('amount', ['default' => 20]);
+        $order->addField('user_id');
+
+        $user->hasMany('Orders', [$order, 'caption' => 'My Orders']);
+
+        // test caption of containsOne reference
+        $this->assertEquals('My Orders', $user->refModel('Orders')->getModelCaption());
+        $this->assertEquals('My Orders', $user->ref('Orders')->getModelCaption());
     }
 
     public function testModelProperty()


### PR DESCRIPTION
**Summary**

* Implements #469 
* Fix path bug in Locale class.
* Implementation covered with tests.

**Detailed**

Now all references (which are based on `Reference` class) can have `caption`property set.
This caption will be then used as caption of referenced model.
Some references (hasOne, containsOne) will also use this caption as caption for respective model field.

This is useful to set caption for Multiline UI widget or CRUD or even a Form. Basically any UI component which is aware of model captions and use `model->getModelCaption()` method.

**Usage Example**

```
$order = new Model(['caption' => 'Orders']); // this will be overwritten by hasMany
$order->addFields(['user_id', 'amount']);

$user = new Model(['table' => 'user']);
$user->hasMany('Orders', [$order, 'caption' => 'All Orders']);
$user->hasMany('BigOrders', [$order->addCondition('amount','>',1000), 'caption' => 'Big Orders']);

// test caption of containsOne reference
$this->assertEquals('All Orders', $user->refModel('Orders')->getModelCaption());
$this->assertEquals('All Orders', $user->ref('Orders')->getModelCaption());
$this->assertEquals('Big Orders', $user->refModel('BigOrders')->getModelCaption());
$this->assertEquals('Big Orders', $user->ref('BigOrders')->getModelCaption());
```
