### PR TITLE
Exception for required field is more descriptive

### DIFF
--- a/src/Field.php
+++ b/src/Field.php
@@ -244,7 +244,7 @@ class Field implements Expressionable
 
             if ($value === null) {
                 if ($this->required) {
-                    throw new ValidationException([$this->name => 'Must not be null']);
+                    throw new ValidationException([$this->name => "Field {$this->name} must not be null"]);
                 }
 
                 return;


### PR DESCRIPTION
Add name of field to Exception. Error message "Must not be null" exception is not descriptive.
