### PR TITLE
Fix model OR condition typecast

### DIFF
--- a/src/Persistence/SQL.php
+++ b/src/Persistence/SQL.php
@@ -358,6 +358,10 @@ class SQL extends Persistence
                         if (is_string($row[0])) {
                             $row[0] = $m->getField($row[0]);
                         }
+
+                        if ($row[0] instanceof Field) {
+                            $row[1] = $this->typecastSaveField($row[0], $row[count($row) == 2 ? 1 : 2]);
+                        }
                     }
                 }
 

--- a/tests/ConditionSQLTest.php
+++ b/tests/ConditionSQLTest.php
@@ -244,6 +244,29 @@ class ConditionSQLTest extends \atk4\schema\PHPUnit_SchemaTestCase
         $this->assertEquals('Sue', $m['name']);
     }
 
+    public function testDateCondition2()
+    {
+        $a = [
+            'user' => [
+                1 => ['id' => 1, 'name' => 'John', 'date' => '1981-12-08'],
+                2 => ['id' => 2, 'name' => 'Sue', 'date' => '1982-12-08'],
+            ], ];
+        $this->setDB($a);
+
+        $m = new Model($this->db, 'user');
+        $m->addField('name');
+        $m->addField('date', ['type'=>'date']);
+
+        $m->addCondition('date', new \DateTime('08-12-1982'));
+        $m->loadAny();
+        $this->assertEquals('Sue', $m['name']);
+        $this->assertEquals('Sue', $m['name']);
+
+        $m->addCondition([ ['date', new \DateTime('08-12-1982')] ]);
+        $m->loadAny();
+        $this->assertEquals('Sue', $m['name']);
+    }
+
     /**
      * @expectedException        \Exception
      */

--- a/tests/ConditionSQLTest.php
+++ b/tests/ConditionSQLTest.php
@@ -260,7 +260,6 @@ class ConditionSQLTest extends \atk4\schema\PHPUnit_SchemaTestCase
         $m->addCondition('date', new \DateTime('08-12-1982'));
         $m->loadAny();
         $this->assertEquals('Sue', $m['name']);
-        $this->assertEquals('Sue', $m['name']);
 
         $m->addCondition([['date', new \DateTime('08-12-1982')]]);
         $m->loadAny();

--- a/tests/ConditionSQLTest.php
+++ b/tests/ConditionSQLTest.php
@@ -262,7 +262,7 @@ class ConditionSQLTest extends \atk4\schema\PHPUnit_SchemaTestCase
         $this->assertEquals('Sue', $m['name']);
         $this->assertEquals('Sue', $m['name']);
 
-        $m->addCondition([ ['date', new \DateTime('08-12-1982')] ]);
+        $m->addCondition([['date', new \DateTime('08-12-1982')]]);
         $m->loadAny();
         $this->assertEquals('Sue', $m['name']);
     }


### PR DESCRIPTION
Model condition now correctly typecasts also conditions passed as array (OR conditions).

fix #474 (see more precise description of bug there).
