### PR TITLE
re-index field seed numeric keys

### DIFF
--- a/src/Model.php
+++ b/src/Model.php
@@ -547,6 +547,10 @@ class Model implements ArrayAccess, IteratorAggregate
             if (is_array($field) && isset($field[0])) {
                 $name = $field[0];
                 unset($field[0]);
+                array_unshift($field, $name);
+                
+                $name = array_shift($field);
+                
                 $this->addField($name, $field);
                 continue;
             }


### PR DESCRIPTION
Re-indexing of numeric keys in the `$field` allows for using the `$field` array as seed with custom field class.
E.g.
```
$model->addFields([
    ['some_field', \Custom\FieldDefinition::class, 'option1' => 'abc']
]);
```
results in creating a field of class `Custom\FieldDefinition`. Presently only `addField` method can be used to achieve that functionality which means not all fields can be defined nicely using the `addFields` method.

Another option to be considered is to use the `$fields` array keys as field names and the seed would be the value (when array). See [this commit](https://github.com/georgehristov/data/commit/d097eb7b3c0b6233f6aada3e5f1e97a038d6a6e2). This both simplifies and enhances functionality as devs are able to use the `$defaults` parameter to define common settings for all fields being added