### PR TITLE
take into account model limit when counting

### DIFF
--- a/src/Persistence/SQL.php
+++ b/src/Persistence/SQL.php
@@ -655,14 +655,14 @@ class SQL extends Persistence
 
             case 'count':
                 $this->initQueryConditions($m, $q);
+                $this->setLimitOrder($m, $q);
                 $m->hook('initSelectQuery', [$q]);
-                if (isset($args['alias'])) {
-                    $q->reset('field')->field('count(*)', $args['alias']);
-                } else {
-                    $q->reset('field')->field('count(*)');
+
+                if ($m->limit) {
+                    $q = $this->dsql()->table($q, $m->table.'_limit');
                 }
 
-                return $q;
+                return $q->reset('field')->field('count(*)', $args['alias'] ?? null);
 
             case 'field':
                 if (!isset($args[0])) {


### PR DESCRIPTION
`Persistence\SQL` does not take into account the model limit when counting records.
This is inconsistent with what `Persistence\Array_` is performing.

If Model has SQL persistence and a limit (0, 3) when performing 'count' action all model records (matching the model scope) will be counted and not only the ones within the limit.

SQL does not support 
`select count(*) from xx limit 0, 3` 
so this fix converts it to
`select count(*) from (select * from xx limit 0, 3)`
if model has a limit set

If this is not desired behavior we can consider removing the limit affecting count in `Persistence\Array_` so both act consistently 