### PR TITLE
introduce shorthand for setting conditions on referenced models

### DIFF
--- a/docs/conditions.rst
+++ b/docs/conditions.rst
@@ -113,6 +113,28 @@ This rather unusual condition will show user records who have registered on same
 date when they were born OR if they were born on 10th. (This is really silly
 condition, please don't judge, if you have a better example, I'd love to hear).
 
+Conditions on Referenced Models
+-------------------------------
+
+Agile Data allows for adding conditions on related models for retrieval of type 'model has references where'.
+
+Setting conditions on references can be done utilizing the Model::refLink method but there is a shorthand format 
+directly integrated with addCondition method using "/" to chain the reference names::
+
+	$contact->addCondition('company/country', 'US');
+	
+This will limit the $contact model to those whose company is in US.
+'company' is the name of the reference in $contact model and 'country' is a field in the referenced model.
+
+If a condition must be set directly on the existence or number of referenced records the special symbol "#" can be
+utilized to indicate the condition is on the number of records::
+
+	$contact->addCondition('company/tickets/#', '>', 0);
+	
+This will limit the $contact model to those whose company has any tickets.
+'company' and 'tickets' are the name of the chained references ('company' is a reference in the $contact model and
+'tickets' is a reference in Company model)
+
 Defining your classes
 ---------------------
 

--- a/src/Model.php
+++ b/src/Model.php
@@ -1236,7 +1236,7 @@ class Model implements ArrayAccess, IteratorAggregate
 
         if (is_string($field)) {
             // shorthand for adding conditions on references
-            // use chained reference names separated by dot "."
+            // use chained reference names separated by "/"
             if (stripos($field, '/') !== false) {
                 $references = explode('/', $field);
 

--- a/src/Model.php
+++ b/src/Model.php
@@ -1186,12 +1186,12 @@ class Model implements ArrayAccess, IteratorAggregate
      *  ->addCondition($expr);
      *
      * Conditions on referenced models are also supported:
-     *  $contact->addCondition('company.country', 'US');
+     *  $contact->addCondition('company/country', 'US');
      * where 'company' is the name of the reference
      * This will limit scope of $contact model to contacts whose company country is set to 'US'
      *
      * Using # in conditions on referenced model will apply the condition on the number of records:
-     * $contact->addCondition('tickets.#', '>', 5);
+     * $contact->addCondition('tickets/#', '>', 5);
      * This will limit scope of $contact model to contacts that have more than 5 tickets
      *
      * To use those, you should consult with documentation of your
@@ -1237,8 +1237,8 @@ class Model implements ArrayAccess, IteratorAggregate
         if (is_string($field)) {
             // shorthand for adding conditions on references
             // use chained reference names separated by dot "."
-            if (stripos($field, '.') !== false) {
-                $references = explode('.', $field);
+            if (stripos($field, '/') !== false) {
+                $references = explode('/', $field);
 
                 $field = array_pop($references);
 

--- a/src/Model.php
+++ b/src/Model.php
@@ -1184,11 +1184,11 @@ class Model implements ArrayAccess, IteratorAggregate
      * There are also vendor-specific expression support:
      *  ->addCondition('my_field', $expr);
      *  ->addCondition($expr);
-     *  
+     *
      * Conditions on referenced models are also supported:
      *  $contact->addCondition('company.country', 'US');
      * where 'company' is the name of the reference
-     * This will limit scope of $contact model to contacts whose company country is set to 'US' 
+     * This will limit scope of $contact model to contacts whose company country is set to 'US'
      *
      * To use those, you should consult with documentation of your
      * persistence driver.
@@ -1229,28 +1229,28 @@ class Model implements ArrayAccess, IteratorAggregate
             return $this;
             */
         }
-        
+
         if (is_string($field)) {
             // shorthand for adding conditions on references
             // use chained reference names separated by dot "."
             if (stripos($field, '.') !== false) {
                 $references = explode('.', $field);
-                
+
                 $field = array_pop($references);
-                
+
                 $model = $this;
                 foreach ($references as $link) {
                     $model = $model->refLink($link);
                 }
 
                 $this->conditions[] = [$model->addCondition(...func_get_args())->action('count'), '>', 0];
-                
+
                 return $this;
             }
 
             $field = $this->getField($field);
         }
-        
+
         if ($field instanceof Field) {
             if ($operator === '=' || func_num_args() == 2) {
                 $v = ($operator === '=' ? $value : $operator);

--- a/src/Model.php
+++ b/src/Model.php
@@ -1184,6 +1184,11 @@ class Model implements ArrayAccess, IteratorAggregate
      * There are also vendor-specific expression support:
      *  ->addCondition('my_field', $expr);
      *  ->addCondition($expr);
+     *  
+     * Conditions on referenced models are also supported:
+     *  $contact->addCondition('company.country', 'US');
+     * where 'company' is the name of the reference
+     * This will limit scope of $contact model to contacts whose company country is set to 'US' 
      *
      * To use those, you should consult with documentation of your
      * persistence driver.
@@ -1224,15 +1229,35 @@ class Model implements ArrayAccess, IteratorAggregate
             return $this;
             */
         }
+        
+        if (is_string($field)) {
+            // shorthand for adding conditions on references
+            // use chained reference names separated by dot "."
+            if (stripos($field, '.') !== false) {
+                $references = explode('.', $field);
+                
+                $field = array_pop($references);
+                
+                $model = $this;
+                foreach ($references as $link) {
+                    $model = $model->refLink($link);
+                }
 
-        $f = is_string($field) ? $this->getField($field) : ($field instanceof Field ? $field : false);
-        if ($f) {
+                $this->conditions[] = [$model->addCondition(...func_get_args())->action('count'), '>', 0];
+                
+                return $this;
+            }
+
+            $field = $this->getField($field);
+        }
+        
+        if ($field instanceof Field) {
             if ($operator === '=' || func_num_args() == 2) {
                 $v = ($operator === '=' ? $value : $operator);
 
                 if (!is_object($v) && !is_array($v)) {
-                    $f->system = true;
-                    $f->default = $v;
+                    $field->system = true;
+                    $field->default = $v;
                 }
             }
         }

--- a/src/Model.php
+++ b/src/Model.php
@@ -1258,9 +1258,7 @@ class Model implements ArrayAccess, IteratorAggregate
                 }
                 $args[0] = $model->action('count');
 
-                $this->conditions[] = $args;
-
-                return $this;
+                return $this->addCondition(...$args);
             }
 
             $field = $this->getField($field);

--- a/src/Model.php
+++ b/src/Model.php
@@ -1190,6 +1190,10 @@ class Model implements ArrayAccess, IteratorAggregate
      * where 'company' is the name of the reference
      * This will limit scope of $contact model to contacts whose company country is set to 'US'
      *
+     * Using # in conditions on referenced model will apply the condition on the number of records:
+     * $contact->addCondition('tickets.#', '>', 5);
+     * This will limit scope of $contact model to contacts that have more than 5 tickets
+     *
      * To use those, you should consult with documentation of your
      * persistence driver.
      *
@@ -1243,7 +1247,18 @@ class Model implements ArrayAccess, IteratorAggregate
                     $model = $model->refLink($link);
                 }
 
-                $this->conditions[] = [$model->addCondition(...func_get_args())->action('count'), '>', 0];
+                $args = func_get_args();
+
+                // '#' will apply condition directly on the record count (has # referenced records)
+                // otherwise applying condition on the referenced model field (has referenced records where)
+                if ($field !== '#') {
+                    $model->addCondition(...$args);
+                    $args[1] = '>';
+                    $args[2] = 0;
+                }
+                $args[0] = $model->action('count');
+
+                $this->conditions[] = $args;
 
                 return $this;
             }

--- a/tests/LookupSQLTest.php
+++ b/tests/LookupSQLTest.php
@@ -318,7 +318,7 @@ class LookupSQLTest extends \atk4\schema\PHPUnit_SchemaTestCase
             //[ 'name'       => 'Romans', 'country_code'=>'UK'],  // does not exist
         ]);
     }
-    
+
     public function testQueryByReference()
     {
         $c = new LCountry($this->db);
@@ -342,9 +342,9 @@ class LookupSQLTest extends \atk4\schema\PHPUnit_SchemaTestCase
         $u->addCondition('country_id.code', 'LV');
 
         $this->assertEquals(1, $u->action('count')->getOne());
-        
+
         $u->loadAny();
-        
+
         $this->assertEquals('LV', $u['country_code']);
     }
 

--- a/tests/LookupSQLTest.php
+++ b/tests/LookupSQLTest.php
@@ -318,6 +318,35 @@ class LookupSQLTest extends \atk4\schema\PHPUnit_SchemaTestCase
             //[ 'name'       => 'Romans', 'country_code'=>'UK'],  // does not exist
         ]);
     }
+    
+    public function testQueryByReference()
+    {
+        $c = new LCountry($this->db);
+
+        // Specifying hasMany here will perform input
+        $c->import([
+            ['Canada', 'code'=>'CA'],
+            ['Latvia', 'code'=>'LV'],
+            ['Japan', 'code'=>'JP'],
+            ['Lithuania', 'code'=>'LT', 'is_eu'=>true],
+            ['Russia', 'code'=>'RU'],
+        ]);
+
+        $u = new LUser($this->db);
+
+        $u->import([
+            ['name'       => 'Alain', 'country_code'=>'CA'],
+            ['name'       => 'Imants', 'country_code'=>'LV'],
+        ]);
+
+        $u->addCondition('country_id.code', 'LV');
+
+        $this->assertEquals(1, $u->action('count')->getOne());
+        
+        $u->loadAny();
+        
+        $this->assertEquals('LV', $u['country_code']);
+    }
 
     /*
      *

--- a/tests/LookupSQLTest.php
+++ b/tests/LookupSQLTest.php
@@ -68,8 +68,8 @@ class LUser extends Model
             ->withTitle()
             ->addFields(['country_code'=>'code', 'is_eu']);
 
-        $this->hasMany('Friends', new LFriend())
-            ->addField('friend_names', ['field'=>'friend_name', 'concat'=>',']);
+//         $this->hasMany('Friends', new LFriend())
+//             ->addField('friend_names', ['field'=>'friend_name', 'concat'=>',']);
     }
 }
 
@@ -342,10 +342,10 @@ class LookupSQLTest extends \atk4\schema\PHPUnit_SchemaTestCase
         $u->addCondition('country_id.code', 'LV');
 
         $this->assertEquals(1, $u->action('count')->getOne());
-        
-        $u->loadAny();
-        
-        $this->assertEquals('LV', $u['country_code']);
+
+        foreach ($u as $user) {
+            $this->assertEquals('LV', $user['country_code']);
+        }
     }
 
     /*

--- a/tests/LookupSQLTest.php
+++ b/tests/LookupSQLTest.php
@@ -334,17 +334,37 @@ class LookupSQLTest extends \atk4\schema\PHPUnit_SchemaTestCase
 
         $u = new LUser($this->db);
 
-        $u->import([
+        $u->import($users = [
             ['name'       => 'Alain', 'country_code'=>'CA'],
             ['name'       => 'Imants', 'country_code'=>'LV'],
         ]);
 
-        $u->addCondition('country_id.code', 'LV');
+        $uu1 = clone $u;
+        
+        $uu1->addCondition('country_id.code', 'LV');
 
-        $this->assertEquals(1, $u->action('count')->getOne());
+        $this->assertEquals(1, $uu1->action('count')->getOne());
 
-        foreach ($u as $user) {
+        foreach ($uu1 as $user) {
             $this->assertEquals('LV', $user['country_code']);
+        }
+        
+        $cc1 = clone $c;
+        
+        // countries with 1 user
+        $cc1->addCondition('Users.#', 1);
+        
+        foreach ($cc1 as $country) {
+            $this->assertTrue(in_array($country['code'], array_column($users, 'country_code')));
+        }
+        
+        $cc2 = clone $c;
+        
+        // countries with 1 user
+        $cc2->addCondition('Users.#', 0);
+        
+        foreach ($cc2 as $country) {
+            $this->assertTrue(! in_array($country['code'], array_column($users, 'country_code')));
         }
     }
 

--- a/tests/LookupSQLTest.php
+++ b/tests/LookupSQLTest.php
@@ -341,7 +341,7 @@ class LookupSQLTest extends \atk4\schema\PHPUnit_SchemaTestCase
 
         $uu1 = clone $u;
         
-        $uu1->addCondition('country_id.code', 'LV');
+        $uu1->addCondition('country_id/code', 'LV');
 
         $this->assertEquals(1, $uu1->action('count')->getOne());
 
@@ -352,7 +352,7 @@ class LookupSQLTest extends \atk4\schema\PHPUnit_SchemaTestCase
         $cc1 = clone $c;
         
         // countries with 1 user
-        $cc1->addCondition('Users.#', 1);
+        $cc1->addCondition('Users/#', 1);
         
         foreach ($cc1 as $country) {
             $this->assertTrue(in_array($country['code'], array_column($users, 'country_code')));
@@ -360,8 +360,8 @@ class LookupSQLTest extends \atk4\schema\PHPUnit_SchemaTestCase
         
         $cc2 = clone $c;
         
-        // countries with 1 user
-        $cc2->addCondition('Users.#', 0);
+        // countries with no user
+        $cc2->addCondition('Users/#', 0);
         
         foreach ($cc2 as $country) {
             $this->assertTrue(! in_array($country['code'], array_column($users, 'country_code')));

--- a/tests/LookupSQLTest.php
+++ b/tests/LookupSQLTest.php
@@ -340,7 +340,7 @@ class LookupSQLTest extends \atk4\schema\PHPUnit_SchemaTestCase
         ]);
 
         $uu1 = clone $u;
-        
+
         $uu1->addCondition('country_id.code', 'LV');
 
         $this->assertEquals(1, $uu1->action('count')->getOne());
@@ -348,23 +348,23 @@ class LookupSQLTest extends \atk4\schema\PHPUnit_SchemaTestCase
         foreach ($uu1 as $user) {
             $this->assertEquals('LV', $user['country_code']);
         }
-        
+
         $cc1 = clone $c;
-        
+
         // countries with 1 user
         $cc1->addCondition('Users.#', 1);
-        
+
         foreach ($cc1 as $country) {
             $this->assertTrue(in_array($country['code'], array_column($users, 'country_code')));
         }
-        
+
         $cc2 = clone $c;
-        
+
         // countries with 1 user
         $cc2->addCondition('Users.#', 0);
-        
+
         foreach ($cc2 as $country) {
-            $this->assertTrue(! in_array($country['code'], array_column($users, 'country_code')));
+            $this->assertTrue(!in_array($country['code'], array_column($users, 'country_code')));
         }
     }
 


### PR DESCRIPTION
Introduce setting conditions on referenced models:
```$contact->addCondition('company/country', 'US');```

where 'company' is the name of the reference

This will limit scope of $contact model to contacts whose company country field is set to 'US'