### PR TITLE
Implement addWith()

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -20,11 +20,11 @@ jobs:
         php: ['7.2', '7.3', 'latest']
     services:
       mysql:
-        image: mysql:8.0
+        image: mariadb:10.15.1
         env:
           MYSQL_ROOT_PASSWORD: password
           MYSQL_DATABASE: db
-        options: --default-auth=mysql_native_password --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=5
+        options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=5
       postgres:
         image: postgres:10-alpine
         env:

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -20,11 +20,11 @@ jobs:
         php: ['7.2', '7.3', 'latest']
     services:
       mysql:
-        image: mysql:8.0
+        image: mysql:8.0.15
         env:
           MYSQL_ROOT_PASSWORD: password
           DB_DATABASE: db
-        options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=5
+        options: --default-authentication-plugin=mysql_native_password --skip-mysqlx --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=5
       postgres:
         image: postgres:10-alpine
         env:

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -23,7 +23,7 @@ jobs:
         image: mariadb:latest
         env:
           MYSQL_ROOT_PASSWORD: password
-          MYSQL_DATABASE: test
+          MYSQL_DATABASE: db
         options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=5
       postgres:
         image: postgres:10-alpine
@@ -50,7 +50,7 @@ jobs:
       - name: Run Tests
         run: |
           mkdir -p build/logs
-          mysql -uroot -ppassword -h mysql -e 'CREATE DATABASE db;'
+          # mysql -uroot -ppassword -h mysql -e 'CREATE DATABASE db;'
       - name: SQLite Testing
         run: vendor/bin/phpunit --configuration phpunit.xml --coverage-text --exclude-group dns
 

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -20,11 +20,11 @@ jobs:
         php: ['7.2', '7.3', 'latest']
     services:
       mysql:
-        image: mariadb:10.4.12
+        image: mysql:8.0
         env:
           MYSQL_ROOT_PASSWORD: password
           MYSQL_DATABASE: db
-        options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=5
+        options: --default-authentication-plugin=mysql_native_password --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=5
       postgres:
         image: postgres:10-alpine
         env:

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -20,11 +20,11 @@ jobs:
         php: ['7.2', '7.3', 'latest']
     services:
       mysql:
-        image: mysql:8.0.15
+        image: mariadb:latest
         env:
           MYSQL_ROOT_PASSWORD: password
-          DB_DATABASE: db
-        options: --default-authentication-plugin=mysql_native_password --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=5
+          MYSQL_DATABASE: db
+        options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=5
       postgres:
         image: postgres:10-alpine
         env:

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -24,7 +24,7 @@ jobs:
         env:
           MYSQL_ROOT_PASSWORD: password
           MYSQL_DATABASE: db
-        options: --default-authentication-plugin=mysql_native_password --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=5
+        options: --default-auth=mysql_native_password --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=5
       postgres:
         image: postgres:10-alpine
         env:

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -20,7 +20,7 @@ jobs:
         php: ['7.2', '7.3', 'latest']
     services:
       mysql:
-        image: mariadb:10.15.1
+        image: mariadb:10.5.1
         env:
           MYSQL_ROOT_PASSWORD: password
           MYSQL_DATABASE: db

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -23,7 +23,7 @@ jobs:
         image: mariadb:latest
         env:
           MYSQL_ROOT_PASSWORD: password
-          MYSQL_DATABASE: db
+          MYSQL_DATABASE: test
         options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=5
       postgres:
         image: postgres:10-alpine

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -24,7 +24,7 @@ jobs:
         env:
           MYSQL_ROOT_PASSWORD: password
           DB_DATABASE: db
-        options: --default-authentication-plugin=mysql_native_password --skip-mysqlx --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=5
+        options: --default-authentication-plugin=mysql_native_password --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=5
       postgres:
         image: postgres:10-alpine
         env:

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -20,7 +20,7 @@ jobs:
         php: ['7.2', '7.3', 'latest']
     services:
       mysql:
-        image: mariadb:latest
+        image: mariadb:10.4.12
         env:
           MYSQL_ROOT_PASSWORD: password
           MYSQL_DATABASE: db

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -20,7 +20,7 @@ jobs:
         php: ['7.2', '7.3', 'latest']
     services:
       mysql:
-        image: mysql:5.7
+        image: mysql:8.0
         env:
           MYSQL_ROOT_PASSWORD: password
           DB_DATABASE: db

--- a/composer.json
+++ b/composer.json
@@ -24,6 +24,8 @@
       "homepage": "https://nearly.guru/"
     }
   ],
+  "minimum-stability": "dev",
+  "prefer-stable": true,
   "require": {
     "php": ">=7.2.0",
     "ext-intl": "*",

--- a/docs/advanced.rst
+++ b/docs/advanced.rst
@@ -448,6 +448,31 @@ As expected - when you add a new model the new values are checked against
 existing records. You can also slightly modify the logic to make addCondition
 additive if you are verifying for the combination of matched fields.
 
+Using WITH cursors
+==================
+
+Many SQL database engines support defining WITH cursors to use in select, update
+and even delete statements.
+
+.. php:method:: addWith(Model $model, string $alias, array $fields, bool $recursive = false)
+
+    Agile toolkit data models also support these cursors. Usage is like this::
+
+    $invoices = new Invoice();
+
+    $contacts = new Contact();
+    $contacts->addWith($invoices, 'inv', ['contact_id'=>'cid', 'ref_no', 'total_net'=>'invoiced'], false);
+    $contacts->join('inv.cid');
+
+.. code-block:: sql
+
+    with
+        `inv` (`cid`, `ref_no`, `total_net`) as (select `contact_id`, `ref_no`, `total_net` from `invoice`)
+    select
+        *
+    from `contact`
+        join `inv` on `inv`.`cid`=`contact`.`id`
+
 Creating Many to Many relationship
 ==================================
 

--- a/docs/advanced.rst
+++ b/docs/advanced.rst
@@ -473,6 +473,8 @@ and even delete statements.
     from `contact`
         join `inv` on `inv`.`cid`=`contact`.`id`
 
+.. note:: Supported starting from MySQL 8.x. MariaDB supported it earlier.
+
 Creating Many to Many relationship
 ==================================
 

--- a/src/Model.php
+++ b/src/Model.php
@@ -184,7 +184,7 @@ class Model implements ArrayAccess, IteratorAggregate
      * @var array
      */
     public $order = [];
-    
+
     /**
      * Array of WITH cursors set.
      *
@@ -1253,7 +1253,7 @@ class Model implements ArrayAccess, IteratorAggregate
     {
         return $this->addCondition($this->id_field, $id);
     }
-    
+
     /**
      * Adds WITH cursor.
      *
@@ -1264,18 +1264,18 @@ class Model implements ArrayAccess, IteratorAggregate
      *
      * @return $this
      */
-    public function addWith(Model $model, string $alias, array $mapping = [], bool $recursive = false)
+    public function addWith(self $model, string $alias, array $mapping = [], bool $recursive = false)
     {
         if (isset($this->with[$alias])) {
             throw new Exception(['With cursor already set with this alias', 'alias'=>$alias]);
         }
-    
+
         $this->with[$alias] = [
-            'model' => $model,
-            'mapping' => $mapping,
+            'model'     => $model,
+            'mapping'   => $mapping,
             'recursive' => $recursive,
         ];
-    
+
         return $this;
     }
 

--- a/src/Model.php
+++ b/src/Model.php
@@ -184,6 +184,13 @@ class Model implements ArrayAccess, IteratorAggregate
      * @var array
      */
     public $order = [];
+    
+    /**
+     * Array of WITH cursors set.
+     *
+     * @var array
+     */
+    public $with = [];
 
     /**
      * Currently loaded record data. This record is associative array
@@ -1245,6 +1252,31 @@ class Model implements ArrayAccess, IteratorAggregate
     public function withID($id)
     {
         return $this->addCondition($this->id_field, $id);
+    }
+    
+    /**
+     * Adds WITH cursor.
+     *
+     * @param Model  $model
+     * @param string $alias
+     * @param array  $mapping
+     * @param bool   $recursive
+     *
+     * @return $this
+     */
+    public function addWith(Model $model, string $alias, array $mapping = [], bool $recursive = false)
+    {
+        if (isset($this->with[$alias])) {
+            throw new Exception(['With cursor already set with this alias', 'alias'=>$alias]);
+        }
+    
+        $this->with[$alias] = [
+            'model' => $model,
+            'mapping' => $mapping,
+            'recursive' => $recursive,
+        ];
+    
+        return $this;
     }
 
     /**

--- a/src/Persistence/SQL.php
+++ b/src/Persistence/SQL.php
@@ -245,7 +245,7 @@ class SQL extends Persistence
                 $d->table($m->table);
             }
         }
-        
+
         // add With cursors
         $this->initWithCursors($m, $d);
 
@@ -258,7 +258,8 @@ class SQL extends Persistence
      * @param Model $m
      * @param Query $q
      */
-    public function initWithCursors(Model $m, Query $q) {
+    public function initWithCursors(Model $m, Query $q)
+    {
         if (!$m->with) {
             return;
         }
@@ -270,7 +271,7 @@ class SQL extends Persistence
                 $fields_from[] = is_int($from) ? $to : $from;
                 $fields_to[] = $to;
             }
-            
+
             // prepare sub-query
             if ($fields_from) {
                 $model->onlyFields($fields_from);

--- a/src/Persistence/SQL.php
+++ b/src/Persistence/SQL.php
@@ -245,8 +245,43 @@ class SQL extends Persistence
                 $d->table($m->table);
             }
         }
+        
+        // add With cursors
+        $this->initWithCursors($m, $d);
 
         return $d;
+    }
+
+    /**
+     * Initializes WITH cursors.
+     *
+     * @param Model $m
+     * @param Query $q
+     */
+    public function initWithCursors(Model $m, Query $q) {
+        if (!$m->with) {
+            return;
+        }
+
+        foreach ($m->with as $alias => ['model'=>$model, 'mapping'=>$mapping, 'recursive'=>$recursive]) {
+            // prepare field names
+            $fields_from = $fields_to = [];
+            foreach ($mapping as $from => $to) {
+                $fields_from[] = is_int($from) ? $to : $from;
+                $fields_to[] = $to;
+            }
+            
+            // prepare sub-query
+            if ($fields_from) {
+                $model->onlyFields($fields_from);
+            }
+            // 2nd parameter here strictly define which fields should be selected
+            // as result system fields will not be added if they are not requested
+            $sub_q = $model->action('select', [$fields_from]);
+
+            // add With cursor
+            $q->with($sub_q, $alias, $fields_to ?: null, $recursive);
+        }
     }
 
     /**
@@ -268,7 +303,7 @@ class SQL extends Persistence
      * Adds model fields in Query.
      *
      * @param Model            $m
-     * @param \atk4\dsql\Query $q
+     * @param Query            $q
      * @param array|null|false $fields
      */
     public function initQueryFields(Model $m, $q, $fields = null)
@@ -584,7 +619,7 @@ class SQL extends Persistence
      * @param string $type
      * @param array  $args
      *
-     * @return \atk4\dsql\Query
+     * @return Query
      */
     public function action(Model $m, $type, $args = [])
     {

--- a/tests/WithTest.php
+++ b/tests/WithTest.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace atk4\data\tests;
+
+use atk4\data\Model;
+use atk4\data\Persistence;
+
+/**
+ * @coversDefaultClass \atk4\data\Model
+ */
+class WithTest extends \atk4\schema\PHPUnit_SchemaTestCase
+{
+    public function testWith()
+    {
+        $a = [
+            'user' => [
+                10 => ['id' => 10, 'name' => 'John', 'salary' => 1000],
+                20 => ['id' => 20, 'name' => 'Peter', 'salary' => 1500],
+            ], 'quote' => [
+                1 => ['id' => 1, 'net' => 100, 'user_id' => 10],
+                2 => ['id' => 2, 'net' => 350, 'user_id' => 20],
+                3 => ['id' => 3, 'net' => 75, 'user_id' => 10],
+            ], 'invoice' => [
+                1 => ['id' => 1, 'net' => 500, 'user_id' => 10],
+                2 => ['id' => 2, 'net' => 200, 'user_id' => 20],
+                3 => ['id' => 3, 'net' => 100, 'user_id' => 20],
+            ], ];
+        $this->setDB($a);
+        $db = new Persistence\SQL($this->db->connection);
+
+        // setup models
+        $m_user = new Model($db, 'user');
+        $m_user->addField('name');
+        $m_user->addField('salary', ['type'=>'money']);
+
+        $m_quote = new Model($db, 'quote');
+        $m_quote->addField('net', ['type'=>'money']);
+        $m_quote->hasOne('user_id', $m_user);
+        // @todo How to add SUM + GROUP BY here ????
+
+        $m_invoice = new Model($db, 'invoice');
+        $m_invoice->addField('net', ['type'=>'money']);
+        $m_invoice->hasOne('user_id', $m_user);
+        // @todo How to add SUM + GROUP BY here ????
+
+        // setup test model
+        $m = clone $m_user;
+        $m->addWith($m_quote, 'q', ['user_id','net'=>'quoted'], false);
+        //$m->addWith($m_invoice, 'i', ['user_id','invoiced']);
+
+        $j_user = $m->join('q.user_id'); // join cursors
+        $j_user->addField('quoted');
+        
+
+        // tests
+        echo $m->action('select')->getDebugQuery();
+
+        var_dump($m->export());
+    
+    }
+    
+    /**
+     * Alias should be unique.
+     *
+     * @expectedException Exception
+     */
+    public function testUniqueAliasException()
+    {
+        $m1 = new Model();
+        $m2 = new Model();
+        $m1->addWith($m2,'t');
+        $m1->addWith($m2,'t');
+    }
+}

--- a/tests/WithTest.php
+++ b/tests/WithTest.php
@@ -45,20 +45,18 @@ class WithTest extends \atk4\schema\PHPUnit_SchemaTestCase
 
         // setup test model
         $m = clone $m_user;
-        $m->addWith($m_quote, 'q', ['user_id','net'=>'quoted'], false);
+        $m->addWith($m_quote, 'q', ['user_id', 'net'=>'quoted'], false);
         //$m->addWith($m_invoice, 'i', ['user_id','invoiced']);
 
         $j_user = $m->join('q.user_id'); // join cursors
         $j_user->addField('quoted');
-        
 
         // tests
         echo $m->action('select')->getDebugQuery();
 
         var_dump($m->export());
-    
     }
-    
+
     /**
      * Alias should be unique.
      *
@@ -68,7 +66,7 @@ class WithTest extends \atk4\schema\PHPUnit_SchemaTestCase
     {
         $m1 = new Model();
         $m2 = new Model();
-        $m1->addWith($m2,'t');
-        $m1->addWith($m2,'t');
+        $m1->addWith($m2, 't');
+        $m1->addWith($m2, 't');
     }
 }


### PR DESCRIPTION
Adds `with` cursors into model.

Method:
`addWith(self $model, string $alias, array $mapping = [], bool $recursive = false)`

Switched to MariaDB instead of MySQL, because only MySQL 8.x supports `with` statement and had issues running mysql 8.x on github docker. I think that's fine to use MariaDB instead.