### PR TITLE
Require PHP 7.4 or higher

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -38,13 +38,13 @@
     "sort-packages": true
   },
   "require": {
-    "php": ">=7.2.0",
+    "php": ">=7.4",
     "ext-intl": "*",
     "atk4/core": "dev-develop",
     "atk4/dsql": "dev-develop"
   },
   "require-release": {
-    "php": ">=7.2.0",
+    "php": ">=7.4",
     "ext-intl": "*",
     "atk4/core": "^2.0",
     "atk4/dsql": "^2.0"


### PR DESCRIPTION
PHP 8.0 is out in winter, is it ok to drop support for PHP 7.2 and 7.3 in favor of only PHP 7.4 and higher?

It would allow:
- typed properties
- short closures which will help to refactor all array callbacks (used a lot for hooks)

Newer PHP versions have also better trait support - see https://github.com/atk4/core/pull/120

PHP version is actually quite easy to upgrade and if someone can't/don't want, composer will prevent them to upgrade..

Please submit your feedback below:
- What PHP versions do you use?
- Do you agree that this is ok for 2.1.x?

PHP on Ubuntu and Debian can be very easily upgraded with https://deb.sury.org/#php-packages repo which is very popular and very stable also for older OS releases. On Windows, PHP can be easily upgraded with Chocolatey, WAMP, .. Almost all webhostings provides PHP 7.4 already.

If you can not upgrade easily, please comment below the reasons to better understand, like you use some packages that are not compatible with PHP 7.4 etc.