### PR TITLE
Add microseconds persistence support for datetime/time types + fix normalization/cloning issue

### DIFF
--- a/docs/advanced.rst
+++ b/docs/advanced.rst
@@ -155,7 +155,7 @@ which I want to define like this::
             return;
         }
 
-        $this->owner->addField('created_dts', ['type'=>'datetime', 'default'=>date('Y-m-d H:i:s')]);
+        $this->owner->addField('created_dts', ['type'=>'datetime', 'default'=>new \DateTime()]);
 
         $this->owner->hasOne('created_by_user_id', 'User');
         if(isset($this->app->user) and $this->app->user->loaded()) {
@@ -170,7 +170,7 @@ which I want to define like this::
             if(isset($this->app->user) and $this->app->user->loaded()) {
                 $data['updated_by'] = $this->app->user->id;
             }
-            $data['updated_dts'] = date('Y-m-d H:i:s');
+            $data['updated_dts'] = new \DateTime();
         });
     }
 

--- a/src/Field.php
+++ b/src/Field.php
@@ -165,7 +165,7 @@ class Field implements Expressionable
     /**
      * Persisting format for type = 'date', 'datetime', 'time' fields.
      *
-     * For example, for date it can be 'Y-m-d', for datetime - 'Y-m-d H:i:s' etc.
+     * For example, for date it can be 'Y-m-d', for datetime - 'Y-m-d H:i:s.u' etc.
      *
      * @var string
      */
@@ -409,11 +409,23 @@ class Field implements Expressionable
                 case 'boolean':
                     throw new Exception(['Use Field\Boolean for type=boolean', 'this'=>$this]);
                 case 'date':
-                    return $v instanceof \DateTimeInterface ? $v->format('Y-m-d') : (string) $v;
                 case 'datetime':
-                    return $v instanceof \DateTimeInterface ? $v->format('c') : (string) $v; // ISO 8601 format 2004-02-12T15:19:21+00:00
                 case 'time':
-                    return $v instanceof \DateTimeInterface ? $v->format('H:i:s') : (string) $v;
+                    if ($v instanceof \DateTimeInterface) {
+                        $dateFormat = 'Y-m-d';
+                        $timeFormat = 'H:i:s'.($v->format('u') > 0 ? '.u' : ''); // add microseconds if presented
+                        if ($this->type === 'date') {
+                            $format = $dateFormat;
+                        } elseif ($this->type === 'time') {
+                            $format = $timeFormat;
+                        } else {
+                            $format = $dateFormat.'\T'.$timeFormat.'P'; // ISO 8601 format 2004-02-12T15:19:21+00:00
+                        }
+
+                        return $v->format($format);
+                    }
+
+                    return (string) $v;
                 case 'array':
                     return json_encode($v); // todo use Persistence->jsonEncode() instead
                 case 'object':

--- a/src/Field.php
+++ b/src/Field.php
@@ -344,14 +344,14 @@ class Field implements Expressionable
                     throw new ValidationException(['must be a '.$f->type, 'class' => $class, 'value type' => gettype($value)]);
                 }
 
-                if ($f->type == 'date') {
+                if ($f->type == 'date' && $value->format('H:i:s.u') !== '00:00:00.000000') {
                     // remove time portion from date type value
-                    $value->setTime(0, 0, 0);
+                    $value = (clone $value)->setTime(0, 0, 0);
                 }
-                if ($f->type == 'time') {
+                if ($f->type == 'time' && $value->format('Y-m-d') !== '1970-01-01') {
                     // remove date portion from date type value
                     // need 1970 in place of 0 - DB
-                    $value->setDate(1970, 1, 1);
+                    $value = (clone $value)->setDate(1970, 1, 1);
                 }
 
                 break;

--- a/src/Persistence/SQL.php
+++ b/src/Persistence/SQL.php
@@ -454,7 +454,7 @@ class SQL extends Persistence
             $tz_class = isset($f->dateTimeZoneClass) ? $f->dateTimeZoneClass : 'DateTimeZone';
 
             if ($v instanceof $dt_class) {
-                $format = ['date' => 'Y-m-d', 'datetime' => 'Y-m-d H:i:s', 'time' => 'H:i:s'];
+                $format = ['date' => 'Y-m-d', 'datetime' => 'Y-m-d H:i:s.u', 'time' => 'H:i:s.u'];
                 $format = $f->persist_format ?: $format[$f->type];
 
                 // datetime only - set to persisting timezone
@@ -533,20 +533,27 @@ class SQL extends Persistence
             } elseif (is_string($v)) {
                 // ! symbol in date format is essential here to remove time part of DateTime - don't remove, this is not a bug
                 $format = ['date' => '+!Y-m-d', 'datetime' => '+!Y-m-d H:i:s', 'time' => '+!H:i:s'];
-                $format = $f->persist_format ?: $format[$f->type];
+                if ($f->persist_format) {
+                    $format = $f->persist_format;
+                } else {
+                    $format = $format[$f->type];
+                    if (strpos($v, '.') !== false) { // time possibly with microseconds, otherwise invalid format
+                        $format = preg_replace('~(?<=H:i:s)(?![. ]*u)~', '.u', $format);
+                    }
+                }
 
                 // datetime only - set from persisting timezone
                 if ($f->type == 'datetime' && isset($f->persist_timezone)) {
                     $v = $dt_class::createFromFormat($format, $v, new $tz_class($f->persist_timezone));
-                    if ($v === false) {
-                        throw new Exception(['Incorrectly formatted datetime', 'format' => $format, 'value' => $value, 'field' => $f]);
+                    if ($v !== false) {
+                        $v->setTimeZone(new $tz_class(date_default_timezone_get()));
                     }
-                    $v->setTimeZone(new $tz_class(date_default_timezone_get()));
                 } else {
                     $v = $dt_class::createFromFormat($format, $v);
-                    if ($v === false) {
-                        throw new Exception(['Incorrectly formatted date/time', 'format' => $format, 'value' => $value, 'field' => $f]);
-                    }
+                }
+
+                if ($v === false) {
+                    throw new Exception(['Incorrectly formatted date/time', 'format' => $format, 'value' => $value, 'field' => $f]);
                 }
 
                 // need to cast here because DateTime::createFromFormat returns DateTime object not $dt_class

--- a/src/Reference/HasOne.php
+++ b/src/Reference/HasOne.php
@@ -120,7 +120,7 @@ class HasOne extends Reference
     /**
      * Persisting format for type = 'date', 'datetime', 'time' fields.
      *
-     * For example, for date it can be 'Y-m-d', for datetime - 'Y-m-d H:i:s' etc.
+     * For example, for date it can be 'Y-m-d', for datetime - 'Y-m-d H:i:s.u' etc.
      *
      * @var string
      */

--- a/tests/FieldTest.php
+++ b/tests/FieldTest.php
@@ -867,13 +867,24 @@ class FieldTest extends \atk4\schema\PHPUnit_SchemaTestCase
         $this->assertEquals('', $model->getField('time')->toString());
         $this->assertEquals('', $model->getField('datetime')->toString());
 
-        $current_date = new \DateTime();
-        $model->set('date', $current_date);
-        $model->set('time', $current_date);
-        $model->set('datetime', $current_date);
+        // datetime without microseconds
+        $dt = new \DateTime('2020-01-21 21:09:42');
+        $model->set('date', $dt);
+        $model->set('time', $dt);
+        $model->set('datetime', $dt);
 
-        $this->assertEquals($current_date->format('Y-m-d'), $model->getField('date')->toString());
-        $this->assertEquals($current_date->format('H:i:s'), $model->getField('time')->toString());
-        $this->assertEquals($current_date->format('c'), $model->getField('datetime')->toString());
+        $this->assertEquals($dt->format('Y-m-d'), $model->getField('date')->toString());
+        $this->assertEquals($dt->format('H:i:s'), $model->getField('time')->toString());
+        $this->assertEquals($dt->format('c'), $model->getField('datetime')->toString());
+
+        // datetime with microseconds
+        $dt = new \DateTime('2020-01-21 21:09:42.895623');
+        $model->set('date', $dt);
+        $model->set('time', $dt);
+        $model->set('datetime', $dt);
+
+        $this->assertEquals($dt->format('Y-m-d'), $model->getField('date')->toString());
+        $this->assertEquals($dt->format('H:i:s.u'), $model->getField('time')->toString());
+        $this->assertEquals($dt->format('Y-m-d\TH:i:s.uP'), $model->getField('datetime')->toString());
     }
 }

--- a/tests/TypecastingTest.php
+++ b/tests/TypecastingTest.php
@@ -17,7 +17,7 @@ class MyTime extends \DateTime
 {
     public function __toString()
     {
-        return $this->format('H:i:s');
+        return $this->format('H:i:s.u');
     }
 }
 
@@ -25,7 +25,7 @@ class MyDateTime extends \DateTime
 {
     public function __toString()
     {
-        return date('Y-m-d H:i:s', $this->format('U'));
+        return $this->format('Y-m-d H:i:s.u');
     }
 }
 
@@ -41,8 +41,8 @@ class TypecastingTest extends \atk4\schema\PHPUnit_SchemaTestCase
                 [
                     'string'   => 'foo',
                     'date'     => '2013-02-20',
-                    'datetime' => '2013-02-20 20:00:12',
-                    'time'     => '12:00:50',
+                    'datetime' => '2013-02-20 20:00:12.000000',
+                    'time'     => '12:00:50.000000',
                     'boolean'  => 1,
                     'integer'  => '2940',
                     'money'    => '8.20',
@@ -87,8 +87,8 @@ class TypecastingTest extends \atk4\schema\PHPUnit_SchemaTestCase
                     'id'       => '1',
                     'string'   => 'foo',
                     'date'     => '2013-02-20',
-                    'datetime' => '2013-02-20 20:00:12',
-                    'time'     => '12:00:50',
+                    'datetime' => '2013-02-20 20:00:12.000000',
+                    'time'     => '12:00:50.000000',
                     'boolean'  => 1,
                     'integer'  => 2940,
                     'money'    => 8.20,
@@ -99,8 +99,8 @@ class TypecastingTest extends \atk4\schema\PHPUnit_SchemaTestCase
                     'id'       => '2',
                     'string'   => 'foo',
                     'date'     => '2013-02-20',
-                    'datetime' => '2013-02-20 20:00:12',
-                    'time'     => '12:00:50',
+                    'datetime' => '2013-02-20 20:00:12.000000',
+                    'time'     => '12:00:50.000000',
                     'boolean'  => '1',
                     'integer'  => '2940',
                     'money'    => '8.2',
@@ -248,8 +248,8 @@ class TypecastingTest extends \atk4\schema\PHPUnit_SchemaTestCase
             'types' => [
                 [
                     'date'     => '2013-02-20',
-                    'datetime' => '2013-02-20 20:00:12',
-                    'time'     => '12:00:50',
+                    'datetime' => '2013-02-20 20:00:12.235689',
+                    'time'     => '12:00:50.235689',
                     'b1'       => 'Y',
                     'b2'       => 'N',
                     'integer'  => '2940',
@@ -285,9 +285,9 @@ class TypecastingTest extends \atk4\schema\PHPUnit_SchemaTestCase
         $this->assertSame('hello world', $m['rot13']);
         $this->assertSame(1, (int) $m->id);
         $this->assertSame(1, (int) $m['id']);
-        $this->assertEquals('2013-02-21 05:00:12', (string) $m['datetime']);
+        $this->assertEquals('2013-02-21 05:00:12.235689', (string) $m['datetime']);
         $this->assertEquals('2013-02-20', (string) $m['date']);
-        $this->assertEquals('12:00:50', (string) $m['time']);
+        $this->assertEquals('12:00:50.235689', (string) $m['time']);
 
         $this->assertEquals(true, $m['b1']);
         $this->assertEquals(false, $m['b2']);
@@ -299,8 +299,8 @@ class TypecastingTest extends \atk4\schema\PHPUnit_SchemaTestCase
                 2 => [
                     'id'       => '2',
                     'date'     => '2013-02-20',
-                    'datetime' => '2013-02-20 20:00:12',
-                    'time'     => '12:00:50',
+                    'datetime' => '2013-02-20 20:00:12.235689',
+                    'time'     => '12:00:50.235689',
                     'b1'       => 'Y',
                     'b2'       => 'N',
                     'integer'  => '2940',
@@ -414,9 +414,9 @@ class TypecastingTest extends \atk4\schema\PHPUnit_SchemaTestCase
 
         date_default_timezone_set('UTC');
         $s = new \DateTime('Monday, 15-Aug-05 22:52:01 UTC');
-        $this->assertEquals('2005-08-16 00:52:01', $db->typecastSaveField($dt, $s));
+        $this->assertEquals('2005-08-16 00:52:01.000000', $db->typecastSaveField($dt, $s));
         $this->assertEquals('2005-08-15', $db->typecastSaveField($d, $s));
-        $this->assertEquals('22:52:01', $db->typecastSaveField($t, $s));
+        $this->assertEquals('22:52:01.000000', $db->typecastSaveField($t, $s));
         $this->assertEquals(new \DateTime('Monday, 15-Aug-05 22:52:01 UTC'), $db->typecastLoadField($dt, '2005-08-16 00:52:01'));
         $this->assertEquals(new \DateTime('Monday, 15-Aug-05'), $db->typecastLoadField($d, '2005-08-15'));
         $this->assertEquals(new \DateTime('1970-01-01 22:52:01'), $db->typecastLoadField($t, '22:52:01'));
@@ -424,9 +424,9 @@ class TypecastingTest extends \atk4\schema\PHPUnit_SchemaTestCase
         date_default_timezone_set('Asia/Tokyo');
 
         $s = new \DateTime('Monday, 15-Aug-05 22:52:01 UTC');
-        $this->assertEquals('2005-08-16 00:52:01', $db->typecastSaveField($dt, $s));
+        $this->assertEquals('2005-08-16 00:52:01.000000', $db->typecastSaveField($dt, $s));
         $this->assertEquals('2005-08-15', $db->typecastSaveField($d, $s));
-        $this->assertEquals('22:52:01', $db->typecastSaveField($t, $s));
+        $this->assertEquals('22:52:01.000000', $db->typecastSaveField($t, $s));
         $this->assertEquals(new \DateTime('Monday, 15-Aug-05 22:52:01 UTC'), $db->typecastLoadField($dt, '2005-08-16 00:52:01'));
         $this->assertEquals(new \DateTime('Monday, 15-Aug-05'), $db->typecastLoadField($d, '2005-08-15'));
         $this->assertEquals(new \DateTime('1970-01-01 22:52:01'), $db->typecastLoadField($t, '22:52:01'));
@@ -434,9 +434,9 @@ class TypecastingTest extends \atk4\schema\PHPUnit_SchemaTestCase
         date_default_timezone_set('America/Los_Angeles');
 
         $s = new \DateTime('Monday, 15-Aug-05 22:52:01'); // uses servers default timezone
-        $this->assertEquals('2005-08-16 07:52:01', $db->typecastSaveField($dt, $s));
+        $this->assertEquals('2005-08-16 07:52:01.000000', $db->typecastSaveField($dt, $s));
         $this->assertEquals('2005-08-15', $db->typecastSaveField($d, $s));
-        $this->assertEquals('22:52:01', $db->typecastSaveField($t, $s));
+        $this->assertEquals('22:52:01.000000', $db->typecastSaveField($t, $s));
         $this->assertEquals(new \DateTime('Monday, 15-Aug-05 22:52:01 America/Los_Angeles'), $db->typecastLoadField($dt, '2005-08-16 07:52:01'));
         $this->assertEquals(new \DateTime('Monday, 15-Aug-05'), $db->typecastLoadField($d, '2005-08-15'));
         $this->assertEquals(new \DateTime('1970-01-01 22:52:01'), $db->typecastLoadField($t, '22:52:01'));


### PR DESCRIPTION
Very important to not loose time precision. All major database engines ignore the microseconds part if the target datatype has less or only integer seconds precision.