### PR TITLE
Action should also support `fields===true` value

### DIFF
--- a/src/UserAction/Generic.php
+++ b/src/UserAction/Generic.php
@@ -67,7 +67,7 @@ class Generic
     /** @var array Argument definition. */
     public $args = [];
 
-    /** @var array|null Specify which fields may be dirty when invoking action. NO_RECORDS|SINGLE_RECORD scopes for adding/modifying */
+    /** @var array|bool Specify which fields may be dirty when invoking action. NO_RECORDS|SINGLE_RECORD scopes for adding/modifying */
     public $fields = [];
 
     /** @var bool Atomic action will automatically begin transaction before and commit it after completing. */
@@ -111,9 +111,9 @@ class Generic
                         'permitted' => $this->fields,
                     ]);
                 }
-            } elseif ($this->fields !== false) {
+            } elseif (!is_bool($this->fields)) {
                 throw new Exception([
-                    'Argument `fields` for the action must be either array or `false`.',
+                    'Argument `fields` for the action must be either array or boolean.',
                     'fields'=> $this->fields,
                 ]);
             }


### PR DESCRIPTION
Otherwise it's not consistent with UI action executor implementation and basically atk/data actions are unusable without UI action executors. So data relies on UI and that's wrong by design.