### PR TITLE
use property to define field seed properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Agile Data is a framework for defining your "business layer" which is separate f
 
 [![Documentation Status](https://readthedocs.org/projects/agile-data/badge/?version=latest)](http://agile-data.readthedocs.io/en/latest/?badge=latest)
 [![Build Status](https://travis-ci.org/atk4/data.png?branch=develop)](https://travis-ci.org/atk4/data)
+![Build](https://github.com/atk4/data/workflows/Unit%20Testing/badge.svg)
 [![Code Climate](https://codeclimate.com/github/atk4/data/badges/gpa.svg)](https://codeclimate.com/github/atk4/data)
 [![StyleCI](https://styleci.io/repos/56442737/shield)](https://styleci.io/repos/56442737)
 [![CodeCov](https://codecov.io/gh/atk4/data/branch/develop/graph/badge.svg)](https://codecov.io/gh/atk4/data)

--- a/docs/model.rst
+++ b/docs/model.rst
@@ -208,21 +208,20 @@ performance. In ATK Data this is not an issue, because "Model" is re-usable::
 
    foreach(new User($db) as $user) {
 
-      var_dump($user->getField['name']);
       // will be the same object every time!!
+      var_dump($user->getField['name']);
 
-
-      var_dump($user)
       // this is also the same object every time!!
+      var_dump($user)
 
    }
 
 Instead, Field handles many very valuable operations which would otherwise fall on the
 shoulders of developer (Read more here :php:class:`Field`)
 
-.. php:method:: addField($name, $defaults)
+.. php:method:: addField($name, $seed)
 
-Creates a new field objects inside your model (by default the class is 'Field').
+Creates a new field object inside your model (by default the class is 'Field').
 The fields are implemented on top of Containers from Agile Core.
 
 Second argument to addField() will contain a seed for the Field class::
@@ -234,13 +233,28 @@ the type::
 
    $field = $this->addField('is_married', ['type'=>'boolean']);
 
-   // $field type is Field\Boolean
+   // $field class now will be Field\Boolean
 
 You may also specify your own Field implementation::
 
    $field = $this->addField('amount_and_currency', new MyAmountCurrencyField());
 
 Read more about :php:class:`Field`
+
+.. php:method:: addFields(array $fields, $defaults = [])
+
+Creates multiple field objects in one method call. See multiple syntax examples::
+
+    $m->addFields(['name'], ['default' => 'anonymous']);
+
+    $m->addFields([
+        'last_name',
+        'login' => ['default' => 'unknown'],
+        'salary' => ['type'=>'money', CustomField::class, 'default' => 100],
+        ['tax', CustomField::class, 'type'=>'money', 'default' => 20],
+        'vat' => new CustomField(['type'=>'money', 'default' => 15]),
+    ]);
+
 
 Read-only Fields
 ^^^^^^^^^^^^^^^^

--- a/locale/en/atk.php
+++ b/locale/en/atk.php
@@ -1,21 +1,21 @@
 <?php
 
 return [
-  'Field requires array for defaults'                                      => 'Field requires array for defaults',
-  'Field value can not be base64 encoded because it is not of string type' => 'Field value can not be base64 encoded because it is not of string type ({{field}})',
-  'Mandatory field value cannot be null'                                   => 'Mandatory field value cannot be null ({{field}})',
-  'Model is already related to another persistence'                        => 'Model is already related to another persistence',
-  'Must not be null'                                                       => 'Must not be null',
-  'Test with plural'                                                       => [
-    'zero'  => 'Test zero',
-    'one'   => 'Test is one',
-    'other' => 'Test are {{count}}',
-  ],
-  'There was error while decoding JSON'             => 'There was error while decoding JSON',
-  'Unable to determine persistence driver from DSN' => 'Unable to determine persistence driver from DSN',
-  'Unable to serialize field value on load'         => 'Unable to serialize field value on load ({{field}})',
-  'Unable to serialize field value on save'         => 'Unable to serialize field value on save ({{field}})',
-  'Unable to typecast field value on load'          => 'Unable to typecast field value on load ({{field}})',
-  'Unable to typecast field value on save'          => 'Unable to typecast field value on save ({{field}})',
-    'Record with specified ID was not found'        => 'Record with specified ID was not found',
+    'Field requires array for defaults'                                      => 'Field requires array for defaults',
+    'Field value can not be base64 encoded because it is not of string type' => 'Field value can not be base64 encoded because it is not of string type ({{field}})',
+    'Mandatory field value cannot be null'                                   => 'Mandatory field value cannot be null ({{field}})',
+    'Model is already related to another persistence'                        => 'Model is already related to another persistence',
+    'Must not be null'                                                       => 'Must not be null',
+    'Test with plural'                                                       => [
+        'zero'  => 'Test zero',
+        'one'   => 'Test is one',
+        'other' => 'Test are {{count}}',
+    ],
+    'There was error while decoding JSON'             => 'There was error while decoding JSON',
+    'Unable to determine persistence driver from DSN' => 'Unable to determine persistence driver from DSN',
+    'Unable to serialize field value on load'         => 'Unable to serialize field value on load ({{field}})',
+    'Unable to serialize field value on save'         => 'Unable to serialize field value on save ({{field}})',
+    'Unable to typecast field value on load'          => 'Unable to typecast field value on load ({{field}})',
+    'Unable to typecast field value on save'          => 'Unable to typecast field value on save ({{field}})',
+    'Record with specified ID was not found'          => 'Record with specified ID was not found',
 ];

--- a/locale/it/atk.php
+++ b/locale/it/atk.php
@@ -1,20 +1,20 @@
 <?php
 
 return [
-  'Field requires array for defaults'                                      => 'Il campo richiede un array per i valori predefiniti',
-  'Field value can not be base64 encoded because it is not of string type' => 'Il valore del campo non può essere codificato in base64 perché non è di tipo stringa ({{field}})',
-  'Mandatory field value cannot be null'                                   => 'Il valore del campo obbligatorio non può essere nullo ({{field}})',
-  'Model is already related to another persistence'                        => 'Il modello è già collegato a una persistenza',
-  'Must not be null'                                                       => 'Non deve essere nullo',
-  'Test with plural'                                                       => [
-    'zero'  => 'Test zero',
-    'one'   => 'Test è uno',
-    'other' => 'Test sono {{count}}',
-  ],
-  'There was error while decoding JSON'             => 'Si è verificato un errore durante la decodifica di JSON',
-  'Unable to determine persistence driver from DSN' => 'Impossibile determinare il driver di persistenza via DSN',
-  'Unable to serialize field value on load'         => 'Impossibile serializzare il valore durante il caricamento ({{field}})',
-  'Unable to serialize field value on save'         => 'Impossibile serializzare il valore durante il salvataggio ({{field}})',
-  'Unable to typecast field value on load'          => 'Impossibile serializzare il valore durante il caricamento ({{field}})',
-  'Unable to typecast field value on save'          => 'Impossibile serializzare il valore durante il salvataggio ({{field}})',
+    'Field requires array for defaults'                                      => 'Il campo richiede un array per i valori predefiniti',
+    'Field value can not be base64 encoded because it is not of string type' => 'Il valore del campo non può essere codificato in base64 perché non è di tipo stringa ({{field}})',
+    'Mandatory field value cannot be null'                                   => 'Il valore del campo obbligatorio non può essere nullo ({{field}})',
+    'Model is already related to another persistence'                        => 'Il modello è già collegato a una persistenza',
+    'Must not be null'                                                       => 'Non deve essere nullo',
+    'Test with plural'                                                       => [
+        'zero'  => 'Test zero',
+        'one'   => 'Test è uno',
+        'other' => 'Test sono {{count}}',
+    ],
+    'There was error while decoding JSON'             => 'Si è verificato un errore durante la decodifica di JSON',
+    'Unable to determine persistence driver from DSN' => 'Impossibile determinare il driver di persistenza via DSN',
+    'Unable to serialize field value on load'         => 'Impossibile serializzare il valore durante il caricamento ({{field}})',
+    'Unable to serialize field value on save'         => 'Impossibile serializzare il valore durante il salvataggio ({{field}})',
+    'Unable to typecast field value on load'          => 'Impossibile serializzare il valore durante il caricamento ({{field}})',
+    'Unable to typecast field value on save'          => 'Impossibile serializzare il valore durante il salvataggio ({{field}})',
 ];

--- a/locale/ru/atk.php
+++ b/locale/ru/atk.php
@@ -1,19 +1,19 @@
 <?php
 
 return [
-  'Field value can not be base64 encoded because it is not of string type' => 'Значение поля не может быть закодировано в base64, поскольку оно не имеет строкового типа ({{field}})',
-  'Mandatory field value cannot be null'                                   => 'Обязательное значение поля не может быть пустым ({{field}})',
-  'Model is already related to another persistence'                        => 'Модель уже связана с другим постоянством',
-  'Test with plural'                                                       => [
-    'zero'  => 'Тест ноль',
-    'one'   => 'Тест один',
-    'other' => 'Тест {{count}}',
-  ],
-  'There was error while decoding JSON'             => 'Произошла ошибка при декодировании JSON',
-  'Unable to determine persistence driver from DSN' => 'Невозможно определить постоянство драйвера из DSN',
-  'Unable to serialize field value on load'         => 'Невозможно сериализовать значение поля при загрузке ({{field}})',
-  'Unable to serialize field value on save'         => 'Невозможно сериализовать значение поля при сохранении ({{field}})',
-  'Unable to typecast field value on load'          => 'Невозможно установить тип поля при загрузке ({{field}})',
-  'Unable to typecast field value on save'          => 'Невозможно сериализовать значение поля при сохранении ({{field}})',
-    'Record with specified ID was not found'        => 'Запись с данным ID не найдена',
+    'Field value can not be base64 encoded because it is not of string type' => 'Значение поля не может быть закодировано в base64, поскольку оно не имеет строкового типа ({{field}})',
+    'Mandatory field value cannot be null'                                   => 'Обязательное значение поля не может быть пустым ({{field}})',
+    'Model is already related to another persistence'                        => 'Модель уже связана с другим постоянством',
+    'Test with plural'                                                       => [
+        'zero'  => 'Тест ноль',
+        'one'   => 'Тест один',
+        'other' => 'Тест {{count}}',
+    ],
+    'There was error while decoding JSON'             => 'Произошла ошибка при декодировании JSON',
+    'Unable to determine persistence driver from DSN' => 'Невозможно определить постоянство драйвера из DSN',
+    'Unable to serialize field value on load'         => 'Невозможно сериализовать значение поля при загрузке ({{field}})',
+    'Unable to serialize field value on save'         => 'Невозможно сериализовать значение поля при сохранении ({{field}})',
+    'Unable to typecast field value on load'          => 'Невозможно установить тип поля при загрузке ({{field}})',
+    'Unable to typecast field value on save'          => 'Невозможно сериализовать значение поля при сохранении ({{field}})',
+    'Record with specified ID was not found'          => 'Запись с данным ID не найдена',
 ];

--- a/phpunit-pgsql.xml
+++ b/phpunit-pgsql.xml
@@ -2,7 +2,7 @@
     <php>
         <var name="DB_DSN" value="pgsql:dbname=atk4-dsql-test;host=localhost" />
         <var name="DB_USER" value="postgres" />
-        <var name="DB_PASSWD" value="" />
+        <var name="DB_PASSWD" value="password" />
         <var name="DB_DBNAME" value="atk4-dsql-test" />
     </php>
     <filter>

--- a/src/Field.php
+++ b/src/Field.php
@@ -198,6 +198,25 @@ class Field implements Expressionable
             'typecast',
             'serialize',
     ];
+    
+    /**
+     * Map field type to seed
+     * 
+     * @var array
+     */
+    protected static $registry = [
+            'boolean'  => Field\Boolean::class,
+            'float'    => Field\Numeric::class,
+            'integer'  => Field\Integer::class,
+            'money'    => Field\Money::class,
+            'text'     => Field\Text::class,
+            'string'   => Field\Line::class,
+            'datetime' => Field\DateTime::class,
+            'date'     => Field\Date::class,
+            'time'     => Field\Time::class,
+            'array'    => Field\Array_::class,
+            'object'   => Field\Object_::class,
+    ];
 
     // }}}
 
@@ -334,6 +353,27 @@ class Field implements Expressionable
         }
         
         return $seed;
+    }
+    
+    /**
+     * Resolve field type to seed from Field::$registry
+     * 
+     * @param string $type
+     */
+    public static function resolve($type)
+    {
+        return self::$registry[$type] ?? null;
+    }
+    
+    /**
+     * Register custom field type to be resolved
+     * 
+     * @param string        $type
+     * @param string|array  $seed
+     */
+    public static function register($type, $seed)
+    {
+        self::$registry[$type] = $seed;
     }
 
     /**

--- a/src/Field.php
+++ b/src/Field.php
@@ -368,13 +368,19 @@ class Field implements Expressionable
     }
     
     /**
-     * Register custom field type to be resolved
+     * Register custom field type to be resolved.
      * 
-     * @param string        $type
-     * @param string|array  $seed
+     * @param string|array      $type
+     * @param string|array|null $seed
      */
-    public static function register($type, $seed)
+    public static function register($type, $seed = null)
     {
+        if (is_array($types = $type)) {
+             foreach ($types as $type => $seed) {
+                 self::register($type, $seed);
+             }   
+        }
+
         self::$registry[$type] = $seed;
     }
 

--- a/src/Field.php
+++ b/src/Field.php
@@ -201,6 +201,7 @@ class Field implements Expressionable
     
     /**
      * Map field type to seed
+     * List can be updated or extended using the Field::register method
      * 
      * @var array
      */
@@ -208,6 +209,7 @@ class Field implements Expressionable
             'boolean'  => Field\Boolean::class,
             'float'    => Field\Numeric::class,
             'integer'  => Field\Integer::class,
+            'int'      => Field\Integer::class,
             'money'    => Field\Money::class,
             'text'     => Field\Text::class,
             'string'   => Field\Line::class,

--- a/src/Field.php
+++ b/src/Field.php
@@ -177,6 +177,27 @@ class Field implements Expressionable
      * @var null|bool|array
      */
     public $serialize = null;
+    
+    protected static $seedProperties = [
+            'default',
+            'type',
+            'enum',
+            'values',
+            'reference',
+            'actual',
+            'join',
+            'system',
+            'never_persist',
+            'never_save',
+            'read_only',
+            'caption',
+            'ui',
+            'persistence',
+            'mandatory',
+            'required',
+            'typecast',
+            'serialize',
+    ];
 
     // }}}
 
@@ -261,7 +282,7 @@ class Field implements Expressionable
             }
             break;
         case 'string':
-            throw new Exception(['Use Field\ShortText for type=string', 'this'=>$this]);
+            throw new Exception(['Use Field\Line for type=string', 'this'=>$this]);
         case 'text':
             throw new Exception(['Use Field\Text for type=text', 'this'=>$this]);
         case 'integer':
@@ -294,38 +315,24 @@ class Field implements Expressionable
      *
      * @return array
      */
-    public function getSeed(array $properties = []) : array
+    public function getSeed(array $defaults = []) : array
     {
+        if (!$defaults) {
+            $seedProperties = static::$seedProperties;
+            foreach (class_parents($this) as $parent) {
+                $seedProperties = array_merge($parent::$seedProperties, $seedProperties);
+            }
+            
+            $defaults = array_intersect_key(get_class_vars(static::class), array_flip($seedProperties));
+        }
+
         $seed = [];
-
-        // [key => default_value]
-        $properties = $properties ?: [
-            'default'       => null,
-            'type'          => null,
-            'enum'          => null,
-            'values'        => null,
-            'reference'     => null,
-            'actual'        => null,
-            'join'          => null,
-            'system'        => false,
-            'never_persist' => false,
-            'never_save'    => false,
-            'read_only'     => false,
-            'caption'       => null,
-            'ui'            => [],
-            'persistence'   => [],
-            'mandatory'     => false,
-            'required'      => false,
-            'typecast'      => null,
-            'serialize'     => null,
-        ];
-
-        foreach ($properties as $k=>$v) {
+        foreach ($defaults as $k=>$v) {
             if ($this->{$k} !== $v) {
                 $seed[$k] = $this->{$k};
             }
         }
-
+        
         return $seed;
     }
 

--- a/src/Field.php
+++ b/src/Field.php
@@ -163,7 +163,7 @@ class Field implements Expressionable
     /**
      * Should we use typecasting when saving/loading data to/from persistence.
      *
-     * Value can be array [$typecast_save_callback, $typecast_load_callback].
+     * Value can be array ['save' => $typecast_save_callback, 'load' => $typecast_load_callback].
      *
      * @var null|bool|array
      */
@@ -172,7 +172,7 @@ class Field implements Expressionable
     /**
      * Should we use serialization when saving/loading data to/from persistence.
      *
-     * Value can be array [$encode_callback, $decode_callback].
+     * Value can be array ['encode' => $encode_callback, 'decode' => $decode_callback].
      *
      * @var null|bool|array
      */
@@ -501,6 +501,49 @@ class Field implements Expressionable
     public function getCaption() : string
     {
         return $this->caption ?? $this->ui['caption'] ?? $this->readableCaption($this->short_name);
+    }
+
+    
+    /**
+     * Returns typecasting callback if defined.
+     * 
+     * @param string $mode - load|save
+     * 
+     * @return callable|false
+     */
+    public function getTypecaster($mode)
+    {
+        // map for backward compatibility with definition
+        // [typecast_save_callback, typecast_load_callback]
+        $map = [
+                'save' => 0,
+                'load' => 1
+        ];
+        
+        $fx = $this->typecast[$mode] ?? $this->typecast[$map[$mode]] ?? false;
+        
+        return is_callable($fx) ? $fx : false;
+    }
+    
+    /**
+     * Returns serialize callback if defined.
+     * 
+     * @param string $mode - encode|decode
+     * 
+     * @return callable|false
+     */
+    public function getSerializer($mode)
+    {
+        // map for backward compatibility with definition
+        // [encode_callback, decode_callback]
+        $map = [
+                'encode' => 0,
+                'decode' => 1
+        ];
+        
+        $fx = $this->serialize[$mode] ?? $this->serialize[$map[$mode]] ?? false;
+        
+        return is_callable($fx) ? $fx : false;
     }
 
     // }}}

--- a/src/Field/Boolean.php
+++ b/src/Field/Boolean.php
@@ -41,6 +41,11 @@ class Boolean extends \atk4\data\Field
      * @var array
      */
     public $enum = null;
+    
+    protected static $seedProperties = [
+            'valueTrue',
+            'valueFalse',
+    ];
 
     /**
      * Constructor.
@@ -94,33 +99,6 @@ class Boolean extends \atk4\data\Field
         }
 
         return $value;
-    }
-
-    /**
-     * Return array of seed properties of this Field object.
-     *
-     * @param array $properties Properties to return, by default will return all properties set.
-     *
-     * @return array
-     */
-    public function getSeed(array $properties = []) : array
-    {
-        $seed = parent::getSeed($properties);
-
-        // [key => default_value]
-        $properties = $properties ?: [
-            'valueTrue'  => true,
-            'valueFalse' => false,
-            'enum'       => null,
-        ];
-
-        foreach ($properties as $k=>$v) {
-            if ($this->{$k} !== $v) {
-                $seed[$k] = $this->{$k};
-            }
-        }
-
-        return $seed;
     }
 
     /**

--- a/src/Field/Callback.php
+++ b/src/Field/Callback.php
@@ -20,6 +20,16 @@ class Callback extends \atk4\data\Field
      *
      * @var mixed
      */
+    public $fx = null;
+    
+    /**
+     * Method to execute for evaluation.
+     *
+     * @var mixed
+     * 
+     * @deprecated use $fx instead
+     * 
+     */
     public $expr = null;
 
     /**
@@ -35,6 +45,11 @@ class Callback extends \atk4\data\Field
      * @var bool
      */
     public $never_persist = true;
+    
+    protected static $seedProperties = [
+            'fx',
+            'expr',
+    ];
 
     /**
      * Initialization.
@@ -44,34 +59,7 @@ class Callback extends \atk4\data\Field
         $this->_init();
 
         $this->owner->addHook('afterLoad', function ($m) {
-            $m->data[$this->short_name] = call_user_func($this->expr, $m);
+            $m->data[$this->short_name] = call_user_func($this->fx ?: $this->expr, $m);
         });
-    }
-
-    /**
-     * Return array of seed properties of this Field object.
-     *
-     * @param array $properties Properties to return, by default will return all properties set.
-     *
-     * @return array
-     */
-    public function getSeed(array $properties = []) : array
-    {
-        $seed = parent::getSeed($properties);
-
-        // [key => default_value]
-        $properties = $properties ?: [
-            'expr'          => null,
-            'read_only'     => true,
-            'never_persist' => true,
-        ];
-
-        foreach ($properties as $k=>$v) {
-            if ($this->{$k} !== $v) {
-                $seed[$k] = $this->{$k};
-            }
-        }
-
-        return $seed;
     }
 }

--- a/src/Field/Date.php
+++ b/src/Field/Date.php
@@ -4,9 +4,6 @@
 
 namespace atk4\data\Field;
 
-use atk4\data\Field;
-use atk4\data\ValidationException;
-
 /**
  * Date field type. Think of it as field type "date" in past.
  */
@@ -20,7 +17,7 @@ class Date extends DateTime
      *
      * @param mixed $value
      *
-     * @throws ValidationException
+     * @throws \atk4\data\ValidationException
      *
      * @return mixed
      */

--- a/src/Field/DateTime.php
+++ b/src/Field/DateTime.php
@@ -43,6 +43,11 @@ class DateTime extends Field
      * @param string
      */
     public $dateTimeZoneClass = 'DateTimeZone';
+    
+    protected static $seedProperties = [
+            'dateTimeClass',
+            'dateTimeZoneClass',
+    ];
 
     /**
      * Validate and normalize value.
@@ -87,33 +92,6 @@ class DateTime extends Field
         }
 
         return $value;
-    }
-
-    /**
-     * Return array of seed properties of this Field object.
-     *
-     * @param array $properties Properties to return, by default will return all properties set.
-     *
-     * @return array
-     */
-    public function getSeed(array $properties = []) : array
-    {
-        $seed = parent::getSeed($properties);
-
-        // [key => default_value]
-        $properties = $properties ?: [
-            'dateTimeClass'     => 'DateTime',
-            'dateTimeZoneClass' => 'DateTimeZone',
-            'persistence'       => ['format' => null, 'timezone' => 'UTC'],
-        ];
-
-        foreach ($properties as $k=>$v) {
-            if ($this->{$k} !== $v) {
-                $seed[$k] = $this->{$k};
-            }
-        }
-
-        return $seed;
     }
 
     /**

--- a/src/Field/DateTime.php
+++ b/src/Field/DateTime.php
@@ -33,7 +33,7 @@ class DateTime extends Field
      *
      * @param string
      */
-    public $dateTimeClass = 'DateTime';
+    public $dateTimeClass = \DateTime::class;
 
     /**
      * Timezone class used for type = 'data', 'datetime', 'time' fields.
@@ -42,7 +42,7 @@ class DateTime extends Field
      *
      * @param string
      */
-    public $dateTimeZoneClass = 'DateTimeZone';
+    public $dateTimeZoneClass = \DateTimeZone::class;
     
     protected static $seedProperties = [
             'dateTimeClass',
@@ -77,7 +77,7 @@ class DateTime extends Field
         }
 
         // we allow http://php.net/manual/en/datetime.formats.relative.php
-        $class = $this->dateTimeClass ?? 'DateTime';
+        $class = $this->dateTimeClass ?? DateTime::class;
 
         if (is_numeric($value)) {
             $value = new $class('@'.$value);

--- a/src/Field/Email.php
+++ b/src/Field/Email.php
@@ -20,6 +20,8 @@ use atk4\data\ValidationException;
  */
 class Email extends Field
 {
+    public $type = 'string';
+    
     /**
      * @var bool Enable lookup for MX record for email addresses stored
      */

--- a/src/Field/Email.php
+++ b/src/Field/Email.php
@@ -39,6 +39,13 @@ class Email extends Field
      * @var array Array of allowed separators
      */
     public $separator = [','];
+    
+    protected static $seedProperties = [
+            'dns_check',
+            'allow_multiple',
+            'include_names',
+            'separator',
+    ];
 
     /**
      * Validate and normalize value.
@@ -84,34 +91,6 @@ class Email extends Field
         }, $emails);
 
         return parent::normalize(implode(', ', $emails));
-    }
-
-    /**
-     * Return array of seed properties of this Field object.
-     *
-     * @param array $properties Properties to return, by default will return all properties set.
-     *
-     * @return array
-     */
-    public function getSeed(array $properties = []) : array
-    {
-        $seed = parent::getSeed($properties);
-
-        // [key => default_value]
-        $properties = $properties ?: [
-            'dns_check'      => false,
-            'allow_multiple' => false,
-            'include_names'  => false,
-            'separator'      => [','],
-        ];
-
-        foreach ($properties as $k=>$v) {
-            if ($this->{$k} !== $v) {
-                $seed[$k] = $this->{$k};
-            }
-        }
-
-        return $seed;
     }
 
     /**

--- a/src/Field/Email.php
+++ b/src/Field/Email.php
@@ -20,8 +20,6 @@ use atk4\data\ValidationException;
  */
 class Email extends Field
 {
-    public $type = 'string';
-    
     /**
      * @var bool Enable lookup for MX record for email addresses stored
      */

--- a/src/Field/Integer.php
+++ b/src/Field/Integer.php
@@ -4,7 +4,6 @@
 
 namespace atk4\data\Field;
 
-use atk4\data\Field;
 use atk4\data\ValidationException;
 
 /**
@@ -18,12 +17,12 @@ class Integer extends Numeric
     /**
      * @var int Specify how many decimal numbers should be saved.
      */
-    public $decimal_numbers = 0;
+    public $decimals = 0;
 
     /**
      * @var bool Enable number rounding. If true will round number, otherwise will round it down (trim).
      */
-    public $enable_rounding = false;
+    public $round = false;
 
     /**
      * Validate and normalize value.
@@ -39,31 +38,5 @@ class Integer extends Numeric
         $value = parent::normalize($value);
 
         return $value === null ? null : (int) $value;
-    }
-
-    /**
-     * Return array of seed properties of this Field object.
-     *
-     * @param array $properties Properties to return, by default will return all properties set.
-     *
-     * @return array
-     */
-    public function getSeed(array $properties = []) : array
-    {
-        $seed = parent::getSeed($properties);
-
-        // [key => default_value]
-        $properties = $properties ?: [
-            'decimal_numbers' => 0,
-            'enable_rounding' => false,
-        ];
-
-        foreach ($properties as $k=>$v) {
-            if ($this->{$k} !== $v) {
-                $seed[$k] = $this->{$k};
-            }
-        }
-
-        return $seed;
     }
 }

--- a/src/Field/Line.php
+++ b/src/Field/Line.php
@@ -4,7 +4,6 @@
 
 namespace atk4\data\Field;
 
-use atk4\data\Field;
 use atk4\data\ValidationException;
 
 /**
@@ -22,6 +21,10 @@ class Line extends Text
      * @var int specify a maximum length for this text.
      */
     public $max_length = 255;
+    
+    protected static $seedProperties = [
+            'max_length',
+    ];
 
     /**
      * Validate and normalize value.
@@ -40,30 +43,5 @@ class Line extends Text
         $value = trim(str_replace(["\r", "\n"], '', $value));
 
         return $value;
-    }
-
-    /**
-     * Return array of seed properties of this Field object.
-     *
-     * @param array $properties Properties to return, by default will return all properties set.
-     *
-     * @return array
-     */
-    public function getSeed(array $properties = []) : array
-    {
-        $seed = parent::getSeed($properties);
-
-        // [key => default_value]
-        $properties = $properties ?: [
-            'max_length' => 255,
-        ];
-
-        foreach ($properties as $k=>$v) {
-            if ($this->{$k} !== $v) {
-                $seed[$k] = $this->{$k};
-            }
-        }
-
-        return $seed;
     }
 }

--- a/src/Field/Money.php
+++ b/src/Field/Money.php
@@ -4,8 +4,6 @@
 
 namespace atk4\data\Field;
 
-use atk4\data\Field;
-
 /**
  * Class Money offers a lightweight implementation of currencies.
  */
@@ -17,30 +15,5 @@ class Money extends Numeric
     /**
      * @var int Specify how many decimal numbers should be saved.
      */
-    public $decimal_numbers = 2;
-
-    /**
-     * Return array of seed properties of this Field object.
-     *
-     * @param array $properties Properties to return, by default will return all properties set.
-     *
-     * @return array
-     */
-    public function getSeed(array $properties = []) : array
-    {
-        $seed = parent::getSeed($properties);
-
-        // [key => default_value]
-        $properties = $properties ?: [
-            'decimal_numbers' => 2,
-        ];
-
-        foreach ($properties as $k=>$v) {
-            if ($this->{$k} !== $v) {
-                $seed[$k] = $this->{$k};
-            }
-        }
-
-        return $seed;
-    }
+    public $decimals = 2;
 }

--- a/src/Field/Numeric.php
+++ b/src/Field/Numeric.php
@@ -18,17 +18,17 @@ class Numeric extends Field
     /**
      * @var int Specify how many decimal numbers should be saved.
      */
-    public $decimal_numbers = 8;
+    public $decimals = 8;
 
     /**
      * @var bool Enable number rounding. If true will round number, otherwise will round it down (trim).
      */
-    public $enable_rounding = true;
+    public $round = true;
 
     /**
      * @var bool Set this to `true` if you wish to also store negative values.
      */
-    public $signed = true;
+    public $signum = true;
 
     /**
      * @var int specify a minimum value for this number.
@@ -39,35 +39,14 @@ class Numeric extends Field
      * @var int specify a maximum value for this number.
      */
     public $max;
-
-    /**
-     * Return array of seed properties of this Field object.
-     *
-     * @param array $properties Properties to return, by default will return all properties set.
-     *
-     * @return array
-     */
-    public function getSeed(array $properties = []) : array
-    {
-        $seed = parent::getSeed($properties);
-
-        // [key => default_value]
-        $properties = $properties ?: [
-            'decimal_numbers' => 8,
-            'enable_rounding' => true,
-            'signed'          => true,
-            'min'             => null,
-            'max'             => null,
-        ];
-
-        foreach ($properties as $k=>$v) {
-            if ($this->{$k} !== $v) {
-                $seed[$k] = $this->{$k};
-            }
-        }
-
-        return $seed;
-    }
+    
+    protected static $seedProperties = [
+            'decimals',
+            'round',
+            'signum',
+            'min',
+            'max',
+    ];
 
     /**
      * Validate and normalize value.
@@ -103,9 +82,9 @@ class Numeric extends Field
         }
 
         $value = (float) $value;
-        $value = $this->enable_rounding ? round($value, $this->decimal_numbers) : $this->roundDown($value, $this->decimal_numbers);
+        $value = $this->round ? round($value, $this->decimals) : $this->roundDown($value, $this->decimals);
 
-        if (!$this->signed && $value < 0) {
+        if (!$this->signum && $value < 0) {
             throw new ValidationException([$this->name => 'Must be positive']);
         }
 

--- a/src/Field/Text.php
+++ b/src/Field/Text.php
@@ -20,6 +20,10 @@ class Text extends Field
      * @var int specify a maximum length for this text.
      */
     public $max_length;
+    
+    protected static $seedProperties = [
+            'max_length',
+    ];
 
     /**
      * Validate and normalize value.
@@ -58,30 +62,5 @@ class Text extends Field
         }
 
         return $value;
-    }
-
-    /**
-     * Return array of seed properties of this Field object.
-     *
-     * @param array $properties Properties to return, by default will return all properties set.
-     *
-     * @return array
-     */
-    public function getSeed(array $properties = []) : array
-    {
-        $seed = parent::getSeed($properties);
-
-        // [key => default_value]
-        $properties = $properties ?: [
-            'max_length' => null,
-        ];
-
-        foreach ($properties as $k=>$v) {
-            if ($this->{$k} !== $v) {
-                $seed[$k] = $this->{$k};
-            }
-        }
-
-        return $seed;
     }
 }

--- a/src/Field/Time.php
+++ b/src/Field/Time.php
@@ -4,7 +4,6 @@
 
 namespace atk4\data\Field;
 
-use atk4\data\Field;
 use atk4\data\ValidationException;
 
 /**

--- a/src/Field/_Percent.php
+++ b/src/Field/_Percent.php
@@ -11,7 +11,7 @@ class _Percent extends Numeric
      * @var int Specify how many decimal numbers should be saved.
      *          IMPORTANT: set to 2+precision, since percentage is stored as a 0 .. 1
      */
-    public $decimal_numbers = 2;
+    public $decimals = 2;
 
     /*
     public function format()

--- a/src/Join.php
+++ b/src/Join.php
@@ -175,9 +175,9 @@ class Join
                     )) {
                      */
                     throw new Exception([
-                            'You are trying to link tables on non-id fields. This is not implemented yet',
-                            'condition' => $this->owner->table.'.'.$this->master_field.' = '.$this->foreign_table,
-                        ]);
+                        'You are trying to link tables on non-id fields. This is not implemented yet',
+                        'condition' => $this->owner->table.'.'.$this->master_field.' = '.$this->foreign_table,
+                    ]);
                     /*
                     }
 
@@ -211,19 +211,21 @@ class Join
      * with this join. That means it won't be loaded from $table, but
      * form the join instead.
      *
-     * @param string $n
-     * @param array  $defaults
+     * @param string $name
+     * @param array  $seed
+     *
+     * @throws \atk4\core\Exception
      *
      * @return Field
      */
-    public function addField($n, $defaults = [])
+    public function addField($name, $seed = [])
     {
-        if ($defaults && !is_array($defaults)) {
-            $defaults = [$defaults];
+        if ($seed && !is_array($seed)) {
+            $seed = [$seed];
         }
-        $defaults['join'] = $this;
+        $seed['join'] = $this;
 
-        return $this->owner->addField($this->prefix.$n, $defaults);
+        return $this->owner->addField($this->prefix.$name, $seed);
     }
 
     /**

--- a/src/Model.php
+++ b/src/Model.php
@@ -524,30 +524,17 @@ class Model implements ArrayAccess, IteratorAggregate
     {
         $seed = $this->mergeSeeds(
             $seed,
-            isset($seed['type']) ? (static::$defaultFieldTypeSeed[$seed['type']] ?? null) : null,
+            Field::resolve($seed['type'] ?? null),
             $this->_default_seed_addField
         );
+        
+        unset($seed['type']);
 
         /** @var Field $field */
         $field = $this->factory($seed, null, '\atk4\data\Field');
 
         return $field;
     }
-
-    /** @var array [type => classname] */
-    protected static $defaultFieldTypeSeed = [
-        'boolean'  => Field\Boolean::class,
-        'float'    => Field\Numeric::class,
-        'integer'  => Field\Integer::class,
-        'money'    => Field\Money::class,
-        'text'     => Field\Text::class,
-        'string'   => Field\Line::class,
-        'datetime' => Field\DateTime::class,
-        'date'     => Field\Date::class,
-        'time'     => Field\Time::class,
-        'array'    => Field\Array_::class,
-        'object'   => Field\Object_::class,
-    ];
 
     /**
      * Adds multiple fields into model.

--- a/src/Model.php
+++ b/src/Model.php
@@ -521,7 +521,7 @@ class Model implements ArrayAccess, IteratorAggregate
     {
         $seed = $this->mergeSeeds(
             $seed,
-            isset($seed['type']) ? ($this->typeToFieldSeed[$seed['type']] ?? null) : null,
+            isset($seed['type']) ? (static::$defaultFieldTypeSeed[$seed['type']] ?? null) : null,
             [Field::class]
         );
 
@@ -532,18 +532,18 @@ class Model implements ArrayAccess, IteratorAggregate
     }
 
     /** @var array [type => classname] */
-    protected $typeToFieldSeed = [
-        'boolean'  => ['Boolean'],
-        'float'    => ['Numeric'],
-        'integer'  => ['Integer'],
-        'money'    => ['Money'],
-        'text'     => ['Text'],
-        'string'   => ['Line'],
-        'datetime' => ['DateTime'],
-        'date'     => ['Date'],
-        'time'     => ['Time'],
-        'array'    => ['Array_'],
-        'object'   => ['Object_'],
+    protected static $defaultFieldTypeSeed = [
+        'boolean'  => Field\Boolean::class,
+        'float'    => Field\Numeric::class,
+        'integer'  => Field\Integer::class,
+        'money'    => Field\Money::class,
+        'text'     => Field\Text::class,
+        'string'   => Field\Line::class,
+        'datetime' => Field\DateTime::class,
+        'date'     => Field\Date::class,
+        'time'     => Field\Time::class,
+        'array'    => Field\Array_::class,
+        'object'   => Field\Object_::class,
     ];
 
     /**

--- a/src/Model.php
+++ b/src/Model.php
@@ -527,8 +527,6 @@ class Model implements ArrayAccess, IteratorAggregate
             Field::resolve($seed['type'] ?? null),
             $this->_default_seed_addField
         );
-        
-        unset($seed['type']);
 
         /** @var Field $field */
         $field = $this->factory($seed, null, '\atk4\data\Field');

--- a/src/Persistence.php
+++ b/src/Persistence.php
@@ -275,17 +275,16 @@ class Persistence
      * Prepare value of a specific field by converting it to
      * persistence-friendly format.
      *
-     * @param Field $f
+     * @param Field $field
      * @param mixed $value
      *
      * @return mixed
      */
-    public function typecastSaveField(Field $f, $value)
+    public function typecastSaveField(Field $field, $value)
     {
         try {
-            // use $f->typecast = [typecast_save_callback, typecast_load_callback]
-            if (is_array($f->typecast) && isset($f->typecast[0]) && is_callable($t = $f->typecast[0])) {
-                return $t($value, $f, $this);
+            if ($typecast = $field->getTypecaster('save')) {
+                return $typecast($value, $field, $this);
             }
 
             // we respect null values
@@ -294,9 +293,9 @@ class Persistence
             }
 
             // run persistence-specific typecasting of field value
-            return $this->_typecastSaveField($f, $value);
+            return $this->_typecastSaveField($field, $value);
         } catch (\Exception $e) {
-            throw new Exception(['Unable to typecast field value on save', 'field' => $f->name], null, $e);
+            throw new Exception(['Unable to typecast field value on save', 'field' => $field->name], null, $e);
         }
     }
 
@@ -304,22 +303,21 @@ class Persistence
      * Cast specific field value from the way how it's stored inside
      * persistence to a PHP format.
      *
-     * @param Field $f
+     * @param Field $field
      * @param mixed $value
      *
      * @return mixed
      */
-    public function typecastLoadField(Field $f, $value)
+    public function typecastLoadField(Field $field, $value)
     {
         try {
-            // use $f->typecast = [typecast_save_callback, typecast_load_callback]
-            if (is_array($f->typecast) && isset($f->typecast[1]) && is_callable($t = $f->typecast[1])) {
-                return $t($value, $f, $this);
+            if ($typecast = $field->getTypecaster('load')) {
+                return $typecast($value, $field, $this);
             }
 
             // only string type fields can use empty string as legit value, for all
             // other field types empty value is the same as no-value, nothing or null
-            if ($f->type && $f->type != 'string' && $value === '') {
+            if ($field->type && $field->type != 'string' && $value === '') {
                 return;
             }
 
@@ -329,9 +327,9 @@ class Persistence
             }
 
             // run persistence-specific typecasting of field value
-            return $this->_typecastLoadField($f, $value);
+            return $this->_typecastLoadField($field, $value);
         } catch (\Exception $e) {
-            throw new Exception(['Unable to typecast field value on load', 'field' => $f->name], null, $e);
+            throw new Exception(['Unable to typecast field value on load', 'field' => $field->name], null, $e);
         }
     }
 
@@ -367,23 +365,22 @@ class Persistence
      * Provided with a value, will perform field serialization.
      * Can be used for the purposes of encryption or storing unsupported formats.
      *
-     * @param Field $f
+     * @param Field $field
      * @param mixed $value
      *
      * @return mixed
      */
-    public function serializeSaveField(Field $f, $value)
+    public function serializeSaveField(Field $field, $value)
     {
         try {
-            // use $f->serialize = [encode_callback, decode_callback]
-            if (is_array($f->serialize) && isset($f->serialize[0]) && is_callable($t = $f->serialize[0])) {
-                return $t($f, $value, $this);
+            if ($encode = $field->getSerializer('encode')) {
+                return $encode($field, $value, $this);
             }
 
             // run persistence-specific serialization of field value
-            return $this->_serializeSaveField($f, $value);
+            return $this->_serializeSaveField($field, $value);
         } catch (\Exception $e) {
-            throw new Exception(['Unable to serialize field value on save', 'field' => $f->name], null, $e);
+            throw new Exception(['Unable to serialize field value on save', 'field' => $field->name], null, $e);
         }
     }
 
@@ -391,23 +388,22 @@ class Persistence
      * Provided with a value, will perform field un-serialization.
      * Can be used for the purposes of encryption or storing unsupported formats.
      *
-     * @param Field $f
+     * @param Field $field
      * @param mixed $value
      *
      * @return mixed
      */
-    public function serializeLoadField(Field $f, $value)
+    public function serializeLoadField(Field $field, $value)
     {
         try {
-            // use $f->serialize = [encode_callback, decode_callback]
-            if (is_array($f->serialize) && isset($f->serialize[1]) && is_callable($t = $f->serialize[1])) {
-                return $t($f, $value, $this);
+            if ($decode = $field->getSerializer('decode')) {
+                return $decode($field, $value, $this);
             }
 
             // run persistence-specific un-serialization of field value
-            return $this->_serializeLoadField($f, $value);
+            return $this->_serializeLoadField($field, $value);
         } catch (\Exception $e) {
-            throw new Exception(['Unable to serialize field value on load', 'field' => $f->name], null, $e);
+            throw new Exception(['Unable to serialize field value on load', 'field' => $field->name], null, $e);
         }
     }
 

--- a/src/Persistence/SQL.php
+++ b/src/Persistence/SQL.php
@@ -117,24 +117,24 @@ class SQL extends Persistence
      * the code inside callback will fail, then all of the transaction
      * will be also rolled back.
      *
-     * @param callable $f
+     * @param callable $fx
      *
      * @return mixed
      */
-    public function atomic($f)
+    public function atomic($fx)
     {
-        return $this->connection->atomic($f);
+        return $this->connection->atomic($fx);
     }
 
     /**
      * Associate model with the data driver.
      *
-     * @param Model|string $m        Model which will use this persistence
+     * @param Model|string $model        Model which will use this persistence
      * @param array        $defaults Properties
      *
      * @return Model
      */
-    public function add($m, $defaults = []): Model
+    public function add($model, $defaults = []): Model
     {
         // Use our own classes for fields, references and expressions unless
         // $defaults specify them otherwise.
@@ -146,64 +146,64 @@ class SQL extends Persistence
             '_default_seed_join'          => $this->_default_seed_join,
         ], $defaults);
 
-        $m = parent::add($m, $defaults);
+        $model = parent::add($model, $defaults);
 
-        if (!isset($m->table) || (!is_string($m->table) && $m->table !== false)) {
+        if (!isset($model->table) || (!is_string($model->table) && $model->table !== false)) {
             throw new Exception([
                 'Property $table must be specified for a model',
-                'model' => $m,
+                'model' => $model,
             ]);
         }
 
         // When we work without table, we can't have any IDs
-        if ($m->table === false) {
-            $m->removeField($m->id_field);
-            $m->addExpression($m->id_field, '1');
+        if ($model->table === false) {
+            $model->removeField($model->id_field);
+            $model->addExpression($model->id_field, '1');
             //} else {
             // SQL databases use ID of int by default
             //$m->getField($m->id_field)->type = 'integer';
         }
 
         // Sequence support
-        if ($m->sequence && $id_field = $m->hasField($m->id_field)) {
-            $id_field->default = $this->dsql()->mode('seq_nextval')->sequence($m->sequence);
+        if ($model->sequence && $id_field = $model->hasField($model->id_field)) {
+            $id_field->default = $this->dsql()->mode('seq_nextval')->sequence($model->sequence);
         }
 
-        return $m;
+        return $model;
     }
 
     /**
      * Initialize persistence.
      *
-     * @param Model $m
+     * @param Model $model
      */
-    protected function initPersistence(Model $m)
+    protected function initPersistence(Model $model)
     {
-        $m->addMethod('expr', $this);
-        $m->addMethod('dsql', $this);
-        $m->addMethod('exprNow', $this);
+        $model->addMethod('expr', $this);
+        $model->addMethod('dsql', $this);
+        $model->addMethod('exprNow', $this);
     }
 
     /**
      * Creates new Expression object from expression string.
      *
-     * @param Model $m
+     * @param Model $model
      * @param mixed $expr
      * @param array $args
      *
      * @return Expression
      */
-    public function expr(Model $m, $expr, $args = []): Expression
+    public function expr(Model $model, $expr, $args = []): Expression
     {
         if (!is_string($expr)) {
             return $this->connection->expr($expr, $args);
         }
         preg_replace_callback(
             '/\[[a-z0-9_]*\]|{[a-z0-9_]*}/i',
-            function ($matches) use (&$args, $m) {
+            function ($matches) use (&$args, $model) {
                 $identifier = substr($matches[0], 1, -1);
                 if ($identifier && !isset($args[$identifier])) {
-                    $args[$identifier] = $m->getField($identifier);
+                    $args[$identifier] = $model->getField($identifier);
                 }
 
                 return $matches[0];
@@ -230,48 +230,40 @@ class SQL extends Persistence
     /**
      * Initializes base query for model $m.
      *
-     * @param Model $m
+     * @param Model $model
      *
      * @return Query
      */
-    public function initQuery(Model $m): Query
+    public function initQuery(Model $model): Query
     {
-        $d = $m->persistence_data['dsql'] = $this->dsql();
+        $query = $model->persistence_data['dsql'] = $this->dsql();
 
-        if ($m->table) {
-            if (isset($m->table_alias)) {
-                $d->table($m->table, $m->table_alias);
-            } else {
-                $d->table($m->table);
-            }
+        if ($model->table) {
+            $query->table($model->table, $model->table_alias ?? null);
         }
 
-        return $d;
+        return $query;
     }
 
     /**
      * Adds Field in Query.
      *
-     * @param Query $q
+     * @param Query $query
      * @param Field $field
      */
-    public function initField(Query $q, Field $field)
+    public function initField(Query $query, Field $field)
     {
-        if ($field->useAlias()) {
-            $q->field($field, $field->short_name);
-        } else {
-            $q->field($field);
-        }
+        $query->field($field, $field->useAlias() ? $field->short_name : null);
     }
 
     /**
      * Adds model fields in Query.
      *
-     * @param Model            $m
-     * @param \atk4\dsql\Query $q
+     * @param Model            $model
+     * @param \atk4\dsql\Query $query
      * @param array|null|false $fields
      */
-    public function initQueryFields(Model $m, $q, $fields = null)
+    public function initQueryFields(Model $model, $query, $fields = null)
     {
         // do nothing on purpose
         if ($fields === false) {
@@ -284,36 +276,36 @@ class SQL extends Persistence
             // Set of fields is strictly defined for purposes of export,
             // so we will ignore even system fields.
             foreach ($fields as $field) {
-                $this->initField($q, $m->getField($field));
+                $this->initField($query, $model->getField($field));
             }
-        } elseif ($m->only_fields) {
+        } elseif ($model->only_fields) {
             $added_fields = [];
 
             // Add requested fields first
-            foreach ($m->only_fields as $field) {
-                $f_object = $m->getField($field);
+            foreach ($model->only_fields as $field) {
+                $f_object = $model->getField($field);
                 if ($f_object->never_persist) {
                     continue;
                 }
-                $this->initField($q, $f_object);
+                $this->initField($query, $f_object);
                 $added_fields[$field] = true;
             }
 
             // now add system fields, if they were not added
-            foreach ($m->getFields() as $field => $f_object) {
+            foreach ($model->getFields() as $field => $f_object) {
                 if ($f_object->never_persist) {
                     continue;
                 }
                 if ($f_object->system && !isset($added_fields[$field])) {
-                    $this->initField($q, $f_object);
+                    $this->initField($query, $f_object);
                 }
             }
         } else {
-            foreach ($m->getFields() as $field => $f_object) {
+            foreach ($model->getFields() as $field => $f_object) {
                 if ($f_object->never_persist) {
                     continue;
                 }
-                $this->initField($q, $f_object);
+                $this->initField($query, $f_object);
             }
         }
     }
@@ -321,33 +313,33 @@ class SQL extends Persistence
     /**
      * Will set limit defined inside $m onto query $q.
      *
-     * @param Model $m
-     * @param Query $q
+     * @param Model $model
+     * @param Query $query
      */
-    protected function setLimitOrder(Model $m, Query $q)
+    protected function setLimitOrder(Model $model, Query $query)
     {
         // set limit
-        if ($m->limit && ($m->limit[0] || $m->limit[1])) {
-            if ($m->limit[0] === null) {
+        if ($model->limit && ($model->limit[0] || $model->limit[1])) {
+            if ($model->limit[0] === null) {
                 // This is max number which is allowed in MySQL server.
                 // But be aware, that PDO will downgrade this number even lower probably because
                 // in LIMIT it expects numeric value and converts string (we set float values as PDO_PARAM_STR)
                 // back to PDO_PARAM_INT which is goes back to max int value specific server can have.
                 // On my Win10,64-bit it is 2147483647, on Travis server 9223372036854775807 etc.
-                $m->limit[0] = '18446744073709551615';
+                $model->limit[0] = '18446744073709551615';
             }
-            $q->limit($m->limit[0], $m->limit[1]);
+            $query->limit($model->limit[0], $model->limit[1]);
         }
 
         // set order
-        if ($m->order) {
-            foreach ($m->order as $o) {
+        if ($model->order) {
+            foreach ($model->order as $o) {
                 if ($o[0] instanceof Expression) {
-                    $q->order($o[0], $o[1]);
+                    $query->order($o[0], $o[1]);
                 } elseif (is_string($o[0])) {
-                    $q->order($m->getField($o[0]), $o[1]);
+                    $query->order($model->getField($o[0]), $o[1]);
                 } else {
-                    throw new Exception(['Unsupported order parameter', 'model' => $m, 'field' => $o[0]]);
+                    throw new Exception(['Unsupported order parameter', 'model' => $model, 'field' => $o[0]]);
                 }
             }
         }
@@ -356,19 +348,19 @@ class SQL extends Persistence
     /**
      * Will apply conditions defined inside $m onto query $q.
      *
-     * @param Model $m
-     * @param Query $q
+     * @param Model $model
+     * @param Query $query
      *
      * @return Query
      */
-    public function initQueryConditions(Model $m, Query $q): Query
+    public function initQueryConditions(Model $model, Query $query): Query
     {
-        if (!isset($m->conditions)) {
+        if (!isset($model->conditions)) {
             // no conditions are set in the model
-            return $q;
+            return $query;
         }
 
-        foreach ($m->conditions as $cond) {
+        foreach ($model->conditions as $cond) {
 
             // Options here are:
             // count($cond) == 1, we will pass the only
@@ -380,7 +372,7 @@ class SQL extends Persistence
                 if (is_array($cond[0])) {
                     foreach ($cond[0] as &$row) {
                         if (is_string($row[0])) {
-                            $row[0] = $m->getField($row[0]);
+                            $row[0] = $model->getField($row[0]);
                         }
 
                         if ($row[0] instanceof Field) {
@@ -391,28 +383,28 @@ class SQL extends Persistence
                     }
                 }
 
-                $q->where($cond[0]);
+                $query->where($cond[0]);
                 continue;
             }
 
             if (is_string($cond[0])) {
-                $cond[0] = $m->getField($cond[0]);
+                $cond[0] = $model->getField($cond[0]);
             }
 
             if (count($cond) == 2) {
                 if ($cond[0] instanceof Field) {
                     $cond[1] = $this->typecastSaveField($cond[0], $cond[1]);
                 }
-                $q->where($cond[0], $cond[1]);
+                $query->where($cond[0], $cond[1]);
             } else {
                 if ($cond[0] instanceof Field) {
                     $cond[2] = $this->typecastSaveField($cond[0], $cond[2]);
                 }
-                $q->where($cond[0], $cond[1], $cond[2]);
+                $query->where($cond[0], $cond[1], $cond[2]);
             }
         }
 
-        return $q;
+        return $query;
     }
 
     /**
@@ -424,42 +416,42 @@ class SQL extends Persistence
      *
      * @return mixed
      */
-    public function _typecastSaveField(Field $f, $value)
+    public function _typecastSaveField(Field $field, $value)
     {
         // work only on copied value not real one !!!
         $v = is_object($value) ? clone $value : $value;
 
-        switch ($f->type) {
+        switch ($field->type) {
         case 'boolean':
             // if enum is not set, then simply cast value to integer
-            if (!isset($f->enum) || !$f->enum) {
+            if (!isset($field->enum) || !$field->enum) {
                 $v = (int) $v;
                 break;
             }
 
             // if enum is set, first lets see if it matches one of those precisely
-            if ($v === $f->enum[1]) {
+            if ($v === $field->enum[1]) {
                 $v = true;
-            } elseif ($v === $f->enum[0]) {
+            } elseif ($v === $field->enum[0]) {
                 $v = false;
             }
 
             // finally, convert into appropriate value
-            $v = $v ? $f->enum[1] : $f->enum[0];
+            $v = $v ? $field->enum[1] : $field->enum[0];
             break;
         case 'date':
         case 'datetime':
         case 'time':
-            $dt_class = isset($f->dateTimeClass) ? $f->dateTimeClass : 'DateTime';
-            $tz_class = isset($f->dateTimeZoneClass) ? $f->dateTimeZoneClass : 'DateTimeZone';
+            $dt_class = $field->dateTimeClass ?? 'DateTime';
+            $tz_class = $field->dateTimeZoneClass ?? 'DateTimeZone';
 
             if ($v instanceof $dt_class) {
                 $format = ['date' => 'Y-m-d', 'datetime' => 'Y-m-d H:i:s', 'time' => 'H:i:s'];
-                $format = $f->persistence['format'] ?? $format[$f->type];
+                $format = $field->persistence['format'] ?? $format[$field->type];
 
                 // datetime only - set to persisting timezone
-                if ($f->type == 'datetime' && isset($f->persistence['timezone'])) {
-                    $v->setTimezone(new $tz_class($f->persistence['timezone']));
+                if ($field->type == 'datetime' && isset($field->persistence['timezone'])) {
+                    $v->setTimezone(new $tz_class($field->persistence['timezone']));
                 }
                 $v = $v->format($format);
             }
@@ -467,7 +459,7 @@ class SQL extends Persistence
         case 'array':
         case 'object':
             // don't encode if we already use some kind of serialization
-            $v = $f->serialize ? $v : $this->jsonEncode($f, $v);
+            $v = $field->serialize ? $v : $this->jsonEncode($field, $v);
             break;
         }
 
@@ -478,12 +470,12 @@ class SQL extends Persistence
      * This is the actual field typecasting, which you can override in your
      * persistence to implement necessary typecasting.
      *
-     * @param Field $f
+     * @param Field $field
      * @param mixed $value
      *
      * @return mixed
      */
-    public function _typecastLoadField(Field $f, $value)
+    public function _typecastLoadField(Field $field, $value)
     {
         // LOB fields return resource stream
         if (is_resource($value)) {
@@ -493,7 +485,7 @@ class SQL extends Persistence
         // work only on copied value not real one !!!
         $v = is_object($value) ? clone $value : $value;
 
-        switch ($f->type) {
+        switch ($field->type) {
         case 'string':
         case 'text':
             // do nothing - it's ok as it is
@@ -508,10 +500,10 @@ class SQL extends Persistence
             $v = round($v, 4);
             break;
         case 'boolean':
-            if (isset($f->enum) && is_array($f->enum)) {
-                if (isset($f->enum[0]) && $v == $f->enum[0]) {
+            if (isset($field->enum) && is_array($field->enum)) {
+                if (isset($field->enum[0]) && $v == $field->enum[0]) {
                     $v = false;
-                } elseif (isset($f->enum[1]) && $v == $f->enum[1]) {
+                } elseif (isset($field->enum[1]) && $v == $field->enum[1]) {
                     $v = true;
                 } else {
                     $v = null;
@@ -525,27 +517,27 @@ class SQL extends Persistence
         case 'date':
         case 'datetime':
         case 'time':
-            $dt_class = isset($f->dateTimeClass) ? $f->dateTimeClass : 'DateTime';
-            $tz_class = isset($f->dateTimeZoneClass) ? $f->dateTimeZoneClass : 'DateTimeZone';
+            $dt_class = isset($field->dateTimeClass) ? $field->dateTimeClass : 'DateTime';
+            $tz_class = isset($field->dateTimeZoneClass) ? $field->dateTimeZoneClass : 'DateTimeZone';
 
             if (is_numeric($v)) {
                 $v = new $dt_class('@'.$v);
             } elseif (is_string($v)) {
                 // ! symbol in date format is essential here to remove time part of DateTime - don't remove, this is not a bug
                 $format = ['date' => '+!Y-m-d', 'datetime' => '+!Y-m-d H:i:s', 'time' => '+!H:i:s'];
-                $format = $f->persistence['format'] ?? $format[$f->type];
+                $format = $field->persistence['format'] ?? $format[$field->type];
 
                 // datetime only - set from persisting timezone
-                if ($f->type == 'datetime' && isset($f->persistence['timezone'])) {
-                    $v = $dt_class::createFromFormat($format, $v, new $tz_class($f->persistence['timezone']));
+                if ($field->type == 'datetime' && isset($field->persistence['timezone'])) {
+                    $v = $dt_class::createFromFormat($format, $v, new $tz_class($field->persistence['timezone']));
                     if ($v === false) {
-                        throw new Exception(['Incorrectly formatted datetime', 'format' => $format, 'value' => $value, 'field' => $f]);
+                        throw new Exception(['Incorrectly formatted datetime', 'format' => $format, 'value' => $value, 'field' => $field]);
                     }
                     $v->setTimeZone(new $tz_class(date_default_timezone_get()));
                 } else {
                     $v = $dt_class::createFromFormat($format, $v);
                     if ($v === false) {
-                        throw new Exception(['Incorrectly formatted date/time', 'format' => $format, 'value' => $value, 'field' => $f]);
+                        throw new Exception(['Incorrectly formatted date/time', 'format' => $format, 'value' => $value, 'field' => $field]);
                     }
                 }
 
@@ -558,11 +550,11 @@ class SQL extends Persistence
             break;
         case 'array':
             // don't decode if we already use some kind of serialization
-            $v = $f->serialize ? $v : $this->jsonDecode($f, $v, true);
+            $v = $field->serialize ? $v : $this->jsonDecode($field, $v, true);
             break;
         case 'object':
             // don't decode if we already use some kind of serialization
-            $v = $f->serialize ? $v : $this->jsonDecode($f, $v, false);
+            $v = $field->serialize ? $v : $this->jsonDecode($field, $v, false);
             break;
         }
 
@@ -572,13 +564,13 @@ class SQL extends Persistence
     /**
      * Executing $model->action('update') will call this method.
      *
-     * @param Model  $m
+     * @param Model  $model
      * @param string $type
      * @param array  $args
      *
      * @return \atk4\dsql\Query
      */
-    public function action(Model $m, $type, $args = [])
+    public function action(Model $model, $type, $args = [])
     {
         if (!is_array($args)) {
             throw new Exception([
@@ -587,37 +579,37 @@ class SQL extends Persistence
             ]);
         }
 
-        $q = $this->initQuery($m);
+        $query = $this->initQuery($model);
         switch ($type) {
             case 'insert':
-                return $q->mode('insert');
+                return $query->mode('insert');
                 // cannot apply conditions now
 
             case 'update':
-                $q->mode('update');
+                $query->mode('update');
                 break;
 
             case 'delete':
-                $q->mode('delete');
-                $this->initQueryConditions($m, $q);
-                $m->hook('initSelectQuery', [$q, $type]);
+                $query->mode('delete');
+                $this->initQueryConditions($model, $query);
+                $model->hook('initSelectQuery', [$query, $type]);
 
-                return $q;
+                return $query;
 
             case 'select':
-                $this->initQueryFields($m, $q, isset($args[0]) ? $args[0] : null);
+                $this->initQueryFields($model, $query, isset($args[0]) ? $args[0] : null);
                 break;
 
             case 'count':
-                $this->initQueryConditions($m, $q);
-                $m->hook('initSelectQuery', [$q]);
+                $this->initQueryConditions($model, $query);
+                $model->hook('initSelectQuery', [$query]);
                 if (isset($args['alias'])) {
-                    $q->reset('field')->field('count(*)', $args['alias']);
+                    $query->reset('field')->field('count(*)', $args['alias']);
                 } else {
-                    $q->reset('field')->field('count(*)');
+                    $query->reset('field')->field('count(*)');
                 }
 
-                return $q;
+                return $query;
 
             case 'field':
                 if (!isset($args[0])) {
@@ -627,19 +619,19 @@ class SQL extends Persistence
                     ]);
                 }
 
-                $field = is_string($args[0]) ? $m->getField($args[0]) : $args[0];
-                $m->hook('initSelectQuery', [$q, $type]);
+                $field = is_string($args[0]) ? $model->getField($args[0]) : $args[0];
+                $model->hook('initSelectQuery', [$query, $type]);
                 if (isset($args['alias'])) {
-                    $q->reset('field')->field($field, $args['alias']);
+                    $query->reset('field')->field($field, $args['alias']);
                 } elseif ($field instanceof Field_SQL_Expression) {
-                    $q->reset('field')->field($field, $field->short_name);
+                    $query->reset('field')->field($field, $field->short_name);
                 } else {
-                    $q->reset('field')->field($field);
+                    $query->reset('field')->field($field);
                 }
-                $this->initQueryConditions($m, $q);
-                $this->setLimitOrder($m, $q);
+                $this->initQueryConditions($model, $query);
+                $this->setLimitOrder($model, $query);
 
-                return $q;
+                return $query;
 
             case 'fx':
             case 'fx0':
@@ -651,9 +643,9 @@ class SQL extends Persistence
                 }
 
                 $fx = $args[0];
-                $field = is_string($args[1]) ? $m->getField($args[1]) : $args[1];
-                $this->initQueryConditions($m, $q);
-                $m->hook('initSelectQuery', [$q, $type]);
+                $field = is_string($args[1]) ? $model->getField($args[1]) : $args[1];
+                $this->initQueryConditions($model, $query);
+                $model->hook('initSelectQuery', [$query, $type]);
 
                 if ($type == 'fx') {
                     $expr = "$fx([])";
@@ -662,14 +654,14 @@ class SQL extends Persistence
                 }
 
                 if (isset($args['alias'])) {
-                    $q->reset('field')->field($q->expr($expr, [$field]), $args['alias']);
+                    $query->reset('field')->field($query->expr($expr, [$field]), $args['alias']);
                 } elseif ($field instanceof Field_SQL_Expression) {
-                    $q->reset('field')->field($q->expr($expr, [$field]), $fx.'_'.$field->short_name);
+                    $query->reset('field')->field($query->expr($expr, [$field]), $fx.'_'.$field->short_name);
                 } else {
-                    $q->reset('field')->field($q->expr($expr, [$field]));
+                    $query->reset('field')->field($query->expr($expr, [$field]));
                 }
 
-                return $q;
+                return $query;
 
             default:
                 throw new Exception([
@@ -678,11 +670,11 @@ class SQL extends Persistence
                 ]);
         }
 
-        $this->initQueryConditions($m, $q);
-        $this->setLimitOrder($m, $q);
-        $m->hook('initSelectQuery', [$q, $type]);
+        $this->initQueryConditions($model, $query);
+        $this->setLimitOrder($model, $query);
+        $model->hook('initSelectQuery', [$query, $type]);
 
-        return $q;
+        return $query;
     }
 
     /**
@@ -737,21 +729,21 @@ class SQL extends Persistence
     /**
      * Loads a record from model and returns a associative array.
      *
-     * @param Model $m
+     * @param Model $model
      * @param mixed $id
      *
      * @return array
      */
-    public function load(Model $m, $id)
+    public function load(Model $model, $id)
     {
-        $data = $this->tryLoad($m, $id);
+        $data = $this->tryLoad($model, $id);
 
         if (!$data) {
             throw new Exception([
                 'Record was not found',
-                'model'      => $m,
+                'model'      => $model,
                 'id'         => $id,
-                'conditions' => $m->conditions,
+                'conditions' => $model->conditions,
             ], 404);
         }
 
@@ -761,24 +753,24 @@ class SQL extends Persistence
     /**
      * Tries to load any one record.
      *
-     * @param Model $m
+     * @param Model $model
      *
      * @return array
      */
-    public function tryLoadAny(Model $m)
+    public function tryLoadAny(Model $model)
     {
-        $load = $m->action('select');
+        $load = $model->action('select');
         $load->limit(1);
 
         // execute action
         try {
-            $data = $this->typecastLoadRow($m, $load->getRow());
+            $data = $this->typecastLoadRow($model, $load->getRow());
         } catch (\PDOException $e) {
             throw new Exception([
                 'Unable to load due to query error',
                 'query'      => $load->getDebugQuery(false),
-                'model'      => $m,
-                'conditions' => $m->conditions,
+                'model'      => $model,
+                'conditions' => $model->conditions,
             ], null, $e);
         }
 
@@ -786,16 +778,16 @@ class SQL extends Persistence
             return;
         }
 
-        if ($m->id_field) {
+        if ($model->id_field) {
 
             // If id_field is not set, model will be read-only
-            if (isset($data[$m->id_field])) {
-                $m->id = $data[$m->id_field];
+            if (isset($data[$model->id_field])) {
+                $model->id = $data[$model->id_field];
             } else {
                 throw new Exception([
                     'Model uses "id_field" but it was not available in the database',
-                    'model'       => $m,
-                    'id_field'    => $m->id_field,
+                    'model'       => $model,
+                    'id_field'    => $model->id_field,
                     'data'        => $data,
                 ]);
             }
@@ -807,19 +799,19 @@ class SQL extends Persistence
     /**
      * Loads any one record.
      *
-     * @param Model $m
+     * @param Model $model
      *
      * @return array
      */
-    public function loadAny(Model $m)
+    public function loadAny(Model $model)
     {
-        $data = $this->tryLoadAny($m);
+        $data = $this->tryLoadAny($model);
 
         if (!$data) {
             throw new Exception([
                 'No matching records were found',
-                'model'      => $m,
-                'conditions' => $m->conditions,
+                'model'      => $model,
+                'conditions' => $model->conditions,
             ], 404);
         }
 
@@ -829,57 +821,57 @@ class SQL extends Persistence
     /**
      * Inserts record in database and returns new record ID.
      *
-     * @param Model $m
+     * @param Model $model
      * @param array $data
      *
      * @return mixed
      */
-    public function insert(Model $m, $data)
+    public function insert(Model $model, $data)
     {
-        $insert = $m->action('insert');
+        $insert = $model->action('insert');
 
         // don't set id field at all if it's NULL
-        if ($m->id_field && array_key_exists($m->id_field, $data) && $data[$m->id_field] === null) {
-            unset($data[$m->id_field]);
+        if ($model->id_field && array_key_exists($model->id_field, $data) && $data[$model->id_field] === null) {
+            unset($data[$model->id_field]);
         }
 
-        $insert->set($this->typecastSaveRow($m, $data));
+        $insert->set($this->typecastSaveRow($model, $data));
 
         $st = null;
 
         try {
-            $m->hook('beforeInsertQuery', [$insert]);
+            $model->hook('beforeInsertQuery', [$insert]);
             $st = $insert->execute();
         } catch (\PDOException $e) {
             throw new Exception([
                 'Unable to execute insert query',
                 'query'      => $insert->getDebugQuery(false),
-                'model'      => $m,
-                'conditions' => $m->conditions,
+                'model'      => $model,
+                'conditions' => $model->conditions,
             ], null, $e);
         }
 
-        $m->hook('afterInsertQuery', [$insert, $st]);
+        $model->hook('afterInsertQuery', [$insert, $st]);
 
-        return $m->lastInsertID();
+        return $model->lastInsertID();
     }
 
     /**
      * Export all DataSet.
      *
-     * @param Model      $m
+     * @param Model      $model
      * @param array|null $fields
      * @param bool       $typecast_data Should we typecast exported data
      *
      * @return array
      */
-    public function export(Model $m, $fields = null, $typecast_data = true)
+    public function export(Model $model, $fields = null, $typecast_data = true)
     {
-        $data = $m->action('select', [$fields])->get();
+        $data = $model->action('select', [$fields])->get();
 
         if ($typecast_data) {
-            $data = array_map(function ($r) use ($m) {
-                return $this->typecastLoadRow($m, $r);
+            $data = array_map(function ($r) use ($model) {
+                return $this->typecastLoadRow($model, $r);
             }, $data);
         }
 
@@ -889,22 +881,22 @@ class SQL extends Persistence
     /**
      * Prepare iterator.
      *
-     * @param Model $m
+     * @param Model $model
      *
      * @return \PDOStatement
      */
-    public function prepareIterator(Model $m)
+    public function prepareIterator(Model $model)
     {
         try {
-            $export = $m->action('select');
+            $export = $model->action('select');
 
             return $export->execute();
         } catch (\PDOException $e) {
             throw new Exception([
                 'Unable to execute iteration query',
                 'query'      => $export->getDebugQuery(false),
-                'model'      => $m,
-                'conditions' => $m->conditions,
+                'model'      => $model,
+                'conditions' => $model->conditions,
             ], null, $e);
         }
     }
@@ -912,29 +904,29 @@ class SQL extends Persistence
     /**
      * Updates record in database.
      *
-     * @param Model $m
+     * @param Model $model
      * @param mixed $id
      * @param array $data
      */
-    public function update(Model $m, $id, $data)
+    public function update(Model $model, $id, $data)
     {
-        if (!$m->id_field) {
+        if (!$model->id_field) {
             throw new Exception(['id_field of a model is not set. Unable to update record.']);
         }
 
-        $update = $this->initQuery($m);
+        $update = $this->initQuery($model);
         $update->mode('update');
 
-        $data = $this->typecastSaveRow($m, $data);
+        $data = $this->typecastSaveRow($model, $data);
 
         // only apply fields that has been modified
         $update->set($data);
-        $update->where($m->getField($m->id_field), $id);
+        $update->where($model->getField($model->id_field), $id);
 
         $st = null;
 
         try {
-            $m->hook('beforeUpdateQuery', [$update]);
+            $model->hook('beforeUpdateQuery', [$update]);
             if ($data) {
                 $st = $update->execute();
             }
@@ -942,43 +934,43 @@ class SQL extends Persistence
             throw new Exception([
                 'Unable to update due to query error',
                 'query'      => $update->getDebugQuery(false),
-                'model'      => $m,
-                'conditions' => $m->conditions,
+                'model'      => $model,
+                'conditions' => $model->conditions,
             ], null, $e);
         }
 
-        if ($m->id_field && isset($data[$m->id_field]) && $m->dirty[$m->id_field]) {
+        if ($model->id_field && isset($data[$model->id_field]) && $model->dirty[$model->id_field]) {
             // ID was changed
-            $m->id = $data[$m->id_field];
+            $model->id = $data[$model->id_field];
         }
 
-        $m->hook('afterUpdateQuery', [$update, $st]);
+        $model->hook('afterUpdateQuery', [$update, $st]);
 
         // if any rows were updated in database, and we had expressions, reload
-        if ($m->reload_after_save === true && (!$st || $st->rowCount())) {
-            $d = $m->dirty;
-            $m->reload();
-            $m->_dirty_after_reload = $m->dirty;
-            $m->dirty = $d;
+        if ($model->reload_after_save === true && (!$st || $st->rowCount())) {
+            $d = $model->dirty;
+            $model->reload();
+            $model->_dirty_after_reload = $model->dirty;
+            $model->dirty = $d;
         }
     }
 
     /**
      * Deletes record from database.
      *
-     * @param Model $m
+     * @param Model $model
      * @param mixed $id
      */
-    public function delete(Model $m, $id)
+    public function delete(Model $model, $id)
     {
-        if (!$m->id_field) {
+        if (!$model->id_field) {
             throw new Exception(['id_field of a model is not set. Unable to delete record.']);
         }
 
-        $delete = $this->initQuery($m);
+        $delete = $this->initQuery($model);
         $delete->mode('delete');
-        $delete->where($m->id_field, $id);
-        $m->hook('beforeDeleteQuery', [$delete]);
+        $delete->where($model->id_field, $id);
+        $model->hook('beforeDeleteQuery', [$delete]);
 
         try {
             $delete->execute();
@@ -986,8 +978,8 @@ class SQL extends Persistence
             throw new Exception([
                 'Unable to delete due to query error',
                 'query'      => $delete->getDebugQuery(false),
-                'model'      => $m,
-                'conditions' => $m->conditions,
+                'model'      => $model,
+                'conditions' => $model->conditions,
             ], null, $e);
         }
     }

--- a/src/Persistence/SQL.php
+++ b/src/Persistence/SQL.php
@@ -107,7 +107,7 @@ class SQL extends Persistence
      *
      * @return Query
      */
-    public function dsql() : Query
+    public function dsql(): Query
     {
         return $this->connection->dsql();
     }
@@ -134,7 +134,7 @@ class SQL extends Persistence
      *
      * @return Model
      */
-    public function add($m, $defaults = []) : Model
+    public function add($m, $defaults = []): Model
     {
         // Use our own classes for fields, references and expressions unless
         // $defaults specify them otherwise.
@@ -181,6 +181,7 @@ class SQL extends Persistence
     {
         $m->addMethod('expr', $this);
         $m->addMethod('dsql', $this);
+        $m->addMethod('exprNow', $this);
     }
 
     /**
@@ -192,7 +193,7 @@ class SQL extends Persistence
      *
      * @return Expression
      */
-    public function expr(Model $m, $expr, $args = []) : Expression
+    public function expr(Model $m, $expr, $args = []): Expression
     {
         if (!is_string($expr)) {
             return $this->connection->expr($expr, $args);
@@ -214,13 +215,26 @@ class SQL extends Persistence
     }
 
     /**
+     * Creates new Query object with current_timestamp(precision) expression.
+     *
+     * @param Model $m
+     * @param int   $precision
+     *
+     * @return Query
+     */
+    public function exprNow($precision = null)
+    {
+        return $this->connection->dsql()->exprNow($precision);
+    }
+
+    /**
      * Initializes base query for model $m.
      *
      * @param Model $m
      *
      * @return Query
      */
-    public function initQuery(Model $m) : Query
+    public function initQuery(Model $m): Query
     {
         $d = $m->persistence_data['dsql'] = $this->dsql();
 
@@ -347,7 +361,7 @@ class SQL extends Persistence
      *
      * @return Query
      */
-    public function initQueryConditions(Model $m, Query $q) : Query
+    public function initQueryConditions(Model $m, Query $q): Query
     {
         if (!isset($m->conditions)) {
             // no conditions are set in the model

--- a/src/Reference.php
+++ b/src/Reference.php
@@ -118,7 +118,7 @@ class Reference
      *
      * @return Model
      */
-    public function getModel($defaults = []) : Model
+    public function getModel($defaults = []): Model
     {
         // set table_alias
         if (!isset($defaults['table_alias'])) {
@@ -176,7 +176,7 @@ class Reference
      *
      * @return Model
      */
-    protected function addToPersistence($model, $defaults = []) : Model
+    protected function addToPersistence($model, $defaults = []): Model
     {
         if (!$model->persistence && $p = $this->getDefaultPersistence($model)) {
             $p->add($model, $defaults);
@@ -221,7 +221,7 @@ class Reference
      *
      * @return Model
      */
-    public function ref($defaults = []) : Model
+    public function ref($defaults = []): Model
     {
         return $this->getModel($defaults);
     }
@@ -237,7 +237,7 @@ class Reference
      *
      * @return Model
      */
-    public function refModel($defaults = []) : Model
+    public function refModel($defaults = []): Model
     {
         return $this->getModel($defaults);
     }

--- a/src/Reference/ContainsMany.php
+++ b/src/Reference/ContainsMany.php
@@ -55,7 +55,7 @@ class ContainsMany extends ContainsOne
      *
      * @return Model
      */
-    public function ref($defaults = []) : Model
+    public function ref($defaults = []): Model
     {
         // get model
         // will not use ID field (no, sorry, will have to use it)

--- a/src/Reference/ContainsOne.php
+++ b/src/Reference/ContainsOne.php
@@ -108,7 +108,7 @@ class ContainsOne extends Reference
      *
      * @return Model
      */
-    public function ref($defaults = []) : Model
+    public function ref($defaults = []): Model
     {
         // get model
         // will not use ID field

--- a/src/Reference/HasMany.php
+++ b/src/Reference/HasMany.php
@@ -41,7 +41,7 @@ class HasMany extends Reference
      *
      * @return Field
      */
-    protected function referenceOurValue() : Field
+    protected function referenceOurValue(): Field
     {
         $this->owner->persistence_data['use_table_prefixes'] = true;
 
@@ -57,7 +57,7 @@ class HasMany extends Reference
      *
      * @return Model
      */
-    public function ref($defaults = []) : Model
+    public function ref($defaults = []): Model
     {
         return $this->getModel($defaults)
             ->addCondition(
@@ -75,7 +75,7 @@ class HasMany extends Reference
      *
      * @return Model
      */
-    public function refLink($defaults = []) : Model
+    public function refLink($defaults = []): Model
     {
         return $this->getModel($defaults)
             ->addCondition(
@@ -95,7 +95,7 @@ class HasMany extends Reference
      *
      * @return Field
      */
-    public function addField($n, $defaults = []) : Field
+    public function addField($n, $defaults = []): Field
     {
         if (!isset($defaults['aggregate']) && !isset($defaults['concat']) && !isset($defaults['expr'])) {
             throw new Exception([

--- a/src/Reference/HasOne.php
+++ b/src/Reference/HasOne.php
@@ -168,7 +168,7 @@ class HasOne extends Reference
      *
      * @return Field
      */
-    protected function referenceOurValue() : Field
+    protected function referenceOurValue(): Field
     {
         $this->owner->persistence_data['use_table_prefixes'] = true;
 
@@ -188,7 +188,7 @@ class HasOne extends Reference
      *
      * @return Model
      */
-    public function ref($defaults = []) : Model
+    public function ref($defaults = []): Model
     {
         $m = $this->getModel($defaults);
 

--- a/src/Reference/HasOne_SQL.php
+++ b/src/Reference/HasOne_SQL.php
@@ -28,7 +28,7 @@ class HasOne_SQL extends HasOne
      *
      * @return Field_SQL_Expression
      */
-    public function addField($field, ?string $their_field = null) : Field_SQL_Expression
+    public function addField($field, ?string $their_field = null): Field_SQL_Expression
     {
         if (is_array($field)) {
             $defaults = $field;
@@ -144,7 +144,7 @@ class HasOne_SQL extends HasOne
      *
      * @return Model
      */
-    public function refLink($defaults = []) : Model
+    public function refLink($defaults = []): Model
     {
         $m = $this->getModel($defaults);
 
@@ -166,7 +166,7 @@ class HasOne_SQL extends HasOne
      *
      * @return Model
      */
-    public function ref($defaults = []) : Model
+    public function ref($defaults = []): Model
     {
         $m = parent::ref($defaults);
 
@@ -212,7 +212,7 @@ class HasOne_SQL extends HasOne
      *
      * @return Field_SQL_Expression
      */
-    public function addTitle($defaults = []) : Field_SQL_Expression
+    public function addTitle($defaults = []): Field_SQL_Expression
     {
         if (!is_array($defaults)) {
             throw new Exception([

--- a/src/UserAction/Generic.php
+++ b/src/UserAction/Generic.php
@@ -195,6 +195,11 @@ class Generic
         return $this->description ?? ('Will execute '.$this->caption);
     }
 
+    /**
+     * Return confirmation message for action.
+     *
+     * @return string
+     */
     public function getConfirmation()
     {
         $confirmation = $this->confirmation;
@@ -208,5 +213,15 @@ class Generic
         }
 
         return $confirmation;
+    }
+
+    /**
+     * Return model associate with this action.
+     *
+     * @return Model
+     */
+    public function getModel()
+    {
+        return $this->owner;
     }
 }

--- a/src/Util/DeepCopy.php
+++ b/src/Util/DeepCopy.php
@@ -325,7 +325,7 @@ class DeepCopy
                 'destination'     => $destination,
                 'destination_info'=> $destination->__debugInfo(),
                 'depth'           => $e->getParams()['field'] ?? '?',
-                ], null, $e);
+            ], null, $e);
         }
     }
 }

--- a/tests/CSVTest.php
+++ b/tests/CSVTest.php
@@ -55,9 +55,9 @@ class CSVTest extends \atk4\core\PHPUnit_AgileTestCase
     public function testTestcase()
     {
         $data = [
-                ['name' => 'John', 'surname' => 'Smith'],
-                ['name' => 'Sarah', 'surname' => 'Jones'],
-            ];
+            ['name' => 'John', 'surname' => 'Smith'],
+            ['name' => 'Sarah', 'surname' => 'Jones'],
+        ];
 
         $this->setDB($data);
         $data2 = $this->getDB();
@@ -67,9 +67,9 @@ class CSVTest extends \atk4\core\PHPUnit_AgileTestCase
     public function testLoadAny()
     {
         $data = [
-                ['name' => 'John', 'surname' => 'Smith'],
-                ['name' => 'Sarah', 'surname' => 'Jones'],
-            ];
+            ['name' => 'John', 'surname' => 'Smith'],
+            ['name' => 'Sarah', 'surname' => 'Jones'],
+        ];
 
         $this->setDB($data);
 
@@ -86,9 +86,9 @@ class CSVTest extends \atk4\core\PHPUnit_AgileTestCase
     public function testLoadAnyException()
     {
         $data = [
-                ['name' => 'John', 'surname' => 'Smith'],
-                ['name' => 'Sarah', 'surname' => 'Jones'],
-            ];
+            ['name' => 'John', 'surname' => 'Smith'],
+            ['name' => 'Sarah', 'surname' => 'Jones'],
+        ];
 
         $this->setDB($data);
 
@@ -109,9 +109,9 @@ class CSVTest extends \atk4\core\PHPUnit_AgileTestCase
     public function testPersistenceCopy()
     {
         $data = [
-                ['name' => 'John', 'surname' => 'Smith', 'gender'=>'M'],
-                ['name' => 'Sarah', 'surname' => 'Jones', 'gender'=>'F'],
-            ];
+            ['name' => 'John', 'surname' => 'Smith', 'gender'=>'M'],
+            ['name' => 'Sarah', 'surname' => 'Jones', 'gender'=>'F'],
+        ];
 
         $this->setDB($data);
 
@@ -138,9 +138,9 @@ class CSVTest extends \atk4\core\PHPUnit_AgileTestCase
     public function testExport()
     {
         $data = [
-                ['name' => 'John', 'surname' => 'Smith'],
-                ['name' => 'Sarah', 'surname' => 'Jones'],
-            ];
+            ['name' => 'John', 'surname' => 'Smith'],
+            ['name' => 'Sarah', 'surname' => 'Jones'],
+        ];
         $this->setDB($data);
 
         $p = new Persistence\CSV($this->file);

--- a/tests/ConditionSQLTest.php
+++ b/tests/ConditionSQLTest.php
@@ -227,6 +227,37 @@ class ConditionSQLTest extends \atk4\schema\PHPUnit_SchemaTestCase
         $this->assertEquals('+123 smiths', $mm['contact_phone']);
     }
 
+    public function testArrayCondition()
+    {
+        $a = [
+            'user' => [
+                1 => ['id' => 1, 'name' => 'John'],
+                2 => ['id' => 2, 'name' => 'Johhny'],
+                3 => ['id' => 3, 'name' => 'Mary'],
+            ], ];
+        $this->setDB($a);
+
+        $m = new Model($this->db, 'user');
+        $m->addField('name');
+        $m->addCondition('name', ['John', 'Doe']);
+        $this->assertEquals(1, count($m->export()));
+
+        $m = new Model($this->db, 'user');
+        $m->addField('name');
+        $m->addCondition('name', 'in', ['Johhny', 'Doe', 'Mary']);
+        $this->assertEquals(2, count($m->export()));
+
+        $m = new Model($this->db, 'user');
+        $m->addField('name');
+        $m->addCondition('name', []); // this should not fail, always should be false
+        $this->assertEquals(0, count($m->export()));
+
+        $m = new Model($this->db, 'user');
+        $m->addField('name');
+        $m->addCondition('name', 'not', []); // this should not fail, always should be true
+        $this->assertEquals(3, count($m->export()));
+    }
+
     public function testDateCondition()
     {
         $a = [

--- a/tests/FieldTest.php
+++ b/tests/FieldTest.php
@@ -876,4 +876,19 @@ class FieldTest extends \atk4\schema\PHPUnit_SchemaTestCase
         $this->assertEquals($current_date->format('H:i:s'), $model->getField('time')->toString());
         $this->assertEquals($current_date->format('c'), $model->getField('datetime')->toString());
     }
+    
+    public function testFieldSeed()
+    {
+        $model = new Model();
+        $model->addField('date', ['type' => 'date', 'caption' => 'Test', 'required'=>true]);
+        $model->addField('integer', ['type' => 'integer', 'caption' => 'Test', 'required'=>true]);
+        
+        foreach (['date', 'integer'] as $name) {
+            $seed = $model->getField($name)->getSeed();
+            
+            $this->assertArrayNotHasKey('type', $seed);
+            $this->assertArrayHasKey('caption', $seed);
+            $this->assertArrayHasKey('required', $seed);;
+        }
+    }
 }

--- a/tests/FieldTest.php
+++ b/tests/FieldTest.php
@@ -880,15 +880,19 @@ class FieldTest extends \atk4\schema\PHPUnit_SchemaTestCase
     public function testFieldSeed()
     {
         $model = new Model();
-        $model->addField('date', ['type' => 'date', 'caption' => 'Test', 'required'=>true]);
-        $model->addField('integer', ['type' => 'integer', 'caption' => 'Test', 'required'=>true]);
         
-        foreach (['date', 'integer'] as $name) {
+        $fields = [
+                'date' => ['type' => 'date', 'caption' => 'Test', 'required'=>true],
+                'integer' => ['type' => 'integer', 'caption' => 'Test', 'required'=>true],
+                'string' => ['type' => 'string', 'caption' => 'Test', 'required'=>true, 'max_length'=>255],
+        ];
+        $model->addFields($fields);
+        
+        foreach ($fields as $name => $defaults) {
             $seed = $model->getField($name)->getSeed();
             
+            $this->assertArraySubset($seed, $defaults);
             $this->assertArrayNotHasKey('type', $seed);
-            $this->assertArrayHasKey('caption', $seed);
-            $this->assertArrayHasKey('required', $seed);;
         }
     }
 }

--- a/tests/FieldTest.php
+++ b/tests/FieldTest.php
@@ -895,4 +895,18 @@ class FieldTest extends \atk4\schema\PHPUnit_SchemaTestCase
             $this->assertArrayNotHasKey('type', $seed);
         }
     }
+    
+    public function testFieldSeedRegistry()
+    {
+        $customTypes = [
+                'some_type' => 'ABC',
+                'other_type' => 'EDF'
+        ];
+
+        Field::register($customTypes);
+
+        foreach ($customTypes as $type => $seed) {
+            $this->assertEquals($seed, Field::resolve($type));
+        }
+    }
 }

--- a/tests/FieldTypesTest.php
+++ b/tests/FieldTypesTest.php
@@ -3,8 +3,8 @@
 namespace atk4\data\tests;
 
 use atk4\data\Model;
-use atk4\data\Persistence_Static;
-use atk4\data\ValidationException;
+use atk4\data\Field\Callback;
+use atk4\data\Field\Integer;
 
 /**
  * Test various Field.
@@ -17,7 +17,7 @@ class FieldTypesTest extends \atk4\schema\PHPUnit_SchemaTestCase
     {
         parent::setUp();
 
-        $this->pers = new Persistence_Static([
+        $this->pers = new \atk4\data\Persistence\Static_([
             1 => ['name'=>'John'],
             2 => ['name'=>'Peter'],
         ]);
@@ -98,5 +98,29 @@ class FieldTypesTest extends \atk4\schema\PHPUnit_SchemaTestCase
 
         $this->expectExceptionMessage('format is invalid');
         $m['email'] = 'Romans <me@gmail.com>';
+    }
+    
+    public function testCallback()
+    {
+        $model = new Model($this->pers);
+        $model->addField('callback', [Callback::class, 'fx'=>function($model) {
+            return $model['name'];
+        }]);
+        
+        $model->each(function($model) {
+            $this->assertEquals($model['callback'], $model['name']);
+        });
+    }
+    
+    public function testInteger()
+    {
+        $model = new Model($this->pers);
+        $model->addField('integer', [Integer::class]);
+        
+        $model['integer'] = 55.55;
+        
+        $model->save();
+
+        $this->assertEquals($model['integer'], 55);
     }
 }

--- a/tests/JoinSQLTest.php
+++ b/tests/JoinSQLTest.php
@@ -410,7 +410,7 @@ class JoinSQLTest extends \atk4\schema\PHPUnit_SchemaTestCase
                 1 => ['id' => 1, 'name' => 'UK'],
                 2 => ['id' => 2, 'name' => 'US'],
                 3 => ['id' => 3, 'name' => 'India'],
-        ], ];
+            ], ];
         $this->setDB($a);
 
         $db = new Persistence\SQL($this->db->connection);
@@ -474,7 +474,7 @@ class JoinSQLTest extends \atk4\schema\PHPUnit_SchemaTestCase
                 1 => ['id' => 1, 'name' => 'UK'],
                 2 => ['id' => 2, 'name' => 'US'],
                 3 => ['id' => 3, 'name' => 'India'],
-        ], ];
+            ], ];
         $this->setDB($a);
 
         $db = new Persistence\SQL($this->db->connection);

--- a/tests/RandomTest.php
+++ b/tests/RandomTest.php
@@ -135,6 +135,42 @@ class RandomTest extends \atk4\schema\PHPUnit_SchemaTestCase
             ], ], $this->getDB());
     }
 
+    public function testAddFields2()
+    {
+        if ($this->driver == 'pgsql') {
+            $this->markTestIncomplete('This test is not supported on PostgreSQL');
+        }
+
+        $a = [
+            'user' => [
+                1 => ['name' => 'John', 'last_name'=>null, 'login'=>null, 'salary'=>null, 'tax'=>null, 'vat'=>null],
+            ], ];
+        $this->setDB($a);
+
+        $db = new Persistence\SQL($this->db->connection);
+        $m = new Model($db, 'user');
+        $m->addFields(['name'], ['default' => 'anonymous']);
+        $m->addFields([
+            'last_name',
+            'login'  => ['default' => 'unknown'],
+            'salary' => ['type'=>'money', CustomField::class, 'default' => 100],
+            ['tax', CustomField::class, 'type'=>'money', 'default' => 20],
+            'vat' => new CustomField(['type'=>'money', 'default' => 15]),
+        ]);
+
+        $m->insert([]);
+
+        $this->assertEquals([
+            ['id'=>1, 'name'=>'John', 'last_name'=>null, 'login'=>null, 'salary'=>null, 'tax'=>null, 'vat'=>null],
+            ['id'=> 2, 'name'=>'anonymous', 'last_name'=>null, 'login'=>'unknown', 'salary'=>100, 'tax'=>20, 'vat'=>15],
+        ], $m->export());
+
+        $m->load(2);
+        $this->assertTrue(is_float($m->get('salary')));
+        $this->assertTrue(is_float($m->get('tax')));
+        $this->assertTrue(is_float($m->get('vat')));
+    }
+
     public function testSameTable()
     {
         if ($this->driver == 'pgsql') {
@@ -492,4 +528,8 @@ class RandomTest extends \atk4\schema\PHPUnit_SchemaTestCase
         $a = $m->newInstance();
         $this->assertTrue(isset($a->persistence));
     }
+}
+
+class CustomField extends \atk4\data\Field
+{
 }

--- a/tests/RefactoredFieldTest.php
+++ b/tests/RefactoredFieldTest.php
@@ -53,8 +53,8 @@ class RefactoredFieldTest extends \atk4\schema\PHPUnit_SchemaTestCase
     {
         $m = new Model();
         $m->addField('n1', ['type' => 'float']);
-        $m->addField('n2', ['type' => 'float', 'required' => true, 'signed' => false]);
-        $m->addField('n3', ['type' => 'float', 'min' => 18, 'max' => 99, 'decimal_numbers' => 2]);
+        $m->addField('n2', ['type' => 'float', 'required' => true, 'signum' => false]);
+        $m->addField('n3', ['type' => 'float', 'min' => 18, 'max' => 99, 'decimals' => 2]);
 
         $m->set('n1', null);
         $this->assertEquals(null, $m['n1']);

--- a/tests/ReferenceSQLTest.php
+++ b/tests/ReferenceSQLTest.php
@@ -266,7 +266,7 @@ class ReferenceSQLTest extends \atk4\schema\PHPUnit_SchemaTestCase
                 ['total_vat', 'aggregate' => 'sum', 'type'=>'money'],
                 ['total_net', 'aggregate' => 'sum'],
                 ['total_gross', 'aggregate' => 'sum'],
-        ]);
+            ]);
         $i->load('1');
 
         // type was set explicitly
@@ -280,9 +280,9 @@ class ReferenceSQLTest extends \atk4\schema\PHPUnit_SchemaTestCase
         $this->assertEquals(49.2, $i['total_gross']);
 
         $i->ref('line')->import([
-                ['total_net' => ($n = 1), 'total_vat' => ($n * $vat), 'total_gross' => ($n * ($vat + 1))],
-                ['total_net' => ($n = 2), 'total_vat' => ($n * $vat), 'total_gross' => ($n * ($vat + 1))],
-            ]);
+            ['total_net' => ($n = 1), 'total_vat' => ($n * $vat), 'total_gross' => ($n * ($vat + 1))],
+            ['total_net' => ($n = 2), 'total_vat' => ($n * $vat), 'total_gross' => ($n * ($vat + 1))],
+        ]);
         $i->reload();
 
         $this->assertEquals($n = 43, $i['total_net']);
@@ -290,8 +290,8 @@ class ReferenceSQLTest extends \atk4\schema\PHPUnit_SchemaTestCase
         $this->assertEquals($n * ($vat + 1), $i['total_gross']);
 
         $i->ref('line')->import([
-                ['total_net' => null, 'total_vat' => null, 'total_gross' => 1],
-            ]);
+            ['total_net' => null, 'total_vat' => null, 'total_gross' => 1],
+        ]);
         $i->reload();
 
         $this->assertEquals($n = 43, $i['total_net']);
@@ -329,7 +329,7 @@ class ReferenceSQLTest extends \atk4\schema\PHPUnit_SchemaTestCase
                 ['len',       'aggregate' => $i->expr('sum(length([name]))')],
                 ['len2',      'expr' => 'sum(length([name]))'],
                 ['chicken5',  'expr' => 'sum([])', 'args'=>['5']],
-        ]);
+            ]);
         $l->load(1);
 
         $this->assertEquals(2, $l['items_name']); // 2 not-null values

--- a/tests/TypecastingTest.php
+++ b/tests/TypecastingTest.php
@@ -197,18 +197,18 @@ class TypecastingTest extends \atk4\schema\PHPUnit_SchemaTestCase
         $m->duplicate()->save();
 
         $a['types'][2] = [
-                    'id'       => 2,
-                    'string'   => '',
-                    'notype'   => '',
-                    'date'     => null,
-                    'datetime' => null,
-                    'time'     => null,
-                    'boolean'  => null,
-                    'integer'  => null,
-                    'money'    => null,
-                    'float'    => null,
-                    'array'    => null,
-                    'object'   => null,
+            'id'       => 2,
+            'string'   => '',
+            'notype'   => '',
+            'date'     => null,
+            'datetime' => null,
+            'time'     => null,
+            'boolean'  => null,
+            'integer'  => null,
+            'money'    => null,
+            'float'    => null,
+            'array'    => null,
+            'object'   => null,
         ];
 
         $this->assertEquals($a, $this->getDB());


### PR DESCRIPTION
- use single generic `Field::getSeed` method that checks seed properties for each field type
- use class constant for field type mapping
- minor changes in `Numeric` field property names for simplification
- backward compatible use of `$fx` property in `Callback` field instead of `$expr`
- add field tests