### PR TITLE
New method $model->getTitles()

### DIFF
--- a/docs/model.rst
+++ b/docs/model.rst
@@ -740,6 +740,10 @@ Title Field
 
     Return title field value of currently loaded record.
 
+.. php:method:: public getTitles
+
+    Returns array of title field values of all model records in format [id => title].
+
 .. _caption:
 
 Model Caption

--- a/src/Model.php
+++ b/src/Model.php
@@ -939,7 +939,7 @@ class Model implements ArrayAccess, IteratorAggregate
     }
 
     /**
-     * Returns array of model record titles [id => title]
+     * Returns array of model record titles [id => title].
      *
      * @return array
      */
@@ -947,9 +947,9 @@ class Model implements ArrayAccess, IteratorAggregate
     {
         $field = $this->title_field && $this->hasField($this->title_field) ? $this->title_field : $this->id_field;
 
-        return array_map(function($row) use ($field) {
-                return $row[$field];
-            }, $this->export([$field], $this->id_field));
+        return array_map(function ($row) use ($field) {
+            return $row[$field];
+        }, $this->export([$field], $this->id_field));
     }
 
     /**
@@ -1994,7 +1994,7 @@ class Model implements ArrayAccess, IteratorAggregate
 
         return $this;
     }
-    
+
     /**
      * Export DataSet as array of hashes.
      *

--- a/src/Model.php
+++ b/src/Model.php
@@ -939,6 +939,20 @@ class Model implements ArrayAccess, IteratorAggregate
     }
 
     /**
+     * Returns array of model record titles [id => title]
+     *
+     * @return array
+     */
+    public function getTitles()
+    {
+        $field = $this->title_field && $this->hasField($this->title_field) ? $this->title_field : $this->id_field;
+
+        return array_map(function($row) use ($field) {
+                return $row[$field];
+            }, $this->export([$field], $this->id_field));
+    }
+
+    /**
      * You can compare new value of the field with existing one without
      * retrieving. In the trivial case it's same as ($value == $model[$name])
      * but this method can be used for:.
@@ -1980,7 +1994,7 @@ class Model implements ArrayAccess, IteratorAggregate
 
         return $this;
     }
-
+    
     /**
      * Export DataSet as array of hashes.
      *

--- a/tests/RandomTest.php
+++ b/tests/RandomTest.php
@@ -414,11 +414,11 @@ class RandomTest extends \atk4\schema\PHPUnit_SchemaTestCase
 
         // default title_field = name
         $this->assertEquals(null, $m->getTitle()); // not loaded model returns null
-        $this->assertEquals([1=>'John',2=>'Sue'], $m->getTitles()); // all titles
+        $this->assertEquals([1=>'John', 2=>'Sue'], $m->getTitles()); // all titles
 
         $m->load(2);
         $this->assertEquals('Sue', $m->getTitle()); // loaded returns title_field value
-        $this->assertEquals([1=>'John',2=>'Sue'], $m->getTitles()); // all titles
+        $this->assertEquals([1=>'John', 2=>'Sue'], $m->getTitles()); // all titles
 
         // set custom title_field
         $m->title_field = 'parent_item_id';
@@ -437,7 +437,7 @@ class RandomTest extends \atk4\schema\PHPUnit_SchemaTestCase
         $m->title_field = 'my_name';
         $m->load(2);
         $this->assertEquals(2, $m->getTitle()); // loaded returns id value
-        $this->assertEquals([1=>1,2=>2], $m->getTitles()); // all titles (my_name)
+        $this->assertEquals([1=>1, 2=>2], $m->getTitles()); // all titles (my_name)
     }
 
     /**

--- a/tests/RandomTest.php
+++ b/tests/RandomTest.php
@@ -414,9 +414,11 @@ class RandomTest extends \atk4\schema\PHPUnit_SchemaTestCase
 
         // default title_field = name
         $this->assertEquals(null, $m->getTitle()); // not loaded model returns null
+        $this->assertEquals([1=>'John',2=>'Sue'], $m->getTitles()); // all titles
 
         $m->load(2);
         $this->assertEquals('Sue', $m->getTitle()); // loaded returns title_field value
+        $this->assertEquals([1=>'John',2=>'Sue'], $m->getTitles()); // all titles
 
         // set custom title_field
         $m->title_field = 'parent_item_id';
@@ -435,6 +437,7 @@ class RandomTest extends \atk4\schema\PHPUnit_SchemaTestCase
         $m->title_field = 'my_name';
         $m->load(2);
         $this->assertEquals(2, $m->getTitle()); // loaded returns id value
+        $this->assertEquals([1=>1,2=>2], $m->getTitles()); // all titles (my_name)
     }
 
     /**


### PR DESCRIPTION
Implements new method `$model->getTitles()`.

It's quite common in projects that you need to export all titles of model. It's simple, `$model->export([$model->title_field])` and that's all. Wrong.
1. Because it's possible that title_field is not set
2. Because it will loose id_field which you most likely also need (ok, you can use 2nd parameter of export method)
3. Because it will return array in more complex structure than you need. It will return:
```
[
    0 => ['id' => 123, 'name' => 'foo', ... other_system_fields here too],
    1 => ['id' => 456, 'name' => 'bar', ... other_system_fields here too],
]
```

But what it you only need this type of array?
```
[
    123 => 'foo',
    456 => 'bar',
]
```

Now there is solution - use `$model->getTitles()`. :)
