### PR TITLE
Enforce array in method prototypes when appropriate

### DIFF
--- a/src/Action/Iterator.php
+++ b/src/Action/Iterator.php
@@ -161,20 +161,16 @@ class Iterator
 
     /**
      * Return all data inside array.
-     *
-     * @return array
      */
-    public function get()
+    public function get(): array
     {
         return iterator_to_array($this->generator, true);
     }
 
     /**
      * Return one row of data.
-     *
-     * @return array
      */
-    public function getRow()
+    public function getRow(): array
     {
         $row = $this->generator->current();
         $this->generator->next();

--- a/src/Join.php
+++ b/src/Join.php
@@ -254,12 +254,11 @@ class Join
     /**
      * Another join will be attached to a current join.
      *
-     * @param string $foreign_table
      * @param array  $defaults
      *
      * @return Join
      */
-    public function join($foreign_table, $defaults = [])
+    public function join(string $foreign_table, $defaults = [])
     {
         if (!is_array($defaults)) {
             $defaults = ['master_field' => $defaults];
@@ -272,12 +271,11 @@ class Join
     /**
      * Another leftJoin will be attached to a current join.
      *
-     * @param string $foreign_table
      * @param array  $defaults
      *
      * @return Join
      */
-    public function leftJoin($foreign_table, $defaults = [])
+    public function leftJoin(string $foreign_table, $defaults = [])
     {
         if (!is_array($defaults)) {
             $defaults = ['master_field' => $defaults];

--- a/src/Join.php
+++ b/src/Join.php
@@ -254,7 +254,7 @@ class Join
     /**
      * Another join will be attached to a current join.
      *
-     * @param array  $defaults
+     * @param array $defaults
      *
      * @return Join
      */
@@ -271,7 +271,7 @@ class Join
     /**
      * Another leftJoin will be attached to a current join.
      *
-     * @param array  $defaults
+     * @param array $defaults
      *
      * @return Join
      */

--- a/src/Model.php
+++ b/src/Model.php
@@ -465,7 +465,7 @@ class Model implements \IteratorAggregate
      *
      * @return array [field => err_spec]
      */
-    public function validate($intent = null)
+    public function validate($intent = null): array
     {
         $errors = [];
         foreach ($this->hook(self::HOOK_VALIDATE, [$intent]) as $handler_error) {
@@ -652,7 +652,7 @@ class Model implements \IteratorAggregate
      *
      * @return Field[]
      */
-    public function getFields($filter = null)
+    public function getFields($filter = null): array
     {
         if ($filter === null) {
             return $this->fields;
@@ -872,10 +872,8 @@ class Model implements \IteratorAggregate
 
     /**
      * Returns array of model record titles [id => title].
-     *
-     * @return array
      */
-    public function getTitles()
+    public function getTitles(): array
     {
         $field = $this->title_field && $this->hasField($this->title_field) ? $this->title_field : $this->id_field;
 
@@ -1235,11 +1233,9 @@ class Model implements \IteratorAggregate
      * Use this instead of save() if you want to squeeze a
      * little more performance out.
      *
-     * @param array $data
-     *
      * @return $this
      */
-    public function saveAndUnload($data = [])
+    public function saveAndUnload(array $data = [])
     {
         $ras = $this->reload_after_save;
         $this->reload_after_save = false;
@@ -1538,8 +1534,6 @@ class Model implements \IteratorAggregate
     /**
      * Save record.
      *
-     * @param array $data
-     *
      * @return $this
      */
     public $_dirty_after_reload = [];
@@ -1668,8 +1662,7 @@ class Model implements \IteratorAggregate
      * This is a temporary method to avoid code duplication, but insert / import should
      * be implemented differently.
      *
-     * @param Model $m   Model where to insert
-     * @param array $row Data row to insert
+     * @param Model $m Model where to insert
      */
     protected function _rawInsert(self $m, array $row)
     {
@@ -1749,7 +1742,7 @@ class Model implements \IteratorAggregate
      * @param string     $key_field     Optional name of field which value we will use as array key
      * @param bool       $typecast_data Should we typecast exported data
      */
-    public function export($fields = null, $key_field = null, $typecast_data = true): array
+    public function export(array $fields = null, $key_field = null, $typecast_data = true): array
     {
         if (!$this->persistence->hasMethod('export')) {
             throw new Exception('Persistence does not support export()');
@@ -1765,7 +1758,7 @@ class Model implements \IteratorAggregate
         $key_field_added = false;
 
         // prepare array with field names
-        if (!is_array($fields)) {
+        if ($fields === null) {
             $fields = [];
 
             if ($this->only_fields) {
@@ -1827,7 +1820,7 @@ class Model implements \IteratorAggregate
      *
      * @return mixed
      */
-    public function getIterator()
+    public function getIterator(): iterable
     {
         foreach ($this->rawIterator() as $data) {
             $this->data = $this->persistence->typecastLoadRow($this, $data);
@@ -1870,10 +1863,8 @@ class Model implements \IteratorAggregate
 
     /**
      * Returns iterator.
-     *
-     * @return \Iterator
      */
-    public function rawIterator()
+    public function rawIterator(): iterable
     {
         return $this->persistence->prepareIterator($this);
     }

--- a/src/Model.php
+++ b/src/Model.php
@@ -1988,7 +1988,7 @@ class Model implements \IteratorAggregate
      * join will also query $foreign_table in order to find additional fields. When inserting
      * the record will be also added inside $foreign_table and relationship will be maintained.
      *
-     * @param array  $defaults
+     * @param array $defaults
      *
      * @return Join
      */
@@ -2013,7 +2013,7 @@ class Model implements \IteratorAggregate
      *
      * @see join()
      *
-     * @param array  $defaults
+     * @param array $defaults
      *
      * @return Join
      */

--- a/src/Model.php
+++ b/src/Model.php
@@ -1988,12 +1988,11 @@ class Model implements \IteratorAggregate
      * join will also query $foreign_table in order to find additional fields. When inserting
      * the record will be also added inside $foreign_table and relationship will be maintained.
      *
-     * @param string $foreign_table
      * @param array  $defaults
      *
      * @return Join
      */
-    public function join($foreign_table, $defaults = [])
+    public function join(string $foreign_table, $defaults = [])
     {
         if (!is_array($defaults)) {
             $defaults = ['master_field' => $defaults];
@@ -2014,12 +2013,11 @@ class Model implements \IteratorAggregate
      *
      * @see join()
      *
-     * @param string $foreign_table
      * @param array  $defaults
      *
      * @return Join
      */
-    public function leftJoin($foreign_table, $defaults = [])
+    public function leftJoin(string $foreign_table, $defaults = [])
     {
         if (!is_array($defaults)) {
             $defaults = ['master_field' => $defaults];

--- a/src/Persistence.php
+++ b/src/Persistence.php
@@ -148,17 +148,9 @@ class Persistence
      *     'age'=>30,
      *     'is_married'=>1
      *   ]
-     *
-     * @param array $row
-     *
-     * @return array
      */
-    public function typecastSaveRow(Model $m, $row)
+    public function typecastSaveRow(Model $m, array $row): array
     {
-        if (!$row) {
-            return $row;
-        }
-
         $result = [];
         foreach ($row as $key => $value) {
             // We have no knowledge of the field, it wasn't defined, so
@@ -215,17 +207,9 @@ class Persistence
      * NOTE: Please DO NOT perform "actual" field mapping here, because data
      * may be "aliased" from SQL persistences or mapped depending on persistence
      * driver.
-     *
-     * @param array $row
-     *
-     * @return array
      */
-    public function typecastLoadRow(Model $m, $row)
+    public function typecastLoadRow(Model $m, array $row): array
     {
-        if (!$row) {
-            return $row;
-        }
-
         $result = [];
         foreach ($row as $key => $value) {
             // We have no knowledge of the field, it wasn't defined, so

--- a/src/Persistence/Array_.php
+++ b/src/Persistence/Array_.php
@@ -78,7 +78,7 @@ class Array_ extends Persistence
     /**
      * Loads model and returns data record.
      *
-     * @param mixed  $id
+     * @param mixed $id
      */
     public function load(Model $m, $id, string $table = null): array
     {
@@ -99,7 +99,7 @@ class Array_ extends Persistence
      * Tries to load model and return data record.
      * Doesn't throw exception if model can't be loaded.
      *
-     * @param mixed  $id
+     * @param mixed $id
      */
     public function tryLoad(Model $m, $id, string $table = null): ?array
     {
@@ -142,7 +142,7 @@ class Array_ extends Persistence
     /**
      * Inserts record in data array and returns new record ID.
      *
-     * @param array  $data
+     * @param array $data
      *
      * @return mixed
      */
@@ -166,8 +166,8 @@ class Array_ extends Persistence
     /**
      * Updates record in data array and returns record ID.
      *
-     * @param mixed  $id
-     * @param array  $data
+     * @param mixed $id
+     * @param array $data
      *
      * @return mixed
      */
@@ -191,7 +191,7 @@ class Array_ extends Persistence
     /**
      * Deletes record in data array.
      *
-     * @param mixed  $id
+     * @param mixed $id
      */
     public function delete(Model $m, $id, string $table = null)
     {
@@ -205,7 +205,7 @@ class Array_ extends Persistence
     /**
      * Generates new record ID.
      *
-     * @param Model  $m
+     * @param Model $m
      *
      * @return string
      */

--- a/src/Persistence/Array_.php
+++ b/src/Persistence/Array_.php
@@ -79,16 +79,15 @@ class Array_ extends Persistence
      * Loads model and returns data record.
      *
      * @param mixed  $id
-     * @param string $table
      */
-    public function load(Model $m, $id, $table = null): array
+    public function load(Model $m, $id, string $table = null): array
     {
         if (isset($m->table) && !isset($this->data[$m->table])) {
             throw (new Exception('Table was not found in the array data source'))
                 ->addMoreInfo('table', $m->table);
         }
 
-        if (!isset($this->data[$table ?: $m->table][$id])) {
+        if (!isset($this->data[$table ?? $m->table][$id])) {
             throw (new Exception('Record with specified ID was not found', 404))
                 ->addMoreInfo('id', $id);
         }
@@ -103,9 +102,9 @@ class Array_ extends Persistence
      * @param mixed  $id
      * @param string $table
      */
-    public function tryLoad(Model $m, $id, $table = null): ?array
+    public function tryLoad(Model $m, $id, string $table = null): ?array
     {
-        if (!isset($table)) {
+        if ($table === null) {
             $table = $m->table;
         }
 
@@ -122,9 +121,9 @@ class Array_ extends Persistence
      *
      * @param mixed $table
      */
-    public function tryLoadAny(Model $m, $table = null): ?array
+    public function tryLoadAny(Model $m, string $table = null): ?array
     {
-        if (!isset($table)) {
+        if ($table === null) {
             $table = $m->table;
         }
 
@@ -145,13 +144,12 @@ class Array_ extends Persistence
      * Inserts record in data array and returns new record ID.
      *
      * @param array  $data
-     * @param string $table
      *
      * @return mixed
      */
-    public function insert(Model $m, $data, $table = null)
+    public function insert(Model $m, $data, string $table = null)
     {
-        if (!isset($table)) {
+        if ($table === null) {
             $table = $m->table;
         }
 
@@ -171,13 +169,12 @@ class Array_ extends Persistence
      *
      * @param mixed  $id
      * @param array  $data
-     * @param string $table
      *
      * @return mixed
      */
-    public function update(Model $m, $id, $data, $table = null)
+    public function update(Model $m, $id, $data, string $table = null)
     {
-        if (!isset($table)) {
+        if ($table === null) {
             $table = $m->table;
         }
 
@@ -196,11 +193,10 @@ class Array_ extends Persistence
      * Deletes record in data array.
      *
      * @param mixed  $id
-     * @param string $table
      */
-    public function delete(Model $m, $id, $table = null)
+    public function delete(Model $m, $id, string $table = null)
     {
-        if (!isset($table)) {
+        if ($table === null) {
             $table = $m->table;
         }
 
@@ -211,13 +207,12 @@ class Array_ extends Persistence
      * Generates new record ID.
      *
      * @param Model  $m
-     * @param string $table
      *
      * @return string
      */
-    public function generateNewId($m, $table = null)
+    public function generateNewId($m, string $table = null)
     {
-        if (!isset($table)) {
+        if ($table === null) {
             $table = $m->table;
         }
 

--- a/src/Persistence/Array_.php
+++ b/src/Persistence/Array_.php
@@ -110,7 +110,7 @@ class Array_ extends Persistence
         }
 
         if (!isset($this->data[$table][$id])) {
-            return null; // no record with such id in table
+            return null;
         }
 
         return $this->typecastLoadRow($m, $this->data[$table][$id]);
@@ -129,7 +129,7 @@ class Array_ extends Persistence
         }
 
         if (!$this->data[$table]) {
-            return null; // no records at all in table
+            return null;
         }
 
         reset($this->data[$table]);
@@ -242,10 +242,8 @@ class Array_ extends Persistence
 
     /**
      * Prepare iterator.
-     *
-     * @return array
      */
-    public function prepareIterator(Model $m)
+    public function prepareIterator(Model $m): iterable
     {
         return $m->action('select')->get();
     }
@@ -253,12 +251,9 @@ class Array_ extends Persistence
     /**
      * Export all DataSet.
      *
-     * @param array|null $fields
-     * @param bool       $typecast_data Should we typecast exported data
-     *
-     * @return array
+     * @param bool $typecast_data Should we typecast exported data
      */
-    public function export(Model $m, $fields = null, $typecast_data = true)
+    public function export(Model $m, array $fields = null, $typecast_data = true): array
     {
         $data = $m->action('select', [$fields])->get();
 
@@ -293,11 +288,8 @@ class Array_ extends Persistence
 
     /**
      * Will set limit defined inside $m onto data.
-     *
-     * @param Model         $m
-     * @param ArrayIterator $action
      */
-    protected function setLimitOrder($m, $action)
+    protected function setLimitOrder(Model $m, \atk4\data\Action\Iterator &$action)
     {
         // first order by
         if ($m->order) {

--- a/src/Persistence/Array_.php
+++ b/src/Persistence/Array_.php
@@ -100,7 +100,6 @@ class Array_ extends Persistence
      * Doesn't throw exception if model can't be loaded.
      *
      * @param mixed  $id
-     * @param string $table
      */
     public function tryLoad(Model $m, $id, string $table = null): ?array
     {

--- a/src/Persistence/Array_.php
+++ b/src/Persistence/Array_.php
@@ -283,7 +283,7 @@ class Array_ extends Persistence
     /**
      * Will set limit defined inside $m onto data.
      */
-    protected function setLimitOrder(Model $m, \atk4\data\Action\Iterator &$action)
+    protected function setLimitOrder(Model $m, \atk4\data\Action\Iterator $action)
     {
         // first order by
         if ($m->order) {

--- a/src/Persistence/Csv.php
+++ b/src/Persistence/Csv.php
@@ -133,15 +133,15 @@ class Csv extends Persistence
 
     /**
      * Returns one line of CSV file as array.
-     *
-     * @return array
      */
-    public function getLine()
+    public function getLine(): ?array
     {
         $data = fgetcsv($this->handle, 0, $this->delimiter, $this->enclosure, $this->escape_char);
-        if ($data) {
-            ++$this->line;
+        if ($data === false || $data === null) {
+            return null;
         }
+
+        ++$this->line;
 
         return $data;
     }
@@ -211,12 +211,8 @@ class Csv extends Persistence
 
     /**
      * Typecasting when load data row.
-     *
-     * @param array $row
-     *
-     * @return array
      */
-    public function typecastLoadRow(Model $m, $row)
+    public function typecastLoadRow(Model $m, array $row): array
     {
         $id = null;
         if (isset($row[$m->id_field])) {
@@ -247,10 +243,8 @@ class Csv extends Persistence
     /**
      * Tries to load model and return data record.
      * Doesn't throw exception if model can't be loaded.
-     *
-     * @return array|null
      */
-    public function tryLoadAny(Model $m)
+    public function tryLoadAny(Model $m): ?array
     {
         if (!$this->mode) {
             $this->mode = 'r';
@@ -264,7 +258,7 @@ class Csv extends Persistence
 
         $data = $this->getLine();
         if (!$data) {
-            return;
+            return null;
         }
 
         $data = $this->typecastLoadRow($m, $data);
@@ -275,10 +269,8 @@ class Csv extends Persistence
 
     /**
      * Prepare iterator.
-     *
-     * @return array
      */
-    public function prepareIterator(Model $m)
+    public function prepareIterator(Model $m): iterable
     {
         if (!$this->mode) {
             $this->mode = 'r';
@@ -304,10 +296,8 @@ class Csv extends Persistence
 
     /**
      * Loads any one record.
-     *
-     * @return array
      */
-    public function loadAny(Model $m)
+    public function loadAny(Model $m): array
     {
         $data = $this->tryLoadAny($m);
 
@@ -402,17 +392,13 @@ class Csv extends Persistence
 
     /**
      * Export all DataSet.
-     *
-     * @param array|null $fields
-     *
-     * @return array
      */
-    public function export(Model $m, $fields = null)
+    public function export(Model $m, array $fields = null): array
     {
         $data = [];
 
         foreach ($m as $junk) {
-            $data[] = $fields ? array_intersect_key($m->get(), array_flip($fields)) : $m->get();
+            $data[] = $fields !== null ? array_intersect_key($m->get(), array_flip($fields)) : $m->get();
         }
 
         // need to close file otherwise file pointer is at the end of file

--- a/src/Persistence/Csv.php
+++ b/src/Persistence/Csv.php
@@ -312,7 +312,7 @@ class Csv extends Persistence
     /**
      * Inserts record in data array and returns new record ID.
      *
-     * @param array  $data
+     * @param array $data
      *
      * @return mixed
      */
@@ -340,8 +340,8 @@ class Csv extends Persistence
     /**
      * Updates record in data array and returns record ID.
      *
-     * @param mixed  $id
-     * @param array  $data
+     * @param mixed $id
+     * @param array $data
      */
     public function update(Model $m, $id, $data, string $table = null)
     {
@@ -351,7 +351,7 @@ class Csv extends Persistence
     /**
      * Deletes record in data array.
      *
-     * @param mixed  $id
+     * @param mixed $id
      */
     public function delete(Model $m, $id, string $table = null)
     {
@@ -361,7 +361,7 @@ class Csv extends Persistence
     /**
      * Generates new record ID.
      *
-     * @param Model  $m
+     * @param Model $m
      *
      * @return string
      */

--- a/src/Persistence/Csv.php
+++ b/src/Persistence/Csv.php
@@ -313,7 +313,6 @@ class Csv extends Persistence
      * Inserts record in data array and returns new record ID.
      *
      * @param array  $data
-     * @param string $table
      *
      * @return mixed
      */

--- a/src/Persistence/Csv.php
+++ b/src/Persistence/Csv.php
@@ -343,9 +343,8 @@ class Csv extends Persistence
      *
      * @param mixed  $id
      * @param array  $data
-     * @param string $table
      */
-    public function update(Model $m, $id, $data, $table = null)
+    public function update(Model $m, $id, $data, string $table = null)
     {
         throw new Exception('Updating records is not supported in CSV persistence.');
     }
@@ -354,9 +353,8 @@ class Csv extends Persistence
      * Deletes record in data array.
      *
      * @param mixed  $id
-     * @param string $table
      */
-    public function delete(Model $m, $id, $table = null)
+    public function delete(Model $m, $id, string $table = null)
     {
         throw new Exception('Deleting records is not supported in CSV persistence.');
     }
@@ -365,13 +363,12 @@ class Csv extends Persistence
      * Generates new record ID.
      *
      * @param Model  $m
-     * @param string $table
      *
      * @return string
      */
-    public function generateNewId($m, $table = null)
+    public function generateNewId($m, string $table = null)
     {
-        if (!isset($table)) {
+        if ($table === null) {
             $table = $m->table;
         }
 

--- a/src/Persistence/Csv.php
+++ b/src/Persistence/Csv.php
@@ -257,7 +257,7 @@ class Csv extends Persistence
         }
 
         $data = $this->getLine();
-        if (!$data) {
+        if ($data === null) {
             return null;
         }
 
@@ -284,7 +284,7 @@ class Csv extends Persistence
 
         while (true) {
             $data = $this->getLine();
-            if (!$data) {
+            if ($data === null) {
                 break;
             }
             $data = $this->typecastLoadRow($m, $data);

--- a/src/Persistence/Sql.php
+++ b/src/Persistence/Sql.php
@@ -701,10 +701,8 @@ class Sql extends Persistence
      * Tries to load data record, but will not fail if record can't be loaded.
      *
      * @param mixed $id
-     *
-     * @return array
      */
-    public function tryLoad(Model $m, $id)
+    public function tryLoad(Model $m, $id): ?array
     {
         if (!$m->id_field) {
             throw (new Exception('Unable to load field by "id" when Model->id_field is not defined.'))
@@ -727,7 +725,7 @@ class Sql extends Persistence
         }
 
         if (!$data) {
-            return;
+            return null;
         }
 
         if (!isset($data[$m->id_field]) || $data[$m->id_field] === null) {
@@ -747,10 +745,8 @@ class Sql extends Persistence
      * Loads a record from model and returns a associative array.
      *
      * @param mixed $id
-     *
-     * @return array
      */
-    public function load(Model $m, $id)
+    public function load(Model $m, $id): array
     {
         $data = $this->tryLoad($m, $id);
 
@@ -766,10 +762,8 @@ class Sql extends Persistence
 
     /**
      * Tries to load any one record.
-     *
-     * @return array
      */
-    public function tryLoadAny(Model $m)
+    public function tryLoadAny(Model $m): ?array
     {
         $load = $m->action('select');
         $load->limit(1);
@@ -786,7 +780,7 @@ class Sql extends Persistence
         }
 
         if (!$data) {
-            return;
+            return null;
         }
 
         if ($m->id_field) {
@@ -806,10 +800,8 @@ class Sql extends Persistence
 
     /**
      * Loads any one record.
-     *
-     * @return array
      */
-    public function loadAny(Model $m)
+    public function loadAny(Model $m): array
     {
         $data = $this->tryLoadAny($m);
 
@@ -859,12 +851,9 @@ class Sql extends Persistence
     /**
      * Export all DataSet.
      *
-     * @param array|null $fields
-     * @param bool       $typecast_data Should we typecast exported data
-     *
-     * @return array
+     * @param bool $typecast_data Should we typecast exported data
      */
-    public function export(Model $m, $fields = null, $typecast_data = true)
+    public function export(Model $m, array $fields = null, $typecast_data = true): array
     {
         $data = $m->action('select', [$fields])->get();
 
@@ -882,7 +871,7 @@ class Sql extends Persistence
      *
      * @return \PDOStatement
      */
-    public function prepareIterator(Model $m)
+    public function prepareIterator(Model $m): iterable
     {
         try {
             $export = $m->action('select');

--- a/src/Persistence/Sql.php
+++ b/src/Persistence/Sql.php
@@ -715,17 +715,17 @@ class Sql extends Persistence
 
         // execute action
         try {
-            $data = $this->typecastLoadRow($m, $load->getRow());
+            $dataRaw = $load->getRow();
+            if ($dataRaw === null) {
+                return null;
+            }
+            $data = $this->typecastLoadRow($m, $dataRaw);
         } catch (\PDOException $e) {
             throw (new Exception('Unable to load due to query error', 0, $e))
                 ->addMoreInfo('query', $load->getDebugQuery())
                 ->addMoreInfo('message', $e->getMessage())
                 ->addMoreInfo('model', $m)
                 ->addMoreInfo('conditions', $m->conditions);
-        }
-
-        if (!$data) {
-            return null;
         }
 
         if (!isset($data[$m->id_field]) || $data[$m->id_field] === null) {
@@ -770,17 +770,17 @@ class Sql extends Persistence
 
         // execute action
         try {
-            $data = $this->typecastLoadRow($m, $load->getRow());
+            $dataRaw = $load->getRow();
+            if ($dataRaw === null) {
+                return null;
+            }
+            $data = $this->typecastLoadRow($m, $dataRaw);
         } catch (\PDOException $e) {
             throw (new Exception('Unable to load due to query error', 0, $e))
                 ->addMoreInfo('query', $load->getDebugQuery())
                 ->addMoreInfo('message', $e->getMessage())
                 ->addMoreInfo('model', $m)
                 ->addMoreInfo('conditions', $m->conditions);
-        }
-
-        if (!$data) {
-            return null;
         }
 
         if ($m->id_field) {

--- a/tests/PersistentArrayTest.php
+++ b/tests/PersistentArrayTest.php
@@ -431,12 +431,8 @@ class PersistentArrayTest extends AtkPhpunit\TestCase
 
     /**
      * Returns exported data, but will use get() instead of export().
-     *
-     * @param array $fields
-     *
-     * @return array
      */
-    protected function _getRows(Model $m, $fields = [])
+    protected function _getRows(Model $m, array $fields = []): array
     {
         $d = [];
         foreach ($m as $junk) {

--- a/tests/ValidationTest.php
+++ b/tests/ValidationTest.php
@@ -19,7 +19,7 @@ class MyValidationModel extends Model
         $this->addField('domain');
     }
 
-    public function validate($intent = null)
+    public function validate($intent = null): array
     {
         $errors = [];
         if ($this->get('name') === 'Python') {
@@ -42,7 +42,7 @@ class BadValidationModel extends Model
         $this->addField('name');
     }
 
-    public function validate($intent = null)
+    public function validate($intent = null): array
     {
         return 'This should be array';
     }


### PR DESCRIPTION
Partial implementation of #554

- `typecastLoadRow()` method does no longer accepts null
- other method prototypes were cleaned up, mostly return types, needs more attention probably only if you override these methods