### PR TITLE
Isolate ArrayAccess from Model to optional/BC trait

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,11 +258,11 @@ While in most cases modern SQL sub-queries have comparable speed to JOIN, Agile 
 
 You can, however, [import fields through joins too](http://agile-data.readthedocs.io/en/develop/joins.html)
 
-#### Q: I don't like the `$book['field'] = 123`, I prefer properties
+#### Q: I don't like the `$book->set('field', 123)`, I prefer properties
 
 Agile Models are not Entities. They don't represent a single record, but rather a set of records. Which is why Model has some important properties: `$model->id`, `$model->persistence` and `model->data`.
 
-To simplify work with model records, you can use `$model['field']` which will be routed to `$model->data['field']`. Read more on [working with individual data records](http://agile-data.readthedocs.io/en/develop/persistence.html).
+Read more on [working with individual data records](http://agile-data.readthedocs.io/en/develop/persistence.html).
 
 #### Q: I do not like to use class `\atk4\data\Model` as a parent
 

--- a/README.md
+++ b/README.md
@@ -258,11 +258,11 @@ While in most cases modern SQL sub-queries have comparable speed to JOIN, Agile 
 
 You can, however, [import fields through joins too](http://agile-data.readthedocs.io/en/develop/joins.html)
 
-#### Q: I don't like the `$book->set('field', 123)`, I prefer properties
+#### Q: I don't like the `$book['field'] = 123`, I prefer properties
 
 Agile Models are not Entities. They don't represent a single record, but rather a set of records. Which is why Model has some important properties: `$model->id`, `$model->persistence` and `model->data`.
 
-Read more on [working with individual data records](http://agile-data.readthedocs.io/en/develop/persistence.html).
+To simplify work with model records, you can use `$model['field']` which will be routed to `$model->data['field']`. Read more on [working with individual data records](http://agile-data.readthedocs.io/en/develop/persistence.html).
 
 #### Q: I do not like to use class `\atk4\data\Model` as a parent
 

--- a/docs/advanced.rst
+++ b/docs/advanced.rst
@@ -434,10 +434,10 @@ inside your model are unique::
                 if ($m->dirty[$field]) {
                     $mm = clone $m;
                     $mm->addCondition($mm->id_field != $this->id);
-                    $mm->tryLoadBy($field, $m->get($field));
+                    $mm->tryLoadBy($field, $m[$field]);
 
                     if ($mm->loaded()) {
-                        throw new \atk4\core\Exception(['Duplicate record exists', 'field'=>$field, 'value'=>$m->get($field)]);
+                        throw new \atk4\core\Exception(['Duplicate record exists', 'field'=>$field, 'value'=>$m[$field]]);
                     }
                 }
             }
@@ -534,7 +534,7 @@ we cannot close amount that is bigger than invoice's total::
 
     $i->ref('Payment')->insert([
         'amount'=>$paid,
-        'amount_closed'=> min($paid, $i->get('total')),
+        'amount_closed'=> min($paid, $i['total']),
         'payment_code'=>'XYZ'
     ]);
 
@@ -563,10 +563,10 @@ payment towards a most suitable invoice::
         // Prioritize older invoices
         $invoices->setOrder('date');
 
-        while($this->get('amount_due') > 0) {
+        while($this['amount_due'] > 0) {
 
             // See if any invoices match by 'reference';
-            $invoices->tryLoadBy('reference', $this->get('reference'));
+            $invoices->tryLoadBy('reference', $this['reference']);
 
             if (!$invoices->loaded()) {
 
@@ -581,7 +581,7 @@ payment towards a most suitable invoice::
             }
 
             // How much we can allocate to this invoice
-            $alloc = min($this->get('amount_due'), $invoices->get('amount_due'))
+            $alloc = min($this['amount_due'], $invoices['amount_due'])
             $this->ref('InvoicePayment')->insert(['amount_closed'=>$alloc, 'invoice_id'=>$invoices->id]);
 
             // Reload ourselves to refresh amount_due
@@ -651,22 +651,22 @@ I have declared those fields with never_persist so they will never be used by
 persistence layer to load or save anything. Next I need a beforeSave handler::
 
     $this->onHook('beforeSave', function($m) {
-        if($m->_isset($m['client_code') && !$m->_isset($m['client_id')) {
+        if(isset($m['client_code']) && !isset($m['client_id'])) {
             $cl = $this->refModel('client_id');
-            $cl->addCondition('code',$m->get('client_code'));
-            $m->set('client_id', $cl->action('field',['id']));
+            $cl->addCondition('code',$m['client_code']);
+            $m['client_id'] = $cl->action('field',['id']);
         }
 
-        if($m->_isset('client_name') && !$m->_isset('client_id')) {
+        if(isset($m['client_name']) && !isset($m['client_id'])) {
             $cl = $this->refModel('client_id');
-            $cl->addCondition('name', 'like', $m->get('client_name'));
-            $m->set('client_id', $cl->action('field',['id']));
+            $cl->addCondition('name', 'like', $m['client_name']);
+            $m['client_id'] = $cl->action('field',['id']);
         }
 
-        if($m->_isset('category') && !$m->_isset('category_id')) {
+        if(isset($m['category']) && !isset($m['category_id'])) {
             $c = $this->refModel('category_id');
-            $c->addCondition($c->title_field, 'like', $m->get('category'));
-            $m->set('category_id', $c->action('field',['id']));
+            $c->addCondition($c->title_field, 'like', $m['category']);
+            $m['category_id'] = $c->action('field',['id']);
         }
     });
 
@@ -682,22 +682,22 @@ Fallback to default value
 You might wonder, with the lookup like that, how the default values will work?
 What if the user-specified entry is not found? Lets look at the code::
 
-    if($m->_isset('category') && !$m->_isset('category_id')) {
+    if(isset($m['category']) && !isset($m['category_id'])) {
         $c = $this->refModel('category_id');
-        $c->addCondition($c->title_field, 'like', $m->get('category'));
-        $m->set('category_id', $c->action('field',['id']));
+        $c->addCondition($c->title_field, 'like', $m['category']);
+        $m['category_id'] = $c->action('field',['id']);
     }
 
 So if category with a name is not found, then sub-query will return "NULL".
 If you wish to use a different value instead, you can create an expression::
 
-    if($m->_isset('category') && !$m->_isset('category_id')) {
+    if(isset($m['category']) && !isset($m['category_id'])) {
         $c = $this->refModel('category_id');
-        $c->addCondition($c->title_field, 'like', $m->get('category'));
-        $m->set('category_id', $this->expr('coalesce([],[])',[
+        $c->addCondition($c->title_field, 'like', $m['category']);
+        $m['category_id'] = $this->expr('coalesce([],[])',[
             $c->action('field',['id']),
             $m->getField('category_id')->default
-        ]));
+        ]);
     }
 
 The beautiful thing about this approach is that default can also be defined
@@ -740,12 +740,12 @@ Next both payment and lines need to be added after invoice is actually created,
 so::
 
     $this->onHook('afterSave', function($m, $is_update){
-        if($m->_isset('payment')) {
-            $m->ref('Payment')->insert($m->get('payment'));
+        if(isset($m['payment'])) {
+            $m->ref('Payment')->insert($m['payment']);
         }
 
-        if($m->_isset('lines')) {
-            $m->ref('Line')->import($m->get('lines'));
+        if(isset($m['lines'])) {
+            $m->ref('Line')->import($m['lines']);
         }
     });
 
@@ -754,9 +754,7 @@ further manipulation, you can reload a clone::
 
     $mm = clone $m;
     $mm->reload();
-    if ($mm->get('amount_due') == 0) {
-        $mm->save(['status'=>'paid']);
-    }
+    if ($mm['amount_due'] == 0) $mm->save(['status'=>'paid']);
 
 Related Record Conditioning
 ===========================
@@ -802,16 +800,16 @@ field only to offer payments made by the same client. Inside Model_Invoice add::
     /// how to use
 
     $m = new Model_Invoice($db);
-    $m->set('client_id', 123);
+    $m['client_id'] = 123;
 
-    $m->set('payment_invoice_id', $m->ref('payment_invoice_id')->tryLoadAny()->id);
+    $m['payment_invoice_id'] = $m->ref('payment_invoice_id')->tryLoadAny()->id;
 
 In this case the payment_invoice_id will be set to ID of any payment by client
 123. There also may be some better uses::
 
     $cl->ref('Invoice')->each(function($m) {
 
-        $m->set('payment_invoice_id', $m->ref('payment_invoice_id')->tryLoadAny()->id);
+        $m['payment_invoice_id'] = $m->ref('payment_invoice_id')->tryLoadAny()->id;
         $m->save();
 
     });

--- a/docs/advanced.rst
+++ b/docs/advanced.rst
@@ -434,10 +434,10 @@ inside your model are unique::
                 if ($m->dirty[$field]) {
                     $mm = clone $m;
                     $mm->addCondition($mm->id_field != $this->id);
-                    $mm->tryLoadBy($field, $m[$field]);
+                    $mm->tryLoadBy($field, $m->get($field));
 
                     if ($mm->loaded()) {
-                        throw new \atk4\core\Exception(['Duplicate record exists', 'field'=>$field, 'value'=>$m[$field]]);
+                        throw new \atk4\core\Exception(['Duplicate record exists', 'field'=>$field, 'value'=>$m->get($field)]);
                     }
                 }
             }
@@ -534,7 +534,7 @@ we cannot close amount that is bigger than invoice's total::
 
     $i->ref('Payment')->insert([
         'amount'=>$paid,
-        'amount_closed'=> min($paid, $i['total']),
+        'amount_closed'=> min($paid, $i->get('total')),
         'payment_code'=>'XYZ'
     ]);
 
@@ -563,10 +563,10 @@ payment towards a most suitable invoice::
         // Prioritize older invoices
         $invoices->setOrder('date');
 
-        while($this['amount_due'] > 0) {
+        while($this->get('amount_due') > 0) {
 
             // See if any invoices match by 'reference';
-            $invoices->tryLoadBy('reference', $this['reference']);
+            $invoices->tryLoadBy('reference', $this->get('reference'));
 
             if (!$invoices->loaded()) {
 
@@ -581,7 +581,7 @@ payment towards a most suitable invoice::
             }
 
             // How much we can allocate to this invoice
-            $alloc = min($this['amount_due'], $invoices['amount_due'])
+            $alloc = min($this->get('amount_due'), $invoices->get('amount_due'))
             $this->ref('InvoicePayment')->insert(['amount_closed'=>$alloc, 'invoice_id'=>$invoices->id]);
 
             // Reload ourselves to refresh amount_due
@@ -651,22 +651,22 @@ I have declared those fields with never_persist so they will never be used by
 persistence layer to load or save anything. Next I need a beforeSave handler::
 
     $this->onHook('beforeSave', function($m) {
-        if(isset($m['client_code']) && !isset($m['client_id'])) {
+        if($m->_isset($m['client_code') && !$m->_isset($m['client_id')) {
             $cl = $this->refModel('client_id');
-            $cl->addCondition('code',$m['client_code']);
-            $m['client_id'] = $cl->action('field',['id']);
+            $cl->addCondition('code',$m->get('client_code'));
+            $m->set('client_id', $cl->action('field',['id']));
         }
 
-        if(isset($m['client_name']) && !isset($m['client_id'])) {
+        if($m->_isset('client_name') && !$m->_isset('client_id')) {
             $cl = $this->refModel('client_id');
-            $cl->addCondition('name', 'like', $m['client_name']);
-            $m['client_id'] = $cl->action('field',['id']);
+            $cl->addCondition('name', 'like', $m->get('client_name'));
+            $m->set('client_id', $cl->action('field',['id']));
         }
 
-        if(isset($m['category']) && !isset($m['category_id'])) {
+        if($m->_isset('category') && !$m->_isset('category_id')) {
             $c = $this->refModel('category_id');
-            $c->addCondition($c->title_field, 'like', $m['category']);
-            $m['category_id'] = $c->action('field',['id']);
+            $c->addCondition($c->title_field, 'like', $m->get('category'));
+            $m->set('category_id', $c->action('field',['id']));
         }
     });
 
@@ -682,22 +682,22 @@ Fallback to default value
 You might wonder, with the lookup like that, how the default values will work?
 What if the user-specified entry is not found? Lets look at the code::
 
-    if(isset($m['category']) && !isset($m['category_id'])) {
+    if($m->_isset('category') && !$m->_isset('category_id')) {
         $c = $this->refModel('category_id');
-        $c->addCondition($c->title_field, 'like', $m['category']);
-        $m['category_id'] = $c->action('field',['id']);
+        $c->addCondition($c->title_field, 'like', $m->get('category'));
+        $m->set('category_id', $c->action('field',['id']));
     }
 
 So if category with a name is not found, then sub-query will return "NULL".
 If you wish to use a different value instead, you can create an expression::
 
-    if(isset($m['category']) && !isset($m['category_id'])) {
+    if($m->_isset('category') && !$m->_isset('category_id')) {
         $c = $this->refModel('category_id');
-        $c->addCondition($c->title_field, 'like', $m['category']);
-        $m['category_id'] = $this->expr('coalesce([],[])',[
+        $c->addCondition($c->title_field, 'like', $m->get('category'));
+        $m->set('category_id', $this->expr('coalesce([],[])',[
             $c->action('field',['id']),
             $m->getField('category_id')->default
-        ]);
+        ]));
     }
 
 The beautiful thing about this approach is that default can also be defined
@@ -740,12 +740,12 @@ Next both payment and lines need to be added after invoice is actually created,
 so::
 
     $this->onHook('afterSave', function($m, $is_update){
-        if(isset($m['payment'])) {
-            $m->ref('Payment')->insert($m['payment']);
+        if($m->_isset('payment')) {
+            $m->ref('Payment')->insert($m->get('payment'));
         }
 
-        if(isset($m['lines'])) {
-            $m->ref('Line')->import($m['lines']);
+        if($m->_isset('lines')) {
+            $m->ref('Line')->import($m->get('lines'));
         }
     });
 
@@ -754,7 +754,9 @@ further manipulation, you can reload a clone::
 
     $mm = clone $m;
     $mm->reload();
-    if ($mm['amount_due'] == 0) $mm->save(['status'=>'paid']);
+    if ($mm->get('amount_due') == 0) {
+        $mm->save(['status'=>'paid']);
+    }
 
 Related Record Conditioning
 ===========================
@@ -800,16 +802,16 @@ field only to offer payments made by the same client. Inside Model_Invoice add::
     /// how to use
 
     $m = new Model_Invoice($db);
-    $m['client_id'] = 123;
+    $m->set('client_id', 123);
 
-    $m['payment_invoice_id'] = $m->ref('payment_invoice_id')->tryLoadAny()->id;
+    $m->set('payment_invoice_id', $m->ref('payment_invoice_id')->tryLoadAny()->id);
 
 In this case the payment_invoice_id will be set to ID of any payment by client
 123. There also may be some better uses::
 
     $cl->ref('Invoice')->each(function($m) {
 
-        $m['payment_invoice_id'] = $m->ref('payment_invoice_id')->tryLoadAny()->id;
+        $m->set('payment_invoice_id', $m->ref('payment_invoice_id')->tryLoadAny()->id);
         $m->save();
 
     });

--- a/docs/conditions.rst
+++ b/docs/conditions.rst
@@ -13,7 +13,7 @@ either explicitly or through a $table property inside a model::
 
     $m = new Model_User($db, 'user');
     $m->load(1);
-    echo $m['gender'];   // "M"
+    echo $m->get('gender');   // "M"
 
 
 Following this line, you can load ANY record from the table. It's possible to

--- a/docs/conditions.rst
+++ b/docs/conditions.rst
@@ -13,7 +13,7 @@ either explicitly or through a $table property inside a model::
 
     $m = new Model_User($db, 'user');
     $m->load(1);
-    echo $m->get('gender');   // "M"
+    echo $m['gender'];   // "M"
 
 
 Following this line, you can load ANY record from the table. It's possible to

--- a/docs/design.rst
+++ b/docs/design.rst
@@ -162,7 +162,7 @@ Code::
     class Model_Client extends Model_User {
         public function sendPasswordReminder() {
 
-            mail($this->get('email'), 'Your password is: '.$this->get('password'));
+            mail($this['email'], 'Your password is: '.$this['password']);
         }
     }
 
@@ -213,7 +213,7 @@ Code to declare fields::
 
 Code to access field values::
 
-    $order->set('amount', 1200.20);
+    $order['amount'] = 1200.20;
 
 Domain Model Relationship
 -------------------------
@@ -273,7 +273,7 @@ Each object is stored with some unique identifier, so you can load and store
 object if you know it's ID::
 
     $order->load(20);
-    $order->set('amount', 1200.20);
+    $order['amount'] = 1200.20;
     $order->save();
 
 
@@ -340,8 +340,8 @@ Hooks can help you perform operations when object is being persisted::
 
             $this->onHook('beforeSave', function($m) {
                 if ($m->isDirty('password')) {
-                    $m->set('password', encrypt_password($m->get('password')));
-                    $m->set('password_change_date', $m->expr('now()'));
+                    $m['password'] = encrypt_password($m['password']);
+                    $m['password_change_date'] = $m->expr('now()');
                 }
             });
         }
@@ -373,19 +373,19 @@ Orders::
     $sum = 0;
     $order = $db->add('Model_Order');
     $order->load(10);
-    $sum += $order->get('amount');
+    $sum += $order['amount'];
 
     $order->load(11);
-    $sum += $order->get('amount');
+    $sum += $order['amount'];
 
     $order->load(13);
-    $sum += $order->get('amount');
+    $sum += $order['amount'];
 
 You can iterate over the DataSet::
 
     $sum = 0;
     foreach($db->add('Model_Order') as $order) {
-        $sum += $order->get('amount');
+        $sum += $order['amount'];
     }
 
 You must remember that the code above will only create a single object and
@@ -409,7 +409,7 @@ worrying that you will introduce unnecessary bindings into persistence and break
 single-purpose principle of your objects::
 
     foreach ($clients as $client) {
-        // echo $client->get('name')."\n";
+        // echo $client['name']."\n";
     }
 
 The above is a Domain Model code. It will iterate through the DataSet of
@@ -418,7 +418,7 @@ a restriction::
 
     $sum = 0;
     foreach($db->add('Model_Order')->addCondition('is_paid', true) as $order) {
-        $sum += $order->get('amount');
+        $sum += $order['amount'];
     }
 
 And again it's much more effective to do this on database side::

--- a/docs/design.rst
+++ b/docs/design.rst
@@ -162,7 +162,7 @@ Code::
     class Model_Client extends Model_User {
         public function sendPasswordReminder() {
 
-            mail($this['email'], 'Your password is: '.$this['password']);
+            mail($this->get('email'), 'Your password is: '.$this->get('password'));
         }
     }
 
@@ -213,7 +213,7 @@ Code to declare fields::
 
 Code to access field values::
 
-    $order['amount'] = 1200.20;
+    $order->set('amount', 1200.20);
 
 Domain Model Relationship
 -------------------------
@@ -273,7 +273,7 @@ Each object is stored with some unique identifier, so you can load and store
 object if you know it's ID::
 
     $order->load(20);
-    $order['amount'] = 1200.20;
+    $order->set('amount', 1200.20);
     $order->save();
 
 
@@ -340,8 +340,8 @@ Hooks can help you perform operations when object is being persisted::
 
             $this->onHook('beforeSave', function($m) {
                 if ($m->isDirty('password')) {
-                    $m['password'] = encrypt_password($m['password']);
-                    $m['password_change_date'] = $m->expr('now()');
+                    $m->set('password', encrypt_password($m->get('password')));
+                    $m->set('password_change_date', $m->expr('now()'));
                 }
             });
         }
@@ -373,19 +373,19 @@ Orders::
     $sum = 0;
     $order = $db->add('Model_Order');
     $order->load(10);
-    $sum += $order['amount'];
+    $sum += $order->get('amount');
 
     $order->load(11);
-    $sum += $order['amount'];
+    $sum += $order->get('amount');
 
     $order->load(13);
-    $sum += $order['amount'];
+    $sum += $order->get('amount');
 
 You can iterate over the DataSet::
 
     $sum = 0;
     foreach($db->add('Model_Order') as $order) {
-        $sum += $order['amount'];
+        $sum += $order->get('amount');
     }
 
 You must remember that the code above will only create a single object and
@@ -409,7 +409,7 @@ worrying that you will introduce unnecessary bindings into persistence and break
 single-purpose principle of your objects::
 
     foreach ($clients as $client) {
-        // echo $client['name']."\n";
+        // echo $client->get('name')."\n";
     }
 
 The above is a Domain Model code. It will iterate through the DataSet of
@@ -418,7 +418,7 @@ a restriction::
 
     $sum = 0;
     foreach($db->add('Model_Order')->addCondition('is_paid', true) as $order) {
-        $sum += $order['amount'];
+        $sum += $order->get('amount');
     }
 
 And again it's much more effective to do this on database side::

--- a/docs/expressions.rst
+++ b/docs/expressions.rst
@@ -25,7 +25,7 @@ Example will calculate "total_gross" by adding up values for "net" and "vat"::
     $m->addExpression('total_gross', '[total_net]+[total_vat]');
     $m->load(1);
 
-    echo $m['total_gross'];
+    echo $m->get('total_gross');
 
 The query using during load() will look like this:
 
@@ -66,7 +66,7 @@ example::
     $m = new Model($db, false);
     $m->addExpression('now', 'now()');
     $m->loadAny();
-    echo $m['now'];
+    echo $m->get('now');
 
 In this example the query will look like this:
 
@@ -128,12 +128,12 @@ the following model::
     }
 
     $m = new Model_Math($db);
-    $m['a'] = 4;
-    $m['b'] = 6;
+    $m->set('a', 4);
+    $m->set('b', 6);
 
     $m->save();
 
-    echo $m['sum'];
+    echo $m->get('sum');
 
 When $m->save() is executed, Agile Data will perform reloading of the model.
 This is to ensure that expression 'sum' would be re-calculated for the values of
@@ -143,15 +143,15 @@ Reload after save will only be executed if you have defined any expressions
 inside your model, however you can affect this behavior::
 
     $m = new Model_Math($db, ['reload_after_save' => false]);
-    $m['a'] = 4;
-    $m['b'] = 6;
+    $m->set('a', 4);
+    $m->set('b', 6);
 
     $m->save();
 
-    echo $m['sum'];   // outputs null
+    echo $m->get('sum');   // outputs null
 
     $m->reload();
-    echo $m['sum'];   // outputs 10
+    echo $m->get('sum');   // outputs 10
 
 Now it requires an explicit reload for your model to fetch the result. There
 is another scenario when your database defines default fields:
@@ -174,21 +174,21 @@ Then try the following code::
     }
 
     $m = new Model_Math($db);
-    $m['a'] = 4;
+    $m->set('a', 4);
 
     $m->save();
 
-    echo $m['a']+$m['b'];
+    echo $m->get('a')+$m->get('b');
 
 This will output 4, because model didn't reload itself due to lack of any
 expressions. This time you can explicitly enable reload after save::
 
     $m = new Model_Math($db, ['reload_after_save' => true]);
-    $m['a'] = 4;
+    $m->set('a', 4);
 
     $m->save();
 
-    echo $m['a']+$m['b']; // outputs 14
+    echo $m->get('a')+$m->get('b'); // outputs 14
 
 .. note:: If your model is using reload_after_save, but you wish to insert
     data without additional query - use :php:meth:`Model::insert()` or

--- a/docs/expressions.rst
+++ b/docs/expressions.rst
@@ -25,7 +25,7 @@ Example will calculate "total_gross" by adding up values for "net" and "vat"::
     $m->addExpression('total_gross', '[total_net]+[total_vat]');
     $m->load(1);
 
-    echo $m->get('total_gross');
+    echo $m['total_gross'];
 
 The query using during load() will look like this:
 
@@ -66,7 +66,7 @@ example::
     $m = new Model($db, false);
     $m->addExpression('now', 'now()');
     $m->loadAny();
-    echo $m->get('now');
+    echo $m['now'];
 
 In this example the query will look like this:
 
@@ -128,12 +128,12 @@ the following model::
     }
 
     $m = new Model_Math($db);
-    $m->set('a', 4);
-    $m->set('b', 6);
+    $m['a'] = 4;
+    $m['b'] = 6;
 
     $m->save();
 
-    echo $m->get('sum');
+    echo $m['sum'];
 
 When $m->save() is executed, Agile Data will perform reloading of the model.
 This is to ensure that expression 'sum' would be re-calculated for the values of
@@ -143,15 +143,15 @@ Reload after save will only be executed if you have defined any expressions
 inside your model, however you can affect this behavior::
 
     $m = new Model_Math($db, ['reload_after_save' => false]);
-    $m->set('a', 4);
-    $m->set('b', 6);
+    $m['a'] = 4;
+    $m['b'] = 6;
 
     $m->save();
 
-    echo $m->get('sum');   // outputs null
+    echo $m['sum'];   // outputs null
 
     $m->reload();
-    echo $m->get('sum');   // outputs 10
+    echo $m['sum'];   // outputs 10
 
 Now it requires an explicit reload for your model to fetch the result. There
 is another scenario when your database defines default fields:
@@ -174,21 +174,21 @@ Then try the following code::
     }
 
     $m = new Model_Math($db);
-    $m->set('a', 4);
+    $m['a'] = 4;
 
     $m->save();
 
-    echo $m->get('a')+$m->get('b');
+    echo $m['a']+$m['b'];
 
 This will output 4, because model didn't reload itself due to lack of any
 expressions. This time you can explicitly enable reload after save::
 
     $m = new Model_Math($db, ['reload_after_save' => true]);
-    $m->set('a', 4);
+    $m['a'] = 4;
 
     $m->save();
 
-    echo $m->get('a')+$m->get('b'); // outputs 14
+    echo $m['a']+$m['b']; // outputs 14
 
 .. note:: If your model is using reload_after_save, but you wish to insert
     data without additional query - use :php:meth:`Model::insert()` or

--- a/docs/fields.rst
+++ b/docs/fields.rst
@@ -31,13 +31,6 @@ can set and read value of that field::
 
     echo $model->get('name');  // john
 
-Agile Data supports and prefers a ArrayAccess format of interacting with fields::
-
-    $model->addField('age');
-    $model['age'] = 29;
-
-    echo $model['age'];
-
 Just like you can reuse :php:class:`Model` to access multiple data records,
 :php:class:`Field` object will be reused also.
 
@@ -61,9 +54,9 @@ Field Type
 Probably a most useful quality of Field is that it has a clear type::
 
     $model->addField('age', ['type'=>'integer']);
-    $model['age'] = "123";
+    $model->set('age', "123");
 
-    var_dump($model['age']);   // int(123)
+    var_dump($model->get('age'));   // int(123)
 
 Agile Data defines some basic types to make sure that values:
 
@@ -74,7 +67,7 @@ Agile Data defines some basic types to make sure that values:
 A good example would be a `date` type::
 
     $model->addField('birth', ['type' => 'date']);
-    $model['birth'] = DateTime::createFromFormat('m/d/Y', '1/10/2014');
+    $model->set('birth', DateTime::createFromFormat('m/d/Y', '1/10/2014'));
 
     $model->save();
 
@@ -155,10 +148,10 @@ the field, but you won't be able to save it.
 
 Example::
 
-    $model['age'] = 0;
+    $model->set('age', 0);
     $model->save();
 
-    $model['age'] = null;
+    $model->set('age', null);
     $model->save();  // exception
 
 
@@ -174,10 +167,10 @@ Some examples that are not allowed are:
 
 Example::
 
-    $model['age'] = 0;
+    $model->set('age', 0);
     $model->save();  // exception
 
-    $model['age'] = null;
+    $model->set('age', null);
     $model->save();  // exception
 
 
@@ -271,7 +264,7 @@ Here is how to use it properly::
 
     $user->addField('mypass', ['Password']);
 
-    $user['mypass'] = 'secret';
+    $user->set('mypass', 'secret');
     $user->save();
 
 Password is automatically hashed with `password_encrypt` before storing. If you
@@ -294,6 +287,6 @@ stored. Final example::
             throw new Exception('Old password is incorrect');
         }
 
-        $this['password'] = $new_pass;
+        $this->set('password', $new_pass);
         $this->save();
     }

--- a/docs/fields.rst
+++ b/docs/fields.rst
@@ -31,6 +31,13 @@ can set and read value of that field::
 
     echo $model->get('name');  // john
 
+Agile Data supports and prefers a ArrayAccess format of interacting with fields::
+
+    $model->addField('age');
+    $model['age'] = 29;
+
+    echo $model['age'];
+
 Just like you can reuse :php:class:`Model` to access multiple data records,
 :php:class:`Field` object will be reused also.
 
@@ -54,9 +61,9 @@ Field Type
 Probably a most useful quality of Field is that it has a clear type::
 
     $model->addField('age', ['type'=>'integer']);
-    $model->set('age', "123");
+    $model['age'] = "123";
 
-    var_dump($model->get('age'));   // int(123)
+    var_dump($model['age']);   // int(123)
 
 Agile Data defines some basic types to make sure that values:
 
@@ -67,7 +74,7 @@ Agile Data defines some basic types to make sure that values:
 A good example would be a `date` type::
 
     $model->addField('birth', ['type' => 'date']);
-    $model->set('birth', DateTime::createFromFormat('m/d/Y', '1/10/2014'));
+    $model['birth'] = DateTime::createFromFormat('m/d/Y', '1/10/2014');
 
     $model->save();
 
@@ -148,10 +155,10 @@ the field, but you won't be able to save it.
 
 Example::
 
-    $model->set('age', 0);
+    $model['age'] = 0;
     $model->save();
 
-    $model->set('age', null);
+    $model['age'] = null;
     $model->save();  // exception
 
 
@@ -167,10 +174,10 @@ Some examples that are not allowed are:
 
 Example::
 
-    $model->set('age', 0);
+    $model['age'] = 0;
     $model->save();  // exception
 
-    $model->set('age', null);
+    $model['age'] = null;
     $model->save();  // exception
 
 
@@ -264,7 +271,7 @@ Here is how to use it properly::
 
     $user->addField('mypass', ['Password']);
 
-    $user->set('mypass', 'secret');
+    $user['mypass'] = 'secret';
     $user->save();
 
 Password is automatically hashed with `password_encrypt` before storing. If you
@@ -287,6 +294,6 @@ stored. Final example::
             throw new Exception('Old password is incorrect');
         }
 
-        $this->set('password', $new_pass);
+        $this['password'] = $new_pass;
         $this->save();
     }

--- a/docs/hooks.rst
+++ b/docs/hooks.rst
@@ -53,8 +53,8 @@ The next code snippet demonstrates a basic usage of a `beforeSave` hook.
 This one will update field values just before record is saved::
 
     $m->onHook('beforeSave', function($m) {
-        $m->set('name', strtoupper($m->get('name')));
-        $m->set('surname', strtoupper($m->get('surname')));
+        $m['name'] = strtoupper($m['name']);
+        $m['surname'] = strtoupper($m['surname']);
     });
 
     $m->insert(['name'=>'John', 'surname'=>'Smith']);
@@ -86,7 +86,7 @@ model will assume the operation was successful.
 You can also break beforeLoad hook which can be used to skip rows::
 
     $model->onHook('afterLoad', function ($m) {
-        if ($m->get('date') < $m->date_from) {
+        if ($m['date'] < $m->date_from) {
             $m->breakHook(false); // will not yield such data row
         }
         // otherwise yields data row
@@ -137,7 +137,7 @@ of save.
 You may actually drop validation exception inside save, insert or update hooks::
 
     $m->onHook('beforeSave', function($m) {
-        if ($m->get('name') === 'Yagi') {
+        if ($m['name'] = 'Yagi') {
             throw new \atk4\data\ValidationException(['name'=>"We don't serve like you"]);
         }
     });

--- a/docs/hooks.rst
+++ b/docs/hooks.rst
@@ -53,8 +53,8 @@ The next code snippet demonstrates a basic usage of a `beforeSave` hook.
 This one will update field values just before record is saved::
 
     $m->onHook('beforeSave', function($m) {
-        $m['name'] = strtoupper($m['name']);
-        $m['surname'] = strtoupper($m['surname']);
+        $m->set('name', strtoupper($m->get('name')));
+        $m->set('surname', strtoupper($m->get('surname')));
     });
 
     $m->insert(['name'=>'John', 'surname'=>'Smith']);
@@ -86,7 +86,7 @@ model will assume the operation was successful.
 You can also break beforeLoad hook which can be used to skip rows::
 
     $model->onHook('afterLoad', function ($m) {
-        if ($m['date'] < $m->date_from) {
+        if ($m->get('date') < $m->date_from) {
             $m->breakHook(false); // will not yield such data row
         }
         // otherwise yields data row
@@ -137,7 +137,7 @@ of save.
 You may actually drop validation exception inside save, insert or update hooks::
 
     $m->onHook('beforeSave', function($m) {
-        if ($m['name'] = 'Yagi') {
+        if ($m->get('name') === 'Yagi') {
             throw new \atk4\data\ValidationException(['name'=>"We don't serve like you"]);
         }
     });

--- a/docs/joins.rst
+++ b/docs/joins.rst
@@ -39,7 +39,7 @@ If driver is unable to query both tables simultaneously, then it will load one
 record first, then load other record and will collect fields together::
 
     $user_data = $user->find($id);
-    $contact_data = $contact->find($user_data->get('contact_id'));
+    $contact_data = $contact->find($user_data['contact_id']);
 
 When saving the record, Joins will automatically record data correctly:
 
@@ -284,7 +284,7 @@ You can also specify ``'on'=>false`` then the ON clause will not be used at all
 and you'll have to add additional where() condition yourself.
 
 ``foreign_alias`` can be specified and will be used as table alias and prefix
-for all fields. It will default to ``"_".$foreign_table->get(0)``. Agile Data will
+for all fields. It will default to ``"_".$foreign_table[0]``. Agile Data will
 also resolve situations when multiple tables have same first character so the
 prefixes will be named '_c' ,'_c_2', '_c_3' etc.
 

--- a/docs/joins.rst
+++ b/docs/joins.rst
@@ -39,7 +39,7 @@ If driver is unable to query both tables simultaneously, then it will load one
 record first, then load other record and will collect fields together::
 
     $user_data = $user->find($id);
-    $contact_data = $contact->find($user_data['contact_id']);
+    $contact_data = $contact->find($user_data->get('contact_id'));
 
 When saving the record, Joins will automatically record data correctly:
 
@@ -284,7 +284,7 @@ You can also specify ``'on'=>false`` then the ON clause will not be used at all
 and you'll have to add additional where() condition yourself.
 
 ``foreign_alias`` can be specified and will be used as table alias and prefix
-for all fields. It will default to ``"_".$foreign_table[0]``. Agile Data will
+for all fields. It will default to ``"_".$foreign_table->get(0)``. Agile Data will
 also resolve situations when multiple tables have same first character so the
 prefixes will be named '_c' ,'_c_2', '_c_3' etc.
 

--- a/docs/model.rst
+++ b/docs/model.rst
@@ -22,7 +22,7 @@ object you can load/unload individual records (See Single record Operations belo
    $m = new User($db);
 
    $m->load(3);
-   $m['note'] = 'just updating';
+   $m->set('note', 'just updating');
    $m->save();
    $m->unload();
 
@@ -179,7 +179,7 @@ You may safely rely on `$this->persistence` property to make choices::
 
       // Fallback
       $this->addCalculatedField('total', function($m) {
-         return $m['amount'] + $m['vat'];
+         return $m->get('amount') + $m->get('vat');
       } );
    }
 
@@ -313,7 +313,7 @@ This can also be useful for calculating relative times::
          parent::init();
 
          $this->addCalculatedField('event_ts_human_friendly', function($m) {
-            return $this->humanTiming($m['event_ts']);
+            return $this->humanTiming($m->get('event_ts'));
          });
 
       }
@@ -357,7 +357,7 @@ a user invokable actions::
 
          $this->save(['password'=> .. ]);
 
-         return 'generated and sent password to '.$m['name'];
+         return 'generated and sent password to '.$m->get('name');
       }
    }
 
@@ -392,17 +392,17 @@ a hook::
    $this->addField('name');
 
    $this->onHook('validate', function($m) {
-      if ($m['name'] == 'C#') {
+      if ($m->get('name') === 'C#') {
          return ['name'=>'No sharp objects are allowed'];
       }
    });
 
 Now if you attempt to save object, you will receive :php:class:`ValidationException`::
 
-   $model['name'] = 'Swift';
+   $model->set('name', 'Swift');
    $model->saveAndUnload();      // all good
 
-   $model['name'] = 'C#';
+   $model->set('name', 'C#');
    $model->saveAndUnload();      // exception here
 
 
@@ -438,7 +438,7 @@ There are some advanced techniques like "SubTypes" or class substitution,
 for example, this hook may be placed in the "User" class init()::
 
    $this->onHook('afterLoad', function($m) {
-      if ($m['purchases'] > 1000) {
+      if ($m->get('purchases') > 1000) {
          $this->breakHook($this->asModel(VIPUser::class);
       }
    });
@@ -469,7 +469,7 @@ of static persistence::
    $m = new Model(new Persistence\Static_(['john', 'peter', 'steve']);
 
    $m->load(1);
-   echo $m['name'];  // peter
+   echo $m->get('name');  // peter
 
 See :php:class:`Persistence\\Static_`
 
@@ -573,8 +573,8 @@ property:
 Model allows you to work with the data of single a record directly. You should
 use the following syntax when accessing fields of an active record::
 
-    $m['name'] = 'John';
-    $m['surname'] = 'Peter';
+    $m->set('name', 'John');
+    $m->set('surname', 'Peter');
 
 When you modify active record, it keeps the original value in the $dirty array:
 
@@ -588,11 +588,11 @@ When you modify active record, it keeps the original value in the $dirty array:
 
     Restore field value to it's original::
 
-        $m['name'] = 'John';
-        echo $m['name']; // John
+        $m->set('name', 'John');
+        echo $m->get('name'); // John
 
-        unset($m['name']);
-        echo $m['name']; // Original value is shown
+        $m->_unset('name');
+        echo $m->get('name'); // Original value is shown
 
     This will restore original value of the field.
 
@@ -609,9 +609,9 @@ When you modify active record, it keeps the original value in the $dirty array:
 
     Return true if field contains unsaved changes (dirty)::
 
-        isset($m['name']); // returns false
-        $m['name'] = 'Other Name';
-        isset($m['name']); // returns true
+        $m->_isset('name'); // returns false
+        $m->set('name', 'Other Name');
+        $m->_isset('name'); // returns true
 
 
 .. php:method:: isDirty
@@ -619,7 +619,7 @@ When you modify active record, it keeps the original value in the $dirty array:
     Return true if one or multiple fields contain unsaved changes (dirty)::
 
         if ($m->isDirty(['name','surname'])) {
-           $m['full_name'] = $m['name'].' '.$m['surname'];
+           $m->set('full_name', $m->get('name').' '.$m->get('surname'));
         }
 
     When the code above is placed in beforeSave hook, it will only be executed
@@ -651,30 +651,30 @@ Full example::
     // Fields can be added after model is created
     $m->addField('salary', ['default'=>1000]);
 
-    echo isset($m['salary']);   // false
-    echo $m['salary'];          // 1000
+    echo $m->_isset('salary');  // false
+    echo $m->get('salary');          // 1000
 
     // Next we load record from $db
     $m->load(1);
 
-    echo $m['salary'];          // 2000 (from db)
-    echo isset($m['salary']);   // false, was not changed
+    echo $m->get('salary');          // 2000 (from db)
+    echo $m->_isset('salary');  // false, was not changed
 
-    $m['salary'] = 3000;
+    $m->set('salary', 3000);
 
-    echo $m['salary'];          // 3000 (changed)
-    echo isset($m['salary']);   // true
+    echo $m->get('salary');          // 3000 (changed)
+    echo $m->_isset('salary');  // true
 
-    unset($m['salary']);        // return to original value
+    $m->_unset('salary');        // return to original value
 
-    echo $m['salary'];          // 2000
-    echo isset($m['salary']);   // false
+    echo $m->get('salary');          // 2000
+    echo $m->_isset('salary');  // false
 
-    $m['salary'] = 3000;
+    $m->set('salary', 3000);
     $m->save();
 
-    echo $m['salary'];          // 3000 (now in db)
-    echo isset($m['salary']);   // false
+    echo $m->get('salary');          // 3000 (now in db)
+    echo $m->_isset('salary');  // false
 
 .. php:method:: protected normalizeFieldName
 
@@ -706,7 +706,7 @@ ID Field
 
 .. tip:: You can change ID value of the current ID field by calling::
 
-        $m['id'] = $new_id;
+        $m->set('id', $new_id);
         $m->save();
 
     This will update existing record with new $id. If you want to save your

--- a/docs/model.rst
+++ b/docs/model.rst
@@ -22,7 +22,7 @@ object you can load/unload individual records (See Single record Operations belo
    $m = new User($db);
 
    $m->load(3);
-   $m['note'] = 'just updating';
+   $m->set('note', 'just updating');
    $m->save();
    $m->unload();
 
@@ -179,7 +179,7 @@ You may safely rely on `$this->persistence` property to make choices::
 
       // Fallback
       $this->addCalculatedField('total', function($m) {
-         return $m['amount'] + $m['vat'];
+         return $m->get('amount') + $m->get('vat');
       } );
    }
 
@@ -313,7 +313,7 @@ This can also be useful for calculating relative times::
          parent::init();
 
          $this->addCalculatedField('event_ts_human_friendly', function($m) {
-            return $this->humanTiming($m['event_ts']);
+            return $this->humanTiming($m->get('event_ts'));
          });
 
       }
@@ -357,7 +357,7 @@ a user invokable actions::
 
          $this->save(['password'=> .. ]);
 
-         return 'generated and sent password to '.$m['name'];
+         return 'generated and sent password to '.$m->get('name');
       }
    }
 
@@ -392,17 +392,17 @@ a hook::
    $this->addField('name');
 
    $this->onHook('validate', function($m) {
-      if ($m['name'] == 'C#') {
+      if ($m->get('name') === 'C#') {
          return ['name'=>'No sharp objects are allowed'];
       }
    });
 
 Now if you attempt to save object, you will receive :php:class:`ValidationException`::
 
-   $model['name'] = 'Swift';
+   $model->set('name', 'Swift');
    $model->saveAndUnload();      // all good
 
-   $model['name'] = 'C#';
+   $model->set('name', 'C#');
    $model->saveAndUnload();      // exception here
 
 
@@ -438,7 +438,7 @@ There are some advanced techniques like "SubTypes" or class substitution,
 for example, this hook may be placed in the "User" class init()::
 
    $this->onHook('afterLoad', function($m) {
-      if ($m['purchases'] > 1000) {
+      if ($m->get('purchases') > 1000) {
          $this->breakHook($this->asModel(VIPUser::class);
       }
    });
@@ -469,7 +469,7 @@ of static persistence::
    $m = new Model(new Persistence\Static_(['john', 'peter', 'steve']);
 
    $m->load(1);
-   echo $m['name'];  // peter
+   echo $m->get('name');  // peter
 
 See :php:class:`Persistence\\Static_`
 
@@ -573,8 +573,8 @@ property:
 Model allows you to work with the data of single a record directly. You should
 use the following syntax when accessing fields of an active record::
 
-    $m['name'] = 'John';
-    $m['surname'] = 'Peter';
+    $m->set('name', 'John');
+    $m->set('surname', 'Peter');
 
 When you modify active record, it keeps the original value in the $dirty array:
 
@@ -588,11 +588,11 @@ When you modify active record, it keeps the original value in the $dirty array:
 
     Restore field value to it's original::
 
-        $m['name'] = 'John';
-        echo $m['name']; // John
+        $m->set('name', 'John');
+        echo $m->get('name'); // John
 
-        unset($m['name']);
-        echo $m['name']; // Original value is shown
+        unset($m->get('name'));
+        echo $m->get('name'); // Original value is shown
 
     This will restore original value of the field.
 
@@ -609,9 +609,9 @@ When you modify active record, it keeps the original value in the $dirty array:
 
     Return true if field contains unsaved changes (dirty)::
 
-        isset($m['name']); // returns false
-        $m['name'] = 'Other Name';
-        isset($m['name']); // returns true
+        $m->_isset('name'); // returns false
+        $m->set('name', 'Other Name');
+        $m->_isset('name'); // returns true
 
 
 .. php:method:: isDirty
@@ -619,7 +619,7 @@ When you modify active record, it keeps the original value in the $dirty array:
     Return true if one or multiple fields contain unsaved changes (dirty)::
 
         if ($m->isDirty(['name','surname'])) {
-           $m['full_name'] = $m['name'].' '.$m['surname'];
+           $m->set('full_name', $m->get('name').' '.$m->get('surname'));
         }
 
     When the code above is placed in beforeSave hook, it will only be executed
@@ -651,30 +651,30 @@ Full example::
     // Fields can be added after model is created
     $m->addField('salary', ['default'=>1000]);
 
-    echo isset($m['salary']);   // false
-    echo $m['salary'];          // 1000
+    echo $m->_isset('salary');  // false
+    echo $m->get('salary');          // 1000
 
     // Next we load record from $db
     $m->load(1);
 
-    echo $m['salary'];          // 2000 (from db)
-    echo isset($m['salary']);   // false, was not changed
+    echo $m->get('salary');          // 2000 (from db)
+    echo $m->_isset('salary');  // false, was not changed
 
-    $m['salary'] = 3000;
+    $m->set('salary', 3000);
 
-    echo $m['salary'];          // 3000 (changed)
-    echo isset($m['salary']);   // true
+    echo $m->get('salary');          // 3000 (changed)
+    echo $m->_isset('salary');  // true
 
-    unset($m['salary']);        // return to original value
+    unset($m->get('salary'));        // return to original value
 
-    echo $m['salary'];          // 2000
-    echo isset($m['salary']);   // false
+    echo $m->get('salary');          // 2000
+    echo $m->_isset('salary');  // false
 
-    $m['salary'] = 3000;
+    $m->set('salary', 3000);
     $m->save();
 
-    echo $m['salary'];          // 3000 (now in db)
-    echo isset($m['salary']);   // false
+    echo $m->get('salary');          // 3000 (now in db)
+    echo $m->_isset('salary');  // false
 
 .. php:method:: protected normalizeFieldName
 
@@ -706,7 +706,7 @@ ID Field
 
 .. tip:: You can change ID value of the current ID field by calling::
 
-        $m['id'] = $new_id;
+        $m->set('id', $new_id);
         $m->save();
 
     This will update existing record with new $id. If you want to save your

--- a/docs/model.rst
+++ b/docs/model.rst
@@ -22,7 +22,7 @@ object you can load/unload individual records (See Single record Operations belo
    $m = new User($db);
 
    $m->load(3);
-   $m->set('note', 'just updating');
+   $m['note'] = 'just updating';
    $m->save();
    $m->unload();
 
@@ -179,7 +179,7 @@ You may safely rely on `$this->persistence` property to make choices::
 
       // Fallback
       $this->addCalculatedField('total', function($m) {
-         return $m->get('amount') + $m->get('vat');
+         return $m['amount'] + $m['vat'];
       } );
    }
 
@@ -313,7 +313,7 @@ This can also be useful for calculating relative times::
          parent::init();
 
          $this->addCalculatedField('event_ts_human_friendly', function($m) {
-            return $this->humanTiming($m->get('event_ts'));
+            return $this->humanTiming($m['event_ts']);
          });
 
       }
@@ -357,7 +357,7 @@ a user invokable actions::
 
          $this->save(['password'=> .. ]);
 
-         return 'generated and sent password to '.$m->get('name');
+         return 'generated and sent password to '.$m['name'];
       }
    }
 
@@ -392,17 +392,17 @@ a hook::
    $this->addField('name');
 
    $this->onHook('validate', function($m) {
-      if ($m->get('name') === 'C#') {
+      if ($m['name'] == 'C#') {
          return ['name'=>'No sharp objects are allowed'];
       }
    });
 
 Now if you attempt to save object, you will receive :php:class:`ValidationException`::
 
-   $model->set('name', 'Swift');
+   $model['name'] = 'Swift';
    $model->saveAndUnload();      // all good
 
-   $model->set('name', 'C#');
+   $model['name'] = 'C#';
    $model->saveAndUnload();      // exception here
 
 
@@ -438,7 +438,7 @@ There are some advanced techniques like "SubTypes" or class substitution,
 for example, this hook may be placed in the "User" class init()::
 
    $this->onHook('afterLoad', function($m) {
-      if ($m->get('purchases') > 1000) {
+      if ($m['purchases'] > 1000) {
          $this->breakHook($this->asModel(VIPUser::class);
       }
    });
@@ -469,7 +469,7 @@ of static persistence::
    $m = new Model(new Persistence\Static_(['john', 'peter', 'steve']);
 
    $m->load(1);
-   echo $m->get('name');  // peter
+   echo $m['name'];  // peter
 
 See :php:class:`Persistence\\Static_`
 
@@ -573,8 +573,8 @@ property:
 Model allows you to work with the data of single a record directly. You should
 use the following syntax when accessing fields of an active record::
 
-    $m->set('name', 'John');
-    $m->set('surname', 'Peter');
+    $m['name'] = 'John';
+    $m['surname'] = 'Peter';
 
 When you modify active record, it keeps the original value in the $dirty array:
 
@@ -588,11 +588,11 @@ When you modify active record, it keeps the original value in the $dirty array:
 
     Restore field value to it's original::
 
-        $m->set('name', 'John');
-        echo $m->get('name'); // John
+        $m['name'] = 'John';
+        echo $m['name']; // John
 
-        unset($m->get('name'));
-        echo $m->get('name'); // Original value is shown
+        unset($m['name']);
+        echo $m['name']; // Original value is shown
 
     This will restore original value of the field.
 
@@ -609,9 +609,9 @@ When you modify active record, it keeps the original value in the $dirty array:
 
     Return true if field contains unsaved changes (dirty)::
 
-        $m->_isset('name'); // returns false
-        $m->set('name', 'Other Name');
-        $m->_isset('name'); // returns true
+        isset($m['name']); // returns false
+        $m['name'] = 'Other Name';
+        isset($m['name']); // returns true
 
 
 .. php:method:: isDirty
@@ -619,7 +619,7 @@ When you modify active record, it keeps the original value in the $dirty array:
     Return true if one or multiple fields contain unsaved changes (dirty)::
 
         if ($m->isDirty(['name','surname'])) {
-           $m->set('full_name', $m->get('name').' '.$m->get('surname'));
+           $m['full_name'] = $m['name'].' '.$m['surname'];
         }
 
     When the code above is placed in beforeSave hook, it will only be executed
@@ -651,30 +651,30 @@ Full example::
     // Fields can be added after model is created
     $m->addField('salary', ['default'=>1000]);
 
-    echo $m->_isset('salary');  // false
-    echo $m->get('salary');          // 1000
+    echo isset($m['salary']);   // false
+    echo $m['salary'];          // 1000
 
     // Next we load record from $db
     $m->load(1);
 
-    echo $m->get('salary');          // 2000 (from db)
-    echo $m->_isset('salary');  // false, was not changed
+    echo $m['salary'];          // 2000 (from db)
+    echo isset($m['salary']);   // false, was not changed
 
-    $m->set('salary', 3000);
+    $m['salary'] = 3000;
 
-    echo $m->get('salary');          // 3000 (changed)
-    echo $m->_isset('salary');  // true
+    echo $m['salary'];          // 3000 (changed)
+    echo isset($m['salary']);   // true
 
-    unset($m->get('salary'));        // return to original value
+    unset($m['salary']);        // return to original value
 
-    echo $m->get('salary');          // 2000
-    echo $m->_isset('salary');  // false
+    echo $m['salary'];          // 2000
+    echo isset($m['salary']);   // false
 
-    $m->set('salary', 3000);
+    $m['salary'] = 3000;
     $m->save();
 
-    echo $m->get('salary');          // 3000 (now in db)
-    echo $m->_isset('salary');  // false
+    echo $m['salary'];          // 3000 (now in db)
+    echo isset($m['salary']);   // false
 
 .. php:method:: protected normalizeFieldName
 
@@ -706,7 +706,7 @@ ID Field
 
 .. tip:: You can change ID value of the current ID field by calling::
 
-        $m->set('id', $new_id);
+        $m['id'] = $new_id;
         $m->save();
 
     This will update existing record with new $id. If you want to save your

--- a/docs/overview.rst
+++ b/docs/overview.rst
@@ -134,7 +134,7 @@ using::
     $user = new User($db);
 
     $user->load(20);            // load specific user record into PHP
-    echo $user['name'].': ';    // access field values
+    echo $user->get('name').': ';    // access field values
 
     $gross = $user->ref('Invoice')
         ->addCondition('status', 'due')
@@ -167,7 +167,7 @@ MongoDB), you would need to define the field differently::
 
     $model->addField('gross');
     $model->onHook('beforeSave', function($m) {
-        $m['gross'] = $m['net'] + $m['vat'];
+        $m->set('gross', $m->get('net') + $m->get('vat'));
     });
 
 When you use persistence-specific code, you must be aware that it will not map
@@ -187,7 +187,7 @@ you want it to work with NoSQL, then your solution might be::
         // persistence does not support expressions
         $model->addField('gross');
         $model->onHook('beforeSave', function($m) {
-            $m['gross'] = $m['net'] + $m['vat'];
+            $m->set('gross', $m->get('net') + $m->get('vat'));
         });
 
     }

--- a/docs/overview.rst
+++ b/docs/overview.rst
@@ -134,7 +134,7 @@ using::
     $user = new User($db);
 
     $user->load(20);            // load specific user record into PHP
-    echo $user->get('name').': ';    // access field values
+    echo $user['name'].': ';    // access field values
 
     $gross = $user->ref('Invoice')
         ->addCondition('status', 'due')
@@ -167,7 +167,7 @@ MongoDB), you would need to define the field differently::
 
     $model->addField('gross');
     $model->onHook('beforeSave', function($m) {
-        $m->set('gross', $m->get('net') + $m->get('vat'));
+        $m['gross'] = $m['net'] + $m['vat'];
     });
 
 When you use persistence-specific code, you must be aware that it will not map
@@ -187,7 +187,7 @@ you want it to work with NoSQL, then your solution might be::
         // persistence does not support expressions
         $model->addField('gross');
         $model->onHook('beforeSave', function($m) {
-            $m->set('gross', $m->get('net') + $m->get('vat'));
+            $m['gross'] = $m['net'] + $m['vat'];
         });
 
     }

--- a/docs/persistence.rst
+++ b/docs/persistence.rst
@@ -46,7 +46,7 @@ There are several ways to link your model up with the persistence::
     Load active record from the DataSet::
 
         $m->load(10);
-        echo $m->get('name');
+        echo $m['name'];
 
     If record not found, will throw exception.
 
@@ -56,7 +56,7 @@ There are several ways to link your model up with the persistence::
     a new record::
 
         $m->load(10);
-        $m->set('name', 'John');
+        $m['name'] = 'John';
         $$m->save();
 
     You can pass argument to save() to set() and save()::
@@ -84,7 +84,7 @@ There are several ways to link your model up with the persistence::
     setOrder()::
 
         $m->loadAny();
-        echo $m->get('name');
+        echo $m['name'];
 
 .. php:method:: tryLoadAny
 
@@ -98,7 +98,7 @@ There are several ways to link your model up with the persistence::
         $m->load(10);
         $m->unload();
 
-        $m->set('name', 'New User');
+        $m['name'] = 'New User';
         $m->save();         // creates new user
 
 .. php:method:: delete($id = null)
@@ -113,7 +113,7 @@ Inserting Record with a specific ID
 When you add a new record with save(), insert() or import, you can specify ID
 explicitly::
 
-    $m->set('id', 123);
+    $m['id'] = 123;
     $m->save();
 
     // or $m->insert(['Record with ID=123', 'id'=>123']);
@@ -122,7 +122,7 @@ However if you change the ID for record that was loaded, then your database
 record will also have its ID changed. Here is example::
 
     $m->load(123);
-    $m->set($m->id_field, 321);
+    $m[$m->id_field] = 321;
     $m->save();
 
 After this your database won't have a record with ID 123 anymore.
@@ -138,19 +138,19 @@ Agile Data ensures that regardless of the selected database, types are converted
 correctly for saving and restored as they were when loading::
 
     $m->addField('is_admin', ['type'=>'boolean']);
-    $m->set('is_admin', false);
+    $m['is_admin'] = false;
     $m->save();
 
     // SQL database will actually store `0`
 
     $m->load();
 
-    $m->get('is_admin');  // converted back to `false`
+    $m['is_admin'];  // converted back to `false`
 
 Behind a two simple lines might be a long path for the value. The various
 components are essential and as developer you must understand the full sequence::
 
-    $m->set('is_admin', false);
+    $m['is_admin'] = false;
     $m->save();
 
 Strict Types an Normalization
@@ -163,30 +163,30 @@ Calling "set()" or using array-access to set the value will start by casting
 the value to an appropriate data-type. If it is impossible to cast the value,
 then exception will be generated::
 
-    $m->set('is_admin', "1"); // OK, but stores as `true`
+    $m['is_admin'] = "1"; // OK, but stores as `true`
 
-    $m->set('is_admin', 123); // throws exception.
+    $m['is_admin'] = 123; // throws exception.
 
 It's not only the 'type' property, but 'enum' can also imply restrictions::
 
     $m->addField('access_type', ['enum' => ['read_only', 'full']]);
 
-    $m->set('access_type', 'full'); // OK
-    $m->set('access_type', 'half-full'); // Exception
+    $m['access_type'] = 'full'; // OK
+    $m['access_type'] = 'half-full'; // Exception
 
 There are also non-trivial types in Agile Data::
 
     $m->addField('salary', ['type' => 'money']);
-    $m->set('salary', "20");  // converts to 20.00
+    $m['salary'] = "20";  // converts to 20.00
 
     $m->addField('date', ['type' => 'date']);
-    $m->set('date', time());  // converts to DateTime class
+    $m['date'] = time();  // converts to DateTime class
 
 Finally, you may create your own custom field types that follow a more
 complex logic::
 
     $m->add(new Field_Currency(), 'balance');
-    $m->set('balance', '12,200.00 EUR');
+    $m['balance'] = '12,200.00 EUR';
 
     // May transparently work with 2 columns: 'balance_amount' and
     // 'balance_currency_id' for example.
@@ -210,9 +210,9 @@ and if set, then value of a field may not be modified directly::
     $m->addField('ref_no', ['read_only' => true]);
     $m->load(123);
 
-    $m->get('ref_no'); // perfect for reading field that is populated by trigger.
+    $m['ref_no']; // perfect for reading field that is populated by trigger.
 
-    $m->set('ref_no', 'foo'); // exception
+    $m['ref_no'] = 'foo'; // exception
 
 Note that `read_only` can still have a default value::
 
@@ -269,7 +269,7 @@ Multi-column fields
 Lets talk more about this currency field::
 
     $m->add(new Field_Currency(), 'balance');
-    $m->set('balance', '12,200.00 EUR');
+    $m['balance'] = '12,200.00 EUR';
 
 It may be designed to split up the value by using two fields in the database:
 `balance_amount` and `balance_currency_id`.
@@ -501,15 +501,15 @@ Start by creating a beforeSave handler for Order::
 
             if (
                 $m->newInstance()
-                    ->addCondition('client_id', $m->get('client_id')) // same client
+                    ->addCondition('client_id', $m['client_id']) // same client
                     ->addCondition($m->id_field, '!=', $m->id)   // has another order
-                    ->tryLoadBy('ref', $m->get('ref'))                // with same ref
+                    ->tryLoadBy('ref', $m['ref'])                // with same ref
                     ->loaded()
             ) {
                 throw new Exception([
                     'Order with ref already exists for this client',
-                    'client' => $this->get('client_id'),
-                    'ref'    => $this->get('ref')
+                    'client' => $this['client_id'],
+                    'ref'    => $this['ref']
                 ]);
             }
         }
@@ -531,7 +531,7 @@ as archived and return that order back. Here is the usage pattern::
     $o->addCondition('is_archived', false); // to restrict loading of archived orders
     $o->load(123);
     $archive = $o->archive();
-    $archive->set('note', $archive->get('note') . "\nArchived on $date.");
+    $archive['note'] .= "\nArchived on $date.";
     $archive->save();
 
 With Agile Data API building it's quite common to create a method that does not
@@ -547,7 +547,7 @@ after-save reloading::
 
     function archive() {
         $this->reload_after_save = false;
-        $this->set('is_archived', true);
+        $this['is_archived'] = true;
         return $this;
     }
 
@@ -561,7 +561,7 @@ The other, more appropriate option is to re-use a vanilla Order record::
 
         $archive = $this->newInstance();
         $archive->load($this->id);
-        $archive->set('is_archived', true);
+        $archive['is_archived'] = true;
 
         $this->unload(); // active record is no longer accessible
 
@@ -603,7 +603,7 @@ The above example would then work like this::
         $this->save(); // just to be sure, no dirty stuff is left over
 
         $archive = $o->asModel('Order');
-        $archive->set('is_archived', true);
+        $archive['is_archived'] = true;
 
         $this->unload(); // active record is no longer accessible.
 
@@ -700,7 +700,7 @@ To use it with any model::
 
     $m = $app->loadQuick(new Order(), 123);
 
-    $m->set('completed', true);
+    $m['completed'] = true;
     $m->save();
 
 To look in more details into the actual method, I have broken it down into chunks::
@@ -756,7 +756,7 @@ done with a single record::
 
     $m = new Order($read_replica);
 
-    $m->set('completed', true);
+    $m['completed'] = true;
 
     $m->withPersistence($write_replica)->save();
     $m->dirty = [];

--- a/docs/persistence.rst
+++ b/docs/persistence.rst
@@ -46,7 +46,7 @@ There are several ways to link your model up with the persistence::
     Load active record from the DataSet::
 
         $m->load(10);
-        echo $m['name'];
+        echo $m->get('name');
 
     If record not found, will throw exception.
 
@@ -56,7 +56,7 @@ There are several ways to link your model up with the persistence::
     a new record::
 
         $m->load(10);
-        $m['name'] = 'John';
+        $m->set('name', 'John');
         $$m->save();
 
     You can pass argument to save() to set() and save()::
@@ -84,7 +84,7 @@ There are several ways to link your model up with the persistence::
     setOrder()::
 
         $m->loadAny();
-        echo $m['name'];
+        echo $m->get('name');
 
 .. php:method:: tryLoadAny
 
@@ -98,7 +98,7 @@ There are several ways to link your model up with the persistence::
         $m->load(10);
         $m->unload();
 
-        $m['name'] = 'New User';
+        $m->set('name', 'New User');
         $m->save();         // creates new user
 
 .. php:method:: delete($id = null)
@@ -113,7 +113,7 @@ Inserting Record with a specific ID
 When you add a new record with save(), insert() or import, you can specify ID
 explicitly::
 
-    $m['id'] = 123;
+    $m->set('id', 123);
     $m->save();
 
     // or $m->insert(['Record with ID=123', 'id'=>123']);
@@ -122,7 +122,7 @@ However if you change the ID for record that was loaded, then your database
 record will also have its ID changed. Here is example::
 
     $m->load(123);
-    $m[$m->id_field] = 321;
+    $m->set($m->id_field, 321);
     $m->save();
 
 After this your database won't have a record with ID 123 anymore.
@@ -138,19 +138,19 @@ Agile Data ensures that regardless of the selected database, types are converted
 correctly for saving and restored as they were when loading::
 
     $m->addField('is_admin', ['type'=>'boolean']);
-    $m['is_admin'] = false;
+    $m->set('is_admin', false);
     $m->save();
 
     // SQL database will actually store `0`
 
     $m->load();
 
-    $m['is_admin'];  // converted back to `false`
+    $m->get('is_admin');  // converted back to `false`
 
 Behind a two simple lines might be a long path for the value. The various
 components are essential and as developer you must understand the full sequence::
 
-    $m['is_admin'] = false;
+    $m->set('is_admin', false);
     $m->save();
 
 Strict Types an Normalization
@@ -163,30 +163,30 @@ Calling "set()" or using array-access to set the value will start by casting
 the value to an appropriate data-type. If it is impossible to cast the value,
 then exception will be generated::
 
-    $m['is_admin'] = "1"; // OK, but stores as `true`
+    $m->set('is_admin', "1"); // OK, but stores as `true`
 
-    $m['is_admin'] = 123; // throws exception.
+    $m->set('is_admin', 123); // throws exception.
 
 It's not only the 'type' property, but 'enum' can also imply restrictions::
 
     $m->addField('access_type', ['enum' => ['read_only', 'full']]);
 
-    $m['access_type'] = 'full'; // OK
-    $m['access_type'] = 'half-full'; // Exception
+    $m->set('access_type', 'full'); // OK
+    $m->set('access_type', 'half-full'); // Exception
 
 There are also non-trivial types in Agile Data::
 
     $m->addField('salary', ['type' => 'money']);
-    $m['salary'] = "20";  // converts to 20.00
+    $m->set('salary', "20");  // converts to 20.00
 
     $m->addField('date', ['type' => 'date']);
-    $m['date'] = time();  // converts to DateTime class
+    $m->set('date', time());  // converts to DateTime class
 
 Finally, you may create your own custom field types that follow a more
 complex logic::
 
     $m->add(new Field_Currency(), 'balance');
-    $m['balance'] = '12,200.00 EUR';
+    $m->set('balance', '12,200.00 EUR');
 
     // May transparently work with 2 columns: 'balance_amount' and
     // 'balance_currency_id' for example.
@@ -210,9 +210,9 @@ and if set, then value of a field may not be modified directly::
     $m->addField('ref_no', ['read_only' => true]);
     $m->load(123);
 
-    $m['ref_no']; // perfect for reading field that is populated by trigger.
+    $m->get('ref_no'); // perfect for reading field that is populated by trigger.
 
-    $m['ref_no'] = 'foo'; // exception
+    $m->set('ref_no', 'foo'); // exception
 
 Note that `read_only` can still have a default value::
 
@@ -269,7 +269,7 @@ Multi-column fields
 Lets talk more about this currency field::
 
     $m->add(new Field_Currency(), 'balance');
-    $m['balance'] = '12,200.00 EUR';
+    $m->set('balance', '12,200.00 EUR');
 
 It may be designed to split up the value by using two fields in the database:
 `balance_amount` and `balance_currency_id`.
@@ -501,15 +501,15 @@ Start by creating a beforeSave handler for Order::
 
             if (
                 $m->newInstance()
-                    ->addCondition('client_id', $m['client_id']) // same client
+                    ->addCondition('client_id', $m->get('client_id')) // same client
                     ->addCondition($m->id_field, '!=', $m->id)   // has another order
-                    ->tryLoadBy('ref', $m['ref'])                // with same ref
+                    ->tryLoadBy('ref', $m->get('ref'))                // with same ref
                     ->loaded()
             ) {
                 throw new Exception([
                     'Order with ref already exists for this client',
-                    'client' => $this['client_id'],
-                    'ref'    => $this['ref']
+                    'client' => $this->get('client_id'),
+                    'ref'    => $this->get('ref')
                 ]);
             }
         }
@@ -531,7 +531,7 @@ as archived and return that order back. Here is the usage pattern::
     $o->addCondition('is_archived', false); // to restrict loading of archived orders
     $o->load(123);
     $archive = $o->archive();
-    $archive['note'] .= "\nArchived on $date.";
+    $archive->set('note', $archive->get('note') . "\nArchived on $date.");
     $archive->save();
 
 With Agile Data API building it's quite common to create a method that does not
@@ -547,7 +547,7 @@ after-save reloading::
 
     function archive() {
         $this->reload_after_save = false;
-        $this['is_archived'] = true;
+        $this->set('is_archived', true);
         return $this;
     }
 
@@ -561,7 +561,7 @@ The other, more appropriate option is to re-use a vanilla Order record::
 
         $archive = $this->newInstance();
         $archive->load($this->id);
-        $archive['is_archived'] = true;
+        $archive->set('is_archived', true);
 
         $this->unload(); // active record is no longer accessible
 
@@ -603,7 +603,7 @@ The above example would then work like this::
         $this->save(); // just to be sure, no dirty stuff is left over
 
         $archive = $o->asModel('Order');
-        $archive['is_archived'] = true;
+        $archive->set('is_archived', true);
 
         $this->unload(); // active record is no longer accessible.
 
@@ -700,7 +700,7 @@ To use it with any model::
 
     $m = $app->loadQuick(new Order(), 123);
 
-    $m['completed'] = true;
+    $m->set('completed', true);
     $m->save();
 
 To look in more details into the actual method, I have broken it down into chunks::
@@ -756,7 +756,7 @@ done with a single record::
 
     $m = new Order($read_replica);
 
-    $m['completed'] = true;
+    $m->set('completed', true);
 
     $m->withPersistence($write_replica)->save();
     $m->dirty = [];

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -224,7 +224,7 @@ You can load / unload records like this::
 
     $m->get();     // inside console, this will show you what's inside your model
 
-    $m->set('email', 'test@example.com');
+    $m['email'] = 'test@example.com';
     $m->save();
 
 You can call `$m->loaded()` to see if there is active record and `$m->id` will
@@ -238,11 +238,11 @@ be saved inside DataSet::
 
     $m = new Model_User($db);
     $m->addCondition('country_id', 2);
-    $m->set('username', 'peter');
+    $m['username'] = 'peter';
     $m->save();
 
     $m->get(); // will show country_id as 2
-    $m->set('country_id', 3);
+    $m['country_id'] = 3;
     $m->save();  // will generate exception because model you try to save doesn't match conditions set
 
 
@@ -387,14 +387,14 @@ The `$dsn` can also be using the PEAR-style DSN format, such as:
 For some persistence classes, you should use constructor directly::
 
     $array = [];
-    $array->set(1, ['name'=>'John']);
-    $array->set(2, ['name'=>'Peter']);
+    $array[1] = ['name'=>'John'];
+    $array[2] = ['name'=>'Peter'];
 
     $db = new \atk4\data\Persistence\Array_($array);
     $m = new \atk4\data\Model($db);
     $m->addField('name');
     $m->load(2);
-    echo $m->get('name');  // Peter
+    echo $m['name'];  // Peter
 
 There are several Persistence classes that deal with different data sources.
 Lets load up our console and try out a different persistence::
@@ -402,8 +402,8 @@ Lets load up our console and try out a different persistence::
     $a=['user'=>[],'contact_info'=>[]];
     $ar = new \atk4\data\Persistence\Array_($a);
     $m = new Model_User($ar);
-    $m->set('username', 'test');
-    $m->set('address_1', 'street');
+    $m['username']='test';
+    $m['address_1']='street'
 
     $m->save();
 
@@ -610,9 +610,9 @@ Actions prove to be very useful in various situations. For instance, if you are
 looking to add a new user::
 
     $m = new Model_User($db);
-    $m->set('username', 'peter');
-    $m->set('address_1', 'street 49');
-    $m->set('country', 'UK');
+    $m['username'] = 'peter';
+    $m['address_1'] = 'street 49';
+    $m['country'] = 'UK';
     $m->save();
 
 Normally this would not work, because country is read-only expression, however
@@ -620,9 +620,9 @@ if you wish to avoid creating an intermediate select to determine ID for 'UK',
 you could do this::
 
     $m = new Model_User($db);
-    $m->set('username', 'peter');
-    $m->set('address_1', 'street 49');
-    $m->set('country_id', (new Model_Country($db))->addCondition('name','UK')->action('field',['id']));
+    $m['username'] = 'peter';
+    $m['address_1'] = 'street 49';
+    $m['country_id'] = (new Model_Country($db))->addCondition('name','UK')->action('field',['id']);
     $m->save();
 
 This way it will not execute any code, but instead it will provide expression

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -224,7 +224,7 @@ You can load / unload records like this::
 
     $m->get();     // inside console, this will show you what's inside your model
 
-    $m['email'] = 'test@example.com';
+    $m->set('email', 'test@example.com');
     $m->save();
 
 You can call `$m->loaded()` to see if there is active record and `$m->id` will
@@ -238,11 +238,11 @@ be saved inside DataSet::
 
     $m = new Model_User($db);
     $m->addCondition('country_id', 2);
-    $m['username'] = 'peter';
+    $m->set('username', 'peter');
     $m->save();
 
     $m->get(); // will show country_id as 2
-    $m['country_id'] = 3;
+    $m->set('country_id', 3);
     $m->save();  // will generate exception because model you try to save doesn't match conditions set
 
 
@@ -387,14 +387,14 @@ The `$dsn` can also be using the PEAR-style DSN format, such as:
 For some persistence classes, you should use constructor directly::
 
     $array = [];
-    $array[1] = ['name'=>'John'];
-    $array[2] = ['name'=>'Peter'];
+    $array->set(1, ['name'=>'John']);
+    $array->set(2, ['name'=>'Peter']);
 
     $db = new \atk4\data\Persistence\Array_($array);
     $m = new \atk4\data\Model($db);
     $m->addField('name');
     $m->load(2);
-    echo $m['name'];  // Peter
+    echo $m->get('name');  // Peter
 
 There are several Persistence classes that deal with different data sources.
 Lets load up our console and try out a different persistence::
@@ -402,8 +402,8 @@ Lets load up our console and try out a different persistence::
     $a=['user'=>[],'contact_info'=>[]];
     $ar = new \atk4\data\Persistence\Array_($a);
     $m = new Model_User($ar);
-    $m['username']='test';
-    $m['address_1']='street'
+    $m->set('username', 'test');
+    $m->set('address_1', 'street');
 
     $m->save();
 
@@ -610,9 +610,9 @@ Actions prove to be very useful in various situations. For instance, if you are
 looking to add a new user::
 
     $m = new Model_User($db);
-    $m['username'] = 'peter';
-    $m['address_1'] = 'street 49';
-    $m['country'] = 'UK';
+    $m->set('username', 'peter');
+    $m->set('address_1', 'street 49');
+    $m->set('country', 'UK');
     $m->save();
 
 Normally this would not work, because country is read-only expression, however
@@ -620,9 +620,9 @@ if you wish to avoid creating an intermediate select to determine ID for 'UK',
 you could do this::
 
     $m = new Model_User($db);
-    $m['username'] = 'peter';
-    $m['address_1'] = 'street 49';
-    $m['country_id'] = (new Model_Country($db))->addCondition('name','UK')->action('field',['id']);
+    $m->set('username', 'peter');
+    $m->set('address_1', 'street 49');
+    $m->set('country_id', (new Model_Country($db))->addCondition('name','UK')->action('field',['id']));
     $m->save();
 
 This way it will not execute any code, but instead it will provide expression

--- a/docs/references.rst
+++ b/docs/references.rst
@@ -89,7 +89,7 @@ If you are worried about performance you can keep 2 models in memory::
     $client = $order->refModel('client_id');
 
     foreach($order as $o) {
-        $client->load($o['client_id']);
+        $client->load($o->get('client_id'));
     }
 
 .. warning:: This code is seriously flawed and is called "N+1 Problem".
@@ -204,7 +204,7 @@ You can also specify a type yourself::
     ->addField('paid_amount', ['aggregate'=>'sum', 'field'=>'amount', 'type'=>'money']);
 
 Aggregate fields are always declared read-only, and if you try to
-change them (`$m['paid_amount'] = 123;`), you will receive exception.
+change them (`$m->set('paid_amount', 123);`), you will receive exception.
 
 Available Aggregation Functions
 -------------------------------
@@ -407,15 +407,15 @@ This would create 'currency' field containing name of the currency::
 
     $i->load(20);
 
-    echo "Currency for invoice 20 is ".$i['currency'];   // EUR
+    echo "Currency for invoice 20 is ".$i->get('currency');   // EUR
 
 Unlike addField() which creates fields read-only, title field can in fact be
 modified::
 
-    $i['currency'] = 'GBP';
+    $i->set('currency', 'GBP');
     $i->save();
 
-    // will update $i['currency_id'] to the corresponding ID for currency with name GBP.
+    // will update $i->get('currency_id') to the corresponding ID for currency with name GBP.
 
 This behavior is awesome when you are importing large amounts of data, because
 the lookup for the currency_id is entirely done in a database.
@@ -466,7 +466,7 @@ Reference Discovery
 You can call :php:meth:`Model::getRefs()` to fetch all the references of a model::
 
     $refs = $model->getRefs();
-    $ref = $refs['owner_id'];
+    $ref = $refs->get('owner_id');
 
 or if you know the reference you'd like to fetch, you can use :php:meth:`Model::getRef()`::
 
@@ -623,7 +623,7 @@ working with a new model::
 
     $m = new Model_User($db);
 
-    $m['name'] = 'John';
+    $m->set('name', 'John');
     $m->save();
 
 In this scenario, a new record will be added into 'user' with 'contact_id' equal
@@ -631,12 +631,12 @@ to null. The next example will traverse into the contact to set it up::
 
     $m = new Model_User($db);
 
-    $m['name'] = 'John';
+    $m->set('name', 'John');
     $m->ref('address_id')->save(['address'=>'street']);
     $m->save();
 
 When entity which you have referenced through ref() is saved, it will automatically
-populate $m['contact_id'] field and the final $m->save() will also store the reference.
+populate $m->get('contact_id') field and the final $m->save() will also store the reference.
 
 ID setting is implemented through a basic hook. Related model will have afterSave
 hook, which will update address_id field of the $m.

--- a/docs/references.rst
+++ b/docs/references.rst
@@ -89,7 +89,7 @@ If you are worried about performance you can keep 2 models in memory::
     $client = $order->refModel('client_id');
 
     foreach($order as $o) {
-        $client->load($o->get('client_id'));
+        $client->load($o['client_id']);
     }
 
 .. warning:: This code is seriously flawed and is called "N+1 Problem".
@@ -204,7 +204,7 @@ You can also specify a type yourself::
     ->addField('paid_amount', ['aggregate'=>'sum', 'field'=>'amount', 'type'=>'money']);
 
 Aggregate fields are always declared read-only, and if you try to
-change them (`$m->set('paid_amount', 123);`), you will receive exception.
+change them (`$m['paid_amount'] = 123;`), you will receive exception.
 
 Available Aggregation Functions
 -------------------------------
@@ -407,15 +407,15 @@ This would create 'currency' field containing name of the currency::
 
     $i->load(20);
 
-    echo "Currency for invoice 20 is ".$i->get('currency');   // EUR
+    echo "Currency for invoice 20 is ".$i['currency'];   // EUR
 
 Unlike addField() which creates fields read-only, title field can in fact be
 modified::
 
-    $i->set('currency', 'GBP');
+    $i['currency'] = 'GBP';
     $i->save();
 
-    // will update $i->get('currency_id') to the corresponding ID for currency with name GBP.
+    // will update $i['currency_id'] to the corresponding ID for currency with name GBP.
 
 This behavior is awesome when you are importing large amounts of data, because
 the lookup for the currency_id is entirely done in a database.
@@ -466,7 +466,7 @@ Reference Discovery
 You can call :php:meth:`Model::getRefs()` to fetch all the references of a model::
 
     $refs = $model->getRefs();
-    $ref = $refs->get('owner_id');
+    $ref = $refs['owner_id'];
 
 or if you know the reference you'd like to fetch, you can use :php:meth:`Model::getRef()`::
 
@@ -623,7 +623,7 @@ working with a new model::
 
     $m = new Model_User($db);
 
-    $m->set('name', 'John');
+    $m['name'] = 'John';
     $m->save();
 
 In this scenario, a new record will be added into 'user' with 'contact_id' equal
@@ -631,12 +631,12 @@ to null. The next example will traverse into the contact to set it up::
 
     $m = new Model_User($db);
 
-    $m->set('name', 'John');
+    $m['name'] = 'John';
     $m->ref('address_id')->save(['address'=>'street']);
     $m->save();
 
 When entity which you have referenced through ref() is saved, it will automatically
-populate $m->get('contact_id') field and the final $m->save() will also store the reference.
+populate $m['contact_id'] field and the final $m->save() will also store the reference.
 
 ID setting is implemented through a basic hook. Related model will have afterSave
 hook, which will update address_id field of the $m.

--- a/docs/references.rst
+++ b/docs/references.rst
@@ -89,7 +89,7 @@ If you are worried about performance you can keep 2 models in memory::
     $client = $order->refModel('client_id');
 
     foreach($order as $o) {
-        $client->load($o['client_id']);
+        $client->load($o->get('client_id'));
     }
 
 .. warning:: This code is seriously flawed and is called "N+1 Problem".
@@ -204,7 +204,7 @@ You can also specify a type yourself::
     ->addField('paid_amount', ['aggregate'=>'sum', 'field'=>'amount', 'type'=>'money']);
 
 Aggregate fields are always declared read-only, and if you try to
-change them (`$m['paid_amount'] = 123;`), you will receive exception.
+change them (`$m->set('paid_amount', 123);`), you will receive exception.
 
 Available Aggregation Functions
 -------------------------------
@@ -407,15 +407,15 @@ This would create 'currency' field containing name of the currency::
 
     $i->load(20);
 
-    echo "Currency for invoice 20 is ".$i['currency'];   // EUR
+    echo "Currency for invoice 20 is ".$i->get('currency');   // EUR
 
 Unlike addField() which creates fields read-only, title field can in fact be
 modified::
 
-    $i['currency'] = 'GBP';
+    $i->set('currency', 'GBP');
     $i->save();
 
-    // will update $i['currency_id'] to the corresponding ID for currency with name GBP.
+    // will update $i->get('currency_id') to the corresponding ID for currency with name GBP.
 
 This behavior is awesome when you are importing large amounts of data, because
 the lookup for the currency_id is entirely done in a database.
@@ -623,7 +623,7 @@ working with a new model::
 
     $m = new Model_User($db);
 
-    $m['name'] = 'John';
+    $m->set('name', 'John');
     $m->save();
 
 In this scenario, a new record will be added into 'user' with 'contact_id' equal
@@ -631,12 +631,12 @@ to null. The next example will traverse into the contact to set it up::
 
     $m = new Model_User($db);
 
-    $m['name'] = 'John';
+    $m->set('name', 'John');
     $m->ref('address_id')->save(['address'=>'street']);
     $m->save();
 
 When entity which you have referenced through ref() is saved, it will automatically
-populate $m['contact_id'] field and the final $m->save() will also store the reference.
+populate $m->get('contact_id') field and the final $m->save() will also store the reference.
 
 ID setting is implemented through a basic hook. Related model will have afterSave
 hook, which will update address_id field of the $m.

--- a/docs/results.rst
+++ b/docs/results.rst
@@ -20,7 +20,7 @@ Create your persistence object first then iterate it::
     $m = new Model_Client($db);
 
     foreach($m as $id => $item) {
-        echo $id.": ".$item['name']."\n";
+        echo $id.": ".$item->get('name')."\n";
     }
 
 You must be aware that $item will actually be same as $m and will point to the model.
@@ -50,7 +50,7 @@ will consume memory), you can do it like this::
     $cat = [];
 
     foreach(new Model_Category($db) as $id => $c) {
-        $cat[$id] = clone $c;
+        $cat->set($id, clone $c);
     }
 
 

--- a/docs/results.rst
+++ b/docs/results.rst
@@ -20,7 +20,7 @@ Create your persistence object first then iterate it::
     $m = new Model_Client($db);
 
     foreach($m as $id => $item) {
-        echo $id.": ".$item->get('name')."\n";
+        echo $id.": ".$item['name']."\n";
     }
 
 You must be aware that $item will actually be same as $m and will point to the model.
@@ -50,7 +50,7 @@ will consume memory), you can do it like this::
     $cat = [];
 
     foreach(new Model_Category($db) as $id => $c) {
-        $cat->set($id, clone $c);
+        $cat[$id] = clone $c;
     }
 
 

--- a/docs/results.rst
+++ b/docs/results.rst
@@ -20,7 +20,7 @@ Create your persistence object first then iterate it::
     $m = new Model_Client($db);
 
     foreach($m as $id => $item) {
-        echo $id.": ".$item['name']."\n";
+        echo $id.": ".$item->get('name')."\n";
     }
 
 You must be aware that $item will actually be same as $m and will point to the model.

--- a/docs/sql.rst
+++ b/docs/sql.rst
@@ -175,10 +175,10 @@ This method allows you to execute code within a 'START TRANSACTION / COMMIT' blo
 
             $this->persistence->atomic(function() use ($p) {
 
-                $this->set('paid', true);
+                $this['paid'] = true;
                 $this->save();
 
-                $p->set('applied', true);
+                $p['applied'] = true;
                 $p->save();
 
             });
@@ -268,7 +268,7 @@ You can also specify alias::
 
     $action = $model->action('count', ['alias'=>'cc']);
     $data = $action->getRow();
-    $cnt = $data->get('cc');
+    $cnt = $data['cc'];
 
 Action: field
 -------------

--- a/docs/sql.rst
+++ b/docs/sql.rst
@@ -175,10 +175,10 @@ This method allows you to execute code within a 'START TRANSACTION / COMMIT' blo
 
             $this->persistence->atomic(function() use ($p) {
 
-                $this['paid'] = true;
+                $this->set('paid', true);
                 $this->save();
 
-                $p['applied'] = true;
+                $p->set('applied', true);
                 $p->save();
 
             });
@@ -268,7 +268,7 @@ You can also specify alias::
 
     $action = $model->action('count', ['alias'=>'cc']);
     $data = $action->getRow();
-    $cnt = $data['cc'];
+    $cnt = $data->get('cc');
 
 Action: field
 -------------

--- a/docs/typecasting.rst
+++ b/docs/typecasting.rst
@@ -14,7 +14,7 @@ operation. Here is the sequence and sample::
     // instructs AD that we will be using it for staring dates
     // through 'DateTime' class.
 
-    $m->set('birthday', 'Jan 1 1960');
+    $m['birthday'] = 'Jan 1 1960';
     // If non-compatible value is provided, it will be converted
     // into a proper date through Normalization process. After
     // this line value of 'birthday' field will be DateTime.
@@ -53,8 +53,8 @@ Here is another example with booleans::
         'enum' => ['No', 'Yes']
     ]);
 
-    $m->set('is_married', 'Yes');  // normalizes into true
-    $m->set('is_married', true);   // better way because no need to normalize
+    $m['is_married'] = 'Yes';  // normalizes into true
+    $m['is_married'] = true;   // better way because no need to normalize
 
     $m->save();   // stores as "Yes" because of type-casting
 
@@ -63,8 +63,8 @@ Value types
 
 Any type can have a value of `null`::
 
-    $m->set('is_married', null);
-    if (!$m->get('is_married')) {
+    $m['is_married'] = null;
+    if (!$m['is_married']) {
         // either null or false
     }
 
@@ -74,11 +74,11 @@ to normalize value::
     $m->addField('age', ['type'=>'integer']);
     $m->addField('name', ['type'=>'string']);
 
-    $m->set('age', '49.80');
-    $m->set('name', '       John');
+    $m['age'] = '49.80';
+    $m['name'] = '       John';
 
-    echo $m->get('age'); // 49 - normalization cast value to integer
-    echo $m->get('name'); // 'John' - normalization trims value
+    echo $m['age']; // 49 - normalization cast value to integer
+    echo $m['name']; // 'John' - normalization trims value
 
 Undefined type
 --------------

--- a/docs/typecasting.rst
+++ b/docs/typecasting.rst
@@ -14,7 +14,7 @@ operation. Here is the sequence and sample::
     // instructs AD that we will be using it for staring dates
     // through 'DateTime' class.
 
-    $m['birthday'] = 'Jan 1 1960';
+    $m->set('birthday', 'Jan 1 1960');
     // If non-compatible value is provided, it will be converted
     // into a proper date through Normalization process. After
     // this line value of 'birthday' field will be DateTime.
@@ -53,8 +53,8 @@ Here is another example with booleans::
         'enum' => ['No', 'Yes']
     ]);
 
-    $m['is_married'] = 'Yes';  // normalizes into true
-    $m['is_married'] = true;   // better way because no need to normalize
+    $m->set('is_married', 'Yes');  // normalizes into true
+    $m->set('is_married', true);   // better way because no need to normalize
 
     $m->save();   // stores as "Yes" because of type-casting
 
@@ -63,8 +63,8 @@ Value types
 
 Any type can have a value of `null`::
 
-    $m['is_married'] = null;
-    if (!$m['is_married']) {
+    $m->set('is_married', null);
+    if (!$m->get('is_married')) {
         // either null or false
     }
 
@@ -74,11 +74,11 @@ to normalize value::
     $m->addField('age', ['type'=>'integer']);
     $m->addField('name', ['type'=>'string']);
 
-    $m['age'] = '49.80';
-    $m['name'] = '       John';
+    $m->set('age', '49.80');
+    $m->set('name', '       John');
 
-    echo $m['age']; // 49 - normalization cast value to integer
-    echo $m['name']; // 'John' - normalization trims value
+    echo $m->get('age'); // 49 - normalization cast value to integer
+    echo $m->get('name'); // 'John' - normalization trims value
 
 Undefined type
 --------------

--- a/docs/types.rst
+++ b/docs/types.rst
@@ -112,9 +112,9 @@ Additionally there is a support for
 All measurements are implemented with :php:class:`Units` and can be further extended::
 
     $model->addField('speed', ['Units', 'postfix'=>'/s', 'scale'=>['m'=>1, 'km'=>1000]]);
-    $model->set('speed', '30km/s');
+    $model['speed'] = '30km/s';
 
-    echo $model->get('speed'); // 30000
+    echo $model['speed']; // 30000
     echo $model->getField('speed')->format(); // 30km/s
     echo $model->getField('speed')->format('m'); // 30000m/s
 

--- a/docs/types.rst
+++ b/docs/types.rst
@@ -112,9 +112,9 @@ Additionally there is a support for
 All measurements are implemented with :php:class:`Units` and can be further extended::
 
     $model->addField('speed', ['Units', 'postfix'=>'/s', 'scale'=>['m'=>1, 'km'=>1000]]);
-    $model['speed'] = '30km/s';
+    $model->set('speed', '30km/s');
 
-    echo $model['speed']; // 30000
+    echo $model->get('speed'); // 30000
     echo $model->getField('speed')->format(); // 30km/s
     echo $model->getField('speed')->format('m'); // 30000m/s
 

--- a/src/Action/Iterator.php
+++ b/src/Action/Iterator.php
@@ -40,7 +40,7 @@ class Iterator
             }
 
             // has row and it matches
-            if ($row[$field] == $value) {
+            if ($row->get($field) == $value) {
                 return true;
             }
 
@@ -72,22 +72,22 @@ class Iterator
             switch ($value) {
                 // case "%str%"
                 case substr($value, -1, 1) === '%' && substr($value, 0, 1) === '%':
-                    return strpos($row[$field], $clean_value) !== false;
+                    return strpos($row->get($field), $clean_value) !== false;
 
                     break;
                 // case "str%"
                 case substr($value, -1, 1) === '%':
-                    return substr($row[$field], 0, strlen($clean_value)) === $clean_value;
+                    return substr($row->get($field), 0, strlen($clean_value)) === $clean_value;
 
                     break;
                 // case "%str"
                 case substr($value, 0, 1) === '%':
-                    return substr($row[$field], -strlen($clean_value)) === $clean_value;
+                    return substr($row->get($field), -strlen($clean_value)) === $clean_value;
 
                     break;
                 // full match
                 default:
-                    return $row[$field] == $clean_value;
+                    return $row->get($field) == $clean_value;
             }
 
             return false;

--- a/src/Action/Iterator.php
+++ b/src/Action/Iterator.php
@@ -40,7 +40,7 @@ class Iterator
             }
 
             // has row and it matches
-            if ($row->get($field) == $value) {
+            if ($row[$field] == $value) {
                 return true;
             }
 
@@ -72,22 +72,22 @@ class Iterator
             switch ($value) {
                 // case "%str%"
                 case substr($value, -1, 1) === '%' && substr($value, 0, 1) === '%':
-                    return strpos($row->get($field), $clean_value) !== false;
+                    return strpos($row[$field], $clean_value) !== false;
 
                     break;
                 // case "str%"
                 case substr($value, -1, 1) === '%':
-                    return substr($row->get($field), 0, strlen($clean_value)) === $clean_value;
+                    return substr($row[$field], 0, strlen($clean_value)) === $clean_value;
 
                     break;
                 // case "%str"
                 case substr($value, 0, 1) === '%':
-                    return substr($row->get($field), -strlen($clean_value)) === $clean_value;
+                    return substr($row[$field], -strlen($clean_value)) === $clean_value;
 
                     break;
                 // full match
                 default:
-                    return $row->get($field) == $clean_value;
+                    return $row[$field] == $clean_value;
             }
 
             return false;

--- a/src/Field.php
+++ b/src/Field.php
@@ -580,7 +580,7 @@ class Field implements Expressionable
             'type', 'system', 'never_persist', 'never_save', 'read_only', 'ui', 'join',
         ] as $key) {
             if (isset($this->{$key})) {
-                $arr->set($key, $this->{$key});
+                $arr[$key] = $this->{$key};
             }
         }
 

--- a/src/Field.php
+++ b/src/Field.php
@@ -580,7 +580,7 @@ class Field implements Expressionable
             'type', 'system', 'never_persist', 'never_save', 'read_only', 'ui', 'join',
         ] as $key) {
             if (isset($this->{$key})) {
-                $arr[$key] = $this->{$key};
+                $arr->set($key, $this->{$key});
             }
         }
 

--- a/src/Field/Email.php
+++ b/src/Field/Email.php
@@ -66,8 +66,8 @@ class Email extends Field
 
             // should actually run only domain trough idn_to_ascii(), but for validation purpose this way it's fine too
             $p = explode('@', $email);
-            $user = $p[0] ?? null;
-            $domain = $p[1] ?? null;
+            $user = $p->get(0) ?? null;
+            $domain = $p->get(1) ?? null;
             if (!filter_var($user . '@' . $this->idn_to_ascii($domain), FILTER_VALIDATE_EMAIL)) {
                 throw new ValidationException([$this->name => 'Email format is invalid']);
             }

--- a/src/Field/Email.php
+++ b/src/Field/Email.php
@@ -66,8 +66,8 @@ class Email extends Field
 
             // should actually run only domain trough idn_to_ascii(), but for validation purpose this way it's fine too
             $p = explode('@', $email);
-            $user = $p->get(0) ?? null;
-            $domain = $p->get(1) ?? null;
+            $user = $p[0] ?? null;
+            $domain = $p[1] ?? null;
             if (!filter_var($user . '@' . $this->idn_to_ascii($domain), FILTER_VALIDATE_EMAIL)) {
                 throw new ValidationException([$this->name => 'Email format is invalid']);
             }

--- a/src/Join/Array_.php
+++ b/src/Join/Array_.php
@@ -74,7 +74,7 @@ class Array_ extends Join
         }
 
         if ($model->hasField($this->master_field)
-            && $model[$this->master_field]
+            && $model->get($this->master_field)
         ) {
             // The value for the master_field is set,
             // we are going to use existing record.
@@ -91,7 +91,7 @@ class Array_ extends Join
             $this->foreign_table
         );
 
-        $data[$this->master_field] = $this->id;
+        $data->set($this->master_field, $this->id);
 
         //$this->owner->set($this->master_field, $this->id);
     }

--- a/src/Join/Array_.php
+++ b/src/Join/Array_.php
@@ -91,7 +91,7 @@ class Array_ extends Join
             $this->foreign_table
         );
 
-        $data->set($this->master_field, $this->id);
+        $data[$this->master_field] = $this->id;
 
         //$this->owner->set($this->master_field, $this->id);
     }

--- a/src/Join/SQL.php
+++ b/src/Join/SQL.php
@@ -189,7 +189,7 @@ class SQL extends Join implements \atk4\dsql\Expressionable
         }
 
         // The value for the master_field is set, so we are going to use existing record anyway
-        if ($model->hasField($this->master_field) && $model[$this->master_field]) {
+        if ($model->hasField($this->master_field) && $model->get($this->master_field)) {
             return;
         }
 
@@ -204,7 +204,7 @@ class SQL extends Join implements \atk4\dsql\Expressionable
         if ($this->join) {
             $this->join->set($this->master_field, $this->id);
         } else {
-            $data[$this->master_field] = $this->id;
+            $data->set($this->master_field, $this->id);
         }
     }
 
@@ -255,7 +255,7 @@ class SQL extends Join implements \atk4\dsql\Expressionable
         if ($this->reverse) {
             $update->where($this->foreign_field, $model->id);
         } else {
-            $update->where($this->foreign_field, $model[$this->master_field]);
+            $update->where($this->foreign_field, $model->get($this->master_field));
         }
 
         $update->update();

--- a/src/Join/SQL.php
+++ b/src/Join/SQL.php
@@ -204,7 +204,7 @@ class SQL extends Join implements \atk4\dsql\Expressionable
         if ($this->join) {
             $this->join->set($this->master_field, $this->id);
         } else {
-            $data->set($this->master_field, $this->id);
+            $data[$this->master_field] = $this->id;
         }
     }
 
@@ -277,7 +277,7 @@ class SQL extends Join implements \atk4\dsql\Expressionable
         if ($this->reverse) {
             $delete->where($this->foreign_field, $this->owner->id);
         } else {
-            $delete->where($this->foreign_field, $this->owner[$this->master_field]);
+            $delete->where($this->foreign_field, $this->owner->get($this->master_field));
         }
 
         $delete->delete()->execute();

--- a/src/Model.php
+++ b/src/Model.php
@@ -967,7 +967,7 @@ class Model implements \IteratorAggregate
         $field = $this->title_field && $this->hasField($this->title_field) ? $this->title_field : $this->id_field;
 
         return array_map(function ($row) use ($field) {
-            return $row->get($field);
+            return $row[$field];
         }, $this->export([$field], $this->id_field));
     }
 
@@ -1503,7 +1503,7 @@ class Model implements \IteratorAggregate
             $class = get_class($class);
         }
 
-        if (is_string($class) && $class->get(0) !== '\\') {
+        if (is_string($class) && $class[0] !== '\\') {
             $class = '\\' . $class;
         }
 
@@ -1818,7 +1818,7 @@ class Model implements \IteratorAggregate
                         // storing into a different table join
                         $field->join->set($name, $value);
                     } else {
-                        $data->set($name, $value);
+                        $data[$name] = $value;
                     }
                 }
 
@@ -1846,7 +1846,7 @@ class Model implements \IteratorAggregate
                         // storing into a different table join
                         $field->join->set($name, $value);
                     } else {
-                        $data->set($name, $value);
+                        $data[$name] = $value;
                     }
                 }
 
@@ -2077,7 +2077,7 @@ class Model implements \IteratorAggregate
         foreach ($this->rawIterator() as $data) {
             $this->data = $this->persistence->typecastLoadRow($this, $data);
             if ($this->id_field) {
-                $this->id = $data->get($this->id_field) ?? null;
+                $this->id = $data[$this->id_field] ?? null;
             }
 
             // you can return false in afterLoad hook to prevent to yield this data row

--- a/src/Model.php
+++ b/src/Model.php
@@ -943,7 +943,7 @@ class Model implements \IteratorAggregate
     }
 
     /**
-     * Return value of $model[$model->title_field]. If not set, returns id value.
+     * Return value of $model->get($model->title_field). If not set, returns id value.
      *
      * @return mixed
      */
@@ -967,13 +967,13 @@ class Model implements \IteratorAggregate
         $field = $this->title_field && $this->hasField($this->title_field) ? $this->title_field : $this->id_field;
 
         return array_map(function ($row) use ($field) {
-            return $row[$field];
+            return $row->get($field);
         }, $this->export([$field], $this->id_field));
     }
 
     /**
      * You can compare new value of the field with existing one without
-     * retrieving. In the trivial case it's same as ($value == $model[$name])
+     * retrieving. In the trivial case it's same as ($value == $model->get($name))
      * but this method can be used for:.
      *
      *  - comparing values that can't be received - passwords, encrypted data
@@ -1409,7 +1409,7 @@ class Model implements \IteratorAggregate
         $this->id = null;
 
         if ($this->id_field) {
-            $this[$this->id_field] = $new_id;
+            $this->set($this->id_field, $new_id);
         }
 
         return $this;
@@ -1476,7 +1476,7 @@ class Model implements \IteratorAggregate
         foreach ($this->data as $field => $value) {
             if ($value !== null && $value !== $this->getField($field)->default) {
                 // Copying only non-default value
-                $m[$field] = $value;
+                $m->set($field, $value);
             }
         }
 
@@ -1503,7 +1503,7 @@ class Model implements \IteratorAggregate
             $class = get_class($class);
         }
 
-        if (is_string($class) && $class[0] !== '\\') {
+        if (is_string($class) && $class->get(0) !== '\\') {
             $class = '\\' . $class;
         }
 
@@ -1556,10 +1556,10 @@ class Model implements \IteratorAggregate
         if ($this->id_field) {
             if ($id === true) {
                 $m->id = $this->id;
-                $m[$m->id_field] = $this[$this->id_field];
+                $m->set($m->id_field, $this->get($this->id_field));
             } elseif ($id) {
                 $m->id = null; // record shouldn't exist yet
-                $m[$m->id_field] = $id;
+                $m->set($m->id_field, $id);
             }
         }
 
@@ -1818,7 +1818,7 @@ class Model implements \IteratorAggregate
                         // storing into a different table join
                         $field->join->set($name, $value);
                     } else {
-                        $data[$name] = $value;
+                        $data->set($name, $value);
                     }
                 }
 
@@ -1846,7 +1846,7 @@ class Model implements \IteratorAggregate
                         // storing into a different table join
                         $field->join->set($name, $value);
                     } else {
-                        $data[$name] = $value;
+                        $data->set($name, $value);
                     }
                 }
 
@@ -2077,13 +2077,13 @@ class Model implements \IteratorAggregate
         foreach ($this->rawIterator() as $data) {
             $this->data = $this->persistence->typecastLoadRow($this, $data);
             if ($this->id_field) {
-                $this->id = $data[$this->id_field] ?? null;
+                $this->id = $data->get($this->id_field) ?? null;
             }
 
             // you can return false in afterLoad hook to prevent to yield this data row
             // use it like this:
             // $model->onHook('afterLoad', function ($m) {
-            //     if ($m['date'] < $m->date_from) $m->breakHook(false);
+            //     if ($m->get('date') < $m->date_from) $m->breakHook(false);
             // })
 
             // you can also use breakHook() with specific object which will then be returned

--- a/src/Model.php
+++ b/src/Model.php
@@ -20,7 +20,7 @@ use atk4\dsql\Query;
  *
  * @property Field[]|Reference[] $elements
  */
-class Model implements \ArrayAccess, \IteratorAggregate
+class Model implements \IteratorAggregate
 {
     use ContainerTrait {
         add as _add;
@@ -991,6 +991,14 @@ class Model implements \ArrayAccess, \IteratorAggregate
     }
 
     /**
+     * Does field exist?
+     */
+    public function _isset(string $name): bool
+    {
+        return array_key_exists($this->normalizeFieldName($name), $this->dirty);
+    }
+
+    /**
      * Remove current field value and use default.
      *
      * @param string|array $name
@@ -1006,55 +1014,6 @@ class Model implements \ArrayAccess, \IteratorAggregate
         }
 
         return $this;
-    }
-
-    // }}}
-
-    // {{{ ArrayAccess support
-
-    /**
-     * Do field exist?
-     *
-     * @param string $name
-     *
-     * @return bool
-     */
-    public function offsetExists($name)
-    {
-        return array_key_exists($this->normalizeFieldName($name), $this->dirty);
-    }
-
-    /**
-     * Returns field value.
-     *
-     * @param string $name
-     *
-     * @return mixed
-     */
-    public function offsetGet($name)
-    {
-        return $this->get($name);
-    }
-
-    /**
-     * Set field value.
-     *
-     * @param string $name
-     * @param mixed  $val
-     */
-    public function offsetSet($name, $val)
-    {
-        $this->set($name, $val);
-    }
-
-    /**
-     * Redo field value.
-     *
-     * @param string $name
-     */
-    public function offsetUnset($name)
-    {
-        $this->_unset($name);
     }
 
     // }}}

--- a/src/ModelArrayAccessTrait.php
+++ b/src/ModelArrayAccessTrait.php
@@ -7,7 +7,7 @@ namespace atk4\data;
  * class CustomModel extends \atk4\data\Model implements \ArrayAccess
  * {
  *     use \atk4\data\ModelArrayAccessTrait;
- * }
+ * }.
  */
 class ModelArrayAccessTrait
 {
@@ -20,7 +20,7 @@ class ModelArrayAccessTrait
      */
     public function offsetExists($name)
     {
-        return $this->_isset($name);;
+        return $this->_isset($name);
     }
 
     /**

--- a/src/ModelArrayAccessTrait.php
+++ b/src/ModelArrayAccessTrait.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace atk4\data;
+
+/**
+ * Trait to add array like support to Model, example usage:
+ * class CustomModel extends \atk4\data\Model implements \ArrayAccess
+ * {
+ *     use \atk4\data\ModelArrayAccessTrait;
+ * }
+ */
+class ModelArrayAccessTrait
+{
+    /**
+     * Does field exist?
+     *
+     * @param string $name
+     *
+     * @return bool
+     */
+    public function offsetExists($name)
+    {
+        return $this->_isset($name);;
+    }
+
+    /**
+     * Returns field value.
+     *
+     * @param string $name
+     *
+     * @return mixed
+     */
+    public function offsetGet($name)
+    {
+        return $this->get($name);
+    }
+
+    /**
+     * Set field value.
+     *
+     * @param string $name
+     * @param mixed  $val
+     */
+    public function offsetSet($name, $val)
+    {
+        $this->set($name, $val);
+    }
+
+    /**
+     * Redo field value.
+     *
+     * @param string $name
+     */
+    public function offsetUnset($name)
+    {
+        $this->_unset($name);
+    }
+}

--- a/src/Reference.php
+++ b/src/Reference.php
@@ -240,7 +240,7 @@ class Reference
         foreach ($this->__debug_fields as $k => $v) {
             $k = is_numeric($k) ? $v : $k;
             if (isset($this->{$v})) {
-                $arr->set($k, $this->{$v});
+                $arr[$k] = $this->{$v};
             }
         }
 

--- a/src/Reference.php
+++ b/src/Reference.php
@@ -240,7 +240,7 @@ class Reference
         foreach ($this->__debug_fields as $k => $v) {
             $k = is_numeric($k) ? $v : $k;
             if (isset($this->{$v})) {
-                $arr[$k] = $this->{$v};
+                $arr->set($k, $this->{$v});
             }
         }
 

--- a/src/Reference/ContainsMany.php
+++ b/src/Reference/ContainsMany.php
@@ -36,7 +36,7 @@ class ContainsMany extends ContainsOne
         $rows = $m->get($this->our_field) ?: [];
         /*
         foreach ($rows as $id=>$row) {
-            $rows->set($id, $this->owner->persistence->typecastLoadRow($m, $row)); // we need this typecasting because we set persistence data directly
+            $rows[$id] = $this->owner->persistence->typecastLoadRow($m, $row); // we need this typecasting because we set persistence data directly
         }
         */
 

--- a/src/Reference/ContainsMany.php
+++ b/src/Reference/ContainsMany.php
@@ -33,10 +33,10 @@ class ContainsMany extends ContainsOne
         */
 
         // set data source of referenced array persistence
-        $rows = $m[$this->our_field] ?: [];
+        $rows = $m->get($this->our_field) ?: [];
         /*
         foreach ($rows as $id=>$row) {
-            $rows[$id] = $this->owner->persistence->typecastLoadRow($m, $row); // we need this typecasting because we set persistence data directly
+            $rows->set($id, $this->owner->persistence->typecastLoadRow($m, $row)); // we need this typecasting because we set persistence data directly
         }
         */
 

--- a/src/Reference/ContainsOne.php
+++ b/src/Reference/ContainsOne.php
@@ -90,7 +90,7 @@ class ContainsOne extends Reference
         */
 
         // set data source of referenced array persistence
-        $row = $m[$this->our_field] ?: [];
+        $row = $m->get($this->our_field) ?: [];
         //$row = $m->persistence->typecastLoadRow($m, $row); // we need this typecasting because we set persistence data directly
 
         $data = [$this->table_alias => $row ? [1 => $row] : []];

--- a/src/Reference/HasMany.php
+++ b/src/Reference/HasMany.php
@@ -21,7 +21,7 @@ class HasMany extends Reference
     {
         if ($this->owner->loaded()) {
             return $this->our_field
-                ? $this->owner[$this->our_field]
+                ? $this->owner->get($this->our_field)
                 : $this->owner->id;
         }
 

--- a/src/Reference/HasOne.php
+++ b/src/Reference/HasOne.php
@@ -217,25 +217,25 @@ class HasOne extends Reference
 
         // add hook to set our_field = null when record of referenced model is deleted
         $m->onHook('afterDelete', function ($m) {
-            $this->owner[$this->our_field] = null;
+            $this->owner->set($this->our_field, null);
         });
 
         // if owner model is loaded, then try to load referenced model
         if ($this->their_field) {
-            if ($this->owner[$this->our_field]) {
-                $m->tryLoadBy($this->their_field, $this->owner[$this->our_field]);
+            if ($this->owner->get($this->our_field)) {
+                $m->tryLoadBy($this->their_field, $this->owner->get($this->our_field));
             }
 
             $m->onHook('afterSave', function ($m) {
-                $this->owner[$this->our_field] = $m->get($this->their_field);
+                $this->owner->set($this->our_field, $m->get($this->their_field));
             });
         } else {
-            if ($this->owner[$this->our_field]) {
-                $m->tryLoad($this->owner[$this->our_field]);
+            if ($this->owner->get($this->our_field)) {
+                $m->tryLoad($this->owner->get($this->our_field));
             }
 
             $m->onHook('afterSave', function ($m) {
-                $this->owner[$this->our_field] = $m->id;
+                $this->owner->set($this->our_field, $m->id);
             });
         }
 

--- a/src/Reference/HasOne.php
+++ b/src/Reference/HasOne.php
@@ -227,7 +227,7 @@ class HasOne extends Reference
             }
 
             $m->onHook('afterSave', function ($m) {
-                $this->owner[$this->our_field] = $m[$this->their_field];
+                $this->owner[$this->our_field] = $m->get($this->their_field);
             });
         } else {
             if ($this->owner[$this->our_field]) {

--- a/src/Reference/HasOne_SQL.php
+++ b/src/Reference/HasOne_SQL.php
@@ -67,9 +67,9 @@ class HasOne_SQL extends HasOne
             if ($m->isDirty($field) && !$m->isDirty($this->our_field)) {
                 $mm = $this->getModel();
 
-                $mm->addCondition($their_field, $m[$field]);
-                $m[$this->our_field] = $mm->action('field', [$mm->id_field]);
-                unset($m[$field]);
+                $mm->addCondition($their_field, $m->get($field));
+                $m->set($this->our_field, $mm->action('field', [$mm->id_field]));
+                $m->_unset($field);
             }
         }, [], 21);
 
@@ -242,8 +242,8 @@ class HasOne_SQL extends HasOne
             if ($m->isDirty($field) && !$m->isDirty($this->our_field)) {
                 $mm = $this->getModel();
 
-                $mm->addCondition($mm->title_field, $m[$field]);
-                $m[$this->our_field] = $mm->action('field', [$mm->id_field]);
+                $mm->addCondition($mm->title_field, $m->get($field));
+                $m->set($this->our_field, $mm->action('field', [$mm->id_field]));
             }
         }, [], 20);
 

--- a/src/Reference/HasOne_SQL.php
+++ b/src/Reference/HasOne_SQL.php
@@ -173,7 +173,7 @@ class HasOne_SQL extends HasOne
         if ($this->owner->loaded() && !$m->loaded()) {
             if ($this->owner->id_field === $this->our_field) {
                 $condition_field = $this->their_field ?: $m->id_field;
-                $condition_value = $this->owner[$this->our_field ?: $this->owner->id_field];
+                $condition_value = $this->owner->get($this->our_field ?: $this->owner->id_field);
                 $m->addCondition($condition_field, $condition_value);
             }
         }

--- a/src/Util/DeepCopy.php
+++ b/src/Util/DeepCopy.php
@@ -200,7 +200,7 @@ class DeepCopy
                 // exclude not needed field values
                 // see self::excluding()
                 foreach ($this->extractKeys($exclusions) as $key => $val) {
-                    $data->_unset($key);
+                    unset($data[$key]);
                 }
 
                 // do data transformation from source to destination
@@ -213,7 +213,7 @@ class DeepCopy
                 // foreach($destination->unique fields) { try load by
 
                 // if we still have id field, then remove it
-                $data->_unset($source->id_field);
+                unset($data[$source->id_field]);
 
                 // Copy fields as they are
                 foreach ($data as $key => $val) {

--- a/src/Util/DeepCopy.php
+++ b/src/Util/DeepCopy.php
@@ -200,7 +200,7 @@ class DeepCopy
                 // exclude not needed field values
                 // see self::excluding()
                 foreach ($this->extractKeys($exclusions) as $key => $val) {
-                    unset($data[$key]);
+                    $data->_unset($key);
                 }
 
                 // do data transformation from source to destination
@@ -213,7 +213,7 @@ class DeepCopy
                 // foreach($destination->unique fields) { try load by
 
                 // if we still have id field, then remove it
-                unset($data[$source->id_field]);
+                $data->_unset($source->id_field);
 
                 // Copy fields as they are
                 foreach ($data as $key => $val) {
@@ -239,30 +239,30 @@ class DeepCopy
 
                     if (
                         isset($this->mapping[$source_table]) &&
-                        array_key_exists($source[$ref_key], $this->mapping[$source_table])
+                        array_key_exists($source->get($ref_key), $this->mapping[$source_table])
                     ) {
                         // no need to deep copy, simply alter ID
-                        $destination[$ref_key] = $this->mapping[$source_table][$source[$ref_key]];
-                        $this->debug(' already copied ' . $source[$ref_key] . ' as ' . $destination[$ref_key]);
+                        $destination->set($ref_key, $this->mapping[$source_table][$source->get($ref_key)]);
+                        $this->debug(' already copied ' . $source->get($ref_key) . ' as ' . $destination->get($ref_key));
                     } else {
                         // hasOne points to null!
-                        $this->debug('Value is ' . $source[$ref_key]);
-                        if (!$source[$ref_key]) {
-                            $destination[$ref_key] = $source[$ref_key];
+                        $this->debug('Value is ' . $source->get($ref_key));
+                        if (!$source->get($ref_key)) {
+                            $destination->set($ref_key, $source->get($ref_key));
 
                             continue;
                         }
 
                         // pointing to non-existent record. Would need to copy
                         try {
-                            $destination[$ref_key] = $this->_copy(
+                            $destination->set($ref_key, $this->_copy(
                                 $source->ref($ref_key),
                                 $destination->refModel($ref_key),
                                 $ref_val,
                                 $exclusions[$ref_key] ?? [],
                                 $transforms[$ref_key] ?? []
-                            )->id;
-                            $this->debug(' ... mapped into ' . $destination[$ref_key]);
+                            )->id);
+                            $this->debug(' ... mapped into ' . $destination->get($ref_key));
                         } catch (DeepCopyException $e) {
                             $this->debug('escalating a problem from ' . $ref_key);
 

--- a/tests/BusinessModelTest.php
+++ b/tests/BusinessModelTest.php
@@ -36,7 +36,7 @@ class BusinessModelTest extends AtkPhpunit\TestCase
         $m->addField('name');
         $m->addField('surname');
 
-        $m['name'] = 5;
+        $m->set('name', 5);
         $this->assertSame(5, $m->get('name'));
 
         $m->set('surname', 'Bilbo');
@@ -59,26 +59,26 @@ class BusinessModelTest extends AtkPhpunit\TestCase
     {
         $m = new Model(['strict_field_check' => false]);
         $m->set(['name' => 5]);
-        $m['name'] = null;
+        $m->set('name', null);
         $this->assertSame(['name' => null], $m->data);
     }
 
     public function testFieldAccess2()
     {
         $m = new Model(['strict_field_check' => false]);
-        $this->assertFalse(isset($m['name']));
+        $this->assertFalse($m->_isset('name'));
         $m->set(['name' => 5]);
-        $this->assertTrue(isset($m['name']));
-        $this->assertSame(5, $m['name']);
+        $this->assertTrue($m->_isset('name'));
+        $this->assertSame(5, $m->get('name'));
 
-        $m['name'] = null;
-        $this->assertFalse(isset($m['name']));
+        $m->set('name', null);
+        $this->assertFalse($m->_isset('name'));
 
         $m = new Model();
         $n = $m->addField('name');
         $m->set($n, 5);
         $m->set($n, 5);
-        $this->assertSame(5, $m['name']);
+        $this->assertSame(5, $m->get('name'));
     }
 
     public function testGet()
@@ -107,50 +107,50 @@ class BusinessModelTest extends AtkPhpunit\TestCase
         $m = new Model();
         $m->addField('name');
         $m->data = ['name' => 5];
-        $m['name'] = 5;
+        $m->set('name', 5);
         $this->assertSame([], $m->dirty);
 
-        $m['name'] = 10;
+        $m->set('name', 10);
         $this->assertSame(['name' => 5], $m->dirty);
 
-        $m['name'] = 15;
+        $m->set('name', 15);
         $this->assertSame(['name' => 5], $m->dirty);
 
-        $m['name'] = 5;
+        $m->set('name', 5);
         $this->assertSame([], $m->dirty);
 
-        $m['name'] = '5';
+        $m->set('name', '5');
         $this->assertSame(5, $m->dirty['name']);
 
-        $m['name'] = '6';
+        $m->set('name', '6');
         $this->assertSame(5, $m->dirty['name']);
-        $m['name'] = '5';
+        $m->set('name', '5');
         $this->assertSame(5, $m->dirty['name']);
 
-        $m['name'] = '5.0';
+        $m->set('name', '5.0');
         $this->assertSame(5, $m->dirty['name']);
 
         $m->dirty = [];
         $m->data = ['name' => ''];
-        $m['name'] = '';
+        $m->set('name', '');
         $this->assertSame([], $m->dirty);
 
         $m->data = ['name' => '5'];
-        $m['name'] = 5;
+        $m->set('name', 5);
         $this->assertSame('5', $m->dirty['name']);
-        $m['name'] = 6;
+        $m->set('name', 6);
         $this->assertSame('5', $m->dirty['name']);
-        $m['name'] = 5;
+        $m->set('name', 5);
         $this->assertSame('5', $m->dirty['name']);
-        $m['name'] = '5';
+        $m->set('name', '5');
         $this->assertSame([], $m->dirty);
 
         $m->data = ['name' => 4.28];
-        $m['name'] = '4.28';
+        $m->set('name', '4.28');
         $this->assertSame(4.28, $m->dirty['name']);
-        $m['name'] = '5.28';
+        $m->set('name', '5.28');
         $this->assertSame(4.28, $m->dirty['name']);
-        $m['name'] = 4.28;
+        $m->set('name', 4.28);
         $this->assertSame([], $m->dirty);
 
         // now with defaults
@@ -160,20 +160,20 @@ class BusinessModelTest extends AtkPhpunit\TestCase
 
         $this->assertSame('John', $m->get('name'));
 
-        $m['name'] = null;
+        $m->set('name', null);
         $this->assertSame(['name' => 'John'], $m->dirty);
         $this->assertSame(['name' => null], $m->data);
-        $this->assertNull($m['name']);
+        $this->assertNull($m->get('name'));
 
-        unset($m['name']);
+        $m->_unset('name');
         $this->assertSame('John', $m->get('name'));
     }
 
     /*
      * This is no longer the case after PR #69
      *
-     * Now changing $m['id'] will actually update the value
-     * of original records. In a way $m['id'] is not a direct
+     * Now changing $m->get('id') will actually update the value
+     * of original records. In a way $m->get('id') is not a direct
      * alias to ID, but has a deeper meaning and behaves more
      * like a regular field.
      *
@@ -185,7 +185,7 @@ class BusinessModelTest extends AtkPhpunit\TestCase
 
         $this->assertNotNull($m->getField('id'));
 
-        $m['id'] = 20;
+        $m->set('id', 20);
         $this->assertEquals(20, $m->id);
     }
      */
@@ -200,7 +200,7 @@ class BusinessModelTest extends AtkPhpunit\TestCase
         $m->addField('surname');
         $m->onlyFields(['surname']);
 
-        $m['name'] = 5;
+        $m->set('name', 5);
     }
 
     public function testException1fixed()
@@ -212,7 +212,7 @@ class BusinessModelTest extends AtkPhpunit\TestCase
 
         $m->allFields();
 
-        $m['name'] = 5;
+        $m->set('name', 5);
     }
 
     /**
@@ -223,13 +223,13 @@ class BusinessModelTest extends AtkPhpunit\TestCase
         $m = new Model();
         $m->addField('name');
         $m->set('foo');
-        $this->assertSame($m['name'], 'foo');
+        $this->assertSame($m->get('name'), 'foo');
 
         $m->set(['bar']);
-        $this->assertSame($m['name'], 'bar');
+        $this->assertSame($m->get('name'), 'bar');
 
         $m->set(['name' => 'baz']);
-        $this->assertSame($m['name'], 'baz');
+        $this->assertSame($m->get('name'), 'baz');
     }
 
     /**
@@ -300,7 +300,7 @@ class BusinessModelTest extends AtkPhpunit\TestCase
     {
         $p = new Persistence();
         $c = new Client($p);
-        $this->assertEquals(10, $c['order']);
+        $this->assertEquals(10, $c->get('order'));
     }
 
     public function testNormalize()
@@ -310,14 +310,14 @@ class BusinessModelTest extends AtkPhpunit\TestCase
         $m->addField('age', ['type' => 'int']);
         $m->addField('data');
 
-        $m['name'] = '';
-        $this->assertSame('', $m['name']);
+        $m->set('name', '');
+        $this->assertSame('', $m->get('name'));
 
-        $m['age'] = '';
-        $this->assertNull($m['age']);
+        $m->set('age', '');
+        $this->assertNull($m->get('age'));
 
-        $m['data'] = '';
-        $this->assertSame('', $m['data']);
+        $m->set('data', '');
+        $this->assertSame('', $m->get('data'));
     }
 
     public function testExampleFromDoc()
@@ -325,24 +325,20 @@ class BusinessModelTest extends AtkPhpunit\TestCase
         $m = new User();
 
         $m->addField('salary', ['default' => 1000]);
-
-        $this->assertFalse(isset($m['salary']));   // false
-        $this->assertSame(1000, $m['salary']);           // 1000
+        $this->assertSame(1000, $m->get('salary'));
+        $this->assertFalse($m->_isset('salary'));
 
         // Next we load record from $db
         $m->data = ['salary' => 2000];
+        $this->assertSame(2000, $m->get('salary'));
+        $this->assertFalse($m->_isset('salary'));
 
-        $this->assertSame(2000, $m['salary']);           // 2000 (from db)
-        $this->assertFalse(isset($m['salary']));   // false, was not changed
+        $m->set('salary', 3000);
+        $this->assertSame(3000, $m->get('salary'));
+        $this->assertTrue($m->_isset('salary'));
 
-        $m['salary'] = 3000;
-
-        $this->assertSame(3000, $m['salary']);          // 3000 (changed)
-        $this->assertTrue(isset($m['salary']));   // true
-
-        unset($m['salary']);        // return to original value
-
-        $this->assertSame(2000, $m['salary']);          // 2000
-        $this->assertFalse(isset($m['salary']));  // false
+        $m->_unset('salary');
+        $this->assertSame(2000, $m->get('salary'));
+        $this->assertFalse($m->_isset('salary'));
     }
 }

--- a/tests/BusinessModelTest.php
+++ b/tests/BusinessModelTest.php
@@ -36,7 +36,7 @@ class BusinessModelTest extends AtkPhpunit\TestCase
         $m->addField('name');
         $m->addField('surname');
 
-        $m->set('name', 5);
+        $m['name'] = 5;
         $this->assertSame(5, $m->get('name'));
 
         $m->set('surname', 'Bilbo');
@@ -59,26 +59,26 @@ class BusinessModelTest extends AtkPhpunit\TestCase
     {
         $m = new Model(['strict_field_check' => false]);
         $m->set(['name' => 5]);
-        $m->set('name', null);
+        $m['name'] = null;
         $this->assertSame(['name' => null], $m->data);
     }
 
     public function testFieldAccess2()
     {
         $m = new Model(['strict_field_check' => false]);
-        $this->assertFalse($m->_isset('name'));
+        $this->assertFalse(isset($m['name']));
         $m->set(['name' => 5]);
-        $this->assertTrue($m->_isset('name'));
-        $this->assertSame(5, $m->get('name'));
+        $this->assertTrue(isset($m['name']));
+        $this->assertSame(5, $m['name']);
 
-        $m->set('name', null);
-        $this->assertFalse($m->_isset('name'));
+        $m['name'] = null;
+        $this->assertFalse(isset($m['name']));
 
         $m = new Model();
         $n = $m->addField('name');
         $m->set($n, 5);
         $m->set($n, 5);
-        $this->assertSame(5, $m->get('name'));
+        $this->assertSame(5, $m['name']);
     }
 
     public function testGet()
@@ -107,50 +107,50 @@ class BusinessModelTest extends AtkPhpunit\TestCase
         $m = new Model();
         $m->addField('name');
         $m->data = ['name' => 5];
-        $m->set('name', 5);
+        $m['name'] = 5;
         $this->assertSame([], $m->dirty);
 
-        $m->set('name', 10);
+        $m['name'] = 10;
         $this->assertSame(['name' => 5], $m->dirty);
 
-        $m->set('name', 15);
+        $m['name'] = 15;
         $this->assertSame(['name' => 5], $m->dirty);
 
-        $m->set('name', 5);
+        $m['name'] = 5;
         $this->assertSame([], $m->dirty);
 
-        $m->set('name', '5');
+        $m['name'] = '5';
         $this->assertSame(5, $m->dirty['name']);
 
-        $m->set('name', '6');
+        $m['name'] = '6';
         $this->assertSame(5, $m->dirty['name']);
-        $m->set('name', '5');
+        $m['name'] = '5';
         $this->assertSame(5, $m->dirty['name']);
 
-        $m->set('name', '5.0');
+        $m['name'] = '5.0';
         $this->assertSame(5, $m->dirty['name']);
 
         $m->dirty = [];
         $m->data = ['name' => ''];
-        $m->set('name', '');
+        $m['name'] = '';
         $this->assertSame([], $m->dirty);
 
         $m->data = ['name' => '5'];
-        $m->set('name', 5);
+        $m['name'] = 5;
         $this->assertSame('5', $m->dirty['name']);
-        $m->set('name', 6);
+        $m['name'] = 6;
         $this->assertSame('5', $m->dirty['name']);
-        $m->set('name', 5);
+        $m['name'] = 5;
         $this->assertSame('5', $m->dirty['name']);
-        $m->set('name', '5');
+        $m['name'] = '5';
         $this->assertSame([], $m->dirty);
 
         $m->data = ['name' => 4.28];
-        $m->set('name', '4.28');
+        $m['name'] = '4.28';
         $this->assertSame(4.28, $m->dirty['name']);
-        $m->set('name', '5.28');
+        $m['name'] = '5.28';
         $this->assertSame(4.28, $m->dirty['name']);
-        $m->set('name', 4.28);
+        $m['name'] = 4.28;
         $this->assertSame([], $m->dirty);
 
         // now with defaults
@@ -160,20 +160,20 @@ class BusinessModelTest extends AtkPhpunit\TestCase
 
         $this->assertSame('John', $m->get('name'));
 
-        $m->set('name', null);
+        $m['name'] = null;
         $this->assertSame(['name' => 'John'], $m->dirty);
         $this->assertSame(['name' => null], $m->data);
-        $this->assertNull($m->get('name'));
+        $this->assertNull($m['name']);
 
-        $m->_unset('name');
+        unset($m['name']);
         $this->assertSame('John', $m->get('name'));
     }
 
     /*
      * This is no longer the case after PR #69
      *
-     * Now changing $m->get('id') will actually update the value
-     * of original records. In a way $m->get('id') is not a direct
+     * Now changing $m['id'] will actually update the value
+     * of original records. In a way $m['id'] is not a direct
      * alias to ID, but has a deeper meaning and behaves more
      * like a regular field.
      *
@@ -185,7 +185,7 @@ class BusinessModelTest extends AtkPhpunit\TestCase
 
         $this->assertNotNull($m->getField('id'));
 
-        $m->set('id', 20);
+        $m['id'] = 20;
         $this->assertEquals(20, $m->id);
     }
      */
@@ -200,7 +200,7 @@ class BusinessModelTest extends AtkPhpunit\TestCase
         $m->addField('surname');
         $m->onlyFields(['surname']);
 
-        $m->set('name', 5);
+        $m['name'] = 5;
     }
 
     public function testException1fixed()
@@ -212,7 +212,7 @@ class BusinessModelTest extends AtkPhpunit\TestCase
 
         $m->allFields();
 
-        $m->set('name', 5);
+        $m['name'] = 5;
     }
 
     /**
@@ -223,13 +223,13 @@ class BusinessModelTest extends AtkPhpunit\TestCase
         $m = new Model();
         $m->addField('name');
         $m->set('foo');
-        $this->assertSame($m->get('name'), 'foo');
+        $this->assertSame($m['name'], 'foo');
 
         $m->set(['bar']);
-        $this->assertSame($m->get('name'), 'bar');
+        $this->assertSame($m['name'], 'bar');
 
         $m->set(['name' => 'baz']);
-        $this->assertSame($m->get('name'), 'baz');
+        $this->assertSame($m['name'], 'baz');
     }
 
     /**
@@ -300,7 +300,7 @@ class BusinessModelTest extends AtkPhpunit\TestCase
     {
         $p = new Persistence();
         $c = new Client($p);
-        $this->assertEquals(10, $c->get('order'));
+        $this->assertEquals(10, $c['order']);
     }
 
     public function testNormalize()
@@ -310,14 +310,14 @@ class BusinessModelTest extends AtkPhpunit\TestCase
         $m->addField('age', ['type' => 'int']);
         $m->addField('data');
 
-        $m->set('name', '');
-        $this->assertSame('', $m->get('name'));
+        $m['name'] = '';
+        $this->assertSame('', $m['name']);
 
-        $m->set('age', '');
-        $this->assertNull($m->get('age'));
+        $m['age'] = '';
+        $this->assertNull($m['age']);
 
-        $m->set('data', '');
-        $this->assertSame('', $m->get('data'));
+        $m['data'] = '';
+        $this->assertSame('', $m['data']);
     }
 
     public function testExampleFromDoc()
@@ -326,23 +326,23 @@ class BusinessModelTest extends AtkPhpunit\TestCase
 
         $m->addField('salary', ['default' => 1000]);
 
-        $this->assertSame(1000, $m->get('salary'));           // 1000
-        $this->assertFalse($m->_isset('salary'));
+        $this->assertFalse(isset($m['salary']));   // false
+        $this->assertSame(1000, $m['salary']);           // 1000
 
         // Next we load record from $db
         $m->data = ['salary' => 2000];
 
-        $this->assertSame(2000, $m->get('salary'));           // 2000 (from db)
-        $this->assertFalse($m->_isset('salary'));          // was not changed
+        $this->assertSame(2000, $m['salary']);           // 2000 (from db)
+        $this->assertFalse(isset($m['salary']));   // false, was not changed
 
-        $m->set('salary', 3000);
+        $m['salary'] = 3000;
 
-        $this->assertSame(3000, $m->get('salary'));          // 3000 (changed)
-        $this->assertTrue($m->_isset('salary'));
+        $this->assertSame(3000, $m['salary']);          // 3000 (changed)
+        $this->assertTrue(isset($m['salary']));   // true
 
-        $m->_unset('salary');        // return to original value
+        unset($m['salary']);        // return to original value
 
-        $this->assertSame(2000, $m->get('salary'));          // 2000
-        $this->assertFalse($m->_isset('salary'));
+        $this->assertSame(2000, $m['salary']);          // 2000
+        $this->assertFalse(isset($m['salary']));  // false
     }
 }

--- a/tests/BusinessModelTest.php
+++ b/tests/BusinessModelTest.php
@@ -36,7 +36,7 @@ class BusinessModelTest extends AtkPhpunit\TestCase
         $m->addField('name');
         $m->addField('surname');
 
-        $m['name'] = 5;
+        $m->set('name', 5);
         $this->assertSame(5, $m->get('name'));
 
         $m->set('surname', 'Bilbo');
@@ -59,26 +59,26 @@ class BusinessModelTest extends AtkPhpunit\TestCase
     {
         $m = new Model(['strict_field_check' => false]);
         $m->set(['name' => 5]);
-        $m['name'] = null;
+        $m->set('name', null);
         $this->assertSame(['name' => null], $m->data);
     }
 
     public function testFieldAccess2()
     {
         $m = new Model(['strict_field_check' => false]);
-        $this->assertFalse(isset($m['name']));
+        $this->assertFalse($m->_isset('name'));
         $m->set(['name' => 5]);
-        $this->assertTrue(isset($m['name']));
-        $this->assertSame(5, $m['name']);
+        $this->assertTrue($m->_isset('name'));
+        $this->assertSame(5, $m->get('name'));
 
-        $m['name'] = null;
-        $this->assertFalse(isset($m['name']));
+        $m->set('name', null);
+        $this->assertFalse($m->_isset('name'));
 
         $m = new Model();
         $n = $m->addField('name');
         $m->set($n, 5);
         $m->set($n, 5);
-        $this->assertSame(5, $m['name']);
+        $this->assertSame(5, $m->get('name'));
     }
 
     public function testGet()
@@ -107,50 +107,50 @@ class BusinessModelTest extends AtkPhpunit\TestCase
         $m = new Model();
         $m->addField('name');
         $m->data = ['name' => 5];
-        $m['name'] = 5;
+        $m->set('name', 5);
         $this->assertSame([], $m->dirty);
 
-        $m['name'] = 10;
+        $m->set('name', 10);
         $this->assertSame(['name' => 5], $m->dirty);
 
-        $m['name'] = 15;
+        $m->set('name', 15);
         $this->assertSame(['name' => 5], $m->dirty);
 
-        $m['name'] = 5;
+        $m->set('name', 5);
         $this->assertSame([], $m->dirty);
 
-        $m['name'] = '5';
+        $m->set('name', '5');
         $this->assertSame(5, $m->dirty['name']);
 
-        $m['name'] = '6';
+        $m->set('name', '6');
         $this->assertSame(5, $m->dirty['name']);
-        $m['name'] = '5';
+        $m->set('name', '5');
         $this->assertSame(5, $m->dirty['name']);
 
-        $m['name'] = '5.0';
+        $m->set('name', '5.0');
         $this->assertSame(5, $m->dirty['name']);
 
         $m->dirty = [];
         $m->data = ['name' => ''];
-        $m['name'] = '';
+        $m->set('name', '');
         $this->assertSame([], $m->dirty);
 
         $m->data = ['name' => '5'];
-        $m['name'] = 5;
+        $m->set('name', 5);
         $this->assertSame('5', $m->dirty['name']);
-        $m['name'] = 6;
+        $m->set('name', 6);
         $this->assertSame('5', $m->dirty['name']);
-        $m['name'] = 5;
+        $m->set('name', 5);
         $this->assertSame('5', $m->dirty['name']);
-        $m['name'] = '5';
+        $m->set('name', '5');
         $this->assertSame([], $m->dirty);
 
         $m->data = ['name' => 4.28];
-        $m['name'] = '4.28';
+        $m->set('name', '4.28');
         $this->assertSame(4.28, $m->dirty['name']);
-        $m['name'] = '5.28';
+        $m->set('name', '5.28');
         $this->assertSame(4.28, $m->dirty['name']);
-        $m['name'] = 4.28;
+        $m->set('name', 4.28);
         $this->assertSame([], $m->dirty);
 
         // now with defaults
@@ -160,20 +160,20 @@ class BusinessModelTest extends AtkPhpunit\TestCase
 
         $this->assertSame('John', $m->get('name'));
 
-        $m['name'] = null;
+        $m->set('name', null);
         $this->assertSame(['name' => 'John'], $m->dirty);
         $this->assertSame(['name' => null], $m->data);
-        $this->assertNull($m['name']);
+        $this->assertNull($m->get('name'));
 
-        unset($m['name']);
+        $m->_unset('name');
         $this->assertSame('John', $m->get('name'));
     }
 
     /*
      * This is no longer the case after PR #69
      *
-     * Now changing $m['id'] will actually update the value
-     * of original records. In a way $m['id'] is not a direct
+     * Now changing $m->get('id') will actually update the value
+     * of original records. In a way $m->get('id') is not a direct
      * alias to ID, but has a deeper meaning and behaves more
      * like a regular field.
      *
@@ -185,7 +185,7 @@ class BusinessModelTest extends AtkPhpunit\TestCase
 
         $this->assertNotNull($m->getField('id'));
 
-        $m['id'] = 20;
+        $m->set('id', 20);
         $this->assertEquals(20, $m->id);
     }
      */
@@ -200,7 +200,7 @@ class BusinessModelTest extends AtkPhpunit\TestCase
         $m->addField('surname');
         $m->onlyFields(['surname']);
 
-        $m['name'] = 5;
+        $m->set('name', 5);
     }
 
     public function testException1fixed()
@@ -212,7 +212,7 @@ class BusinessModelTest extends AtkPhpunit\TestCase
 
         $m->allFields();
 
-        $m['name'] = 5;
+        $m->set('name', 5);
     }
 
     /**
@@ -223,13 +223,13 @@ class BusinessModelTest extends AtkPhpunit\TestCase
         $m = new Model();
         $m->addField('name');
         $m->set('foo');
-        $this->assertSame($m['name'], 'foo');
+        $this->assertSame($m->get('name'), 'foo');
 
         $m->set(['bar']);
-        $this->assertSame($m['name'], 'bar');
+        $this->assertSame($m->get('name'), 'bar');
 
         $m->set(['name' => 'baz']);
-        $this->assertSame($m['name'], 'baz');
+        $this->assertSame($m->get('name'), 'baz');
     }
 
     /**
@@ -300,7 +300,7 @@ class BusinessModelTest extends AtkPhpunit\TestCase
     {
         $p = new Persistence();
         $c = new Client($p);
-        $this->assertEquals(10, $c['order']);
+        $this->assertEquals(10, $c->get('order'));
     }
 
     public function testNormalize()
@@ -310,14 +310,14 @@ class BusinessModelTest extends AtkPhpunit\TestCase
         $m->addField('age', ['type' => 'int']);
         $m->addField('data');
 
-        $m['name'] = '';
-        $this->assertSame('', $m['name']);
+        $m->set('name', '');
+        $this->assertSame('', $m->get('name'));
 
-        $m['age'] = '';
-        $this->assertNull($m['age']);
+        $m->set('age', '');
+        $this->assertNull($m->get('age'));
 
-        $m['data'] = '';
-        $this->assertSame('', $m['data']);
+        $m->set('data', '');
+        $this->assertSame('', $m->get('data'));
     }
 
     public function testExampleFromDoc()
@@ -326,23 +326,23 @@ class BusinessModelTest extends AtkPhpunit\TestCase
 
         $m->addField('salary', ['default' => 1000]);
 
-        $this->assertFalse(isset($m['salary']));   // false
-        $this->assertSame(1000, $m['salary']);           // 1000
+        $this->assertSame(1000, $m->get('salary'));           // 1000
+        $this->assertFalse($m->_isset('salary'));
 
         // Next we load record from $db
         $m->data = ['salary' => 2000];
 
-        $this->assertSame(2000, $m['salary']);           // 2000 (from db)
-        $this->assertFalse(isset($m['salary']));   // false, was not changed
+        $this->assertSame(2000, $m->get('salary'));           // 2000 (from db)
+        $this->assertFalse($m->_isset('salary'));          // was not changed
 
-        $m['salary'] = 3000;
+        $m->set('salary', 3000);
 
-        $this->assertSame(3000, $m['salary']);          // 3000 (changed)
-        $this->assertTrue(isset($m['salary']));   // true
+        $this->assertSame(3000, $m->get('salary'));          // 3000 (changed)
+        $this->assertTrue($m->_isset('salary'));
 
-        unset($m['salary']);        // return to original value
+        $m->_unset('salary');        // return to original value
 
-        $this->assertSame(2000, $m['salary']);          // 2000
-        $this->assertFalse(isset($m['salary']));  // false
+        $this->assertSame(2000, $m->get('salary'));          // 2000
+        $this->assertFalse($m->_isset('salary'));
     }
 }

--- a/tests/CSVTest.php
+++ b/tests/CSVTest.php
@@ -94,8 +94,8 @@ class CSVTest extends AtkPhpunit\TestCase
         $m->addField('surname');
         $m->loadAny();
 
-        $this->assertSame('John', $m->get('name'));
-        $this->assertSame('Smith', $m->get('surname'));
+        $this->assertSame('John', $m['name']);
+        $this->assertSame('Smith', $m['surname']);
     }
 
     public function testLoadAnyException()
@@ -114,8 +114,8 @@ class CSVTest extends AtkPhpunit\TestCase
         $m->loadAny();
         $m->loadAny();
 
-        $this->assertSame('Sarah', $m->get('name'));
-        $this->assertSame('Jones', $m->get('surname'));
+        $this->assertSame('Sarah', $m['name']);
+        $this->assertSame('Jones', $m['surname']);
 
         $m->tryLoadAny();
         $this->assertFalse($m->loaded());

--- a/tests/CSVTest.php
+++ b/tests/CSVTest.php
@@ -94,8 +94,8 @@ class CSVTest extends AtkPhpunit\TestCase
         $m->addField('surname');
         $m->loadAny();
 
-        $this->assertSame('John', $m['name']);
-        $this->assertSame('Smith', $m['surname']);
+        $this->assertSame('John', $m->get('name'));
+        $this->assertSame('Smith', $m->get('surname'));
     }
 
     public function testLoadAnyException()
@@ -114,8 +114,8 @@ class CSVTest extends AtkPhpunit\TestCase
         $m->loadAny();
         $m->loadAny();
 
-        $this->assertSame('Sarah', $m['name']);
-        $this->assertSame('Jones', $m['surname']);
+        $this->assertSame('Sarah', $m->get('name'));
+        $this->assertSame('Jones', $m->get('surname'));
 
         $m->tryLoadAny();
         $this->assertFalse($m->loaded());

--- a/tests/ConditionSQLTest.php
+++ b/tests/ConditionSQLTest.php
@@ -22,16 +22,16 @@ class ConditionSQLTest extends \atk4\schema\PhpunitTestCase
         $m->addFields(['name', 'gender']);
 
         $m->tryLoad(1);
-        $this->assertSame('John', $m['name']);
+        $this->assertSame('John', $m->get('name'));
         $m->tryLoad(2);
-        $this->assertSame('Sue', $m['name']);
+        $this->assertSame('Sue', $m->get('name'));
 
         $mm = clone $m;
         $mm->addCondition('gender', 'M');
         $mm->tryLoad(1);
-        $this->assertSame('John', $mm['name']);
+        $this->assertSame('John', $mm->get('name'));
         $mm->tryLoad(2);
-        $this->assertNull($mm['name']);
+        $this->assertNull($mm->get('name'));
 
         if ($this->driverType === 'sqlite') {
             $this->assertSame(
@@ -43,9 +43,9 @@ class ConditionSQLTest extends \atk4\schema\PhpunitTestCase
         $mm = clone $m;
         $mm->withID(2); // = addCondition(id, 2)
         $mm->tryLoad(1);
-        $this->assertNull($mm['name']);
+        $this->assertNull($mm->get('name'));
         $mm->tryLoad(2);
-        $this->assertSame('Sue', $mm['name']);
+        $this->assertSame('Sue', $mm->get('name'));
     }
 
     public function testNull()
@@ -66,8 +66,8 @@ class ConditionSQLTest extends \atk4\schema\PhpunitTestCase
 
         $nullCount = 0;
         foreach ($m as $user) {
-            $this->assertNull($user['gender']);
-            $this->assertContains('Null', $user['name']);
+            $this->assertNull($user->get('gender'));
+            $this->assertContains('Null', $user->get('name'));
 
             ++$nullCount;
         }
@@ -88,37 +88,37 @@ class ConditionSQLTest extends \atk4\schema\PhpunitTestCase
         $m->addFields(['name', 'gender']);
 
         $m->tryLoad(1);
-        $this->assertSame('John', $m['name']);
+        $this->assertSame('John', $m->get('name'));
         $m->tryLoad(2);
-        $this->assertSame('Sue', $m['name']);
+        $this->assertSame('Sue', $m->get('name'));
 
         $mm = clone $m;
         $mm->addCondition('gender', 'M');
         $mm->tryLoad(1);
-        $this->assertSame('John', $mm['name']);
+        $this->assertSame('John', $mm->get('name'));
         $mm->tryLoad(2);
-        $this->assertNull($mm['name']);
+        $this->assertNull($mm->get('name'));
 
         $mm = clone $m;
         $mm->addCondition('gender', '!=', 'M');
         $mm->tryLoad(1);
-        $this->assertNull($mm['name']);
+        $this->assertNull($mm->get('name'));
         $mm->tryLoad(2);
-        $this->assertSame('Sue', $mm['name']);
+        $this->assertSame('Sue', $mm->get('name'));
 
         $mm = clone $m;
         $mm->addCondition('id', '>', 1);
         $mm->tryLoad(1);
-        $this->assertNull($mm['name']);
+        $this->assertNull($mm->get('name'));
         $mm->tryLoad(2);
-        $this->assertSame('Sue', $mm['name']);
+        $this->assertSame('Sue', $mm->get('name'));
 
         $mm = clone $m;
         $mm->addCondition('id', 'in', [1, 3]);
         $mm->tryLoad(1);
-        $this->assertSame('John', $mm['name']);
+        $this->assertSame('John', $mm->get('name'));
         $mm->tryLoad(2);
-        $this->assertNull($mm['name']);
+        $this->assertNull($mm->get('name'));
     }
 
     public function testExpressions1()
@@ -134,23 +134,23 @@ class ConditionSQLTest extends \atk4\schema\PhpunitTestCase
         $m->addFields(['name', 'gender']);
 
         $m->tryLoad(1);
-        $this->assertSame('John', $m['name']);
+        $this->assertSame('John', $m->get('name'));
         $m->tryLoad(2);
-        $this->assertSame('Sue', $m['name']);
+        $this->assertSame('Sue', $m->get('name'));
 
         $mm = clone $m;
         $mm->addCondition($mm->expr('[] > 1', [$mm->getField('id')]));
         $mm->tryLoad(1);
-        $this->assertNull($mm['name']);
+        $this->assertNull($mm->get('name'));
         $mm->tryLoad(2);
-        $this->assertSame('Sue', $mm['name']);
+        $this->assertSame('Sue', $mm->get('name'));
 
         $mm = clone $m;
         $mm->addCondition($mm->expr('[id] > 1'));
         $mm->tryLoad(1);
-        $this->assertNull($mm['name']);
+        $this->assertNull($mm->get('name'));
         $mm->tryLoad(2);
-        $this->assertSame('Sue', $mm['name']);
+        $this->assertSame('Sue', $mm->get('name'));
     }
 
     public function testExpressions2()
@@ -166,37 +166,37 @@ class ConditionSQLTest extends \atk4\schema\PhpunitTestCase
         $m->addFields(['name', 'gender', 'surname']);
 
         $m->tryLoad(1);
-        $this->assertSame('John', $m['name']);
+        $this->assertSame('John', $m->get('name'));
         $m->tryLoad(2);
-        $this->assertSame('Sue', $m['name']);
+        $this->assertSame('Sue', $m->get('name'));
 
         $mm = clone $m;
         $mm->addCondition($mm->expr('[name] = [surname]'));
         $mm->tryLoad(1);
-        $this->assertNull($mm['name']);
+        $this->assertNull($mm->get('name'));
         $mm->tryLoad(2);
-        $this->assertSame('Sue', $mm['name']);
+        $this->assertSame('Sue', $mm->get('name'));
 
         $mm = clone $m;
         $mm->addCondition($m->getField('name'), $m->getField('surname'));
         $mm->tryLoad(1);
-        $this->assertNull($mm['name']);
+        $this->assertNull($mm->get('name'));
         $mm->tryLoad(2);
-        $this->assertSame('Sue', $mm['name']);
+        $this->assertSame('Sue', $mm->get('name'));
 
         $mm = clone $m;
         $mm->addCondition($mm->expr('[name] != [surname]'));
         $mm->tryLoad(1);
-        $this->assertSame('John', $mm['name']);
+        $this->assertSame('John', $mm->get('name'));
         $mm->tryLoad(2);
-        $this->assertNull($mm['name']);
+        $this->assertNull($mm->get('name'));
 
         $mm = clone $m;
         $mm->addCondition($m->getField('name'), '!=', $m->getField('surname'));
         $mm->tryLoad(1);
-        $this->assertSame('John', $mm['name']);
+        $this->assertSame('John', $mm->get('name'));
         $mm->tryLoad(2);
-        $this->assertNull($mm['name']);
+        $this->assertNull($mm->get('name'));
     }
 
     public function testExpressionJoin()
@@ -222,36 +222,36 @@ class ConditionSQLTest extends \atk4\schema\PhpunitTestCase
         $m->join('contact')->addField('contact_phone');
 
         $m->tryLoad(1);
-        $this->assertSame('John', $m['name']);
-        $this->assertSame('+123 smiths', $m['contact_phone']);
+        $this->assertSame('John', $m->get('name'));
+        $this->assertSame('+123 smiths', $m->get('contact_phone'));
         $m->tryLoad(2);
-        $this->assertSame('Sue', $m['name']);
-        $this->assertSame('+321 sues', $m['contact_phone']);
+        $this->assertSame('Sue', $m->get('name'));
+        $this->assertSame('+321 sues', $m->get('contact_phone'));
         $m->tryLoad(3);
-        $this->assertSame('Peter', $m['name']);
-        $this->assertSame('+123 smiths', $m['contact_phone']);
+        $this->assertSame('Peter', $m->get('name'));
+        $this->assertSame('+123 smiths', $m->get('contact_phone'));
 
         $mm = clone $m;
         $mm->addCondition($mm->expr('[name] = [surname]'));
         $mm->tryLoad(1);
         $this->assertFalse($mm->loaded());
         $mm->tryLoad(2);
-        $this->assertSame('Sue', $mm['name']);
-        $this->assertSame('+321 sues', $mm['contact_phone']);
+        $this->assertSame('Sue', $mm->get('name'));
+        $this->assertSame('+321 sues', $mm->get('contact_phone'));
         $mm->tryLoad(3);
         $this->assertFalse($mm->loaded());
 
         $mm = clone $m;
         $mm->addCondition($mm->expr('"+123 smiths" = [contact_phone]'));
         $mm->tryLoad(1);
-        $this->assertSame('John', $mm['name']);
-        $this->assertSame('+123 smiths', $mm['contact_phone']);
+        $this->assertSame('John', $mm->get('name'));
+        $this->assertSame('+123 smiths', $mm->get('contact_phone'));
         $mm->tryLoad(2);
-        $this->assertNull($mm['name']);
-        $this->assertNull($mm['contact_phone']);
+        $this->assertNull($mm->get('name'));
+        $this->assertNull($mm->get('contact_phone'));
         $mm->tryLoad(3);
-        $this->assertSame('Peter', $mm['name']);
-        $this->assertSame('+123 smiths', $mm['contact_phone']);
+        $this->assertSame('Peter', $mm->get('name'));
+        $this->assertSame('+123 smiths', $mm->get('contact_phone'));
     }
 
     public function testArrayCondition()
@@ -299,7 +299,7 @@ class ConditionSQLTest extends \atk4\schema\PhpunitTestCase
         $m->addField('date', ['type' => 'date']);
 
         $m->tryLoadBy('date', new \DateTime('08-12-1982'));
-        $this->assertSame('Sue', $m['name']);
+        $this->assertSame('Sue', $m->get('name'));
     }
 
     public function testDateCondition2()
@@ -317,11 +317,11 @@ class ConditionSQLTest extends \atk4\schema\PhpunitTestCase
 
         $m->addCondition('date', new \DateTime('08-12-1982'));
         $m->loadAny();
-        $this->assertSame('Sue', $m['name']);
+        $this->assertSame('Sue', $m->get('name'));
 
         $m->addCondition([['date', new \DateTime('08-12-1982')]]);
         $m->loadAny();
-        $this->assertSame('Sue', $m['name']);
+        $this->assertSame('Sue', $m->get('name'));
     }
 
     /**

--- a/tests/ConditionSQLTest.php
+++ b/tests/ConditionSQLTest.php
@@ -22,16 +22,16 @@ class ConditionSQLTest extends \atk4\schema\PhpunitTestCase
         $m->addFields(['name', 'gender']);
 
         $m->tryLoad(1);
-        $this->assertSame('John', $m->get('name'));
+        $this->assertSame('John', $m['name']);
         $m->tryLoad(2);
-        $this->assertSame('Sue', $m->get('name'));
+        $this->assertSame('Sue', $m['name']);
 
         $mm = clone $m;
         $mm->addCondition('gender', 'M');
         $mm->tryLoad(1);
-        $this->assertSame('John', $mm->get('name'));
+        $this->assertSame('John', $mm['name']);
         $mm->tryLoad(2);
-        $this->assertNull($mm->get('name'));
+        $this->assertNull($mm['name']);
 
         if ($this->driverType === 'sqlite') {
             $this->assertSame(
@@ -43,9 +43,9 @@ class ConditionSQLTest extends \atk4\schema\PhpunitTestCase
         $mm = clone $m;
         $mm->withID(2); // = addCondition(id, 2)
         $mm->tryLoad(1);
-        $this->assertNull($mm->get('name'));
+        $this->assertNull($mm['name']);
         $mm->tryLoad(2);
-        $this->assertSame('Sue', $mm->get('name'));
+        $this->assertSame('Sue', $mm['name']);
     }
 
     public function testNull()
@@ -66,8 +66,8 @@ class ConditionSQLTest extends \atk4\schema\PhpunitTestCase
 
         $nullCount = 0;
         foreach ($m as $user) {
-            $this->assertNull($user->get('gender'));
-            $this->assertContains('Null', $user->get('name'));
+            $this->assertNull($user['gender']);
+            $this->assertContains('Null', $user['name']);
 
             ++$nullCount;
         }
@@ -88,37 +88,37 @@ class ConditionSQLTest extends \atk4\schema\PhpunitTestCase
         $m->addFields(['name', 'gender']);
 
         $m->tryLoad(1);
-        $this->assertSame('John', $m->get('name'));
+        $this->assertSame('John', $m['name']);
         $m->tryLoad(2);
-        $this->assertSame('Sue', $m->get('name'));
+        $this->assertSame('Sue', $m['name']);
 
         $mm = clone $m;
         $mm->addCondition('gender', 'M');
         $mm->tryLoad(1);
-        $this->assertSame('John', $mm->get('name'));
+        $this->assertSame('John', $mm['name']);
         $mm->tryLoad(2);
-        $this->assertNull($mm->get('name'));
+        $this->assertNull($mm['name']);
 
         $mm = clone $m;
         $mm->addCondition('gender', '!=', 'M');
         $mm->tryLoad(1);
-        $this->assertNull($mm->get('name'));
+        $this->assertNull($mm['name']);
         $mm->tryLoad(2);
-        $this->assertSame('Sue', $mm->get('name'));
+        $this->assertSame('Sue', $mm['name']);
 
         $mm = clone $m;
         $mm->addCondition('id', '>', 1);
         $mm->tryLoad(1);
-        $this->assertNull($mm->get('name'));
+        $this->assertNull($mm['name']);
         $mm->tryLoad(2);
-        $this->assertSame('Sue', $mm->get('name'));
+        $this->assertSame('Sue', $mm['name']);
 
         $mm = clone $m;
         $mm->addCondition('id', 'in', [1, 3]);
         $mm->tryLoad(1);
-        $this->assertSame('John', $mm->get('name'));
+        $this->assertSame('John', $mm['name']);
         $mm->tryLoad(2);
-        $this->assertNull($mm->get('name'));
+        $this->assertNull($mm['name']);
     }
 
     public function testExpressions1()
@@ -134,23 +134,23 @@ class ConditionSQLTest extends \atk4\schema\PhpunitTestCase
         $m->addFields(['name', 'gender']);
 
         $m->tryLoad(1);
-        $this->assertSame('John', $m->get('name'));
+        $this->assertSame('John', $m['name']);
         $m->tryLoad(2);
-        $this->assertSame('Sue', $m->get('name'));
+        $this->assertSame('Sue', $m['name']);
 
         $mm = clone $m;
         $mm->addCondition($mm->expr('[] > 1', [$mm->getField('id')]));
         $mm->tryLoad(1);
-        $this->assertNull($mm->get('name'));
+        $this->assertNull($mm['name']);
         $mm->tryLoad(2);
-        $this->assertSame('Sue', $mm->get('name'));
+        $this->assertSame('Sue', $mm['name']);
 
         $mm = clone $m;
         $mm->addCondition($mm->expr('[id] > 1'));
         $mm->tryLoad(1);
-        $this->assertNull($mm->get('name'));
+        $this->assertNull($mm['name']);
         $mm->tryLoad(2);
-        $this->assertSame('Sue', $mm->get('name'));
+        $this->assertSame('Sue', $mm['name']);
     }
 
     public function testExpressions2()
@@ -166,37 +166,37 @@ class ConditionSQLTest extends \atk4\schema\PhpunitTestCase
         $m->addFields(['name', 'gender', 'surname']);
 
         $m->tryLoad(1);
-        $this->assertSame('John', $m->get('name'));
+        $this->assertSame('John', $m['name']);
         $m->tryLoad(2);
-        $this->assertSame('Sue', $m->get('name'));
+        $this->assertSame('Sue', $m['name']);
 
         $mm = clone $m;
         $mm->addCondition($mm->expr('[name] = [surname]'));
         $mm->tryLoad(1);
-        $this->assertNull($mm->get('name'));
+        $this->assertNull($mm['name']);
         $mm->tryLoad(2);
-        $this->assertSame('Sue', $mm->get('name'));
+        $this->assertSame('Sue', $mm['name']);
 
         $mm = clone $m;
         $mm->addCondition($m->getField('name'), $m->getField('surname'));
         $mm->tryLoad(1);
-        $this->assertNull($mm->get('name'));
+        $this->assertNull($mm['name']);
         $mm->tryLoad(2);
-        $this->assertSame('Sue', $mm->get('name'));
+        $this->assertSame('Sue', $mm['name']);
 
         $mm = clone $m;
         $mm->addCondition($mm->expr('[name] != [surname]'));
         $mm->tryLoad(1);
-        $this->assertSame('John', $mm->get('name'));
+        $this->assertSame('John', $mm['name']);
         $mm->tryLoad(2);
-        $this->assertNull($mm->get('name'));
+        $this->assertNull($mm['name']);
 
         $mm = clone $m;
         $mm->addCondition($m->getField('name'), '!=', $m->getField('surname'));
         $mm->tryLoad(1);
-        $this->assertSame('John', $mm->get('name'));
+        $this->assertSame('John', $mm['name']);
         $mm->tryLoad(2);
-        $this->assertNull($mm->get('name'));
+        $this->assertNull($mm['name']);
     }
 
     public function testExpressionJoin()
@@ -222,36 +222,36 @@ class ConditionSQLTest extends \atk4\schema\PhpunitTestCase
         $m->join('contact')->addField('contact_phone');
 
         $m->tryLoad(1);
-        $this->assertSame('John', $m->get('name'));
-        $this->assertSame('+123 smiths', $m->get('contact_phone'));
+        $this->assertSame('John', $m['name']);
+        $this->assertSame('+123 smiths', $m['contact_phone']);
         $m->tryLoad(2);
-        $this->assertSame('Sue', $m->get('name'));
-        $this->assertSame('+321 sues', $m->get('contact_phone'));
+        $this->assertSame('Sue', $m['name']);
+        $this->assertSame('+321 sues', $m['contact_phone']);
         $m->tryLoad(3);
-        $this->assertSame('Peter', $m->get('name'));
-        $this->assertSame('+123 smiths', $m->get('contact_phone'));
+        $this->assertSame('Peter', $m['name']);
+        $this->assertSame('+123 smiths', $m['contact_phone']);
 
         $mm = clone $m;
         $mm->addCondition($mm->expr('[name] = [surname]'));
         $mm->tryLoad(1);
         $this->assertFalse($mm->loaded());
         $mm->tryLoad(2);
-        $this->assertSame('Sue', $mm->get('name'));
-        $this->assertSame('+321 sues', $mm->get('contact_phone'));
+        $this->assertSame('Sue', $mm['name']);
+        $this->assertSame('+321 sues', $mm['contact_phone']);
         $mm->tryLoad(3);
         $this->assertFalse($mm->loaded());
 
         $mm = clone $m;
         $mm->addCondition($mm->expr('"+123 smiths" = [contact_phone]'));
         $mm->tryLoad(1);
-        $this->assertSame('John', $mm->get('name'));
-        $this->assertSame('+123 smiths', $mm->get('contact_phone'));
+        $this->assertSame('John', $mm['name']);
+        $this->assertSame('+123 smiths', $mm['contact_phone']);
         $mm->tryLoad(2);
-        $this->assertNull($mm->get('name'));
-        $this->assertNull($mm->get('contact_phone'));
+        $this->assertNull($mm['name']);
+        $this->assertNull($mm['contact_phone']);
         $mm->tryLoad(3);
-        $this->assertSame('Peter', $mm->get('name'));
-        $this->assertSame('+123 smiths', $mm->get('contact_phone'));
+        $this->assertSame('Peter', $mm['name']);
+        $this->assertSame('+123 smiths', $mm['contact_phone']);
     }
 
     public function testArrayCondition()
@@ -299,7 +299,7 @@ class ConditionSQLTest extends \atk4\schema\PhpunitTestCase
         $m->addField('date', ['type' => 'date']);
 
         $m->tryLoadBy('date', new \DateTime('08-12-1982'));
-        $this->assertSame('Sue', $m->get('name'));
+        $this->assertSame('Sue', $m['name']);
     }
 
     public function testDateCondition2()
@@ -317,11 +317,11 @@ class ConditionSQLTest extends \atk4\schema\PhpunitTestCase
 
         $m->addCondition('date', new \DateTime('08-12-1982'));
         $m->loadAny();
-        $this->assertSame('Sue', $m->get('name'));
+        $this->assertSame('Sue', $m['name']);
 
         $m->addCondition([['date', new \DateTime('08-12-1982')]]);
         $m->loadAny();
-        $this->assertSame('Sue', $m->get('name'));
+        $this->assertSame('Sue', $m['name']);
     }
 
     /**

--- a/tests/ContainsManyTest.php
+++ b/tests/ContainsManyTest.php
@@ -35,7 +35,7 @@ class Invoice2 extends Model
         $this->addCalculatedField('total_gross', function ($m) {
             $total = 0;
             foreach ($m->ref('lines') as $line) {
-                $total += $line['total_gross'];
+                $total += $line->get('total_gross');
             }
 
             return $total;
@@ -45,7 +45,7 @@ class Invoice2 extends Model
         $this->addCalculatedField('discounts_total_sum', function ($m) {
             $total = 0;
             foreach ($m->ref('lines') as $line) {
-                $total += $line['total_gross'] * $line['discounts_percent'] / 100;
+                $total += $line->get('total_gross') * $line->get('discounts_percent') / 100;
             }
 
             return $total;
@@ -69,7 +69,7 @@ class Line2 extends Model
         $this->addField('add_date', ['type' => 'datetime']);
 
         $this->addExpression('total_gross', function ($m) {
-            return $m['price'] * $m['qty'] * (1 + $m->ref('vat_rate_id')['rate'] / 100);
+            return $m->get('price') * $m->get('qty') * (1 + $m->ref('vat_rate_id')['rate'] / 100);
         });
 
         // each line can have multiple discounts and calculate total of these discounts
@@ -78,7 +78,7 @@ class Line2 extends Model
         $this->addCalculatedField('discounts_percent', function ($m) {
             $total = 0;
             foreach ($m->ref('discounts') as $d) {
-                $total += $d['percent'];
+                $total += $d->get('percent');
             }
 
             return $total;
@@ -199,15 +199,15 @@ class ContainsManyTest extends \atk4\schema\PhpunitTestCase
 
         // try hasOne reference
         $v = $i->ref('lines')->load(4)->ref('vat_rate_id');
-        $this->assertSame(15, $v['rate']);
+        $this->assertSame(15, $v->get('rate'));
 
         // test expression fields
         $v = $i->ref('lines')->load(4);
-        $this->assertSame(50 * 3 * (1 + 15 / 100), $v['total_gross']);
+        $this->assertSame(50 * 3 * (1 + 15 / 100), $v->get('total_gross'));
 
         // and what about calculated field?
         $i->reload(); // we need to reload invoice for changes in lines to be recalculated
-        $this->assertSame(10 * 2 * (1 + 21 / 100) + 40 * 1 * (1 + 21 / 100) + 50 * 3 * (1 + 15 / 100), $i['total_gross']); // =245.10
+        $this->assertSame(10 * 2 * (1 + 21 / 100) + 40 * 1 * (1 + 21 / 100) + 50 * 3 * (1 + 15 / 100), $i->get('total_gross')); // =245.10
 
         //var_dump($i->export(), $i->export(null,null,false));
     }
@@ -259,10 +259,10 @@ class ContainsManyTest extends \atk4\schema\PhpunitTestCase
         ], $i->ref('lines')->load(1)->ref('discounts')->export());
 
         // is total_gross correctly calculated?
-        $this->assertSame(10 * 2 * (1 + 21 / 100) + 15 * 5 * (1 + 15 / 100), $i['total_gross']); // =110.45
+        $this->assertSame(10 * 2 * (1 + 21 / 100) + 15 * 5 * (1 + 15 / 100), $i->get('total_gross')); // =110.45
 
         // do we also correctly calculate discounts from nested containsMany?
-        $this->assertSame(24.2 * 15 / 100 + 86.25 * 20 / 100, $i['discounts_total_sum']); // =20.88
+        $this->assertSame(24.2 * 15 / 100 + 86.25 * 20 / 100, $i->get('discounts_total_sum')); // =20.88
 
         // let's test how it all looks in persistence without typecasting
         $exp_lines = $i->export(null, null, false)[0]['lines'];

--- a/tests/ContainsManyTest.php
+++ b/tests/ContainsManyTest.php
@@ -35,7 +35,7 @@ class Invoice2 extends Model
         $this->addCalculatedField('total_gross', function ($m) {
             $total = 0;
             foreach ($m->ref('lines') as $line) {
-                $total += $line->get('total_gross');
+                $total += $line['total_gross'];
             }
 
             return $total;
@@ -45,7 +45,7 @@ class Invoice2 extends Model
         $this->addCalculatedField('discounts_total_sum', function ($m) {
             $total = 0;
             foreach ($m->ref('lines') as $line) {
-                $total += $line->get('total_gross') * $line->get('discounts_percent') / 100;
+                $total += $line['total_gross'] * $line['discounts_percent'] / 100;
             }
 
             return $total;
@@ -69,7 +69,7 @@ class Line2 extends Model
         $this->addField('add_date', ['type' => 'datetime']);
 
         $this->addExpression('total_gross', function ($m) {
-            return $m->get('price') * $m->get('qty') * (1 + $m->ref('vat_rate_id')['rate'] / 100);
+            return $m['price'] * $m['qty'] * (1 + $m->ref('vat_rate_id')['rate'] / 100);
         });
 
         // each line can have multiple discounts and calculate total of these discounts
@@ -78,7 +78,7 @@ class Line2 extends Model
         $this->addCalculatedField('discounts_percent', function ($m) {
             $total = 0;
             foreach ($m->ref('discounts') as $d) {
-                $total += $d->get('percent');
+                $total += $d['percent'];
             }
 
             return $total;
@@ -199,15 +199,15 @@ class ContainsManyTest extends \atk4\schema\PhpunitTestCase
 
         // try hasOne reference
         $v = $i->ref('lines')->load(4)->ref('vat_rate_id');
-        $this->assertSame(15, $v->get('rate'));
+        $this->assertSame(15, $v['rate']);
 
         // test expression fields
         $v = $i->ref('lines')->load(4);
-        $this->assertSame(50 * 3 * (1 + 15 / 100), $v->get('total_gross'));
+        $this->assertSame(50 * 3 * (1 + 15 / 100), $v['total_gross']);
 
         // and what about calculated field?
         $i->reload(); // we need to reload invoice for changes in lines to be recalculated
-        $this->assertSame(10 * 2 * (1 + 21 / 100) + 40 * 1 * (1 + 21 / 100) + 50 * 3 * (1 + 15 / 100), $i->get('total_gross')); // =245.10
+        $this->assertSame(10 * 2 * (1 + 21 / 100) + 40 * 1 * (1 + 21 / 100) + 50 * 3 * (1 + 15 / 100), $i['total_gross']); // =245.10
 
         //var_dump($i->export(), $i->export(null,null,false));
     }
@@ -259,10 +259,10 @@ class ContainsManyTest extends \atk4\schema\PhpunitTestCase
         ], $i->ref('lines')->load(1)->ref('discounts')->export());
 
         // is total_gross correctly calculated?
-        $this->assertSame(10 * 2 * (1 + 21 / 100) + 15 * 5 * (1 + 15 / 100), $i->get('total_gross')); // =110.45
+        $this->assertSame(10 * 2 * (1 + 21 / 100) + 15 * 5 * (1 + 15 / 100), $i['total_gross']); // =110.45
 
         // do we also correctly calculate discounts from nested containsMany?
-        $this->assertSame(24.2 * 15 / 100 + 86.25 * 20 / 100, $i->get('discounts_total_sum')); // =20.88
+        $this->assertSame(24.2 * 15 / 100 + 86.25 * 20 / 100, $i['discounts_total_sum']); // =20.88
 
         // let's test how it all looks in persistence without typecasting
         $exp_lines = $i->export(null, null, false)[0]['lines'];

--- a/tests/ContainsOneTest.php
+++ b/tests/ContainsOneTest.php
@@ -149,7 +149,7 @@ class ContainsOneTest extends \atk4\schema\PhpunitTestCase
 
         // now try to change some field in address
         $i->ref('addr')->set('address', 'bar')->save();
-        $this->assertSame('bar', $i->ref('addr')['address']);
+        $this->assertSame('bar', $i->ref('addr')->get('address'));
 
         // now add nested containsOne - DoorCode
         $c = $i->ref('addr')->ref('door_code');
@@ -164,10 +164,10 @@ class ContainsOneTest extends \atk4\schema\PhpunitTestCase
 
         // try hasOne reference
         $c = $i->ref('addr')->ref('country_id');
-        $this->assertSame('Latvia', $c['name']);
+        $this->assertSame('Latvia', $c->get('name'));
         $i->ref('addr')->set('country_id', 2)->save();
         $c = $i->ref('addr')->ref('country_id');
-        $this->assertSame('United Kingdom', $c['name']);
+        $this->assertSame('United Kingdom', $c->get('name'));
 
         // let's test how it all looks in persistence without typecasting
         $exp_addr = $i->export(null, null, false)[0]['addr'];

--- a/tests/ContainsOneTest.php
+++ b/tests/ContainsOneTest.php
@@ -164,10 +164,10 @@ class ContainsOneTest extends \atk4\schema\PhpunitTestCase
 
         // try hasOne reference
         $c = $i->ref('addr')->ref('country_id');
-        $this->assertSame('Latvia', $c['name']);
+        $this->assertSame('Latvia', $c->get('name'));
         $i->ref('addr')->set('country_id', 2)->save();
         $c = $i->ref('addr')->ref('country_id');
-        $this->assertSame('United Kingdom', $c['name']);
+        $this->assertSame('United Kingdom', $c->get('name'));
 
         // let's test how it all looks in persistence without typecasting
         $exp_addr = $i->export(null, null, false)[0]['addr'];

--- a/tests/ContainsOneTest.php
+++ b/tests/ContainsOneTest.php
@@ -164,10 +164,10 @@ class ContainsOneTest extends \atk4\schema\PhpunitTestCase
 
         // try hasOne reference
         $c = $i->ref('addr')->ref('country_id');
-        $this->assertSame('Latvia', $c->get('name'));
+        $this->assertSame('Latvia', $c['name']);
         $i->ref('addr')->set('country_id', 2)->save();
         $c = $i->ref('addr')->ref('country_id');
-        $this->assertSame('United Kingdom', $c->get('name'));
+        $this->assertSame('United Kingdom', $c['name']);
 
         // let's test how it all looks in persistence without typecasting
         $exp_addr = $i->export(null, null, false)[0]['addr'];

--- a/tests/DeepCopyTest.php
+++ b/tests/DeepCopyTest.php
@@ -45,7 +45,7 @@ class DCInvoice extends Model
 
         $this->onHook('afterCopy', function ($m, $s) {
             if (get_class($s) === static::class) {
-                $m['ref'] = $m['ref'] . '_copy';
+                $m->set('ref', $m->get('ref') . '_copy');
             }
         });
     }
@@ -161,7 +161,7 @@ class DeepCopyTest extends \atk4\schema\PhpunitTestCase
         $quote->loadAny();
 
         // total price should match
-        $this->assertEquals(90.00, $quote['total']);
+        $this->assertEquals(90.00, $quote->get('total'));
 
         $dc = new DeepCopy();
         $invoice = $dc
@@ -171,21 +171,21 @@ class DeepCopyTest extends \atk4\schema\PhpunitTestCase
             ->copy();
 
         // price now will be with VAT
-        $this->assertSame('q1', $invoice['ref']);
-        $this->assertEquals(108.90, $invoice['total']);
+        $this->assertSame('q1', $invoice->get('ref'));
+        $this->assertEquals(108.90, $invoice->get('total'));
         $this->assertEquals(1, $invoice->id);
 
         // Note that we did not specify that 'client_id' should be copied, so same value here
-        $this->assertSame($quote['client_id'], $invoice['client_id']);
+        $this->assertSame($quote->get('client_id'), $invoice->get('client_id'));
         $this->assertSame('John', $invoice->ref('client_id')['name']);
 
         // now to add payment for the invoice. Payment originates from the same client as noted on the invoice
-        $invoice->ref('Payments')->insert(['amount' => $invoice['total'] - 5, 'client_id' => $invoice['client_id']]);
+        $invoice->ref('Payments')->insert(['amount' => $invoice->get('total') - 5, 'client_id' => $invoice->get('client_id')]);
 
         $invoice->reload();
 
         // now that invoice is mostly paid, due amount will reflect that
-        $this->assertEquals(5, $invoice['due']);
+        $this->assertEquals(5, $invoice->get('due'));
 
         // Next we copy invocie into simply a new record. Duplicate. However this time we will also duplicate payments,
         // and client. Because Payment references client too, we need to duplicate that one also, this way new record
@@ -199,19 +199,19 @@ class DeepCopyTest extends \atk4\schema\PhpunitTestCase
 
         // Invoice copy receives a new ID
         $this->assertNotSame($invoice->id, $invoice_copy->id);
-        $this->assertSame('q1_copy', $invoice_copy['ref']);
+        $this->assertSame('q1_copy', $invoice_copy->get('ref'));
 
         // ..however the due amount is the same - 5
-        $this->assertEquals(5, $invoice_copy['due']);
+        $this->assertEquals(5, $invoice_copy->get('due'));
 
         // ..client record was created in the process
-        $this->assertNotSame($invoice_copy['client_id'], $invoice['client_id']);
+        $this->assertNotSame($invoice_copy->get('client_id'), $invoice->get('client_id'));
 
         // ..but he is still called John
         $this->assertSame('John', $invoice_copy->ref('client_id')['name']);
 
         // finally, the client_id used for newly created payment and new invoice correspond
-        $this->assertSame($invoice_copy['client_id'], $invoice_copy->ref('Payments')->loadAny()['client_id']);
+        $this->assertSame($invoice_copy->get('client_id'), $invoice_copy->ref('Payments')->loadAny()['client_id']);
 
         // the final test is to copy client entirely!
 
@@ -274,13 +274,13 @@ class DeepCopyTest extends \atk4\schema\PhpunitTestCase
 
         $invoice = new DCInvoice();
         $invoice->onHook('afterCopy', function ($m) {
-            if (!$m['ref']) {
+            if (!$m->get('ref')) {
                 throw new \atk4\core\Exception('no ref');
             }
         });
 
         // total price should match
-        $this->assertEquals(90.00, $quote['total']);
+        $this->assertEquals(90.00, $quote->get('total'));
 
         $dc = new DeepCopy();
 
@@ -316,13 +316,13 @@ class DeepCopyTest extends \atk4\schema\PhpunitTestCase
 
         $invoice = new DCInvoice();
         $invoice->onHook('afterCopy', function ($m) {
-            if (!$m['ref']) {
+            if (!$m->get('ref')) {
                 throw new \atk4\core\Exception('no ref');
             }
         });
 
         // total price should match
-        $this->assertEquals(90.00, $quote['total']);
+        $this->assertEquals(90.00, $quote->get('total'));
 
         $dc = new DeepCopy();
 

--- a/tests/DeepCopyTest.php
+++ b/tests/DeepCopyTest.php
@@ -45,7 +45,7 @@ class DCInvoice extends Model
 
         $this->onHook('afterCopy', function ($m, $s) {
             if (get_class($s) === static::class) {
-                $m['ref'] = $m['ref'] . '_copy';
+                $m->set('ref', $m->get('ref') . '_copy');
             }
         });
     }
@@ -161,7 +161,7 @@ class DeepCopyTest extends \atk4\schema\PhpunitTestCase
         $quote->loadAny();
 
         // total price should match
-        $this->assertEquals(90.00, $quote['total']);
+        $this->assertEquals(90.00, $quote->get('total'));
 
         $dc = new DeepCopy();
         $invoice = $dc
@@ -171,21 +171,21 @@ class DeepCopyTest extends \atk4\schema\PhpunitTestCase
             ->copy();
 
         // price now will be with VAT
-        $this->assertSame('q1', $invoice['ref']);
-        $this->assertEquals(108.90, $invoice['total']);
+        $this->assertSame('q1', $invoice->get('ref'));
+        $this->assertEquals(108.90, $invoice->get('total'));
         $this->assertEquals(1, $invoice->id);
 
         // Note that we did not specify that 'client_id' should be copied, so same value here
-        $this->assertSame($quote['client_id'], $invoice['client_id']);
-        $this->assertSame('John', $invoice->ref('client_id')['name']);
+        $this->assertSame($quote->get('client_id'), $invoice->get('client_id'));
+        $this->assertSame('John', $invoice->ref('client_id')->get('name'));
 
         // now to add payment for the invoice. Payment originates from the same client as noted on the invoice
-        $invoice->ref('Payments')->insert(['amount' => $invoice['total'] - 5, 'client_id' => $invoice['client_id']]);
+        $invoice->ref('Payments')->insert(['amount' => $invoice->get('total') - 5, 'client_id' => $invoice->get('client_id')]);
 
         $invoice->reload();
 
         // now that invoice is mostly paid, due amount will reflect that
-        $this->assertEquals(5, $invoice['due']);
+        $this->assertEquals(5, $invoice->get('due'));
 
         // Next we copy invocie into simply a new record. Duplicate. However this time we will also duplicate payments,
         // and client. Because Payment references client too, we need to duplicate that one also, this way new record
@@ -199,19 +199,19 @@ class DeepCopyTest extends \atk4\schema\PhpunitTestCase
 
         // Invoice copy receives a new ID
         $this->assertNotSame($invoice->id, $invoice_copy->id);
-        $this->assertSame('q1_copy', $invoice_copy['ref']);
+        $this->assertSame('q1_copy', $invoice_copy->get('ref'));
 
         // ..however the due amount is the same - 5
-        $this->assertEquals(5, $invoice_copy['due']);
+        $this->assertEquals(5, $invoice_copy->get('due'));
 
         // ..client record was created in the process
-        $this->assertNotSame($invoice_copy['client_id'], $invoice['client_id']);
+        $this->assertNotSame($invoice_copy->get('client_id'), $invoice->get('client_id'));
 
         // ..but he is still called John
-        $this->assertSame('John', $invoice_copy->ref('client_id')['name']);
+        $this->assertSame('John', $invoice_copy->ref('client_id')->get('name'));
 
         // finally, the client_id used for newly created payment and new invoice correspond
-        $this->assertSame($invoice_copy['client_id'], $invoice_copy->ref('Payments')->loadAny()['client_id']);
+        $this->assertSame($invoice_copy->get('client_id'), $invoice_copy->ref('Payments')->loadAny()->get('client_id'));
 
         // the final test is to copy client entirely!
 
@@ -274,13 +274,13 @@ class DeepCopyTest extends \atk4\schema\PhpunitTestCase
 
         $invoice = new DCInvoice();
         $invoice->onHook('afterCopy', function ($m) {
-            if (!$m['ref']) {
+            if (!$m->get('ref')) {
                 throw new \atk4\core\Exception('no ref');
             }
         });
 
         // total price should match
-        $this->assertEquals(90.00, $quote['total']);
+        $this->assertEquals(90.00, $quote->get('total'));
 
         $dc = new DeepCopy();
 
@@ -316,13 +316,13 @@ class DeepCopyTest extends \atk4\schema\PhpunitTestCase
 
         $invoice = new DCInvoice();
         $invoice->onHook('afterCopy', function ($m) {
-            if (!$m['ref']) {
+            if (!$m->get('ref')) {
                 throw new \atk4\core\Exception('no ref');
             }
         });
 
         // total price should match
-        $this->assertEquals(90.00, $quote['total']);
+        $this->assertEquals(90.00, $quote->get('total'));
 
         $dc = new DeepCopy();
 

--- a/tests/DeepCopyTest.php
+++ b/tests/DeepCopyTest.php
@@ -45,7 +45,7 @@ class DCInvoice extends Model
 
         $this->onHook('afterCopy', function ($m, $s) {
             if (get_class($s) === static::class) {
-                $m->set('ref', $m->get('ref') . '_copy');
+                $m['ref'] = $m['ref'] . '_copy';
             }
         });
     }
@@ -161,7 +161,7 @@ class DeepCopyTest extends \atk4\schema\PhpunitTestCase
         $quote->loadAny();
 
         // total price should match
-        $this->assertEquals(90.00, $quote->get('total'));
+        $this->assertEquals(90.00, $quote['total']);
 
         $dc = new DeepCopy();
         $invoice = $dc
@@ -171,21 +171,21 @@ class DeepCopyTest extends \atk4\schema\PhpunitTestCase
             ->copy();
 
         // price now will be with VAT
-        $this->assertSame('q1', $invoice->get('ref'));
-        $this->assertEquals(108.90, $invoice->get('total'));
+        $this->assertSame('q1', $invoice['ref']);
+        $this->assertEquals(108.90, $invoice['total']);
         $this->assertEquals(1, $invoice->id);
 
         // Note that we did not specify that 'client_id' should be copied, so same value here
-        $this->assertSame($quote->get('client_id'), $invoice->get('client_id'));
+        $this->assertSame($quote['client_id'], $invoice['client_id']);
         $this->assertSame('John', $invoice->ref('client_id')['name']);
 
         // now to add payment for the invoice. Payment originates from the same client as noted on the invoice
-        $invoice->ref('Payments')->insert(['amount' => $invoice->get('total') - 5, 'client_id' => $invoice->get('client_id')]);
+        $invoice->ref('Payments')->insert(['amount' => $invoice['total'] - 5, 'client_id' => $invoice['client_id']]);
 
         $invoice->reload();
 
         // now that invoice is mostly paid, due amount will reflect that
-        $this->assertEquals(5, $invoice->get('due'));
+        $this->assertEquals(5, $invoice['due']);
 
         // Next we copy invocie into simply a new record. Duplicate. However this time we will also duplicate payments,
         // and client. Because Payment references client too, we need to duplicate that one also, this way new record
@@ -199,19 +199,19 @@ class DeepCopyTest extends \atk4\schema\PhpunitTestCase
 
         // Invoice copy receives a new ID
         $this->assertNotSame($invoice->id, $invoice_copy->id);
-        $this->assertSame('q1_copy', $invoice_copy->get('ref'));
+        $this->assertSame('q1_copy', $invoice_copy['ref']);
 
         // ..however the due amount is the same - 5
-        $this->assertEquals(5, $invoice_copy->get('due'));
+        $this->assertEquals(5, $invoice_copy['due']);
 
         // ..client record was created in the process
-        $this->assertNotSame($invoice_copy->get('client_id'), $invoice->get('client_id'));
+        $this->assertNotSame($invoice_copy['client_id'], $invoice['client_id']);
 
         // ..but he is still called John
         $this->assertSame('John', $invoice_copy->ref('client_id')['name']);
 
         // finally, the client_id used for newly created payment and new invoice correspond
-        $this->assertSame($invoice_copy->get('client_id'), $invoice_copy->ref('Payments')->loadAny()['client_id']);
+        $this->assertSame($invoice_copy['client_id'], $invoice_copy->ref('Payments')->loadAny()['client_id']);
 
         // the final test is to copy client entirely!
 
@@ -274,13 +274,13 @@ class DeepCopyTest extends \atk4\schema\PhpunitTestCase
 
         $invoice = new DCInvoice();
         $invoice->onHook('afterCopy', function ($m) {
-            if (!$m->get('ref')) {
+            if (!$m['ref']) {
                 throw new \atk4\core\Exception('no ref');
             }
         });
 
         // total price should match
-        $this->assertEquals(90.00, $quote->get('total'));
+        $this->assertEquals(90.00, $quote['total']);
 
         $dc = new DeepCopy();
 
@@ -316,13 +316,13 @@ class DeepCopyTest extends \atk4\schema\PhpunitTestCase
 
         $invoice = new DCInvoice();
         $invoice->onHook('afterCopy', function ($m) {
-            if (!$m->get('ref')) {
+            if (!$m['ref']) {
                 throw new \atk4\core\Exception('no ref');
             }
         });
 
         // total price should match
-        $this->assertEquals(90.00, $quote->get('total'));
+        $this->assertEquals(90.00, $quote['total']);
 
         $dc = new DeepCopy();
 

--- a/tests/ExpressionSQLTest.php
+++ b/tests/ExpressionSQLTest.php
@@ -16,7 +16,7 @@ class ExpressionSQLTest extends \atk4\schema\PhpunitTestCase
         $m = new Model($db, false);
         $m->addExpression('x', '2+3');
         $m->tryLoadAny();
-        $this->assertEquals(5, $m->get('x'));
+        $this->assertEquals(5, $m['x']);
     }
 
     public function testBasic()
@@ -40,12 +40,12 @@ class ExpressionSQLTest extends \atk4\schema\PhpunitTestCase
         }
 
         $i->tryLoad(1);
-        $this->assertEquals(10, $i->get('total_net'));
-        $this->assertEquals($i->get('total_net') + $i->get('total_vat'), $i->get('total_gross'));
+        $this->assertEquals(10, $i['total_net']);
+        $this->assertEquals($i['total_net'] + $i['total_vat'], $i['total_gross']);
 
         $i->tryLoad(2);
-        $this->assertEquals(20, $i->get('total_net'));
-        $this->assertEquals($i->get('total_net') + $i->get('total_vat'), $i->get('total_gross'));
+        $this->assertEquals(20, $i['total_net']);
+        $this->assertEquals($i['total_net'] + $i['total_vat'], $i['total_gross']);
 
         $i->addExpression('double_total_gross', '[total_gross]*2');
 
@@ -57,7 +57,7 @@ class ExpressionSQLTest extends \atk4\schema\PhpunitTestCase
         }
 
         $i->tryLoad(1);
-        $this->assertEquals(($i->get('total_net') + $i->get('total_vat')) * 2, $i->get('double_total_gross'));
+        $this->assertEquals(($i['total_net'] + $i['total_vat']) * 2, $i['double_total_gross']);
     }
 
     public function testBasicCallback()
@@ -83,12 +83,12 @@ class ExpressionSQLTest extends \atk4\schema\PhpunitTestCase
         }
 
         $i->tryLoad(1);
-        $this->assertEquals(10, $i->get('total_net'));
-        $this->assertEquals($i->get('total_net') + $i->get('total_vat'), $i->get('total_gross'));
+        $this->assertEquals(10, $i['total_net']);
+        $this->assertEquals($i['total_net'] + $i['total_vat'], $i['total_gross']);
 
         $i->tryLoad(2);
-        $this->assertEquals(20, $i->get('total_net'));
-        $this->assertEquals($i->get('total_net') + $i->get('total_vat'), $i->get('total_gross'));
+        $this->assertEquals(20, $i['total_net']);
+        $this->assertEquals($i['total_net'] + $i['total_vat'], $i['total_gross']);
     }
 
     public function testQuery()
@@ -112,8 +112,8 @@ class ExpressionSQLTest extends \atk4\schema\PhpunitTestCase
         }
 
         $i->tryLoad(1);
-        $this->assertEquals(10, $i->get('total_net'));
-        $this->assertEquals(30, $i->get('sum_net'));
+        $this->assertEquals(10, $i['total_net']);
+        $this->assertEquals(30, $i['sum_net']);
 
         $q = $db->dsql();
         $q->field($i->action('count'), 'total_orders');
@@ -158,9 +158,9 @@ class ExpressionSQLTest extends \atk4\schema\PhpunitTestCase
         }
 
         $m->tryLoad(1);
-        $this->assertNull($m->get('name'));
+        $this->assertNull($m['name']);
         $m->tryLoad(2);
-        $this->assertSame('Sue', $m->get('name'));
+        $this->assertSame('Sue', $m['name']);
     }
 
     public function testReloading()
@@ -178,10 +178,10 @@ class ExpressionSQLTest extends \atk4\schema\PhpunitTestCase
         $m->addExpression('sum', '[a] + [b]');
 
         $m->load(1);
-        $this->assertEquals(4, $m->get('sum'));
+        $this->assertEquals(4, $m['sum']);
 
         $m->save(['a' => 3]);
-        $this->assertEquals(5, $m->get('sum'));
+        $this->assertEquals(5, $m['sum']);
 
         $this->assertEquals(9, $m->unload()->save(['a' => 4, 'b' => 5])->get('sum'));
 
@@ -192,10 +192,10 @@ class ExpressionSQLTest extends \atk4\schema\PhpunitTestCase
         $m->addExpression('sum', '[a] + [b]');
 
         $m->load(1);
-        $this->assertEquals(4, $m->get('sum'));
+        $this->assertEquals(4, $m['sum']);
 
         $m->save(['a' => 3]);
-        $this->assertEquals(4, $m->get('sum'));
+        $this->assertEquals(4, $m['sum']);
 
         $this->assertNull($m->unload()->save(['a' => 4, 'b' => 5])->get('sum'));
     }

--- a/tests/ExpressionSQLTest.php
+++ b/tests/ExpressionSQLTest.php
@@ -16,7 +16,7 @@ class ExpressionSQLTest extends \atk4\schema\PhpunitTestCase
         $m = new Model($db, false);
         $m->addExpression('x', '2+3');
         $m->tryLoadAny();
-        $this->assertEquals(5, $m['x']);
+        $this->assertEquals(5, $m->get('x'));
     }
 
     public function testBasic()
@@ -40,12 +40,12 @@ class ExpressionSQLTest extends \atk4\schema\PhpunitTestCase
         }
 
         $i->tryLoad(1);
-        $this->assertEquals(10, $i['total_net']);
-        $this->assertEquals($i['total_net'] + $i['total_vat'], $i['total_gross']);
+        $this->assertEquals(10, $i->get('total_net'));
+        $this->assertEquals($i->get('total_net') + $i->get('total_vat'), $i->get('total_gross'));
 
         $i->tryLoad(2);
-        $this->assertEquals(20, $i['total_net']);
-        $this->assertEquals($i['total_net'] + $i['total_vat'], $i['total_gross']);
+        $this->assertEquals(20, $i->get('total_net'));
+        $this->assertEquals($i->get('total_net') + $i->get('total_vat'), $i->get('total_gross'));
 
         $i->addExpression('double_total_gross', '[total_gross]*2');
 
@@ -57,7 +57,7 @@ class ExpressionSQLTest extends \atk4\schema\PhpunitTestCase
         }
 
         $i->tryLoad(1);
-        $this->assertEquals(($i['total_net'] + $i['total_vat']) * 2, $i['double_total_gross']);
+        $this->assertEquals(($i->get('total_net') + $i->get('total_vat')) * 2, $i->get('double_total_gross'));
     }
 
     public function testBasicCallback()
@@ -83,12 +83,12 @@ class ExpressionSQLTest extends \atk4\schema\PhpunitTestCase
         }
 
         $i->tryLoad(1);
-        $this->assertEquals(10, $i['total_net']);
-        $this->assertEquals($i['total_net'] + $i['total_vat'], $i['total_gross']);
+        $this->assertEquals(10, $i->get('total_net'));
+        $this->assertEquals($i->get('total_net') + $i->get('total_vat'), $i->get('total_gross'));
 
         $i->tryLoad(2);
-        $this->assertEquals(20, $i['total_net']);
-        $this->assertEquals($i['total_net'] + $i['total_vat'], $i['total_gross']);
+        $this->assertEquals(20, $i->get('total_net'));
+        $this->assertEquals($i->get('total_net') + $i->get('total_vat'), $i->get('total_gross'));
     }
 
     public function testQuery()
@@ -112,8 +112,8 @@ class ExpressionSQLTest extends \atk4\schema\PhpunitTestCase
         }
 
         $i->tryLoad(1);
-        $this->assertEquals(10, $i['total_net']);
-        $this->assertEquals(30, $i['sum_net']);
+        $this->assertEquals(10, $i->get('total_net'));
+        $this->assertEquals(30, $i->get('sum_net'));
 
         $q = $db->dsql();
         $q->field($i->action('count'), 'total_orders');
@@ -158,9 +158,9 @@ class ExpressionSQLTest extends \atk4\schema\PhpunitTestCase
         }
 
         $m->tryLoad(1);
-        $this->assertNull($m['name']);
+        $this->assertNull($m->get('name'));
         $m->tryLoad(2);
-        $this->assertSame('Sue', $m['name']);
+        $this->assertSame('Sue', $m->get('name'));
     }
 
     public function testReloading()
@@ -178,10 +178,10 @@ class ExpressionSQLTest extends \atk4\schema\PhpunitTestCase
         $m->addExpression('sum', '[a] + [b]');
 
         $m->load(1);
-        $this->assertEquals(4, $m['sum']);
+        $this->assertEquals(4, $m->get('sum'));
 
         $m->save(['a' => 3]);
-        $this->assertEquals(5, $m['sum']);
+        $this->assertEquals(5, $m->get('sum'));
 
         $this->assertEquals(9, $m->unload()->save(['a' => 4, 'b' => 5])->get('sum'));
 
@@ -192,10 +192,10 @@ class ExpressionSQLTest extends \atk4\schema\PhpunitTestCase
         $m->addExpression('sum', '[a] + [b]');
 
         $m->load(1);
-        $this->assertEquals(4, $m['sum']);
+        $this->assertEquals(4, $m->get('sum'));
 
         $m->save(['a' => 3]);
-        $this->assertEquals(4, $m['sum']);
+        $this->assertEquals(4, $m->get('sum'));
 
         $this->assertNull($m->unload()->save(['a' => 4, 'b' => 5])->get('sum'));
     }

--- a/tests/FieldHereditaryTest.php
+++ b/tests/FieldHereditaryTest.php
@@ -14,11 +14,11 @@ class FieldHereditaryTest extends \atk4\schema\PhpunitTestCase
         // default title field
         $m = new Model($p);
         $m->addExpression('caps', function ($m) {
-            return strtoupper($m->get('name'));
+            return strtoupper($m['name']);
         });
 
         $m->load(1);
-        $this->assertSame('world', $m->get('name'));
-        $this->assertSame('WORLD', $m->get('caps'));
+        $this->assertSame('world', $m['name']);
+        $this->assertSame('WORLD', $m['caps']);
     }
 }

--- a/tests/FieldHereditaryTest.php
+++ b/tests/FieldHereditaryTest.php
@@ -14,11 +14,11 @@ class FieldHereditaryTest extends \atk4\schema\PhpunitTestCase
         // default title field
         $m = new Model($p);
         $m->addExpression('caps', function ($m) {
-            return strtoupper($m['name']);
+            return strtoupper($m->get('name'));
         });
 
         $m->load(1);
-        $this->assertSame('world', $m['name']);
-        $this->assertSame('WORLD', $m['caps']);
+        $this->assertSame('world', $m->get('name'));
+        $this->assertSame('WORLD', $m->get('caps'));
     }
 }

--- a/tests/FieldTest.php
+++ b/tests/FieldTest.php
@@ -16,26 +16,26 @@ class FieldTest extends \atk4\schema\PhpunitTestCase
 
         $this->assertFalse($m->isDirty('foo'));
 
-        $m['foo'] = 'abc';
+        $m->set('foo', 'abc');
         $this->assertFalse($m->isDirty('foo'));
 
-        $m['foo'] = 'bca';
+        $m->set('foo', 'bca');
         $this->assertTrue($m->isDirty('foo'));
 
-        $m['foo'] = 'abc';
+        $m->set('foo', 'abc');
         $this->assertFalse($m->isDirty('foo'));
 
         // set initial data
         $m->data['foo'] = 'xx';
         $this->assertFalse($m->isDirty('foo'));
 
-        $m['foo'] = 'abc';
+        $m->set('foo', 'abc');
         $this->assertTrue($m->isDirty('foo'));
 
-        $m['foo'] = 'bca';
+        $m->set('foo', 'bca');
         $this->assertTrue($m->isDirty('foo'));
 
-        $m['foo'] = 'xx';
+        $m->set('foo', 'xx');
         $this->assertFalse($m->isDirty('foo'));
     }
 
@@ -45,7 +45,7 @@ class FieldTest extends \atk4\schema\PhpunitTestCase
         $m->addField('foo', ['default' => 'abc']);
 
         $this->assertTrue($m->compare('foo', 'abc'));
-        $m['foo'] = 'zzz';
+        $m->set('foo', 'zzz');
 
         $this->assertFalse($m->compare('foo', 'abc'));
         $this->assertTrue($m->compare('foo', 'zzz'));
@@ -55,10 +55,10 @@ class FieldTest extends \atk4\schema\PhpunitTestCase
     {
         $m = new Model();
         $m->addField('foo', ['mandatory' => true]);
-        $m['foo'] = 'abc';
-        $m['foo'] = null;
-        $m['foo'] = '';
-        unset($m['foo']);
+        $m->set('foo', 'abc');
+        $m->set('foo', null);
+        $m->set('foo', '');
+        $m->_unset('name');
     }
 
     /**
@@ -68,8 +68,8 @@ class FieldTest extends \atk4\schema\PhpunitTestCase
     {
         $m = new Model();
         $m->addField('foo', ['required' => true]);
-        $m['foo'] = '';
-        unset($m['foo']);
+        $m->set('foo', '');
+        $m->_unset('name');
     }
 
     /**
@@ -79,8 +79,8 @@ class FieldTest extends \atk4\schema\PhpunitTestCase
     {
         $m = new Model();
         $m->addField('foo', ['required' => true]);
-        $m['foo'] = null;
-        unset($m['foo']);
+        $m->set('foo', null);
+        $m->_unset('name');
     }
 
     /**
@@ -195,14 +195,14 @@ class FieldTest extends \atk4\schema\PhpunitTestCase
     {
         $m = new Model();
         $m->addField('foo', ['read_only' => true]);
-        $m['foo'] = 'bar';
+        $m->set('foo', 'bar');
     }
 
     public function testReadOnly2()
     {
         $m = new Model();
         $m->addField('foo', ['read_only' => true, 'default' => 'abc']);
-        $m['foo'] = 'abc';
+        $m->set('foo', 'abc');
     }
 
     public function testReadOnly3()
@@ -210,7 +210,7 @@ class FieldTest extends \atk4\schema\PhpunitTestCase
         $m = new Model();
         $m->addField('foo', ['read_only' => true, 'default' => 'abc']);
         $m->data['foo'] = 'xx';
-        $m['foo'] = 'xx';
+        $m->set('foo', 'xx');
     }
 
     /**
@@ -220,19 +220,19 @@ class FieldTest extends \atk4\schema\PhpunitTestCase
     {
         $m = new Model();
         $m->addField('foo', ['enum' => ['foo', 'bar']]);
-        $m['foo'] = 'xx';
+        $m->set('foo', 'xx');
     }
 
     public function testEnum2()
     {
         $m = new Model();
         $m->addField('foo', ['enum' => [1, 'bar']]);
-        $m['foo'] = 1;
+        $m->set('foo', 1);
 
-        $this->assertSame(1, $m['foo']);
+        $this->assertSame(1, $m->get('foo'));
 
-        $m['foo'] = 'bar';
-        $this->assertSame('bar', $m['foo']);
+        $m->set('foo', 'bar');
+        $this->assertSame('bar', $m->get('foo'));
     }
 
     /**
@@ -242,7 +242,7 @@ class FieldTest extends \atk4\schema\PhpunitTestCase
     {
         $m = new Model();
         $m->addField('foo', ['enum' => [1, 'bar']]);
-        $m['foo'] = true;
+        $m->set('foo', true);
     }
 
     public function testEnum4()
@@ -252,9 +252,9 @@ class FieldTest extends \atk4\schema\PhpunitTestCase
         // to a weird behaviours of PHP
         $m = new Model();
         $m->addField('foo', ['enum' => [1, 'bar'], 'default' => 1]);
-        $m['foo'] = null;
+        $m->set('foo', null);
 
-        $this->assertNull($m['foo']);
+        $this->assertNull($m->get('foo'));
     }
 
     /**
@@ -264,19 +264,19 @@ class FieldTest extends \atk4\schema\PhpunitTestCase
     {
         $m = new Model();
         $m->addField('foo', ['values' => ['foo', 'bar']]);
-        $m['foo'] = 4;
+        $m->set('foo', 4);
     }
 
     public function testValues2()
     {
         $m = new Model();
         $m->addField('foo', ['values' => [3 => 'bar']]);
-        $m['foo'] = 3;
+        $m->set('foo', 3);
 
-        $this->assertSame(3, $m['foo']);
+        $this->assertSame(3, $m->get('foo'));
 
-        $m['foo'] = null;
-        $this->assertNull($m['foo']);
+        $m->set('foo', null);
+        $this->assertNull($m->get('foo'));
     }
 
     /**
@@ -286,7 +286,7 @@ class FieldTest extends \atk4\schema\PhpunitTestCase
     {
         $m = new Model();
         $m->addField('foo', ['values' => [1 => 'bar']]);
-        $m['foo'] = true;
+        $m->set('foo', true);
     }
 
     /**
@@ -296,7 +296,7 @@ class FieldTest extends \atk4\schema\PhpunitTestCase
     {
         $m = new Model();
         $m->addField('foo', ['values' => [1 => 'bar']]);
-        $m['foo'] = 'bar';
+        $m->set('foo', 'bar');
     }
 
     public function testValues4()
@@ -306,7 +306,7 @@ class FieldTest extends \atk4\schema\PhpunitTestCase
         // to a weird behaviours of PHP
         $m = new Model();
         $m->addField('foo', ['values' => ['1a' => 'bar']]);
-        $m['foo'] = '1a';
+        $m->set('foo', '1a');
     }
 
     public function testPersist()
@@ -323,47 +323,47 @@ class FieldTest extends \atk4\schema\PhpunitTestCase
         $m->addField('surname', ['never_save' => true]);
         $m->load(1);
 
-        $this->assertNull($m['name']);
-        $this->assertSame('Smith', $m['surname']);
+        $this->assertNull($m->get('name'));
+        $this->assertSame('Smith', $m->get('surname'));
 
-        $m['name'] = 'Bill';
-        $m['surname'] = 'Stalker';
+        $m->set('name', 'Bill');
+        $m->set('surname', 'Stalker');
         $m->save();
         $this->assertEquals($a, $this->getDB());
 
         $m->reload();
-        $this->assertSame('Smith', $m['surname']);
+        $this->assertSame('Smith', $m->get('surname'));
         $m->getField('surname')->never_save = false;
-        $m['surname'] = 'Stalker';
+        $m->set('surname', 'Stalker');
         $m->save();
-        $a['item'][1]['surname'] = 'Stalker';
+        $a->get('item')[1]['surname'] = 'Stalker';
         $this->assertEquals($a, $this->getDB());
 
         $m->onHook('beforeSave', function ($m) {
             if ($m->isDirty('name')) {
-                $m['surname'] = $m['name'];
-                unset($m['name']);
+                $m->set('surname', $m->get('name'));
+                $m->_unset('name');
             } elseif ($m->isDirty('surname')) {
-                $m['name'] = $m['surname'];
-                unset($m['surname']);
+                $m->set('name', $m->get('surname'));
+                $m->_unset('surname');
             }
         });
 
-        $m['name'] = 'X';
+        $m->set('name', 'X');
         $m->save();
 
-        $a['item'][1]['surname'] = 'X';
+        $a->get('item')[1]['surname'] = 'X';
 
         $this->assertEquals($a, $this->getDB());
-        $this->assertNull($m['name']);
-        $this->assertSame('X', $m['surname']);
+        $this->assertNull($m->get('name'));
+        $this->assertSame('X', $m->get('surname'));
 
-        $m['surname'] = 'Y';
+        $m->set('surname', 'Y');
         $m->save();
 
         $this->assertEquals($a, $this->getDB());
-        $this->assertSame('Y', $m['name']);
-        $this->assertSame('X', $m['surname']);
+        $this->assertSame('Y', $m->get('name'));
+        $this->assertSame('X', $m->get('surname'));
     }
 
     public function testTitle()
@@ -395,8 +395,8 @@ class FieldTest extends \atk4\schema\PhpunitTestCase
 
         $m->load(1);
 
-        $this->assertSame('John', $m['name']);
-        $this->assertSame('Programmer', $m['category']);
+        $this->assertSame('John', $m->get('name'));
+        $this->assertSame('Programmer', $m->get('category'));
 
         $m->insert(['Peter', 'category' => 'Sales']);
 
@@ -421,14 +421,14 @@ class FieldTest extends \atk4\schema\PhpunitTestCase
     {
         $m = new Model();
         $m->addField('foo');
-        $m['baz'] = 'bar';
+        $m->set('baz', 'bar');
     }
 
     public function testStrict1()
     {
         $m = new Model(['strict_field_check' => false]);
         $m->addField('foo');
-        $m['baz'] = 'bar';
+        $m->set('baz', 'bar');
     }
 
     public function testActual()
@@ -449,10 +449,10 @@ class FieldTest extends \atk4\schema\PhpunitTestCase
         $m->addField('surname');
         $m->insert(['first_name' => 'Peter', 'surname' => 'qq']);
         $m->loadBy('first_name', 'John');
-        $this->assertSame('John', $m['first_name']);
+        $this->assertSame('John', $m->get('first_name'));
 
         $d = $m->export();
-        $this->assertSame('John', $d[0]['first_name']);
+        $this->assertSame('John', $d->get(0)['first_name']);
 
         $a = [
             'user' => [
@@ -461,7 +461,7 @@ class FieldTest extends \atk4\schema\PhpunitTestCase
             ], ];
         $this->assertEquals($a, $this->getDB());
 
-        $m['first_name'] = 'Scott';
+        $m->set('first_name', 'Scott');
         $m->save();
 
         $a = [
@@ -485,14 +485,14 @@ class FieldTest extends \atk4\schema\PhpunitTestCase
         $m->addField('net', ['type' => 'money']);
         $m->addField('vat', ['type' => 'money']);
         $m->addCalculatedField('total', function ($m) {
-            return $m['net'] + $m['vat'];
+            return $m->get('net') + $m->get('vat');
         });
         $m->insert(['net' => 30, 'vat' => 8]);
 
         $m->load(1);
-        $this->assertEquals(121, $m['total']);
+        $this->assertEquals(121, $m->get('total'));
         $m->load(2);
-        $this->assertEquals(38, $m['total']);
+        $this->assertEquals(38, $m->get('total'));
 
         $d = $m->export(); // in export calculated fields are not included
         $this->assertFalse(isset($d[0]['total']));
@@ -558,11 +558,11 @@ class FieldTest extends \atk4\schema\PhpunitTestCase
         $m->save(['name' => 'John', 'secret' => 'i am a woman']);
 
         $a = $this->getDB();
-        $this->assertNotNull($a['user'][1]['secret']);
-        $this->assertNotSame('i am a woman', $a['user'][1]['secret']);
+        $this->assertNotNull($a->get('user')[1]['secret']);
+        $this->assertNotSame('i am a woman', $a->get('user')[1]['secret']);
 
         $m->unload()->load(1);
-        $this->assertSame('i am a woman', $m['secret']);
+        $this->assertSame('i am a woman', $m->get('secret'));
     }
 
     public function testNormalize()
@@ -585,65 +585,65 @@ class FieldTest extends \atk4\schema\PhpunitTestCase
         $m->addField('object', ['type' => 'object']);
 
         // string
-        $m['string'] = "Two\r\nLines  ";
-        $this->assertSame('TwoLines', $m['string']);
+        $m->set('string', "Two\r\nLines  ");
+        $this->assertSame('TwoLines', $m->get('string'));
 
-        $m['string'] = "Two\rLines  ";
-        $this->assertSame('TwoLines', $m['string']);
+        $m->set('string', "Two\rLines  ");
+        $this->assertSame('TwoLines', $m->get('string'));
 
-        $m['string'] = "Two\nLines  ";
-        $this->assertSame('TwoLines', $m['string']);
+        $m->set('string', "Two\nLines  ");
+        $this->assertSame('TwoLines', $m->get('string'));
 
         // text
-        $m['text'] = "Two\r\nLines  ";
-        $this->assertSame("Two\nLines", $m['text']);
+        $m->set('text', "Two\r\nLines  ");
+        $this->assertSame("Two\nLines", $m->get('text'));
 
-        $m['text'] = "Two\rLines  ";
-        $this->assertSame("Two\nLines", $m['text']);
+        $m->set('text', "Two\rLines  ");
+        $this->assertSame("Two\nLines", $m->get('text'));
 
-        $m['text'] = "Two\nLines  ";
-        $this->assertSame("Two\nLines", $m['text']);
+        $m->set('text', "Two\nLines  ");
+        $this->assertSame("Two\nLines", $m->get('text'));
 
         // integer, money, float
-        $m['integer'] = '12,345.67676767'; // no digits after dot
-        $this->assertSame(12345, $m['integer']);
+        $m->set('integer', '12,345.67676767'); // no digits after dot
+        $this->assertSame(12345, $m->get('integer'));
 
-        $m['money'] = '12,345.67676767'; // 4 digits after dot
-        $this->assertSame(12345.6768, $m['money']);
+        $m->set('money', '12,345.67676767'); // 4 digits after dot
+        $this->assertSame(12345.6768, $m->get('money'));
 
-        $m['float'] = '12,345.67676767'; // don't round
-        $this->assertSame(12345.67676767, $m['float']);
+        $m->set('float', '12,345.67676767'); // don't round
+        $this->assertSame(12345.67676767, $m->get('float'));
 
         // boolean
-        $m['boolean'] = 0;
-        $this->assertFalse($m['boolean']);
-        $m['boolean'] = 1;
-        $this->assertTrue($m['boolean']);
+        $m->set('boolean', 0);
+        $this->assertFalse($m->get('boolean'));
+        $m->set('boolean', 1);
+        $this->assertTrue($m->get('boolean'));
 
-        $m['boolean_enum'] = 'N';
-        $this->assertFalse($m['boolean_enum']);
-        $m['boolean_enum'] = 'Y';
-        $this->assertTrue($m['boolean_enum']);
+        $m->set('boolean_enum', 'N');
+        $this->assertFalse($m->get('boolean_enum'));
+        $m->set('boolean_enum', 'Y');
+        $this->assertTrue($m->get('boolean_enum'));
 
         // date, datetime, time
-        $m['date'] = 123;
-        $this->assertInstanceof('DateTime', $m['date']);
-        $m['date'] = '123';
-        $this->assertInstanceof('DateTime', $m['date']);
-        $m['date'] = '2018-05-31';
-        $this->assertInstanceof('DateTime', $m['date']);
-        $m['datetime'] = 123;
-        $this->assertInstanceof('DateTime', $m['datetime']);
-        $m['datetime'] = '123';
-        $this->assertInstanceof('DateTime', $m['datetime']);
-        $m['datetime'] = '2018-05-31 12:13:14';
-        $this->assertInstanceof('DateTime', $m['datetime']);
-        $m['time'] = 123;
-        $this->assertInstanceof('DateTime', $m['time']);
-        $m['time'] = '123';
-        $this->assertInstanceof('DateTime', $m['time']);
-        $m['time'] = '12:13:14';
-        $this->assertInstanceof('DateTime', $m['time']);
+        $m->set('date', 123);
+        $this->assertInstanceof('DateTime', $m->get('date'));
+        $m->set('date', '123');
+        $this->assertInstanceof('DateTime', $m->get('date'));
+        $m->set('date', '2018-05-31');
+        $this->assertInstanceof('DateTime', $m->get('date'));
+        $m->set('datetime', 123);
+        $this->assertInstanceof('DateTime', $m->get('datetime'));
+        $m->set('datetime', '123');
+        $this->assertInstanceof('DateTime', $m->get('datetime'));
+        $m->set('datetime', '2018-05-31 12:13:14');
+        $this->assertInstanceof('DateTime', $m->get('datetime'));
+        $m->set('time', 123);
+        $this->assertInstanceof('DateTime', $m->get('time'));
+        $m->set('time', '123');
+        $this->assertInstanceof('DateTime', $m->get('time'));
+        $m->set('time', '12:13:14');
+        $this->assertInstanceof('DateTime', $m->get('time'));
     }
 
     /**
@@ -653,7 +653,7 @@ class FieldTest extends \atk4\schema\PhpunitTestCase
     {
         $m = new Model(['strict_types' => true]);
         $m->addField('foo', ['type' => 'string']);
-        $m['foo'] = [];
+        $m->set('foo', []);
     }
 
     /**
@@ -663,7 +663,7 @@ class FieldTest extends \atk4\schema\PhpunitTestCase
     {
         $m = new Model(['strict_types' => true]);
         $m->addField('foo', ['type' => 'text']);
-        $m['foo'] = [];
+        $m->set('foo', []);
     }
 
     /**
@@ -673,7 +673,7 @@ class FieldTest extends \atk4\schema\PhpunitTestCase
     {
         $m = new Model(['strict_types' => true]);
         $m->addField('foo', ['type' => 'integer']);
-        $m['foo'] = [];
+        $m->set('foo', []);
     }
 
     /**
@@ -683,7 +683,7 @@ class FieldTest extends \atk4\schema\PhpunitTestCase
     {
         $m = new Model(['strict_types' => true]);
         $m->addField('foo', ['type' => 'money']);
-        $m['foo'] = [];
+        $m->set('foo', []);
     }
 
     /**
@@ -693,7 +693,7 @@ class FieldTest extends \atk4\schema\PhpunitTestCase
     {
         $m = new Model(['strict_types' => true]);
         $m->addField('foo', ['type' => 'float']);
-        $m['foo'] = [];
+        $m->set('foo', []);
     }
 
     /**
@@ -703,7 +703,7 @@ class FieldTest extends \atk4\schema\PhpunitTestCase
     {
         $m = new Model(['strict_types' => true]);
         $m->addField('foo', ['type' => 'date']);
-        $m['foo'] = [];
+        $m->set('foo', []);
     }
 
     /**
@@ -713,7 +713,7 @@ class FieldTest extends \atk4\schema\PhpunitTestCase
     {
         $m = new Model(['strict_types' => true]);
         $m->addField('foo', ['type' => 'datetime']);
-        $m['foo'] = [];
+        $m->set('foo', []);
     }
 
     /**
@@ -723,7 +723,7 @@ class FieldTest extends \atk4\schema\PhpunitTestCase
     {
         $m = new Model(['strict_types' => true]);
         $m->addField('foo', ['type' => 'time']);
-        $m['foo'] = [];
+        $m->set('foo', []);
     }
 
     /**
@@ -733,7 +733,7 @@ class FieldTest extends \atk4\schema\PhpunitTestCase
     {
         $m = new Model(['strict_types' => true]);
         $m->addField('foo', ['type' => 'integer']);
-        $m['foo'] = '123---456';
+        $m->set('foo', '123---456');
     }
 
     /**
@@ -743,7 +743,7 @@ class FieldTest extends \atk4\schema\PhpunitTestCase
     {
         $m = new Model(['strict_types' => true]);
         $m->addField('foo', ['type' => 'money']);
-        $m['foo'] = '123---456';
+        $m->set('foo', '123---456');
     }
 
     /**
@@ -753,7 +753,7 @@ class FieldTest extends \atk4\schema\PhpunitTestCase
     {
         $m = new Model(['strict_types' => true]);
         $m->addField('foo', ['type' => 'float']);
-        $m['foo'] = '123---456';
+        $m->set('foo', '123---456');
     }
 
     /**
@@ -763,7 +763,7 @@ class FieldTest extends \atk4\schema\PhpunitTestCase
     {
         $m = new Model(['strict_types' => true]);
         $m->addField('foo', ['type' => 'array']);
-        $m['foo'] = 'ABC';
+        $m->set('foo', 'ABC');
     }
 
     /**
@@ -773,7 +773,7 @@ class FieldTest extends \atk4\schema\PhpunitTestCase
     {
         $m = new Model(['strict_types' => true]);
         $m->addField('foo', ['type' => 'object']);
-        $m['foo'] = 'ABC';
+        $m->set('foo', 'ABC');
     }
 
     /**
@@ -783,7 +783,7 @@ class FieldTest extends \atk4\schema\PhpunitTestCase
     {
         $m = new Model(['strict_types' => true]);
         $m->addField('foo', ['type' => 'boolean']);
-        $m['foo'] = 'ABC';
+        $m->set('foo', 'ABC');
     }
 
     public function testToString()
@@ -932,34 +932,34 @@ class FieldTest extends \atk4\schema\PhpunitTestCase
         $m->addField('is_vip_3', ['type' => 'boolean', 'valueTrue' => 'Y', 'valueFalse' => 'N']);
 
         $m->set('is_vip_1', 'No');
-        $this->assertFalse($m['is_vip_1']);
+        $this->assertFalse($m->get('is_vip_1'));
         $m->set('is_vip_1', 'Yes');
-        $this->assertTrue($m['is_vip_1']);
+        $this->assertTrue($m->get('is_vip_1'));
         $m->set('is_vip_1', false);
-        $this->assertFalse($m['is_vip_1']);
+        $this->assertFalse($m->get('is_vip_1'));
         $m->set('is_vip_1', true);
-        $this->assertTrue($m['is_vip_1']);
+        $this->assertTrue($m->get('is_vip_1'));
         $m->set('is_vip_1', 0);
-        $this->assertFalse($m['is_vip_1']);
+        $this->assertFalse($m->get('is_vip_1'));
         $m->set('is_vip_1', 1);
-        $this->assertTrue($m['is_vip_1']);
+        $this->assertTrue($m->get('is_vip_1'));
 
         $m->set('is_vip_2', 0);
-        $this->assertFalse($m['is_vip_2']);
+        $this->assertFalse($m->get('is_vip_2'));
         $m->set('is_vip_2', 1);
-        $this->assertTrue($m['is_vip_2']);
+        $this->assertTrue($m->get('is_vip_2'));
         $m->set('is_vip_2', false);
-        $this->assertFalse($m['is_vip_2']);
+        $this->assertFalse($m->get('is_vip_2'));
         $m->set('is_vip_2', true);
-        $this->assertTrue($m['is_vip_2']);
+        $this->assertTrue($m->get('is_vip_2'));
 
         $m->set('is_vip_3', 'N');
-        $this->assertFalse($m['is_vip_3']);
+        $this->assertFalse($m->get('is_vip_3'));
         $m->set('is_vip_3', 'Y');
-        $this->assertTrue($m['is_vip_3']);
+        $this->assertTrue($m->get('is_vip_3'));
         $m->set('is_vip_3', false);
-        $this->assertFalse($m['is_vip_3']);
+        $this->assertFalse($m->get('is_vip_3'));
         $m->set('is_vip_3', true);
-        $this->assertTrue($m['is_vip_3']);
+        $this->assertTrue($m->get('is_vip_3'));
     }
 }

--- a/tests/FieldTest.php
+++ b/tests/FieldTest.php
@@ -58,7 +58,7 @@ class FieldTest extends \atk4\schema\PhpunitTestCase
         $m->set('foo', 'abc');
         $m->set('foo', null);
         $m->set('foo', '');
-        $m->_unset('name');
+        $m->_unset('foo');
     }
 
     /**
@@ -69,7 +69,7 @@ class FieldTest extends \atk4\schema\PhpunitTestCase
         $m = new Model();
         $m->addField('foo', ['required' => true]);
         $m->set('foo', '');
-        $m->_unset('name');
+        $m->_unset('foo');
     }
 
     /**
@@ -80,7 +80,7 @@ class FieldTest extends \atk4\schema\PhpunitTestCase
         $m = new Model();
         $m->addField('foo', ['required' => true]);
         $m->set('foo', null);
-        $m->_unset('name');
+        $m->_unset('foo');
     }
 
     /**

--- a/tests/FieldTest.php
+++ b/tests/FieldTest.php
@@ -16,26 +16,26 @@ class FieldTest extends \atk4\schema\PhpunitTestCase
 
         $this->assertFalse($m->isDirty('foo'));
 
-        $m->set('foo', 'abc');
+        $m['foo'] = 'abc';
         $this->assertFalse($m->isDirty('foo'));
 
-        $m->set('foo', 'bca');
+        $m['foo'] = 'bca';
         $this->assertTrue($m->isDirty('foo'));
 
-        $m->set('foo', 'abc');
+        $m['foo'] = 'abc';
         $this->assertFalse($m->isDirty('foo'));
 
         // set initial data
         $m->data['foo'] = 'xx';
         $this->assertFalse($m->isDirty('foo'));
 
-        $m->set('foo', 'abc');
+        $m['foo'] = 'abc';
         $this->assertTrue($m->isDirty('foo'));
 
-        $m->set('foo', 'bca');
+        $m['foo'] = 'bca';
         $this->assertTrue($m->isDirty('foo'));
 
-        $m->set('foo', 'xx');
+        $m['foo'] = 'xx';
         $this->assertFalse($m->isDirty('foo'));
     }
 
@@ -45,7 +45,7 @@ class FieldTest extends \atk4\schema\PhpunitTestCase
         $m->addField('foo', ['default' => 'abc']);
 
         $this->assertTrue($m->compare('foo', 'abc'));
-        $m->set('foo', 'zzz');
+        $m['foo'] = 'zzz';
 
         $this->assertFalse($m->compare('foo', 'abc'));
         $this->assertTrue($m->compare('foo', 'zzz'));
@@ -55,10 +55,10 @@ class FieldTest extends \atk4\schema\PhpunitTestCase
     {
         $m = new Model();
         $m->addField('foo', ['mandatory' => true]);
-        $m->set('foo', 'abc');
-        $m->set('foo', null);
-        $m->set('foo', '');
-        $m->_unset('name');
+        $m['foo'] = 'abc';
+        $m['foo'] = null;
+        $m['foo'] = '';
+        unset($m['foo']);
     }
 
     /**
@@ -68,8 +68,8 @@ class FieldTest extends \atk4\schema\PhpunitTestCase
     {
         $m = new Model();
         $m->addField('foo', ['required' => true]);
-        $m->set('foo', '');
-        $m->_unset('name');
+        $m['foo'] = '';
+        unset($m['foo']);
     }
 
     /**
@@ -79,8 +79,8 @@ class FieldTest extends \atk4\schema\PhpunitTestCase
     {
         $m = new Model();
         $m->addField('foo', ['required' => true]);
-        $m->set('foo', null);
-        $m->_unset('name');
+        $m['foo'] = null;
+        unset($m['foo']);
     }
 
     /**
@@ -195,14 +195,14 @@ class FieldTest extends \atk4\schema\PhpunitTestCase
     {
         $m = new Model();
         $m->addField('foo', ['read_only' => true]);
-        $m->set('foo', 'bar');
+        $m['foo'] = 'bar';
     }
 
     public function testReadOnly2()
     {
         $m = new Model();
         $m->addField('foo', ['read_only' => true, 'default' => 'abc']);
-        $m->set('foo', 'abc');
+        $m['foo'] = 'abc';
     }
 
     public function testReadOnly3()
@@ -210,7 +210,7 @@ class FieldTest extends \atk4\schema\PhpunitTestCase
         $m = new Model();
         $m->addField('foo', ['read_only' => true, 'default' => 'abc']);
         $m->data['foo'] = 'xx';
-        $m->set('foo', 'xx');
+        $m['foo'] = 'xx';
     }
 
     /**
@@ -220,19 +220,19 @@ class FieldTest extends \atk4\schema\PhpunitTestCase
     {
         $m = new Model();
         $m->addField('foo', ['enum' => ['foo', 'bar']]);
-        $m->set('foo', 'xx');
+        $m['foo'] = 'xx';
     }
 
     public function testEnum2()
     {
         $m = new Model();
         $m->addField('foo', ['enum' => [1, 'bar']]);
-        $m->set('foo', 1);
+        $m['foo'] = 1;
 
-        $this->assertSame(1, $m->get('foo'));
+        $this->assertSame(1, $m['foo']);
 
-        $m->set('foo', 'bar');
-        $this->assertSame('bar', $m->get('foo'));
+        $m['foo'] = 'bar';
+        $this->assertSame('bar', $m['foo']);
     }
 
     /**
@@ -242,7 +242,7 @@ class FieldTest extends \atk4\schema\PhpunitTestCase
     {
         $m = new Model();
         $m->addField('foo', ['enum' => [1, 'bar']]);
-        $m->set('foo', true);
+        $m['foo'] = true;
     }
 
     public function testEnum4()
@@ -252,9 +252,9 @@ class FieldTest extends \atk4\schema\PhpunitTestCase
         // to a weird behaviours of PHP
         $m = new Model();
         $m->addField('foo', ['enum' => [1, 'bar'], 'default' => 1]);
-        $m->set('foo', null);
+        $m['foo'] = null;
 
-        $this->assertNull($m->get('foo'));
+        $this->assertNull($m['foo']);
     }
 
     /**
@@ -264,19 +264,19 @@ class FieldTest extends \atk4\schema\PhpunitTestCase
     {
         $m = new Model();
         $m->addField('foo', ['values' => ['foo', 'bar']]);
-        $m->set('foo', 4);
+        $m['foo'] = 4;
     }
 
     public function testValues2()
     {
         $m = new Model();
         $m->addField('foo', ['values' => [3 => 'bar']]);
-        $m->set('foo', 3);
+        $m['foo'] = 3;
 
-        $this->assertSame(3, $m->get('foo'));
+        $this->assertSame(3, $m['foo']);
 
-        $m->set('foo', null);
-        $this->assertNull($m->get('foo'));
+        $m['foo'] = null;
+        $this->assertNull($m['foo']);
     }
 
     /**
@@ -286,7 +286,7 @@ class FieldTest extends \atk4\schema\PhpunitTestCase
     {
         $m = new Model();
         $m->addField('foo', ['values' => [1 => 'bar']]);
-        $m->set('foo', true);
+        $m['foo'] = true;
     }
 
     /**
@@ -296,7 +296,7 @@ class FieldTest extends \atk4\schema\PhpunitTestCase
     {
         $m = new Model();
         $m->addField('foo', ['values' => [1 => 'bar']]);
-        $m->set('foo', 'bar');
+        $m['foo'] = 'bar';
     }
 
     public function testValues4()
@@ -306,7 +306,7 @@ class FieldTest extends \atk4\schema\PhpunitTestCase
         // to a weird behaviours of PHP
         $m = new Model();
         $m->addField('foo', ['values' => ['1a' => 'bar']]);
-        $m->set('foo', '1a');
+        $m['foo'] = '1a';
     }
 
     public function testPersist()
@@ -323,47 +323,47 @@ class FieldTest extends \atk4\schema\PhpunitTestCase
         $m->addField('surname', ['never_save' => true]);
         $m->load(1);
 
-        $this->assertNull($m->get('name'));
-        $this->assertSame('Smith', $m->get('surname'));
+        $this->assertNull($m['name']);
+        $this->assertSame('Smith', $m['surname']);
 
-        $m->set('name', 'Bill');
-        $m->set('surname', 'Stalker');
+        $m['name'] = 'Bill';
+        $m['surname'] = 'Stalker';
         $m->save();
         $this->assertEquals($a, $this->getDB());
 
         $m->reload();
-        $this->assertSame('Smith', $m->get('surname'));
+        $this->assertSame('Smith', $m['surname']);
         $m->getField('surname')->never_save = false;
-        $m->set('surname', 'Stalker');
+        $m['surname'] = 'Stalker';
         $m->save();
-        $a->get('item')[1]['surname'] = 'Stalker';
+        $a['item'][1]['surname'] = 'Stalker';
         $this->assertEquals($a, $this->getDB());
 
         $m->onHook('beforeSave', function ($m) {
             if ($m->isDirty('name')) {
-                $m->set('surname', $m->get('name'));
-                $m->_unset('name');
+                $m['surname'] = $m['name'];
+                unset($m['name']);
             } elseif ($m->isDirty('surname')) {
-                $m->set('name', $m->get('surname'));
-                $m->_unset('surname');
+                $m['name'] = $m['surname'];
+                unset($m['surname']);
             }
         });
 
-        $m->set('name', 'X');
+        $m['name'] = 'X';
         $m->save();
 
-        $a->get('item')[1]['surname'] = 'X';
+        $a['item'][1]['surname'] = 'X';
 
         $this->assertEquals($a, $this->getDB());
-        $this->assertNull($m->get('name'));
-        $this->assertSame('X', $m->get('surname'));
+        $this->assertNull($m['name']);
+        $this->assertSame('X', $m['surname']);
 
-        $m->set('surname', 'Y');
+        $m['surname'] = 'Y';
         $m->save();
 
         $this->assertEquals($a, $this->getDB());
-        $this->assertSame('Y', $m->get('name'));
-        $this->assertSame('X', $m->get('surname'));
+        $this->assertSame('Y', $m['name']);
+        $this->assertSame('X', $m['surname']);
     }
 
     public function testTitle()
@@ -395,8 +395,8 @@ class FieldTest extends \atk4\schema\PhpunitTestCase
 
         $m->load(1);
 
-        $this->assertSame('John', $m->get('name'));
-        $this->assertSame('Programmer', $m->get('category'));
+        $this->assertSame('John', $m['name']);
+        $this->assertSame('Programmer', $m['category']);
 
         $m->insert(['Peter', 'category' => 'Sales']);
 
@@ -421,14 +421,14 @@ class FieldTest extends \atk4\schema\PhpunitTestCase
     {
         $m = new Model();
         $m->addField('foo');
-        $m->set('baz', 'bar');
+        $m['baz'] = 'bar';
     }
 
     public function testStrict1()
     {
         $m = new Model(['strict_field_check' => false]);
         $m->addField('foo');
-        $m->set('baz', 'bar');
+        $m['baz'] = 'bar';
     }
 
     public function testActual()
@@ -449,10 +449,10 @@ class FieldTest extends \atk4\schema\PhpunitTestCase
         $m->addField('surname');
         $m->insert(['first_name' => 'Peter', 'surname' => 'qq']);
         $m->loadBy('first_name', 'John');
-        $this->assertSame('John', $m->get('first_name'));
+        $this->assertSame('John', $m['first_name']);
 
         $d = $m->export();
-        $this->assertSame('John', $d->get(0)['first_name']);
+        $this->assertSame('John', $d[0]['first_name']);
 
         $a = [
             'user' => [
@@ -461,7 +461,7 @@ class FieldTest extends \atk4\schema\PhpunitTestCase
             ], ];
         $this->assertEquals($a, $this->getDB());
 
-        $m->set('first_name', 'Scott');
+        $m['first_name'] = 'Scott';
         $m->save();
 
         $a = [
@@ -485,14 +485,14 @@ class FieldTest extends \atk4\schema\PhpunitTestCase
         $m->addField('net', ['type' => 'money']);
         $m->addField('vat', ['type' => 'money']);
         $m->addCalculatedField('total', function ($m) {
-            return $m->get('net') + $m->get('vat');
+            return $m['net'] + $m['vat'];
         });
         $m->insert(['net' => 30, 'vat' => 8]);
 
         $m->load(1);
-        $this->assertEquals(121, $m->get('total'));
+        $this->assertEquals(121, $m['total']);
         $m->load(2);
-        $this->assertEquals(38, $m->get('total'));
+        $this->assertEquals(38, $m['total']);
 
         $d = $m->export(); // in export calculated fields are not included
         $this->assertFalse(isset($d[0]['total']));
@@ -558,11 +558,11 @@ class FieldTest extends \atk4\schema\PhpunitTestCase
         $m->save(['name' => 'John', 'secret' => 'i am a woman']);
 
         $a = $this->getDB();
-        $this->assertNotNull($a->get('user')[1]['secret']);
-        $this->assertNotSame('i am a woman', $a->get('user')[1]['secret']);
+        $this->assertNotNull($a['user'][1]['secret']);
+        $this->assertNotSame('i am a woman', $a['user'][1]['secret']);
 
         $m->unload()->load(1);
-        $this->assertSame('i am a woman', $m->get('secret'));
+        $this->assertSame('i am a woman', $m['secret']);
     }
 
     public function testNormalize()
@@ -585,65 +585,65 @@ class FieldTest extends \atk4\schema\PhpunitTestCase
         $m->addField('object', ['type' => 'object']);
 
         // string
-        $m->set('string', "Two\r\nLines  ");
-        $this->assertSame('TwoLines', $m->get('string'));
+        $m['string'] = "Two\r\nLines  ";
+        $this->assertSame('TwoLines', $m['string']);
 
-        $m->set('string', "Two\rLines  ");
-        $this->assertSame('TwoLines', $m->get('string'));
+        $m['string'] = "Two\rLines  ";
+        $this->assertSame('TwoLines', $m['string']);
 
-        $m->set('string', "Two\nLines  ");
-        $this->assertSame('TwoLines', $m->get('string'));
+        $m['string'] = "Two\nLines  ";
+        $this->assertSame('TwoLines', $m['string']);
 
         // text
-        $m->set('text', "Two\r\nLines  ");
-        $this->assertSame("Two\nLines", $m->get('text'));
+        $m['text'] = "Two\r\nLines  ";
+        $this->assertSame("Two\nLines", $m['text']);
 
-        $m->set('text', "Two\rLines  ");
-        $this->assertSame("Two\nLines", $m->get('text'));
+        $m['text'] = "Two\rLines  ";
+        $this->assertSame("Two\nLines", $m['text']);
 
-        $m->set('text', "Two\nLines  ");
-        $this->assertSame("Two\nLines", $m->get('text'));
+        $m['text'] = "Two\nLines  ";
+        $this->assertSame("Two\nLines", $m['text']);
 
         // integer, money, float
-        $m->set('integer', '12,345.67676767'); // no digits after dot
-        $this->assertSame(12345, $m->get('integer'));
+        $m['integer'] = '12,345.67676767'; // no digits after dot
+        $this->assertSame(12345, $m['integer']);
 
-        $m->set('money', '12,345.67676767'); // 4 digits after dot
-        $this->assertSame(12345.6768, $m->get('money'));
+        $m['money'] = '12,345.67676767'; // 4 digits after dot
+        $this->assertSame(12345.6768, $m['money']);
 
-        $m->set('float', '12,345.67676767'); // don't round
-        $this->assertSame(12345.67676767, $m->get('float'));
+        $m['float'] = '12,345.67676767'; // don't round
+        $this->assertSame(12345.67676767, $m['float']);
 
         // boolean
-        $m->set('boolean', 0);
-        $this->assertFalse($m->get('boolean'));
-        $m->set('boolean', 1);
-        $this->assertTrue($m->get('boolean'));
+        $m['boolean'] = 0;
+        $this->assertFalse($m['boolean']);
+        $m['boolean'] = 1;
+        $this->assertTrue($m['boolean']);
 
-        $m->set('boolean_enum', 'N');
-        $this->assertFalse($m->get('boolean_enum'));
-        $m->set('boolean_enum', 'Y');
-        $this->assertTrue($m->get('boolean_enum'));
+        $m['boolean_enum'] = 'N';
+        $this->assertFalse($m['boolean_enum']);
+        $m['boolean_enum'] = 'Y';
+        $this->assertTrue($m['boolean_enum']);
 
         // date, datetime, time
-        $m->set('date', 123);
-        $this->assertInstanceof('DateTime', $m->get('date'));
-        $m->set('date', '123');
-        $this->assertInstanceof('DateTime', $m->get('date'));
-        $m->set('date', '2018-05-31');
-        $this->assertInstanceof('DateTime', $m->get('date'));
-        $m->set('datetime', 123);
-        $this->assertInstanceof('DateTime', $m->get('datetime'));
-        $m->set('datetime', '123');
-        $this->assertInstanceof('DateTime', $m->get('datetime'));
-        $m->set('datetime', '2018-05-31 12:13:14');
-        $this->assertInstanceof('DateTime', $m->get('datetime'));
-        $m->set('time', 123);
-        $this->assertInstanceof('DateTime', $m->get('time'));
-        $m->set('time', '123');
-        $this->assertInstanceof('DateTime', $m->get('time'));
-        $m->set('time', '12:13:14');
-        $this->assertInstanceof('DateTime', $m->get('time'));
+        $m['date'] = 123;
+        $this->assertInstanceof('DateTime', $m['date']);
+        $m['date'] = '123';
+        $this->assertInstanceof('DateTime', $m['date']);
+        $m['date'] = '2018-05-31';
+        $this->assertInstanceof('DateTime', $m['date']);
+        $m['datetime'] = 123;
+        $this->assertInstanceof('DateTime', $m['datetime']);
+        $m['datetime'] = '123';
+        $this->assertInstanceof('DateTime', $m['datetime']);
+        $m['datetime'] = '2018-05-31 12:13:14';
+        $this->assertInstanceof('DateTime', $m['datetime']);
+        $m['time'] = 123;
+        $this->assertInstanceof('DateTime', $m['time']);
+        $m['time'] = '123';
+        $this->assertInstanceof('DateTime', $m['time']);
+        $m['time'] = '12:13:14';
+        $this->assertInstanceof('DateTime', $m['time']);
     }
 
     /**
@@ -653,7 +653,7 @@ class FieldTest extends \atk4\schema\PhpunitTestCase
     {
         $m = new Model(['strict_types' => true]);
         $m->addField('foo', ['type' => 'string']);
-        $m->set('foo', []);
+        $m['foo'] = [];
     }
 
     /**
@@ -663,7 +663,7 @@ class FieldTest extends \atk4\schema\PhpunitTestCase
     {
         $m = new Model(['strict_types' => true]);
         $m->addField('foo', ['type' => 'text']);
-        $m->set('foo', []);
+        $m['foo'] = [];
     }
 
     /**
@@ -673,7 +673,7 @@ class FieldTest extends \atk4\schema\PhpunitTestCase
     {
         $m = new Model(['strict_types' => true]);
         $m->addField('foo', ['type' => 'integer']);
-        $m->set('foo', []);
+        $m['foo'] = [];
     }
 
     /**
@@ -683,7 +683,7 @@ class FieldTest extends \atk4\schema\PhpunitTestCase
     {
         $m = new Model(['strict_types' => true]);
         $m->addField('foo', ['type' => 'money']);
-        $m->set('foo', []);
+        $m['foo'] = [];
     }
 
     /**
@@ -693,7 +693,7 @@ class FieldTest extends \atk4\schema\PhpunitTestCase
     {
         $m = new Model(['strict_types' => true]);
         $m->addField('foo', ['type' => 'float']);
-        $m->set('foo', []);
+        $m['foo'] = [];
     }
 
     /**
@@ -703,7 +703,7 @@ class FieldTest extends \atk4\schema\PhpunitTestCase
     {
         $m = new Model(['strict_types' => true]);
         $m->addField('foo', ['type' => 'date']);
-        $m->set('foo', []);
+        $m['foo'] = [];
     }
 
     /**
@@ -713,7 +713,7 @@ class FieldTest extends \atk4\schema\PhpunitTestCase
     {
         $m = new Model(['strict_types' => true]);
         $m->addField('foo', ['type' => 'datetime']);
-        $m->set('foo', []);
+        $m['foo'] = [];
     }
 
     /**
@@ -723,7 +723,7 @@ class FieldTest extends \atk4\schema\PhpunitTestCase
     {
         $m = new Model(['strict_types' => true]);
         $m->addField('foo', ['type' => 'time']);
-        $m->set('foo', []);
+        $m['foo'] = [];
     }
 
     /**
@@ -733,7 +733,7 @@ class FieldTest extends \atk4\schema\PhpunitTestCase
     {
         $m = new Model(['strict_types' => true]);
         $m->addField('foo', ['type' => 'integer']);
-        $m->set('foo', '123---456');
+        $m['foo'] = '123---456';
     }
 
     /**
@@ -743,7 +743,7 @@ class FieldTest extends \atk4\schema\PhpunitTestCase
     {
         $m = new Model(['strict_types' => true]);
         $m->addField('foo', ['type' => 'money']);
-        $m->set('foo', '123---456');
+        $m['foo'] = '123---456';
     }
 
     /**
@@ -753,7 +753,7 @@ class FieldTest extends \atk4\schema\PhpunitTestCase
     {
         $m = new Model(['strict_types' => true]);
         $m->addField('foo', ['type' => 'float']);
-        $m->set('foo', '123---456');
+        $m['foo'] = '123---456';
     }
 
     /**
@@ -763,7 +763,7 @@ class FieldTest extends \atk4\schema\PhpunitTestCase
     {
         $m = new Model(['strict_types' => true]);
         $m->addField('foo', ['type' => 'array']);
-        $m->set('foo', 'ABC');
+        $m['foo'] = 'ABC';
     }
 
     /**
@@ -773,7 +773,7 @@ class FieldTest extends \atk4\schema\PhpunitTestCase
     {
         $m = new Model(['strict_types' => true]);
         $m->addField('foo', ['type' => 'object']);
-        $m->set('foo', 'ABC');
+        $m['foo'] = 'ABC';
     }
 
     /**
@@ -783,7 +783,7 @@ class FieldTest extends \atk4\schema\PhpunitTestCase
     {
         $m = new Model(['strict_types' => true]);
         $m->addField('foo', ['type' => 'boolean']);
-        $m->set('foo', 'ABC');
+        $m['foo'] = 'ABC';
     }
 
     public function testToString()
@@ -932,34 +932,34 @@ class FieldTest extends \atk4\schema\PhpunitTestCase
         $m->addField('is_vip_3', ['type' => 'boolean', 'valueTrue' => 'Y', 'valueFalse' => 'N']);
 
         $m->set('is_vip_1', 'No');
-        $this->assertFalse($m->get('is_vip_1'));
+        $this->assertFalse($m['is_vip_1']);
         $m->set('is_vip_1', 'Yes');
-        $this->assertTrue($m->get('is_vip_1'));
+        $this->assertTrue($m['is_vip_1']);
         $m->set('is_vip_1', false);
-        $this->assertFalse($m->get('is_vip_1'));
+        $this->assertFalse($m['is_vip_1']);
         $m->set('is_vip_1', true);
-        $this->assertTrue($m->get('is_vip_1'));
+        $this->assertTrue($m['is_vip_1']);
         $m->set('is_vip_1', 0);
-        $this->assertFalse($m->get('is_vip_1'));
+        $this->assertFalse($m['is_vip_1']);
         $m->set('is_vip_1', 1);
-        $this->assertTrue($m->get('is_vip_1'));
+        $this->assertTrue($m['is_vip_1']);
 
         $m->set('is_vip_2', 0);
-        $this->assertFalse($m->get('is_vip_2'));
+        $this->assertFalse($m['is_vip_2']);
         $m->set('is_vip_2', 1);
-        $this->assertTrue($m->get('is_vip_2'));
+        $this->assertTrue($m['is_vip_2']);
         $m->set('is_vip_2', false);
-        $this->assertFalse($m->get('is_vip_2'));
+        $this->assertFalse($m['is_vip_2']);
         $m->set('is_vip_2', true);
-        $this->assertTrue($m->get('is_vip_2'));
+        $this->assertTrue($m['is_vip_2']);
 
         $m->set('is_vip_3', 'N');
-        $this->assertFalse($m->get('is_vip_3'));
+        $this->assertFalse($m['is_vip_3']);
         $m->set('is_vip_3', 'Y');
-        $this->assertTrue($m->get('is_vip_3'));
+        $this->assertTrue($m['is_vip_3']);
         $m->set('is_vip_3', false);
-        $this->assertFalse($m->get('is_vip_3'));
+        $this->assertFalse($m['is_vip_3']);
         $m->set('is_vip_3', true);
-        $this->assertTrue($m->get('is_vip_3'));
+        $this->assertTrue($m['is_vip_3']);
     }
 }

--- a/tests/FieldTest.php
+++ b/tests/FieldTest.php
@@ -16,26 +16,26 @@ class FieldTest extends \atk4\schema\PhpunitTestCase
 
         $this->assertFalse($m->isDirty('foo'));
 
-        $m['foo'] = 'abc';
+        $m->set('foo', 'abc');
         $this->assertFalse($m->isDirty('foo'));
 
-        $m['foo'] = 'bca';
+        $m->set('foo', 'bca');
         $this->assertTrue($m->isDirty('foo'));
 
-        $m['foo'] = 'abc';
+        $m->set('foo', 'abc');
         $this->assertFalse($m->isDirty('foo'));
 
         // set initial data
         $m->data['foo'] = 'xx';
         $this->assertFalse($m->isDirty('foo'));
 
-        $m['foo'] = 'abc';
+        $m->set('foo', 'abc');
         $this->assertTrue($m->isDirty('foo'));
 
-        $m['foo'] = 'bca';
+        $m->set('foo', 'bca');
         $this->assertTrue($m->isDirty('foo'));
 
-        $m['foo'] = 'xx';
+        $m->set('foo', 'xx');
         $this->assertFalse($m->isDirty('foo'));
     }
 
@@ -45,7 +45,7 @@ class FieldTest extends \atk4\schema\PhpunitTestCase
         $m->addField('foo', ['default' => 'abc']);
 
         $this->assertTrue($m->compare('foo', 'abc'));
-        $m['foo'] = 'zzz';
+        $m->set('foo', 'zzz');
 
         $this->assertFalse($m->compare('foo', 'abc'));
         $this->assertTrue($m->compare('foo', 'zzz'));
@@ -55,10 +55,10 @@ class FieldTest extends \atk4\schema\PhpunitTestCase
     {
         $m = new Model();
         $m->addField('foo', ['mandatory' => true]);
-        $m['foo'] = 'abc';
-        $m['foo'] = null;
-        $m['foo'] = '';
-        unset($m['foo']);
+        $m->set('foo', 'abc');
+        $m->set('foo', null);
+        $m->set('foo', '');
+        $m->_unset('name');
     }
 
     /**
@@ -68,8 +68,8 @@ class FieldTest extends \atk4\schema\PhpunitTestCase
     {
         $m = new Model();
         $m->addField('foo', ['required' => true]);
-        $m['foo'] = '';
-        unset($m['foo']);
+        $m->set('foo', '');
+        $m->_unset('name');
     }
 
     /**
@@ -79,8 +79,8 @@ class FieldTest extends \atk4\schema\PhpunitTestCase
     {
         $m = new Model();
         $m->addField('foo', ['required' => true]);
-        $m['foo'] = null;
-        unset($m['foo']);
+        $m->set('foo', null);
+        $m->_unset('name');
     }
 
     /**
@@ -195,14 +195,14 @@ class FieldTest extends \atk4\schema\PhpunitTestCase
     {
         $m = new Model();
         $m->addField('foo', ['read_only' => true]);
-        $m['foo'] = 'bar';
+        $m->set('foo', 'bar');
     }
 
     public function testReadOnly2()
     {
         $m = new Model();
         $m->addField('foo', ['read_only' => true, 'default' => 'abc']);
-        $m['foo'] = 'abc';
+        $m->set('foo', 'abc');
     }
 
     public function testReadOnly3()
@@ -210,7 +210,7 @@ class FieldTest extends \atk4\schema\PhpunitTestCase
         $m = new Model();
         $m->addField('foo', ['read_only' => true, 'default' => 'abc']);
         $m->data['foo'] = 'xx';
-        $m['foo'] = 'xx';
+        $m->set('foo', 'xx');
     }
 
     /**
@@ -220,19 +220,19 @@ class FieldTest extends \atk4\schema\PhpunitTestCase
     {
         $m = new Model();
         $m->addField('foo', ['enum' => ['foo', 'bar']]);
-        $m['foo'] = 'xx';
+        $m->set('foo', 'xx');
     }
 
     public function testEnum2()
     {
         $m = new Model();
         $m->addField('foo', ['enum' => [1, 'bar']]);
-        $m['foo'] = 1;
+        $m->set('foo', 1);
 
-        $this->assertSame(1, $m['foo']);
+        $this->assertSame(1, $m->get('foo'));
 
-        $m['foo'] = 'bar';
-        $this->assertSame('bar', $m['foo']);
+        $m->set('foo', 'bar');
+        $this->assertSame('bar', $m->get('foo'));
     }
 
     /**
@@ -242,7 +242,7 @@ class FieldTest extends \atk4\schema\PhpunitTestCase
     {
         $m = new Model();
         $m->addField('foo', ['enum' => [1, 'bar']]);
-        $m['foo'] = true;
+        $m->set('foo', true);
     }
 
     public function testEnum4()
@@ -252,9 +252,9 @@ class FieldTest extends \atk4\schema\PhpunitTestCase
         // to a weird behaviours of PHP
         $m = new Model();
         $m->addField('foo', ['enum' => [1, 'bar'], 'default' => 1]);
-        $m['foo'] = null;
+        $m->set('foo', null);
 
-        $this->assertNull($m['foo']);
+        $this->assertNull($m->get('foo'));
     }
 
     /**
@@ -264,19 +264,19 @@ class FieldTest extends \atk4\schema\PhpunitTestCase
     {
         $m = new Model();
         $m->addField('foo', ['values' => ['foo', 'bar']]);
-        $m['foo'] = 4;
+        $m->set('foo', 4);
     }
 
     public function testValues2()
     {
         $m = new Model();
         $m->addField('foo', ['values' => [3 => 'bar']]);
-        $m['foo'] = 3;
+        $m->set('foo', 3);
 
-        $this->assertSame(3, $m['foo']);
+        $this->assertSame(3, $m->get('foo'));
 
-        $m['foo'] = null;
-        $this->assertNull($m['foo']);
+        $m->set('foo', null);
+        $this->assertNull($m->get('foo'));
     }
 
     /**
@@ -286,7 +286,7 @@ class FieldTest extends \atk4\schema\PhpunitTestCase
     {
         $m = new Model();
         $m->addField('foo', ['values' => [1 => 'bar']]);
-        $m['foo'] = true;
+        $m->set('foo', true);
     }
 
     /**
@@ -296,7 +296,7 @@ class FieldTest extends \atk4\schema\PhpunitTestCase
     {
         $m = new Model();
         $m->addField('foo', ['values' => [1 => 'bar']]);
-        $m['foo'] = 'bar';
+        $m->set('foo', 'bar');
     }
 
     public function testValues4()
@@ -306,7 +306,7 @@ class FieldTest extends \atk4\schema\PhpunitTestCase
         // to a weird behaviours of PHP
         $m = new Model();
         $m->addField('foo', ['values' => ['1a' => 'bar']]);
-        $m['foo'] = '1a';
+        $m->set('foo', '1a');
     }
 
     public function testPersist()
@@ -323,47 +323,47 @@ class FieldTest extends \atk4\schema\PhpunitTestCase
         $m->addField('surname', ['never_save' => true]);
         $m->load(1);
 
-        $this->assertNull($m['name']);
-        $this->assertSame('Smith', $m['surname']);
+        $this->assertNull($m->get('name'));
+        $this->assertSame('Smith', $m->get('surname'));
 
-        $m['name'] = 'Bill';
-        $m['surname'] = 'Stalker';
+        $m->set('name', 'Bill');
+        $m->set('surname', 'Stalker');
         $m->save();
         $this->assertEquals($a, $this->getDB());
 
         $m->reload();
-        $this->assertSame('Smith', $m['surname']);
+        $this->assertSame('Smith', $m->get('surname'));
         $m->getField('surname')->never_save = false;
-        $m['surname'] = 'Stalker';
+        $m->set('surname', 'Stalker');
         $m->save();
         $a['item'][1]['surname'] = 'Stalker';
         $this->assertEquals($a, $this->getDB());
 
         $m->onHook('beforeSave', function ($m) {
             if ($m->isDirty('name')) {
-                $m['surname'] = $m['name'];
-                unset($m['name']);
+                $m->set('surname', $m->get('name'));
+                $m->_unset('name');
             } elseif ($m->isDirty('surname')) {
-                $m['name'] = $m['surname'];
-                unset($m['surname']);
+                $m->set('name', $m->get('surname'));
+                $m->_unset('surname');
             }
         });
 
-        $m['name'] = 'X';
+        $m->set('name', 'X');
         $m->save();
 
         $a['item'][1]['surname'] = 'X';
 
         $this->assertEquals($a, $this->getDB());
-        $this->assertNull($m['name']);
-        $this->assertSame('X', $m['surname']);
+        $this->assertNull($m->get('name'));
+        $this->assertSame('X', $m->get('surname'));
 
-        $m['surname'] = 'Y';
+        $m->set('surname', 'Y');
         $m->save();
 
         $this->assertEquals($a, $this->getDB());
-        $this->assertSame('Y', $m['name']);
-        $this->assertSame('X', $m['surname']);
+        $this->assertSame('Y', $m->get('name'));
+        $this->assertSame('X', $m->get('surname'));
     }
 
     public function testTitle()
@@ -395,8 +395,8 @@ class FieldTest extends \atk4\schema\PhpunitTestCase
 
         $m->load(1);
 
-        $this->assertSame('John', $m['name']);
-        $this->assertSame('Programmer', $m['category']);
+        $this->assertSame('John', $m->get('name'));
+        $this->assertSame('Programmer', $m->get('category'));
 
         $m->insert(['Peter', 'category' => 'Sales']);
 
@@ -421,14 +421,14 @@ class FieldTest extends \atk4\schema\PhpunitTestCase
     {
         $m = new Model();
         $m->addField('foo');
-        $m['baz'] = 'bar';
+        $m->set('baz', 'bar');
     }
 
     public function testStrict1()
     {
         $m = new Model(['strict_field_check' => false]);
         $m->addField('foo');
-        $m['baz'] = 'bar';
+        $m->set('baz', 'bar');
     }
 
     public function testActual()
@@ -449,7 +449,7 @@ class FieldTest extends \atk4\schema\PhpunitTestCase
         $m->addField('surname');
         $m->insert(['first_name' => 'Peter', 'surname' => 'qq']);
         $m->loadBy('first_name', 'John');
-        $this->assertSame('John', $m['first_name']);
+        $this->assertSame('John', $m->get('first_name'));
 
         $d = $m->export();
         $this->assertSame('John', $d[0]['first_name']);
@@ -461,7 +461,7 @@ class FieldTest extends \atk4\schema\PhpunitTestCase
             ], ];
         $this->assertEquals($a, $this->getDB());
 
-        $m['first_name'] = 'Scott';
+        $m->set('first_name', 'Scott');
         $m->save();
 
         $a = [
@@ -485,14 +485,14 @@ class FieldTest extends \atk4\schema\PhpunitTestCase
         $m->addField('net', ['type' => 'money']);
         $m->addField('vat', ['type' => 'money']);
         $m->addCalculatedField('total', function ($m) {
-            return $m['net'] + $m['vat'];
+            return $m->get('net') + $m->get('vat');
         });
         $m->insert(['net' => 30, 'vat' => 8]);
 
         $m->load(1);
-        $this->assertEquals(121, $m['total']);
+        $this->assertEquals(121, $m->get('total'));
         $m->load(2);
-        $this->assertEquals(38, $m['total']);
+        $this->assertEquals(38, $m->get('total'));
 
         $d = $m->export(); // in export calculated fields are not included
         $this->assertFalse(isset($d[0]['total']));
@@ -562,7 +562,7 @@ class FieldTest extends \atk4\schema\PhpunitTestCase
         $this->assertNotSame('i am a woman', $a['user'][1]['secret']);
 
         $m->unload()->load(1);
-        $this->assertSame('i am a woman', $m['secret']);
+        $this->assertSame('i am a woman', $m->get('secret'));
     }
 
     public function testNormalize()
@@ -585,65 +585,65 @@ class FieldTest extends \atk4\schema\PhpunitTestCase
         $m->addField('object', ['type' => 'object']);
 
         // string
-        $m['string'] = "Two\r\nLines  ";
-        $this->assertSame('TwoLines', $m['string']);
+        $m->set('string', "Two\r\nLines  ");
+        $this->assertSame('TwoLines', $m->get('string'));
 
-        $m['string'] = "Two\rLines  ";
-        $this->assertSame('TwoLines', $m['string']);
+        $m->set('string', "Two\rLines  ");
+        $this->assertSame('TwoLines', $m->get('string'));
 
-        $m['string'] = "Two\nLines  ";
-        $this->assertSame('TwoLines', $m['string']);
+        $m->set('string', "Two\nLines  ");
+        $this->assertSame('TwoLines', $m->get('string'));
 
         // text
-        $m['text'] = "Two\r\nLines  ";
-        $this->assertSame("Two\nLines", $m['text']);
+        $m->set('text', "Two\r\nLines  ");
+        $this->assertSame("Two\nLines", $m->get('text'));
 
-        $m['text'] = "Two\rLines  ";
-        $this->assertSame("Two\nLines", $m['text']);
+        $m->set('text', "Two\rLines  ");
+        $this->assertSame("Two\nLines", $m->get('text'));
 
-        $m['text'] = "Two\nLines  ";
-        $this->assertSame("Two\nLines", $m['text']);
+        $m->set('text', "Two\nLines  ");
+        $this->assertSame("Two\nLines", $m->get('text'));
 
         // integer, money, float
-        $m['integer'] = '12,345.67676767'; // no digits after dot
-        $this->assertSame(12345, $m['integer']);
+        $m->set('integer', '12,345.67676767'); // no digits after dot
+        $this->assertSame(12345, $m->get('integer'));
 
-        $m['money'] = '12,345.67676767'; // 4 digits after dot
-        $this->assertSame(12345.6768, $m['money']);
+        $m->set('money', '12,345.67676767'); // 4 digits after dot
+        $this->assertSame(12345.6768, $m->get('money'));
 
-        $m['float'] = '12,345.67676767'; // don't round
-        $this->assertSame(12345.67676767, $m['float']);
+        $m->set('float', '12,345.67676767'); // don't round
+        $this->assertSame(12345.67676767, $m->get('float'));
 
         // boolean
-        $m['boolean'] = 0;
-        $this->assertFalse($m['boolean']);
-        $m['boolean'] = 1;
-        $this->assertTrue($m['boolean']);
+        $m->set('boolean', 0);
+        $this->assertFalse($m->get('boolean'));
+        $m->set('boolean', 1);
+        $this->assertTrue($m->get('boolean'));
 
-        $m['boolean_enum'] = 'N';
-        $this->assertFalse($m['boolean_enum']);
-        $m['boolean_enum'] = 'Y';
-        $this->assertTrue($m['boolean_enum']);
+        $m->set('boolean_enum', 'N');
+        $this->assertFalse($m->get('boolean_enum'));
+        $m->set('boolean_enum', 'Y');
+        $this->assertTrue($m->get('boolean_enum'));
 
         // date, datetime, time
-        $m['date'] = 123;
-        $this->assertInstanceof('DateTime', $m['date']);
-        $m['date'] = '123';
-        $this->assertInstanceof('DateTime', $m['date']);
-        $m['date'] = '2018-05-31';
-        $this->assertInstanceof('DateTime', $m['date']);
-        $m['datetime'] = 123;
-        $this->assertInstanceof('DateTime', $m['datetime']);
-        $m['datetime'] = '123';
-        $this->assertInstanceof('DateTime', $m['datetime']);
-        $m['datetime'] = '2018-05-31 12:13:14';
-        $this->assertInstanceof('DateTime', $m['datetime']);
-        $m['time'] = 123;
-        $this->assertInstanceof('DateTime', $m['time']);
-        $m['time'] = '123';
-        $this->assertInstanceof('DateTime', $m['time']);
-        $m['time'] = '12:13:14';
-        $this->assertInstanceof('DateTime', $m['time']);
+        $m->set('date', 123);
+        $this->assertInstanceof('DateTime', $m->get('date'));
+        $m->set('date', '123');
+        $this->assertInstanceof('DateTime', $m->get('date'));
+        $m->set('date', '2018-05-31');
+        $this->assertInstanceof('DateTime', $m->get('date'));
+        $m->set('datetime', 123);
+        $this->assertInstanceof('DateTime', $m->get('datetime'));
+        $m->set('datetime', '123');
+        $this->assertInstanceof('DateTime', $m->get('datetime'));
+        $m->set('datetime', '2018-05-31 12:13:14');
+        $this->assertInstanceof('DateTime', $m->get('datetime'));
+        $m->set('time', 123);
+        $this->assertInstanceof('DateTime', $m->get('time'));
+        $m->set('time', '123');
+        $this->assertInstanceof('DateTime', $m->get('time'));
+        $m->set('time', '12:13:14');
+        $this->assertInstanceof('DateTime', $m->get('time'));
     }
 
     /**
@@ -653,7 +653,7 @@ class FieldTest extends \atk4\schema\PhpunitTestCase
     {
         $m = new Model(['strict_types' => true]);
         $m->addField('foo', ['type' => 'string']);
-        $m['foo'] = [];
+        $m->set('foo', []);
     }
 
     /**
@@ -663,7 +663,7 @@ class FieldTest extends \atk4\schema\PhpunitTestCase
     {
         $m = new Model(['strict_types' => true]);
         $m->addField('foo', ['type' => 'text']);
-        $m['foo'] = [];
+        $m->set('foo', []);
     }
 
     /**
@@ -673,7 +673,7 @@ class FieldTest extends \atk4\schema\PhpunitTestCase
     {
         $m = new Model(['strict_types' => true]);
         $m->addField('foo', ['type' => 'integer']);
-        $m['foo'] = [];
+        $m->set('foo', []);
     }
 
     /**
@@ -683,7 +683,7 @@ class FieldTest extends \atk4\schema\PhpunitTestCase
     {
         $m = new Model(['strict_types' => true]);
         $m->addField('foo', ['type' => 'money']);
-        $m['foo'] = [];
+        $m->set('foo', []);
     }
 
     /**
@@ -693,7 +693,7 @@ class FieldTest extends \atk4\schema\PhpunitTestCase
     {
         $m = new Model(['strict_types' => true]);
         $m->addField('foo', ['type' => 'float']);
-        $m['foo'] = [];
+        $m->set('foo', []);
     }
 
     /**
@@ -703,7 +703,7 @@ class FieldTest extends \atk4\schema\PhpunitTestCase
     {
         $m = new Model(['strict_types' => true]);
         $m->addField('foo', ['type' => 'date']);
-        $m['foo'] = [];
+        $m->set('foo', []);
     }
 
     /**
@@ -713,7 +713,7 @@ class FieldTest extends \atk4\schema\PhpunitTestCase
     {
         $m = new Model(['strict_types' => true]);
         $m->addField('foo', ['type' => 'datetime']);
-        $m['foo'] = [];
+        $m->set('foo', []);
     }
 
     /**
@@ -723,7 +723,7 @@ class FieldTest extends \atk4\schema\PhpunitTestCase
     {
         $m = new Model(['strict_types' => true]);
         $m->addField('foo', ['type' => 'time']);
-        $m['foo'] = [];
+        $m->set('foo', []);
     }
 
     /**
@@ -733,7 +733,7 @@ class FieldTest extends \atk4\schema\PhpunitTestCase
     {
         $m = new Model(['strict_types' => true]);
         $m->addField('foo', ['type' => 'integer']);
-        $m['foo'] = '123---456';
+        $m->set('foo', '123---456');
     }
 
     /**
@@ -743,7 +743,7 @@ class FieldTest extends \atk4\schema\PhpunitTestCase
     {
         $m = new Model(['strict_types' => true]);
         $m->addField('foo', ['type' => 'money']);
-        $m['foo'] = '123---456';
+        $m->set('foo', '123---456');
     }
 
     /**
@@ -753,7 +753,7 @@ class FieldTest extends \atk4\schema\PhpunitTestCase
     {
         $m = new Model(['strict_types' => true]);
         $m->addField('foo', ['type' => 'float']);
-        $m['foo'] = '123---456';
+        $m->set('foo', '123---456');
     }
 
     /**
@@ -763,7 +763,7 @@ class FieldTest extends \atk4\schema\PhpunitTestCase
     {
         $m = new Model(['strict_types' => true]);
         $m->addField('foo', ['type' => 'array']);
-        $m['foo'] = 'ABC';
+        $m->set('foo', 'ABC');
     }
 
     /**
@@ -773,7 +773,7 @@ class FieldTest extends \atk4\schema\PhpunitTestCase
     {
         $m = new Model(['strict_types' => true]);
         $m->addField('foo', ['type' => 'object']);
-        $m['foo'] = 'ABC';
+        $m->set('foo', 'ABC');
     }
 
     /**
@@ -783,7 +783,7 @@ class FieldTest extends \atk4\schema\PhpunitTestCase
     {
         $m = new Model(['strict_types' => true]);
         $m->addField('foo', ['type' => 'boolean']);
-        $m['foo'] = 'ABC';
+        $m->set('foo', 'ABC');
     }
 
     public function testToString()
@@ -932,34 +932,34 @@ class FieldTest extends \atk4\schema\PhpunitTestCase
         $m->addField('is_vip_3', ['type' => 'boolean', 'valueTrue' => 'Y', 'valueFalse' => 'N']);
 
         $m->set('is_vip_1', 'No');
-        $this->assertFalse($m['is_vip_1']);
+        $this->assertFalse($m->get('is_vip_1'));
         $m->set('is_vip_1', 'Yes');
-        $this->assertTrue($m['is_vip_1']);
+        $this->assertTrue($m->get('is_vip_1'));
         $m->set('is_vip_1', false);
-        $this->assertFalse($m['is_vip_1']);
+        $this->assertFalse($m->get('is_vip_1'));
         $m->set('is_vip_1', true);
-        $this->assertTrue($m['is_vip_1']);
+        $this->assertTrue($m->get('is_vip_1'));
         $m->set('is_vip_1', 0);
-        $this->assertFalse($m['is_vip_1']);
+        $this->assertFalse($m->get('is_vip_1'));
         $m->set('is_vip_1', 1);
-        $this->assertTrue($m['is_vip_1']);
+        $this->assertTrue($m->get('is_vip_1'));
 
         $m->set('is_vip_2', 0);
-        $this->assertFalse($m['is_vip_2']);
+        $this->assertFalse($m->get('is_vip_2'));
         $m->set('is_vip_2', 1);
-        $this->assertTrue($m['is_vip_2']);
+        $this->assertTrue($m->get('is_vip_2'));
         $m->set('is_vip_2', false);
-        $this->assertFalse($m['is_vip_2']);
+        $this->assertFalse($m->get('is_vip_2'));
         $m->set('is_vip_2', true);
-        $this->assertTrue($m['is_vip_2']);
+        $this->assertTrue($m->get('is_vip_2'));
 
         $m->set('is_vip_3', 'N');
-        $this->assertFalse($m['is_vip_3']);
+        $this->assertFalse($m->get('is_vip_3'));
         $m->set('is_vip_3', 'Y');
-        $this->assertTrue($m['is_vip_3']);
+        $this->assertTrue($m->get('is_vip_3'));
         $m->set('is_vip_3', false);
-        $this->assertFalse($m['is_vip_3']);
+        $this->assertFalse($m->get('is_vip_3'));
         $m->set('is_vip_3', true);
-        $this->assertTrue($m['is_vip_3']);
+        $this->assertTrue($m->get('is_vip_3'));
     }
 }

--- a/tests/FieldTypesTest.php
+++ b/tests/FieldTypesTest.php
@@ -27,14 +27,14 @@ class FieldTypesTest extends \atk4\schema\PhpunitTestCase
         $m = new Model($this->pers);
         $m->addField('email', ['Email']);
 
-        $m['email'] = ' foo@example.com';
+        $m->set('email', ' foo@example.com');
         $m->save();
 
         // padding removed
-        $this->assertSame('foo@example.com', $m['email']);
+        $this->assertSame('foo@example.com', $m->get('email'));
 
         $this->expectExceptionMessage('format is invalid');
-        $m['email'] = 'qq';
+        $m->set('email', 'qq');
     }
 
     public function testEmail2()
@@ -43,11 +43,11 @@ class FieldTypesTest extends \atk4\schema\PhpunitTestCase
         $m->addField('email', ['Email']);
         $m->addField('emails', ['Email', 'allow_multiple' => true]);
 
-        $m['emails'] = 'bar@exampe.com ,foo@example.com';
-        $this->assertSame('bar@exampe.com, foo@example.com', $m['emails']);
+        $m->set('emails', 'bar@exampe.com ,foo@example.com');
+        $this->assertSame('bar@exampe.com, foo@example.com', $m->get('emails'));
 
         $this->expectExceptionMessage('a single email');
-        $m['email'] = 'bar@exampe.com ,foo@example.com';
+        $m->set('email', 'bar@exampe.com ,foo@example.com');
     }
 
     public function testEmail3()
@@ -55,12 +55,12 @@ class FieldTypesTest extends \atk4\schema\PhpunitTestCase
         $m = new Model($this->pers);
         $m->addField('email', ['Email', 'dns_check' => true]);
 
-        $m['email'] = ' foo@gmail.com';
+        $m->set('email', ' foo@gmail.com');
 
         $this->markTestIncomplete(); // @TODO, test below is failing, to be solved later
 
         $this->expectExceptionMessage('does not exist');
-        $m['email'] = ' foo@lrcanoetuhasnotdusantotehusontehuasntddaontehudnouhtd.com';
+        $m->set('email', ' foo@lrcanoetuhasnotdusantotehusontehuasntddaontehudnouhtd.com');
     }
 
     public function testEmail4()
@@ -71,11 +71,11 @@ class FieldTypesTest extends \atk4\schema\PhpunitTestCase
         $m->addField('email_idn', ['Email', 'dns_check' => true]);
         $m->addField('email', ['Email']);
 
-        $m['email_name'] = 'Romans <me@gmail.com>';
-        $m['email_names'] = 'Romans1 <me1@gmail.com>, Romans2 <me2@gmail.com>; Romans3 <me3@gmail.com>';
-        $m['email_idn'] = 'test@日本レジストリサービス.jp';
+        $m->set('email_name', 'Romans <me@gmail.com>');
+        $m->set('email_names', 'Romans1 <me1@gmail.com>, Romans2 <me2@gmail.com>; Romans3 <me3@gmail.com>');
+        $m->set('email_idn', 'test@日本レジストリサービス.jp');
 
         $this->expectExceptionMessage('format is invalid');
-        $m['email'] = 'Romans <me@gmail.com>';
+        $m->set('email', 'Romans <me@gmail.com>');
     }
 }

--- a/tests/FieldTypesTest.php
+++ b/tests/FieldTypesTest.php
@@ -27,14 +27,14 @@ class FieldTypesTest extends \atk4\schema\PhpunitTestCase
         $m = new Model($this->pers);
         $m->addField('email', ['Email']);
 
-        $m->set('email', ' foo@example.com');
+        $m['email'] = ' foo@example.com';
         $m->save();
 
         // padding removed
-        $this->assertSame('foo@example.com', $m->get('email'));
+        $this->assertSame('foo@example.com', $m['email']);
 
         $this->expectExceptionMessage('format is invalid');
-        $m->set('email', 'qq');
+        $m['email'] = 'qq';
     }
 
     public function testEmail2()
@@ -43,11 +43,11 @@ class FieldTypesTest extends \atk4\schema\PhpunitTestCase
         $m->addField('email', ['Email']);
         $m->addField('emails', ['Email', 'allow_multiple' => true]);
 
-        $m->set('emails', 'bar@exampe.com ,foo@example.com');
-        $this->assertSame('bar@exampe.com, foo@example.com', $m->get('emails'));
+        $m['emails'] = 'bar@exampe.com ,foo@example.com';
+        $this->assertSame('bar@exampe.com, foo@example.com', $m['emails']);
 
         $this->expectExceptionMessage('a single email');
-        $m->set('email', 'bar@exampe.com ,foo@example.com');
+        $m['email'] = 'bar@exampe.com ,foo@example.com';
     }
 
     public function testEmail3()
@@ -55,12 +55,12 @@ class FieldTypesTest extends \atk4\schema\PhpunitTestCase
         $m = new Model($this->pers);
         $m->addField('email', ['Email', 'dns_check' => true]);
 
-        $m->set('email', ' foo@gmail.com');
+        $m['email'] = ' foo@gmail.com';
 
         $this->markTestIncomplete(); // @TODO, test below is failing, to be solved later
 
         $this->expectExceptionMessage('does not exist');
-        $m->set('email', ' foo@lrcanoetuhasnotdusantotehusontehuasntddaontehudnouhtd.com');
+        $m['email'] = ' foo@lrcanoetuhasnotdusantotehusontehuasntddaontehudnouhtd.com';
     }
 
     public function testEmail4()
@@ -71,11 +71,11 @@ class FieldTypesTest extends \atk4\schema\PhpunitTestCase
         $m->addField('email_idn', ['Email', 'dns_check' => true]);
         $m->addField('email', ['Email']);
 
-        $m->set('email_name', 'Romans <me@gmail.com>');
-        $m->set('email_names', 'Romans1 <me1@gmail.com>, Romans2 <me2@gmail.com>; Romans3 <me3@gmail.com>');
-        $m->set('email_idn', 'test@日本レジストリサービス.jp');
+        $m['email_name'] = 'Romans <me@gmail.com>';
+        $m['email_names'] = 'Romans1 <me1@gmail.com>, Romans2 <me2@gmail.com>; Romans3 <me3@gmail.com>';
+        $m['email_idn'] = 'test@日本レジストリサービス.jp';
 
         $this->expectExceptionMessage('format is invalid');
-        $m->set('email', 'Romans <me@gmail.com>');
+        $m['email'] = 'Romans <me@gmail.com>';
     }
 }

--- a/tests/IteratorTest.php
+++ b/tests/IteratorTest.php
@@ -198,9 +198,9 @@ class IteratorTest extends \atk4\schema\PhpunitTestCase
             $data[$id] = clone $item;
         }
 
-        $this->assertEquals(10, $data[1]['total_net']);
-        $this->assertEquals(20, $data[2]['total_net']);
-        $this->assertEquals(15, $data[3]['total_net']);
-        $this->assertNull($i['total_net']);
+        $this->assertEquals(10, $data[1]->get('total_net'));
+        $this->assertEquals(20, $data[2]->get('total_net'));
+        $this->assertEquals(15, $data[3]->get('total_net'));
+        $this->assertNull($i->get('total_net'));
     }
 }

--- a/tests/IteratorTest.php
+++ b/tests/IteratorTest.php
@@ -195,12 +195,12 @@ class IteratorTest extends \atk4\schema\PhpunitTestCase
 
         $data = [];
         foreach ($i as $id => $item) {
-            $data[$id] = clone $item;
+            $data->set($id, clone $item);
         }
 
-        $this->assertEquals(10, $data[1]['total_net']);
-        $this->assertEquals(20, $data[2]['total_net']);
-        $this->assertEquals(15, $data[3]['total_net']);
-        $this->assertNull($i['total_net']);
+        $this->assertEquals(10, $data->get(1)['total_net']);
+        $this->assertEquals(20, $data->get(2)['total_net']);
+        $this->assertEquals(15, $data->get(3)['total_net']);
+        $this->assertNull($i->get('total_net'));
     }
 }

--- a/tests/IteratorTest.php
+++ b/tests/IteratorTest.php
@@ -195,12 +195,12 @@ class IteratorTest extends \atk4\schema\PhpunitTestCase
 
         $data = [];
         foreach ($i as $id => $item) {
-            $data->set($id, clone $item);
+            $data[$id] = clone $item;
         }
 
-        $this->assertEquals(10, $data->get(1)['total_net']);
-        $this->assertEquals(20, $data->get(2)['total_net']);
-        $this->assertEquals(15, $data->get(3)['total_net']);
-        $this->assertNull($i->get('total_net'));
+        $this->assertEquals(10, $data[1]['total_net']);
+        $this->assertEquals(20, $data[2]['total_net']);
+        $this->assertEquals(15, $data[3]['total_net']);
+        $this->assertNull($i['total_net']);
     }
 }

--- a/tests/JoinArrayTest.php
+++ b/tests/JoinArrayTest.php
@@ -67,8 +67,8 @@ class JoinArrayTest extends AtkPhpunit\TestCase
         $j = $m_u->join('contact');
         $j->addField('contact_phone');
 
-        $m_u->set('name', 'John');
-        $m_u->set('contact_phone', '+123');
+        $m_u['name'] = 'John';
+        $m_u['contact_phone'] = '+123';
 
         $m_u->save();
 
@@ -78,8 +78,8 @@ class JoinArrayTest extends AtkPhpunit\TestCase
         ], $a);
 
         $m_u->unload();
-        $m_u->set('name', 'Peter');
-        $m_u->set('contact_id', 1);
+        $m_u['name'] = 'Peter';
+        $m_u['contact_id'] = 1;
         $m_u->save();
         $m_u->unload();
 
@@ -92,8 +92,8 @@ class JoinArrayTest extends AtkPhpunit\TestCase
             ],
         ], $a);
 
-        $m_u->set('name', 'Joe');
-        $m_u->set('contact_phone', '+321');
+        $m_u['name'] = 'Joe';
+        $m_u['contact_phone'] = '+321';
         $m_u->save();
 
         $this->assertEquals([
@@ -117,8 +117,8 @@ class JoinArrayTest extends AtkPhpunit\TestCase
         $j = $m_u->join('contact.test_id');
         $j->addField('contact_phone');
 
-        $m_u->set('name', 'John');
-        $m_u->set('contact_phone', '+123');
+        $m_u['name'] = 'John';
+        $m_u['contact_phone'] = '+123';
 
         $m_u->save();
 
@@ -128,7 +128,7 @@ class JoinArrayTest extends AtkPhpunit\TestCase
         ], $a);
 
         $m_u->unload();
-        $m_u->set('name', 'Peter');
+        $m_u['name'] = 'Peter';
         $m_u->save();
         $this->assertEquals([
             'user' => [
@@ -142,8 +142,8 @@ class JoinArrayTest extends AtkPhpunit\TestCase
 
         unset($a['contact'][2]);
         $m_u->unload();
-        $m_u->set('name', 'Sue');
-        $m_u->set('contact_phone', '+444');
+        $m_u['name'] = 'Sue';
+        $m_u['contact_phone'] = '+444';
         $m_u->save();
         $this->assertEquals([
             'user' => [
@@ -166,8 +166,8 @@ class JoinArrayTest extends AtkPhpunit\TestCase
         $j = $m_u->join('contact', 'test_id');
         $j->addField('contact_phone');
 
-        $m_u->set('name', 'John');
-        $m_u->set('contact_phone', '+123');
+        $m_u['name'] = 'John';
+        $m_u['contact_phone'] = '+123';
 
         $m_u->save();
 
@@ -188,9 +188,9 @@ class JoinArrayTest extends AtkPhpunit\TestCase
         $j = $m_u->join('contact.code','code');
         $j->addField('contact_phone');
 
-        $m_u->get('name')='John';
-        $m_u->get('code')='C28';
-        $m_u->get('contact_phone')='+123';
+        $m_u['name']='John';
+        $m_u['code']='C28';
+        $m_u['contact_phone']='+123';
 
         $m_u->save();
 
@@ -255,8 +255,8 @@ class JoinArrayTest extends AtkPhpunit\TestCase
         $j->addField('contact_phone');
 
         $m_u->load(1);
-        $m_u->set('name', 'John 2');
-        $m_u->set('contact_phone', '+555');
+        $m_u['name'] = 'John 2';
+        $m_u['contact_phone'] = '+555';
         $m_u->save();
 
         $this->assertSame(
@@ -273,8 +273,8 @@ class JoinArrayTest extends AtkPhpunit\TestCase
         );
 
         $m_u->load(3);
-        $m_u->set('name', 'XX');
-        $m_u->set('contact_phone', '+999');
+        $m_u['name'] = 'XX';
+        $m_u['contact_phone'] = '+999';
         $m_u->save();
 
         $this->assertSame(
@@ -291,8 +291,8 @@ class JoinArrayTest extends AtkPhpunit\TestCase
         );
 
         $m_u->tryLoad(4);
-        $m_u->set('name', 'YYY');
-        $m_u->set('contact_phone', '+777');
+        $m_u['name'] = 'YYY';
+        $m_u['contact_phone'] = '+777';
         $m_u->save();
 
         $this->assertEquals(

--- a/tests/JoinArrayTest.php
+++ b/tests/JoinArrayTest.php
@@ -67,8 +67,8 @@ class JoinArrayTest extends AtkPhpunit\TestCase
         $j = $m_u->join('contact');
         $j->addField('contact_phone');
 
-        $m_u['name'] = 'John';
-        $m_u['contact_phone'] = '+123';
+        $m_u->set('name', 'John');
+        $m_u->set('contact_phone', '+123');
 
         $m_u->save();
 
@@ -78,8 +78,8 @@ class JoinArrayTest extends AtkPhpunit\TestCase
         ], $a);
 
         $m_u->unload();
-        $m_u['name'] = 'Peter';
-        $m_u['contact_id'] = 1;
+        $m_u->set('name', 'Peter');
+        $m_u->set('contact_id', 1);
         $m_u->save();
         $m_u->unload();
 
@@ -92,8 +92,8 @@ class JoinArrayTest extends AtkPhpunit\TestCase
             ],
         ], $a);
 
-        $m_u['name'] = 'Joe';
-        $m_u['contact_phone'] = '+321';
+        $m_u->set('name', 'Joe');
+        $m_u->set('contact_phone', '+321');
         $m_u->save();
 
         $this->assertEquals([
@@ -117,8 +117,8 @@ class JoinArrayTest extends AtkPhpunit\TestCase
         $j = $m_u->join('contact.test_id');
         $j->addField('contact_phone');
 
-        $m_u['name'] = 'John';
-        $m_u['contact_phone'] = '+123';
+        $m_u->set('name', 'John');
+        $m_u->set('contact_phone', '+123');
 
         $m_u->save();
 
@@ -128,7 +128,7 @@ class JoinArrayTest extends AtkPhpunit\TestCase
         ], $a);
 
         $m_u->unload();
-        $m_u['name'] = 'Peter';
+        $m_u->set('name', 'Peter');
         $m_u->save();
         $this->assertEquals([
             'user' => [
@@ -142,8 +142,8 @@ class JoinArrayTest extends AtkPhpunit\TestCase
 
         unset($a['contact'][2]);
         $m_u->unload();
-        $m_u['name'] = 'Sue';
-        $m_u['contact_phone'] = '+444';
+        $m_u->set('name', 'Sue');
+        $m_u->set('contact_phone', '+444');
         $m_u->save();
         $this->assertEquals([
             'user' => [
@@ -166,8 +166,8 @@ class JoinArrayTest extends AtkPhpunit\TestCase
         $j = $m_u->join('contact', 'test_id');
         $j->addField('contact_phone');
 
-        $m_u['name'] = 'John';
-        $m_u['contact_phone'] = '+123';
+        $m_u->set('name', 'John');
+        $m_u->set('contact_phone', '+123');
 
         $m_u->save();
 
@@ -188,9 +188,9 @@ class JoinArrayTest extends AtkPhpunit\TestCase
         $j = $m_u->join('contact.code','code');
         $j->addField('contact_phone');
 
-        $m_u['name']='John';
-        $m_u['code']='C28';
-        $m_u['contact_phone']='+123';
+        $m_u->get('name')='John';
+        $m_u->get('code')='C28';
+        $m_u->get('contact_phone')='+123';
 
         $m_u->save();
 
@@ -255,8 +255,8 @@ class JoinArrayTest extends AtkPhpunit\TestCase
         $j->addField('contact_phone');
 
         $m_u->load(1);
-        $m_u['name'] = 'John 2';
-        $m_u['contact_phone'] = '+555';
+        $m_u->set('name', 'John 2');
+        $m_u->set('contact_phone', '+555');
         $m_u->save();
 
         $this->assertSame(
@@ -273,8 +273,8 @@ class JoinArrayTest extends AtkPhpunit\TestCase
         );
 
         $m_u->load(3);
-        $m_u['name'] = 'XX';
-        $m_u['contact_phone'] = '+999';
+        $m_u->set('name', 'XX');
+        $m_u->set('contact_phone', '+999');
         $m_u->save();
 
         $this->assertSame(
@@ -291,8 +291,8 @@ class JoinArrayTest extends AtkPhpunit\TestCase
         );
 
         $m_u->tryLoad(4);
-        $m_u['name'] = 'YYY';
-        $m_u['contact_phone'] = '+777';
+        $m_u->set('name', 'YYY');
+        $m_u->set('contact_phone', '+777');
         $m_u->save();
 
         $this->assertEquals(

--- a/tests/JoinSQLTest.php
+++ b/tests/JoinSQLTest.php
@@ -76,8 +76,8 @@ class JoinSQLTest extends \atk4\schema\PhpunitTestCase
         $j = $m_u->join('contact');
         $j->addField('contact_phone');
 
-        $m_u->set('name', 'John');
-        $m_u->set('contact_phone', '+123');
+        $m_u['name'] = 'John';
+        $m_u['contact_phone'] = '+123';
 
         $m_u->save();
 
@@ -88,8 +88,8 @@ class JoinSQLTest extends \atk4\schema\PhpunitTestCase
             'contact' => [1 => ['id' => 1, 'contact_phone' => '+123']],
         ], $this->getDB('user,contact'));
 
-        $m_u->set('name', 'Joe');
-        $m_u->set('contact_phone', '+321');
+        $m_u['name'] = 'Joe';
+        $m_u['contact_phone'] = '+321';
         $m_u->save();
 
         $this->assertEquals([
@@ -119,8 +119,8 @@ class JoinSQLTest extends \atk4\schema\PhpunitTestCase
         $j = $m_u->join('contact.test_id');
         $j->addFields(['contact_phone']);
 
-        $m_u->set('name', 'John');
-        $m_u->set('contact_phone', '+123');
+        $m_u['name'] = 'John';
+        $m_u['contact_phone'] = '+123';
 
         $m_u->save();
 
@@ -130,7 +130,7 @@ class JoinSQLTest extends \atk4\schema\PhpunitTestCase
         ], $this->getDB('user,contact'));
 
         $m_u->unload();
-        $m_u->set('name', 'Peter');
+        $m_u['name'] = 'Peter';
         $m_u->save();
         $this->assertEquals([
             'user' => [
@@ -144,8 +144,8 @@ class JoinSQLTest extends \atk4\schema\PhpunitTestCase
 
         $this->db->connection->dsql()->table('contact')->where('id', 2)->delete();
         $m_u->unload();
-        $m_u->set('name', 'Sue');
-        $m_u->set('contact_phone', '+444');
+        $m_u['name'] = 'Sue';
+        $m_u['contact_phone'] = '+444';
         $m_u->save();
         $this->assertEquals([
             'user' => [
@@ -180,8 +180,8 @@ class JoinSQLTest extends \atk4\schema\PhpunitTestCase
         $j = $m_u->join('contact', 'test_id');
         $j->addField('contact_phone');
 
-        $m_u->set('name', 'John');
-        $m_u->set('contact_phone', '+123');
+        $m_u['name'] = 'John';
+        $m_u['contact_phone'] = '+123';
 
         $m_u->save();
 
@@ -254,8 +254,8 @@ class JoinSQLTest extends \atk4\schema\PhpunitTestCase
         $j->addField('contact_phone');
 
         $m_u->load(1);
-        $m_u->set('name', 'John 2');
-        $m_u->set('contact_phone', '+555');
+        $m_u['name'] = 'John 2';
+        $m_u['contact_phone'] = '+555';
         $m_u->save();
 
         $this->assertEquals(
@@ -272,10 +272,10 @@ class JoinSQLTest extends \atk4\schema\PhpunitTestCase
         );
 
         $m_u->load(1);
-        $m_u->set('name', 'XX');
-        $m_u->set('contact_phone', '+999');
+        $m_u['name'] = 'XX';
+        $m_u['contact_phone'] = '+999';
         $m_u->load(3);
-        $m_u->set('name', 'XX');
+        $m_u['name'] = 'XX';
         $m_u->save();
 
         $this->assertEquals(
@@ -291,7 +291,7 @@ class JoinSQLTest extends \atk4\schema\PhpunitTestCase
             $this->getDB()
         );
 
-        $m_u->set('contact_phone', '+999');
+        $m_u['contact_phone'] = '+999';
         $m_u->save();
 
         $this->assertEquals(
@@ -308,8 +308,8 @@ class JoinSQLTest extends \atk4\schema\PhpunitTestCase
         );
 
         $m_u->tryLoad(4);
-        $m_u->set('name', 'YYY');
-        $m_u->set('contact_phone', '+777');
+        $m_u['name'] = 'YYY';
+        $m_u['contact_phone'] = '+777';
         $m_u->save();
 
         $this->assertEquals(
@@ -384,13 +384,13 @@ class JoinSQLTest extends \atk4\schema\PhpunitTestCase
         $j->addField('contact_phone');
 
         $m_u->onHook('afterSave', function ($m) {
-            if ($m->get('contact_phone') !== '+123') {
-                $m->set('contact_phone', '+123');
+            if ($m['contact_phone'] !== '+123') {
+                $m['contact_phone'] = '+123';
                 $m->save();
             }
         });
 
-        $m_u->set('name', 'John');
+        $m_u['name'] = 'John';
         $m_u->save();
 
         $this->assertEquals([
@@ -436,7 +436,7 @@ class JoinSQLTest extends \atk4\schema\PhpunitTestCase
 
         $m_u->loadBy('country_name', 'US');
         $this->assertEquals(30, $m_u->id);
-        $m_u->set('country_name', 'USA');
+        $m_u['country_name'] = 'USA';
         $m_u->save();
 
         $m_u->tryLoad(40);

--- a/tests/JoinSQLTest.php
+++ b/tests/JoinSQLTest.php
@@ -76,8 +76,8 @@ class JoinSQLTest extends \atk4\schema\PhpunitTestCase
         $j = $m_u->join('contact');
         $j->addField('contact_phone');
 
-        $m_u['name'] = 'John';
-        $m_u['contact_phone'] = '+123';
+        $m_u->set('name', 'John');
+        $m_u->set('contact_phone', '+123');
 
         $m_u->save();
 
@@ -88,8 +88,8 @@ class JoinSQLTest extends \atk4\schema\PhpunitTestCase
             'contact' => [1 => ['id' => 1, 'contact_phone' => '+123']],
         ], $this->getDB('user,contact'));
 
-        $m_u['name'] = 'Joe';
-        $m_u['contact_phone'] = '+321';
+        $m_u->set('name', 'Joe');
+        $m_u->set('contact_phone', '+321');
         $m_u->save();
 
         $this->assertEquals([
@@ -119,8 +119,8 @@ class JoinSQLTest extends \atk4\schema\PhpunitTestCase
         $j = $m_u->join('contact.test_id');
         $j->addFields(['contact_phone']);
 
-        $m_u['name'] = 'John';
-        $m_u['contact_phone'] = '+123';
+        $m_u->set('name', 'John');
+        $m_u->set('contact_phone', '+123');
 
         $m_u->save();
 
@@ -130,7 +130,7 @@ class JoinSQLTest extends \atk4\schema\PhpunitTestCase
         ], $this->getDB('user,contact'));
 
         $m_u->unload();
-        $m_u['name'] = 'Peter';
+        $m_u->set('name', 'Peter');
         $m_u->save();
         $this->assertEquals([
             'user' => [
@@ -144,8 +144,8 @@ class JoinSQLTest extends \atk4\schema\PhpunitTestCase
 
         $this->db->connection->dsql()->table('contact')->where('id', 2)->delete();
         $m_u->unload();
-        $m_u['name'] = 'Sue';
-        $m_u['contact_phone'] = '+444';
+        $m_u->set('name', 'Sue');
+        $m_u->set('contact_phone', '+444');
         $m_u->save();
         $this->assertEquals([
             'user' => [
@@ -180,8 +180,8 @@ class JoinSQLTest extends \atk4\schema\PhpunitTestCase
         $j = $m_u->join('contact', 'test_id');
         $j->addField('contact_phone');
 
-        $m_u['name'] = 'John';
-        $m_u['contact_phone'] = '+123';
+        $m_u->set('name', 'John');
+        $m_u->set('contact_phone', '+123');
 
         $m_u->save();
 
@@ -254,8 +254,8 @@ class JoinSQLTest extends \atk4\schema\PhpunitTestCase
         $j->addField('contact_phone');
 
         $m_u->load(1);
-        $m_u['name'] = 'John 2';
-        $m_u['contact_phone'] = '+555';
+        $m_u->set('name', 'John 2');
+        $m_u->set('contact_phone', '+555');
         $m_u->save();
 
         $this->assertEquals(
@@ -272,10 +272,10 @@ class JoinSQLTest extends \atk4\schema\PhpunitTestCase
         );
 
         $m_u->load(1);
-        $m_u['name'] = 'XX';
-        $m_u['contact_phone'] = '+999';
+        $m_u->set('name', 'XX');
+        $m_u->set('contact_phone', '+999');
         $m_u->load(3);
-        $m_u['name'] = 'XX';
+        $m_u->set('name', 'XX');
         $m_u->save();
 
         $this->assertEquals(
@@ -291,7 +291,7 @@ class JoinSQLTest extends \atk4\schema\PhpunitTestCase
             $this->getDB()
         );
 
-        $m_u['contact_phone'] = '+999';
+        $m_u->set('contact_phone', '+999');
         $m_u->save();
 
         $this->assertEquals(
@@ -308,8 +308,8 @@ class JoinSQLTest extends \atk4\schema\PhpunitTestCase
         );
 
         $m_u->tryLoad(4);
-        $m_u['name'] = 'YYY';
-        $m_u['contact_phone'] = '+777';
+        $m_u->set('name', 'YYY');
+        $m_u->set('contact_phone', '+777');
         $m_u->save();
 
         $this->assertEquals(
@@ -384,13 +384,13 @@ class JoinSQLTest extends \atk4\schema\PhpunitTestCase
         $j->addField('contact_phone');
 
         $m_u->onHook('afterSave', function ($m) {
-            if ($m['contact_phone'] !== '+123') {
-                $m['contact_phone'] = '+123';
+            if ($m->get('contact_phone') !== '+123') {
+                $m->set('contact_phone', '+123');
                 $m->save();
             }
         });
 
-        $m_u['name'] = 'John';
+        $m_u->set('name', 'John');
         $m_u->save();
 
         $this->assertEquals([
@@ -436,7 +436,7 @@ class JoinSQLTest extends \atk4\schema\PhpunitTestCase
 
         $m_u->loadBy('country_name', 'US');
         $this->assertEquals(30, $m_u->id);
-        $m_u['country_name'] = 'USA';
+        $m_u->set('country_name', 'USA');
         $m_u->save();
 
         $m_u->tryLoad(40);

--- a/tests/JoinTest.php
+++ b/tests/JoinTest.php
@@ -21,8 +21,8 @@ class JoinTest extends AtkPhpunit\TestCase
         $j = $m->join('contact');
         $j->addField('contact_phone');
 
-        $m['name'] = 'John';
-        $m['contact_phone'] = '+123';
+        $m->set('name', 'John');
+        $m->set('contact_phone', '+123');
         $m->save();
 
         /*

--- a/tests/JoinTest.php
+++ b/tests/JoinTest.php
@@ -21,8 +21,8 @@ class JoinTest extends AtkPhpunit\TestCase
         $j = $m->join('contact');
         $j->addField('contact_phone');
 
-        $m->set('name', 'John');
-        $m->set('contact_phone', '+123');
+        $m['name'] = 'John';
+        $m['contact_phone'] = '+123';
         $m->save();
 
         /*

--- a/tests/LookupSQLTest.php
+++ b/tests/LookupSQLTest.php
@@ -110,8 +110,8 @@ class LFriend extends Model
             $c = clone $m;
             $c->skip_reverse = true;
             $this->insert([
-                'user_id'=>$m->get('friend_id'),
-                'friend_id'=>$m->get('user_id')
+                'user_id'=>$m['friend_id'],
+                'friend_id'=>$m['user_id']
             ]);
         });
 
@@ -124,8 +124,8 @@ class LFriend extends Model
             $c->skip_reverse = true;
 
             $c->loadBy([
-                'user_id'=>$m->get('friend_id'),
-                'friend_id'=>$m->get('user_id')
+                'user_id'=>$m['friend_id'],
+                'friend_id'=>$m['user_id']
             ])->delete();
 
 
@@ -181,7 +181,7 @@ class LookupSQLTest extends \atk4\schema\PhpunitTestCase
         $c->saveAndUnload(['Latvia', 'code' => 'LV', 'is_eu' => true]);
 
         // setting field prior will affect save()
-        $c->set('is_eu', true);
+        $c['is_eu'] = true;
         $c->save(['Estonia', 'code' => 'ES']);
 
         // is_eu will NOT BLEED into this record, because insert() does not make use of current model values.

--- a/tests/LookupSQLTest.php
+++ b/tests/LookupSQLTest.php
@@ -110,8 +110,8 @@ class LFriend extends Model
             $c = clone $m;
             $c->skip_reverse = true;
             $this->insert([
-                'user_id'=>$m['friend_id'],
-                'friend_id'=>$m['user_id']
+                'user_id'=>$m->get('friend_id'),
+                'friend_id'=>$m->get('user_id')
             ]);
         });
 
@@ -124,8 +124,8 @@ class LFriend extends Model
             $c->skip_reverse = true;
 
             $c->loadBy([
-                'user_id'=>$m['friend_id'],
-                'friend_id'=>$m['user_id']
+                'user_id'=>$m->get('friend_id'),
+                'friend_id'=>$m->get('user_id')
             ])->delete();
 
 
@@ -181,7 +181,7 @@ class LookupSQLTest extends \atk4\schema\PhpunitTestCase
         $c->saveAndUnload(['Latvia', 'code' => 'LV', 'is_eu' => true]);
 
         // setting field prior will affect save()
-        $c['is_eu'] = true;
+        $c->set('is_eu', true);
         $c->save(['Estonia', 'code' => 'ES']);
 
         // is_eu will NOT BLEED into this record, because insert() does not make use of current model values.

--- a/tests/Model/Smbo/Account.php
+++ b/tests/Model/Smbo/Account.php
@@ -22,11 +22,11 @@ class Account extends \atk4\data\Model
     public function transfer(self $a, $amount)
     {
         $t = new Transfer($this->persistence, ['detached' => true]);
-        $t->set('account_id', $this->id);
+        $t['account_id'] = $this->id;
 
-        $t->set('destination_account_id', $a->id);
+        $t['destination_account_id'] = $a->id;
 
-        $t->set('amount', -$amount);
+        $t['amount'] = -$amount;
 
         return $t;
     }

--- a/tests/Model/Smbo/Account.php
+++ b/tests/Model/Smbo/Account.php
@@ -22,11 +22,11 @@ class Account extends \atk4\data\Model
     public function transfer(self $a, $amount)
     {
         $t = new Transfer($this->persistence, ['detached' => true]);
-        $t['account_id'] = $this->id;
+        $t->set('account_id', $this->id);
 
-        $t['destination_account_id'] = $a->id;
+        $t->set('destination_account_id', $a->id);
 
-        $t['amount'] = -$amount;
+        $t->set('amount', -$amount);
 
         return $t;
     }

--- a/tests/Model/Smbo/Transfer.php
+++ b/tests/Model/Smbo/Transfer.php
@@ -23,14 +23,14 @@ class Transfer extends Payment
 
         $this->onHook('beforeSave', function ($m) {
             // only for new records and when destination_account_id is set
-            if ($m['destination_account_id'] && !$m->id) {
+            if ($m->get('destination_account_id') && !$m->id) {
                 // In this section we test if "clone" works ok
 
                 $this->other_leg_creation = $m2 = clone $m;
-                $m2['account_id'] = $m2['destination_account_id'];
-                $m2['amount'] = -$m2['amount'];
+                $m2->set('account_id', $m2->get('destination_account_id'));
+                $m2->set('amount', -$m2->get('amount'));
 
-                unset($m2['destination_account_id']);
+                $m2->_unset('destination_account_id');
 
                 /*/
 
@@ -39,14 +39,14 @@ class Transfer extends Payment
                 $this->other_leg_creation = $m2 = new Transfer($this->persistence);
                 $m2->set($m->get());
                 $m2->unset('destination_account_id');
-                $m2['account_id'] = $m['destination_account_id'];
-                $m2['amount'] = -$m2['amount']; // neagtive amount
+                $m2->set('account_id', $m->get('destination_account_id'));
+                $m2->set('amount', -$m2->get('amount')); // neagtive amount
 
                 // */
 
                 $m2->reload_after_save = false; // avoid check
 
-                $m['transfer_document_id'] = $m2->save()->id;
+                $m->set('transfer_document_id', $m2->save()->id);
             }
         });
 

--- a/tests/Model/Smbo/Transfer.php
+++ b/tests/Model/Smbo/Transfer.php
@@ -23,14 +23,14 @@ class Transfer extends Payment
 
         $this->onHook('beforeSave', function ($m) {
             // only for new records and when destination_account_id is set
-            if ($m->get('destination_account_id') && !$m->id) {
+            if ($m['destination_account_id'] && !$m->id) {
                 // In this section we test if "clone" works ok
 
                 $this->other_leg_creation = $m2 = clone $m;
-                $m2->set('account_id', $m2->get('destination_account_id'));
-                $m2->set('amount', -$m2->get('amount'));
+                $m2['account_id'] = $m2['destination_account_id'];
+                $m2['amount'] = -$m2['amount'];
 
-                $m2->_unset('destination_account_id');
+                unset($m2['destination_account_id']);
 
                 /*/
 
@@ -39,14 +39,14 @@ class Transfer extends Payment
                 $this->other_leg_creation = $m2 = new Transfer($this->persistence);
                 $m2->set($m->get());
                 $m2->unset('destination_account_id');
-                $m2->set('account_id', $m->get('destination_account_id'));
-                $m2->set('amount', -$m2->get('amount')); // neagtive amount
+                $m2['account_id'] = $m['destination_account_id'];
+                $m2['amount'] = -$m2['amount']; // neagtive amount
 
                 // */
 
                 $m2->reload_after_save = false; // avoid check
 
-                $m->set('transfer_document_id', $m2->save()->id);
+                $m['transfer_document_id'] = $m2->save()->id;
             }
         });
 

--- a/tests/ModelWithoutIDTest.php
+++ b/tests/ModelWithoutIDTest.php
@@ -44,7 +44,7 @@ class ModelWithoutIDTest extends \atk4\schema\PhpunitTestCase
 
         $n = [];
         foreach ($this->m as $row) {
-            $n[] = $row->get('name');
+            $n[] = $row['name'];
             $this->assertNull($row->id);
         }
         $this->assertSame(['Sue', 'John'], $n);

--- a/tests/ModelWithoutIDTest.php
+++ b/tests/ModelWithoutIDTest.php
@@ -36,15 +36,15 @@ class ModelWithoutIDTest extends \atk4\schema\PhpunitTestCase
     public function testBasic()
     {
         $this->m->tryLoadAny();
-        $this->assertSame('John', $this->m['name']);
+        $this->assertSame('John', $this->m->get('name'));
 
         $this->m->setOrder('name desc');
         $this->m->tryLoadAny();
-        $this->assertSame('Sue', $this->m['name']);
+        $this->assertSame('Sue', $this->m->get('name'));
 
         $n = [];
         foreach ($this->m as $row) {
-            $n[] = $row['name'];
+            $n[] = $row->get('name');
             $this->assertNull($row->id);
         }
         $this->assertSame(['Sue', 'John'], $n);
@@ -107,14 +107,14 @@ class ModelWithoutIDTest extends \atk4\schema\PhpunitTestCase
     public function testLoadBy()
     {
         $this->m->loadBy('name', 'Sue');
-        $this->assertSame('Sue', $this->m['name']);
+        $this->assertSame('Sue', $this->m->get('name'));
     }
 
     public function testLoadCondition()
     {
         $this->m->addCondition('name', 'Sue');
         $this->m->loadAny();
-        $this->assertSame('Sue', $this->m['name']);
+        $this->assertSame('Sue', $this->m->get('name'));
     }
 
     /**
@@ -144,7 +144,7 @@ class ModelWithoutIDTest extends \atk4\schema\PhpunitTestCase
     public function testFailUpdate()
     {
         $this->m->id = 1;
-        $this->m['name'] = 'foo';
+        $this->m->set('name', 'foo');
         $this->m->saveAndUnload();
     }
 }

--- a/tests/ModelWithoutIDTest.php
+++ b/tests/ModelWithoutIDTest.php
@@ -44,7 +44,7 @@ class ModelWithoutIDTest extends \atk4\schema\PhpunitTestCase
 
         $n = [];
         foreach ($this->m as $row) {
-            $n[] = $row['name'];
+            $n[] = $row->get('name');
             $this->assertNull($row->id);
         }
         $this->assertSame(['Sue', 'John'], $n);

--- a/tests/PersistentArrayOfStringsTest.php
+++ b/tests/PersistentArrayOfStringsTest.php
@@ -71,10 +71,10 @@ class PersistentArrayOfStringsTest extends AtkPhpunit\TestCase
 
         // typecasting enabled in export()
         $data = $m->export(null, null, true);
-        $this->assertInstanceOf('DateTime', $data[1]['date']);
-        $this->assertInstanceOf('DateTime', $data[1]['datetime']);
-        $this->assertInstanceOf('DateTime', $data[1]['time']);
-        $this->assertTrue(is_array($data[1]['array']));
-        $this->assertTrue(is_object($data[1]['object']));
+        $this->assertInstanceOf('DateTime', $data->get(1)['date']);
+        $this->assertInstanceOf('DateTime', $data->get(1)['datetime']);
+        $this->assertInstanceOf('DateTime', $data->get(1)['time']);
+        $this->assertTrue(is_array($data->get(1)['array']));
+        $this->assertTrue(is_object($data->get(1)['object']));
     }
 }

--- a/tests/PersistentArrayOfStringsTest.php
+++ b/tests/PersistentArrayOfStringsTest.php
@@ -71,10 +71,10 @@ class PersistentArrayOfStringsTest extends AtkPhpunit\TestCase
 
         // typecasting enabled in export()
         $data = $m->export(null, null, true);
-        $this->assertInstanceOf('DateTime', $data->get(1)['date']);
-        $this->assertInstanceOf('DateTime', $data->get(1)['datetime']);
-        $this->assertInstanceOf('DateTime', $data->get(1)['time']);
-        $this->assertTrue(is_array($data->get(1)['array']));
-        $this->assertTrue(is_object($data->get(1)['object']));
+        $this->assertInstanceOf('DateTime', $data[1]['date']);
+        $this->assertInstanceOf('DateTime', $data[1]['datetime']);
+        $this->assertInstanceOf('DateTime', $data[1]['time']);
+        $this->assertTrue(is_array($data[1]['array']));
+        $this->assertTrue(is_object($data[1]['object']));
     }
 }

--- a/tests/PersistentArrayTest.php
+++ b/tests/PersistentArrayTest.php
@@ -31,7 +31,7 @@ class PersistentArrayTest extends AtkPhpunit\TestCase
         $m->addField('surname');
 
         $m->load(1);
-        $this->assertSame('John', $m['name']);
+        $this->assertSame('John', $m->get('name'));
 
         $m->unload();
         $this->assertFalse($m->loaded());
@@ -40,15 +40,15 @@ class PersistentArrayTest extends AtkPhpunit\TestCase
         $this->assertTrue($m->loaded());
 
         $m->load(2);
-        $this->assertSame('Jones', $m['surname']);
-        $m['surname'] = 'Smith';
+        $this->assertSame('Jones', $m->get('surname'));
+        $m->set('surname', 'Smith');
         $m->save();
 
         $m->load(1);
-        $this->assertSame('John', $m['name']);
+        $this->assertSame('John', $m->get('name'));
 
         $m->load(2);
-        $this->assertSame('Smith', $m['surname']);
+        $this->assertSame('Smith', $m->get('surname'));
     }
 
     public function testSaveAs()
@@ -90,7 +90,7 @@ class PersistentArrayTest extends AtkPhpunit\TestCase
 
         $m->load(1);
         $this->assertTrue($m->loaded());
-        $m['gender'] = 'F';
+        $m->set('gender', 'F');
         $m->saveAndUnload();
         $this->assertFalse($m->loaded());
 
@@ -121,13 +121,13 @@ class PersistentArrayTest extends AtkPhpunit\TestCase
         $m->addField('surname');
 
         $m->load(1);
-        $m['name'] = 'Peter';
+        $m->set('name', 'Peter');
         $m->save();
 
         $m->load(2);
-        $m['surname'] = 'Smith';
+        $m->set('surname', 'Smith');
         $m->save();
-        $m['surname'] = 'QQ';
+        $m->set('surname', 'QQ');
         $m->save();
 
         $this->assertSame([
@@ -192,7 +192,7 @@ class PersistentArrayTest extends AtkPhpunit\TestCase
         $output = '';
 
         foreach ($m as $row) {
-            $output .= $row['name'];
+            $output .= $row->get('name');
         }
 
         $this->assertSame('JohnSarah', $output);
@@ -214,18 +214,18 @@ class PersistentArrayTest extends AtkPhpunit\TestCase
         $m->addField('surname');
 
         $m->load(1);
-        $this->assertSame('John', $m['name']);
+        $this->assertSame('John', $m->get('name'));
 
         $m->load(2);
-        $this->assertSame('Jones', $m['surname']);
-        $m['surname'] = 'Smith';
+        $this->assertSame('Jones', $m->get('surname'));
+        $m->set('surname', 'Smith');
         $m->save();
 
         $m->load(1);
-        $this->assertSame('John', $m['name']);
+        $this->assertSame('John', $m->get('name'));
 
         $m->load(2);
-        $this->assertSame('Smith', $m['surname']);
+        $this->assertSame('Smith', $m->get('surname'));
     }
 
     /**
@@ -698,10 +698,10 @@ class PersistentArrayTest extends AtkPhpunit\TestCase
         $user->hasOne('country_id', $country);
 
         $user->load(1);
-        $this->assertSame('Latvia', $user->ref('country_id')['name']);
+        $this->assertSame('Latvia', $user->ref('country_id')->get('name'));
 
         $user->load(2);
-        $this->assertSame('UK', $user->ref('country_id')['name']);
+        $this->assertSame('UK', $user->ref('country_id')->get('name'));
     }
 
     /**

--- a/tests/PersistentArrayTest.php
+++ b/tests/PersistentArrayTest.php
@@ -31,7 +31,7 @@ class PersistentArrayTest extends AtkPhpunit\TestCase
         $m->addField('surname');
 
         $m->load(1);
-        $this->assertSame('John', $m['name']);
+        $this->assertSame('John', $m->get('name'));
 
         $m->unload();
         $this->assertFalse($m->loaded());
@@ -40,15 +40,15 @@ class PersistentArrayTest extends AtkPhpunit\TestCase
         $this->assertTrue($m->loaded());
 
         $m->load(2);
-        $this->assertSame('Jones', $m['surname']);
-        $m['surname'] = 'Smith';
+        $this->assertSame('Jones', $m->get('surname'));
+        $m->set('surname', 'Smith');
         $m->save();
 
         $m->load(1);
-        $this->assertSame('John', $m['name']);
+        $this->assertSame('John', $m->get('name'));
 
         $m->load(2);
-        $this->assertSame('Smith', $m['surname']);
+        $this->assertSame('Smith', $m->get('surname'));
     }
 
     public function testSaveAs()
@@ -90,7 +90,7 @@ class PersistentArrayTest extends AtkPhpunit\TestCase
 
         $m->load(1);
         $this->assertTrue($m->loaded());
-        $m['gender'] = 'F';
+        $m->set('gender', 'F');
         $m->saveAndUnload();
         $this->assertFalse($m->loaded());
 
@@ -121,13 +121,13 @@ class PersistentArrayTest extends AtkPhpunit\TestCase
         $m->addField('surname');
 
         $m->load(1);
-        $m['name'] = 'Peter';
+        $m->set('name', 'Peter');
         $m->save();
 
         $m->load(2);
-        $m['surname'] = 'Smith';
+        $m->set('surname', 'Smith');
         $m->save();
-        $m['surname'] = 'QQ';
+        $m->set('surname', 'QQ');
         $m->save();
 
         $this->assertSame([
@@ -192,7 +192,7 @@ class PersistentArrayTest extends AtkPhpunit\TestCase
         $output = '';
 
         foreach ($m as $row) {
-            $output .= $row['name'];
+            $output .= $row->get('name');
         }
 
         $this->assertSame('JohnSarah', $output);
@@ -214,18 +214,18 @@ class PersistentArrayTest extends AtkPhpunit\TestCase
         $m->addField('surname');
 
         $m->load(1);
-        $this->assertSame('John', $m['name']);
+        $this->assertSame('John', $m->get('name'));
 
         $m->load(2);
-        $this->assertSame('Jones', $m['surname']);
-        $m['surname'] = 'Smith';
+        $this->assertSame('Jones', $m->get('surname'));
+        $m->set('surname', 'Smith');
         $m->save();
 
         $m->load(1);
-        $this->assertSame('John', $m['name']);
+        $this->assertSame('John', $m->get('name'));
 
         $m->load(2);
-        $this->assertSame('Smith', $m['surname']);
+        $this->assertSame('Smith', $m->get('surname'));
     }
 
     /**
@@ -366,9 +366,9 @@ class PersistentArrayTest extends AtkPhpunit\TestCase
         $m->addCondition('country', 'LIKE', 'La%');
         $result = $m->action('select')->get();
         $this->assertSame(3, count($result));
-        $this->assertSame($a['countries'][3], $result[3]);
-        $this->assertSame($a['countries'][7], $result[7]);
-        $this->assertSame($a['countries'][9], $result[9]);
+        $this->assertSame($a->get('countries')[3], $result->get(3));
+        $this->assertSame($a->get('countries')[7], $result->get(7));
+        $this->assertSame($a->get('countries')[9], $result->get(9));
         unset($result);
         $m->unload();
 
@@ -377,10 +377,10 @@ class PersistentArrayTest extends AtkPhpunit\TestCase
         $m->addCondition('country', 'LIKE', '%ia');
         $result = $m->action('select')->get();
         $this->assertSame(4, count($result));
-        $this->assertSame($a['countries'][3], $result[3]);
-        $this->assertSame($a['countries'][7], $result[7]);
-        $this->assertSame($a['countries'][8], $result[8]);
-        $this->assertSame($a['countries'][9], $result[9]);
+        $this->assertSame($a->get('countries')[3], $result->get(3));
+        $this->assertSame($a->get('countries')[7], $result->get(7));
+        $this->assertSame($a->get('countries')[8], $result->get(8));
+        $this->assertSame($a->get('countries')[9], $result->get(9));
         unset($result);
         $m->unload();
 
@@ -389,13 +389,13 @@ class PersistentArrayTest extends AtkPhpunit\TestCase
         $m->addCondition('country', 'LIKE', '%a%');
         $result = $m->action('select')->get();
         $this->assertSame(7, count($result));
-        $this->assertSame($a['countries'][1], $result[1]);
-        $this->assertSame($a['countries'][2], $result[2]);
-        $this->assertSame($a['countries'][3], $result[3]);
-        $this->assertSame($a['countries'][6], $result[6]);
-        $this->assertSame($a['countries'][7], $result[7]);
-        $this->assertSame($a['countries'][8], $result[8]);
-        $this->assertSame($a['countries'][9], $result[9]);
+        $this->assertSame($a->get('countries')[1], $result->get(1));
+        $this->assertSame($a->get('countries')[2], $result->get(2));
+        $this->assertSame($a->get('countries')[3], $result->get(3));
+        $this->assertSame($a->get('countries')[6], $result->get(6));
+        $this->assertSame($a->get('countries')[7], $result->get(7));
+        $this->assertSame($a->get('countries')[8], $result->get(8));
+        $this->assertSame($a->get('countries')[9], $result->get(9));
         unset($result);
         $m->unload();
 
@@ -573,7 +573,7 @@ class PersistentArrayTest extends AtkPhpunit\TestCase
         $m->addField('surname');
 
         $this->assertSame(4, $m->action('count')->getOne());
-        $this->assertSame($a['data'], $m->export());
+        $this->assertSame($a->get('data'), $m->export());
 
         $m->addCondition('name', 'Sarah');
         $this->assertSame(3, $m->action('count')->getOne());

--- a/tests/PersistentArrayTest.php
+++ b/tests/PersistentArrayTest.php
@@ -31,7 +31,7 @@ class PersistentArrayTest extends AtkPhpunit\TestCase
         $m->addField('surname');
 
         $m->load(1);
-        $this->assertSame('John', $m->get('name'));
+        $this->assertSame('John', $m['name']);
 
         $m->unload();
         $this->assertFalse($m->loaded());
@@ -40,15 +40,15 @@ class PersistentArrayTest extends AtkPhpunit\TestCase
         $this->assertTrue($m->loaded());
 
         $m->load(2);
-        $this->assertSame('Jones', $m->get('surname'));
-        $m->set('surname', 'Smith');
+        $this->assertSame('Jones', $m['surname']);
+        $m['surname'] = 'Smith';
         $m->save();
 
         $m->load(1);
-        $this->assertSame('John', $m->get('name'));
+        $this->assertSame('John', $m['name']);
 
         $m->load(2);
-        $this->assertSame('Smith', $m->get('surname'));
+        $this->assertSame('Smith', $m['surname']);
     }
 
     public function testSaveAs()
@@ -90,7 +90,7 @@ class PersistentArrayTest extends AtkPhpunit\TestCase
 
         $m->load(1);
         $this->assertTrue($m->loaded());
-        $m->set('gender', 'F');
+        $m['gender'] = 'F';
         $m->saveAndUnload();
         $this->assertFalse($m->loaded());
 
@@ -121,13 +121,13 @@ class PersistentArrayTest extends AtkPhpunit\TestCase
         $m->addField('surname');
 
         $m->load(1);
-        $m->set('name', 'Peter');
+        $m['name'] = 'Peter';
         $m->save();
 
         $m->load(2);
-        $m->set('surname', 'Smith');
+        $m['surname'] = 'Smith';
         $m->save();
-        $m->set('surname', 'QQ');
+        $m['surname'] = 'QQ';
         $m->save();
 
         $this->assertSame([
@@ -192,7 +192,7 @@ class PersistentArrayTest extends AtkPhpunit\TestCase
         $output = '';
 
         foreach ($m as $row) {
-            $output .= $row->get('name');
+            $output .= $row['name'];
         }
 
         $this->assertSame('JohnSarah', $output);
@@ -214,18 +214,18 @@ class PersistentArrayTest extends AtkPhpunit\TestCase
         $m->addField('surname');
 
         $m->load(1);
-        $this->assertSame('John', $m->get('name'));
+        $this->assertSame('John', $m['name']);
 
         $m->load(2);
-        $this->assertSame('Jones', $m->get('surname'));
-        $m->set('surname', 'Smith');
+        $this->assertSame('Jones', $m['surname']);
+        $m['surname'] = 'Smith';
         $m->save();
 
         $m->load(1);
-        $this->assertSame('John', $m->get('name'));
+        $this->assertSame('John', $m['name']);
 
         $m->load(2);
-        $this->assertSame('Smith', $m->get('surname'));
+        $this->assertSame('Smith', $m['surname']);
     }
 
     /**
@@ -366,9 +366,9 @@ class PersistentArrayTest extends AtkPhpunit\TestCase
         $m->addCondition('country', 'LIKE', 'La%');
         $result = $m->action('select')->get();
         $this->assertSame(3, count($result));
-        $this->assertSame($a->get('countries')[3], $result->get(3));
-        $this->assertSame($a->get('countries')[7], $result->get(7));
-        $this->assertSame($a->get('countries')[9], $result->get(9));
+        $this->assertSame($a['countries'][3], $result[3]);
+        $this->assertSame($a['countries'][7], $result[7]);
+        $this->assertSame($a['countries'][9], $result[9]);
         unset($result);
         $m->unload();
 
@@ -377,10 +377,10 @@ class PersistentArrayTest extends AtkPhpunit\TestCase
         $m->addCondition('country', 'LIKE', '%ia');
         $result = $m->action('select')->get();
         $this->assertSame(4, count($result));
-        $this->assertSame($a->get('countries')[3], $result->get(3));
-        $this->assertSame($a->get('countries')[7], $result->get(7));
-        $this->assertSame($a->get('countries')[8], $result->get(8));
-        $this->assertSame($a->get('countries')[9], $result->get(9));
+        $this->assertSame($a['countries'][3], $result[3]);
+        $this->assertSame($a['countries'][7], $result[7]);
+        $this->assertSame($a['countries'][8], $result[8]);
+        $this->assertSame($a['countries'][9], $result[9]);
         unset($result);
         $m->unload();
 
@@ -389,13 +389,13 @@ class PersistentArrayTest extends AtkPhpunit\TestCase
         $m->addCondition('country', 'LIKE', '%a%');
         $result = $m->action('select')->get();
         $this->assertSame(7, count($result));
-        $this->assertSame($a->get('countries')[1], $result->get(1));
-        $this->assertSame($a->get('countries')[2], $result->get(2));
-        $this->assertSame($a->get('countries')[3], $result->get(3));
-        $this->assertSame($a->get('countries')[6], $result->get(6));
-        $this->assertSame($a->get('countries')[7], $result->get(7));
-        $this->assertSame($a->get('countries')[8], $result->get(8));
-        $this->assertSame($a->get('countries')[9], $result->get(9));
+        $this->assertSame($a['countries'][1], $result[1]);
+        $this->assertSame($a['countries'][2], $result[2]);
+        $this->assertSame($a['countries'][3], $result[3]);
+        $this->assertSame($a['countries'][6], $result[6]);
+        $this->assertSame($a['countries'][7], $result[7]);
+        $this->assertSame($a['countries'][8], $result[8]);
+        $this->assertSame($a['countries'][9], $result[9]);
         unset($result);
         $m->unload();
 
@@ -573,7 +573,7 @@ class PersistentArrayTest extends AtkPhpunit\TestCase
         $m->addField('surname');
 
         $this->assertSame(4, $m->action('count')->getOne());
-        $this->assertSame($a->get('data'), $m->export());
+        $this->assertSame($a['data'], $m->export());
 
         $m->addCondition('name', 'Sarah');
         $this->assertSame(3, $m->action('count')->getOne());

--- a/tests/PersistentSQLTest.php
+++ b/tests/PersistentSQLTest.php
@@ -26,18 +26,18 @@ class PersistentSQLTest extends \atk4\schema\PhpunitTestCase
         $m->addField('surname');
 
         $m->load(1);
-        $this->assertSame('John', $m->get('name'));
+        $this->assertSame('John', $m['name']);
 
         $m->load(2);
-        $this->assertSame('Jones', $m->get('surname'));
-        $m->set('surname', 'Smith');
+        $this->assertSame('Jones', $m['surname']);
+        $m['surname'] = 'Smith';
         $m->save();
 
         $m->load(1);
-        $this->assertSame('John', $m->get('name'));
+        $this->assertSame('John', $m['name']);
 
         $m->load(2);
-        $this->assertSame('Smith', $m->get('surname'));
+        $this->assertSame('Smith', $m['surname']);
     }
 
     public function testPersistenceInsert()
@@ -56,23 +56,23 @@ class PersistentSQLTest extends \atk4\schema\PhpunitTestCase
         $m->addField('surname');
 
         $ids = [];
-        foreach ($a->get('user') as $id => $row) {
+        foreach ($a['user'] as $id => $row) {
             $ids[] = $this->db->insert($m, $row);
         }
 
-        $m->load($ids->get(0));
-        $this->assertSame('John', $m->get('name'));
+        $m->load($ids[0]);
+        $this->assertSame('John', $m['name']);
 
-        $m->load($ids->get(1));
-        $this->assertSame('Jones', $m->get('surname'));
-        $m->set('surname', 'Smith');
+        $m->load($ids[1]);
+        $this->assertSame('Jones', $m['surname']);
+        $m['surname'] = 'Smith';
         $m->save();
 
-        $m->load($ids->get(0));
-        $this->assertSame('John', $m->get('name'));
+        $m->load($ids[0]);
+        $this->assertSame('John', $m['name']);
 
-        $m->load($ids->get(1));
-        $this->assertSame('Smith', $m->get('surname'));
+        $m->load($ids[1]);
+        $this->assertSame('Smith', $m['surname']);
     }
 
     public function testModelInsert()
@@ -90,13 +90,13 @@ class PersistentSQLTest extends \atk4\schema\PhpunitTestCase
         $m->addField('surname');
 
         $ms = [];
-        foreach ($a->get('user') as $id => $row) {
+        foreach ($a['user'] as $id => $row) {
             $ms[] = $m->insert($row);
         }
 
-        $this->assertSame('John', $m->load($ms->get(0))['name']);
+        $this->assertSame('John', $m->load($ms[0])['name']);
 
-        $this->assertSame('Jones', $m->load($ms->get(1))['surname']);
+        $this->assertSame('Jones', $m->load($ms[1])['surname']);
     }
 
     public function testModelSaveNoReload()
@@ -116,11 +116,11 @@ class PersistentSQLTest extends \atk4\schema\PhpunitTestCase
         // insert new record, model id field
         $m->reload_after_save = false;
         $m->save(['name' => 'Jane', 'surname' => 'Doe']);
-        $this->assertSame('Jane', $m->get('name'));
-        $this->assertSame('Doe', $m->get('surname'));
+        $this->assertSame('Jane', $m['name']);
+        $this->assertSame('Doe', $m['surname']);
         $this->assertEquals(3, $m->id);
         // id field value is set with new id value even if reload_after_save = false
-        $this->assertEquals(3, $m->get($m->id_field));
+        $this->assertEquals(3, $m[$m->id_field]);
     }
 
     public function testModelInsertRows()
@@ -137,7 +137,7 @@ class PersistentSQLTest extends \atk4\schema\PhpunitTestCase
         $m->addField('name');
         $m->addField('surname');
 
-        $m->import($a->get('user')); // import data
+        $m->import($a['user']); // import data
 
         $this->assertEquals(2, $m->action('count')->getOne());
     }
@@ -157,24 +157,24 @@ class PersistentSQLTest extends \atk4\schema\PhpunitTestCase
         $m->addField('surname');
 
         $ids = [];
-        foreach ($a->get('user') as $id => $row) {
+        foreach ($a['user'] as $id => $row) {
             $ids[] = $this->db->insert($m, $row);
         }
         $this->assertFalse($m->loaded());
 
-        $m->delete($ids->get(0));
+        $m->delete($ids[0]);
         $this->assertFalse($m->loaded());
 
-        $m->load($ids->get(1));
-        $this->assertSame('Jones', $m->get('surname'));
-        $m->set('surname', 'Smith');
+        $m->load($ids[1]);
+        $this->assertSame('Jones', $m['surname']);
+        $m['surname'] = 'Smith';
         $m->save();
 
-        $m->tryLoad($ids->get(0));
+        $m->tryLoad($ids[0]);
         $this->assertFalse($m->loaded());
 
-        $m->load($ids->get(1));
-        $this->assertSame('Smith', $m->get('surname'));
+        $m->load($ids[1]);
+        $this->assertSame('Smith', $m['surname']);
     }
 
     /**

--- a/tests/PersistentSQLTest.php
+++ b/tests/PersistentSQLTest.php
@@ -26,18 +26,18 @@ class PersistentSQLTest extends \atk4\schema\PhpunitTestCase
         $m->addField('surname');
 
         $m->load(1);
-        $this->assertSame('John', $m['name']);
+        $this->assertSame('John', $m->get('name'));
 
         $m->load(2);
-        $this->assertSame('Jones', $m['surname']);
-        $m['surname'] = 'Smith';
+        $this->assertSame('Jones', $m->get('surname'));
+        $m->set('surname', 'Smith');
         $m->save();
 
         $m->load(1);
-        $this->assertSame('John', $m['name']);
+        $this->assertSame('John', $m->get('name'));
 
         $m->load(2);
-        $this->assertSame('Smith', $m['surname']);
+        $this->assertSame('Smith', $m->get('surname'));
     }
 
     public function testPersistenceInsert()
@@ -56,23 +56,23 @@ class PersistentSQLTest extends \atk4\schema\PhpunitTestCase
         $m->addField('surname');
 
         $ids = [];
-        foreach ($a['user'] as $id => $row) {
+        foreach ($a->get('user') as $id => $row) {
             $ids[] = $this->db->insert($m, $row);
         }
 
-        $m->load($ids[0]);
-        $this->assertSame('John', $m['name']);
+        $m->load($ids->get(0));
+        $this->assertSame('John', $m->get('name'));
 
-        $m->load($ids[1]);
-        $this->assertSame('Jones', $m['surname']);
-        $m['surname'] = 'Smith';
+        $m->load($ids->get(1));
+        $this->assertSame('Jones', $m->get('surname'));
+        $m->set('surname', 'Smith');
         $m->save();
 
-        $m->load($ids[0]);
-        $this->assertSame('John', $m['name']);
+        $m->load($ids->get(0));
+        $this->assertSame('John', $m->get('name'));
 
-        $m->load($ids[1]);
-        $this->assertSame('Smith', $m['surname']);
+        $m->load($ids->get(1));
+        $this->assertSame('Smith', $m->get('surname'));
     }
 
     public function testModelInsert()
@@ -90,13 +90,13 @@ class PersistentSQLTest extends \atk4\schema\PhpunitTestCase
         $m->addField('surname');
 
         $ms = [];
-        foreach ($a['user'] as $id => $row) {
+        foreach ($a->get('user') as $id => $row) {
             $ms[] = $m->insert($row);
         }
 
-        $this->assertSame('John', $m->load($ms[0])['name']);
+        $this->assertSame('John', $m->load($ms->get(0))['name']);
 
-        $this->assertSame('Jones', $m->load($ms[1])['surname']);
+        $this->assertSame('Jones', $m->load($ms->get(1))['surname']);
     }
 
     public function testModelSaveNoReload()
@@ -116,11 +116,11 @@ class PersistentSQLTest extends \atk4\schema\PhpunitTestCase
         // insert new record, model id field
         $m->reload_after_save = false;
         $m->save(['name' => 'Jane', 'surname' => 'Doe']);
-        $this->assertSame('Jane', $m['name']);
-        $this->assertSame('Doe', $m['surname']);
+        $this->assertSame('Jane', $m->get('name'));
+        $this->assertSame('Doe', $m->get('surname'));
         $this->assertEquals(3, $m->id);
         // id field value is set with new id value even if reload_after_save = false
-        $this->assertEquals(3, $m[$m->id_field]);
+        $this->assertEquals(3, $m->get($m->id_field));
     }
 
     public function testModelInsertRows()
@@ -137,7 +137,7 @@ class PersistentSQLTest extends \atk4\schema\PhpunitTestCase
         $m->addField('name');
         $m->addField('surname');
 
-        $m->import($a['user']); // import data
+        $m->import($a->get('user')); // import data
 
         $this->assertEquals(2, $m->action('count')->getOne());
     }
@@ -157,24 +157,24 @@ class PersistentSQLTest extends \atk4\schema\PhpunitTestCase
         $m->addField('surname');
 
         $ids = [];
-        foreach ($a['user'] as $id => $row) {
+        foreach ($a->get('user') as $id => $row) {
             $ids[] = $this->db->insert($m, $row);
         }
         $this->assertFalse($m->loaded());
 
-        $m->delete($ids[0]);
+        $m->delete($ids->get(0));
         $this->assertFalse($m->loaded());
 
-        $m->load($ids[1]);
-        $this->assertSame('Jones', $m['surname']);
-        $m['surname'] = 'Smith';
+        $m->load($ids->get(1));
+        $this->assertSame('Jones', $m->get('surname'));
+        $m->set('surname', 'Smith');
         $m->save();
 
-        $m->tryLoad($ids[0]);
+        $m->tryLoad($ids->get(0));
         $this->assertFalse($m->loaded());
 
-        $m->load($ids[1]);
-        $this->assertSame('Smith', $m['surname']);
+        $m->load($ids->get(1));
+        $this->assertSame('Smith', $m->get('surname'));
     }
 
     /**

--- a/tests/PersistentSQLTest.php
+++ b/tests/PersistentSQLTest.php
@@ -26,18 +26,18 @@ class PersistentSQLTest extends \atk4\schema\PhpunitTestCase
         $m->addField('surname');
 
         $m->load(1);
-        $this->assertSame('John', $m['name']);
+        $this->assertSame('John', $m->get('name'));
 
         $m->load(2);
-        $this->assertSame('Jones', $m['surname']);
-        $m['surname'] = 'Smith';
+        $this->assertSame('Jones', $m->get('surname'));
+        $m->set('surname', 'Smith');
         $m->save();
 
         $m->load(1);
-        $this->assertSame('John', $m['name']);
+        $this->assertSame('John', $m->get('name'));
 
         $m->load(2);
-        $this->assertSame('Smith', $m['surname']);
+        $this->assertSame('Smith', $m->get('surname'));
     }
 
     public function testPersistenceInsert()
@@ -61,18 +61,18 @@ class PersistentSQLTest extends \atk4\schema\PhpunitTestCase
         }
 
         $m->load($ids[0]);
-        $this->assertSame('John', $m['name']);
+        $this->assertSame('John', $m->get('name'));
 
         $m->load($ids[1]);
-        $this->assertSame('Jones', $m['surname']);
-        $m['surname'] = 'Smith';
+        $this->assertSame('Jones', $m->get('surname'));
+        $m->set('surname', 'Smith');
         $m->save();
 
         $m->load($ids[0]);
-        $this->assertSame('John', $m['name']);
+        $this->assertSame('John', $m->get('name'));
 
         $m->load($ids[1]);
-        $this->assertSame('Smith', $m['surname']);
+        $this->assertSame('Smith', $m->get('surname'));
     }
 
     public function testModelInsert()
@@ -94,9 +94,9 @@ class PersistentSQLTest extends \atk4\schema\PhpunitTestCase
             $ms[] = $m->insert($row);
         }
 
-        $this->assertSame('John', $m->load($ms[0])['name']);
+        $this->assertSame('John', $m->load($ms[0])->get('name'));
 
-        $this->assertSame('Jones', $m->load($ms[1])['surname']);
+        $this->assertSame('Jones', $m->load($ms[1])->get('surname'));
     }
 
     public function testModelSaveNoReload()
@@ -116,11 +116,11 @@ class PersistentSQLTest extends \atk4\schema\PhpunitTestCase
         // insert new record, model id field
         $m->reload_after_save = false;
         $m->save(['name' => 'Jane', 'surname' => 'Doe']);
-        $this->assertSame('Jane', $m['name']);
-        $this->assertSame('Doe', $m['surname']);
+        $this->assertSame('Jane', $m->get('name'));
+        $this->assertSame('Doe', $m->get('surname'));
         $this->assertEquals(3, $m->id);
         // id field value is set with new id value even if reload_after_save = false
-        $this->assertEquals(3, $m[$m->id_field]);
+        $this->assertEquals(3, $m->get($m->id_field));
     }
 
     public function testModelInsertRows()
@@ -166,15 +166,15 @@ class PersistentSQLTest extends \atk4\schema\PhpunitTestCase
         $this->assertFalse($m->loaded());
 
         $m->load($ids[1]);
-        $this->assertSame('Jones', $m['surname']);
-        $m['surname'] = 'Smith';
+        $this->assertSame('Jones', $m->get('surname'));
+        $m->set('surname', 'Smith');
         $m->save();
 
         $m->tryLoad($ids[0]);
         $this->assertFalse($m->loaded());
 
         $m->load($ids[1]);
-        $this->assertSame('Smith', $m['surname']);
+        $this->assertSame('Smith', $m->get('surname'));
     }
 
     /**

--- a/tests/RandomTest.php
+++ b/tests/RandomTest.php
@@ -284,7 +284,7 @@ class RandomTest extends \atk4\schema\PhpunitTestCase
             }
         });
 
-        $this->assertSame('Sue', $m['name']);
+        $this->assertSame('Sue', $m->get('name'));
 
         $a = [
             'item' => [
@@ -292,7 +292,7 @@ class RandomTest extends \atk4\schema\PhpunitTestCase
             ], ];
         $this->setDB($a);
 
-        $m['name'] = 'Peter';
+        $m->set('name', 'Peter');
 
         try {
             $m->save();
@@ -336,7 +336,7 @@ class RandomTest extends \atk4\schema\PhpunitTestCase
         $m->set('john');
         $m->save();
 
-        $this->assertSame('rec #3', $m->load(3)['name']);
+        $this->assertSame('rec #3', $m->load(3)->get('name'));
 
         $m->delete();
     }
@@ -377,9 +377,9 @@ class RandomTest extends \atk4\schema\PhpunitTestCase
         $m->addField('x2', new \atk4\data\Field());
         $m->load(1);
 
-        $this->assertEquals(3.4, $m['bid']);
-        $this->assertSame('y1', $m['x1']);
-        $this->assertSame('y2', $m['x2']);
+        $this->assertEquals(3.4, $m->get('bid'));
+        $this->assertSame('y1', $m->get('x1'));
+        $this->assertSame('y2', $m->get('x2'));
     }
 
     public function testModelCaption()

--- a/tests/RandomTest.php
+++ b/tests/RandomTest.php
@@ -284,7 +284,7 @@ class RandomTest extends \atk4\schema\PhpunitTestCase
             }
         });
 
-        $this->assertSame('Sue', $m['name']);
+        $this->assertSame('Sue', $m->get('name'));
 
         $a = [
             'item' => [
@@ -292,7 +292,7 @@ class RandomTest extends \atk4\schema\PhpunitTestCase
             ], ];
         $this->setDB($a);
 
-        $m['name'] = 'Peter';
+        $m->set('name', 'Peter');
 
         try {
             $m->save();
@@ -377,9 +377,9 @@ class RandomTest extends \atk4\schema\PhpunitTestCase
         $m->addField('x2', new \atk4\data\Field());
         $m->load(1);
 
-        $this->assertEquals(3.4, $m['bid']);
-        $this->assertSame('y1', $m['x1']);
-        $this->assertSame('y2', $m['x2']);
+        $this->assertEquals(3.4, $m->get('bid'));
+        $this->assertSame('y1', $m->get('x1'));
+        $this->assertSame('y2', $m->get('x2'));
     }
 
     public function testModelCaption()

--- a/tests/RandomTest.php
+++ b/tests/RandomTest.php
@@ -284,7 +284,7 @@ class RandomTest extends \atk4\schema\PhpunitTestCase
             }
         });
 
-        $this->assertSame('Sue', $m->get('name'));
+        $this->assertSame('Sue', $m['name']);
 
         $a = [
             'item' => [
@@ -292,7 +292,7 @@ class RandomTest extends \atk4\schema\PhpunitTestCase
             ], ];
         $this->setDB($a);
 
-        $m->set('name', 'Peter');
+        $m['name'] = 'Peter';
 
         try {
             $m->save();
@@ -377,9 +377,9 @@ class RandomTest extends \atk4\schema\PhpunitTestCase
         $m->addField('x2', new \atk4\data\Field());
         $m->load(1);
 
-        $this->assertEquals(3.4, $m->get('bid'));
-        $this->assertSame('y1', $m->get('x1'));
-        $this->assertSame('y2', $m->get('x2'));
+        $this->assertEquals(3.4, $m['bid']);
+        $this->assertSame('y1', $m['x1']);
+        $this->assertSame('y2', $m['x2']);
     }
 
     public function testModelCaption()

--- a/tests/ReadOnlyModeTest.php
+++ b/tests/ReadOnlyModeTest.php
@@ -36,15 +36,15 @@ class ReadOnlyModeTest extends \atk4\schema\PhpunitTestCase
     public function testBasic()
     {
         $this->m->tryLoadAny();
-        $this->assertSame('John', $this->m['name']);
+        $this->assertSame('John', $this->m->get('name'));
 
         $this->m->setOrder('name desc');
         $this->m->tryLoadAny();
-        $this->assertSame('Sue', $this->m['name']);
+        $this->assertSame('Sue', $this->m->get('name'));
 
         $n = [];
         foreach ($this->m as $row) {
-            $n[] = $row['name'];
+            $n[] = $row->get('name');
         }
         $this->assertSame(['Sue', 'John'], $n);
     }
@@ -65,7 +65,7 @@ class ReadOnlyModeTest extends \atk4\schema\PhpunitTestCase
     public function testLoadSave()
     {
         $this->m->load(1);
-        $this->m['name'] = 'X';
+        $this->m->set('name', 'X');
         $this->m->save();
     }
 
@@ -96,14 +96,14 @@ class ReadOnlyModeTest extends \atk4\schema\PhpunitTestCase
     public function testLoadBy()
     {
         $this->m->loadBy('name', 'Sue');
-        $this->assertSame('Sue', $this->m['name']);
+        $this->assertSame('Sue', $this->m->get('name'));
     }
 
     public function testLoadCondition()
     {
         $this->m->addCondition('name', 'Sue');
         $this->m->loadAny();
-        $this->assertSame('Sue', $this->m['name']);
+        $this->assertSame('Sue', $this->m->get('name'));
     }
 
     /**

--- a/tests/ReadOnlyModeTest.php
+++ b/tests/ReadOnlyModeTest.php
@@ -44,7 +44,7 @@ class ReadOnlyModeTest extends \atk4\schema\PhpunitTestCase
 
         $n = [];
         foreach ($this->m as $row) {
-            $n[] = $row->get('name');
+            $n[] = $row['name'];
         }
         $this->assertSame(['Sue', 'John'], $n);
     }

--- a/tests/ReadOnlyModeTest.php
+++ b/tests/ReadOnlyModeTest.php
@@ -44,7 +44,7 @@ class ReadOnlyModeTest extends \atk4\schema\PhpunitTestCase
 
         $n = [];
         foreach ($this->m as $row) {
-            $n[] = $row['name'];
+            $n[] = $row->get('name');
         }
         $this->assertSame(['Sue', 'John'], $n);
     }

--- a/tests/ReferenceSQLTest.php
+++ b/tests/ReferenceSQLTest.php
@@ -36,19 +36,19 @@ class ReferenceSQLTest extends \atk4\schema\PhpunitTestCase
 
         $oo = $u->load(1)->ref('Orders');
         $oo->tryLoad(1);
-        $this->assertEquals(20, $oo['amount']);
+        $this->assertEquals(20, $oo->get('amount'));
         $oo->tryLoad(2);
-        $this->assertNull($oo['amount']);
+        $this->assertNull($oo->get('amount'));
         $oo->tryLoad(3);
-        $this->assertEquals(5, $oo['amount']);
+        $this->assertEquals(5, $oo->get('amount'));
 
         $oo = $u->load(2)->ref('Orders');
         $oo->tryLoad(1);
-        $this->assertNull($oo['amount']);
+        $this->assertNull($oo->get('amount'));
         $oo->tryLoad(2);
-        $this->assertEquals(15, $oo['amount']);
+        $this->assertEquals(15, $oo->get('amount'));
         $oo->tryLoad(3);
-        $this->assertNull($oo['amount']);
+        $this->assertNull($oo->get('amount'));
 
         $oo = $u->unload()->addCondition('id', '>', '1')->ref('Orders');
         if ($this->driverType === 'sqlite') {
@@ -98,11 +98,11 @@ class ReferenceSQLTest extends \atk4\schema\PhpunitTestCase
 
         $cc = $u->load(1)->ref('cur');
         $cc->tryLoadAny();
-        $this->assertSame('Euro', $cc['name']);
+        $this->assertSame('Euro', $cc->get('name'));
 
         $cc = $u->load(2)->ref('cur');
         $cc->tryLoadAny();
-        $this->assertSame('Pound', $cc['name']);
+        $this->assertSame('Pound', $cc->get('name'));
     }
 
     public function testLink2()
@@ -145,10 +145,10 @@ class ReferenceSQLTest extends \atk4\schema\PhpunitTestCase
 
         $o->hasOne('user_id', $u);
 
-        $this->assertSame('John', $o->load(1)->ref('user_id')['name']);
-        $this->assertSame('Peter', $o->load(2)->ref('user_id')['name']);
-        $this->assertSame('John', $o->load(3)->ref('user_id')['name']);
-        $this->assertSame('Joe', $o->load(5)->ref('user_id')['name']);
+        $this->assertSame('John', $o->load(1)->ref('user_id')->get('name'));
+        $this->assertSame('Peter', $o->load(2)->ref('user_id')->get('name'));
+        $this->assertSame('John', $o->load(3)->ref('user_id')->get('name'));
+        $this->assertSame('Joe', $o->load(5)->ref('user_id')->get('name'));
 
         $o->unload();
         $o->addCondition('amount', '>', 6);
@@ -186,22 +186,22 @@ class ReferenceSQLTest extends \atk4\schema\PhpunitTestCase
         $o = (new Model($this->db, 'order'))->addFields(['amount']);
         $o->hasOne('user_id', $u)->addFields(['username' => 'name', ['date', 'type' => 'date']]);
 
-        $this->assertSame('John', $o->load(1)['username']);
-        $this->assertEquals(new \DateTime('2001-01-02'), $o->load(1)['date']);
+        $this->assertSame('John', $o->load(1)->get('username'));
+        $this->assertEquals(new \DateTime('2001-01-02'), $o->load(1)->get('date'));
 
-        $this->assertSame('Peter', $o->load(2)['username']);
-        $this->assertSame('John', $o->load(3)['username']);
-        $this->assertSame('Joe', $o->load(5)['username']);
+        $this->assertSame('Peter', $o->load(2)->get('username'));
+        $this->assertSame('John', $o->load(3)->get('username'));
+        $this->assertSame('Joe', $o->load(5)->get('username'));
 
         // few more tests
         $o = (new Model($this->db, 'order'))->addFields(['amount']);
         $o->hasOne('user_id', $u)->addFields(['username' => 'name', 'thedate' => ['date', 'type' => 'date']]);
-        $this->assertSame('John', $o->load(1)['username']);
-        $this->assertEquals(new \DateTime('2001-01-02'), $o->load(1)['thedate']);
+        $this->assertSame('John', $o->load(1)->get('username'));
+        $this->assertEquals(new \DateTime('2001-01-02'), $o->load(1)->get('thedate'));
 
         $o = (new Model($this->db, 'order'))->addFields(['amount']);
         $o->hasOne('user_id', $u)->addFields(['date'], ['type' => 'date']);
-        $this->assertEquals(new \DateTime('2001-01-02'), $o->load(1)['date']);
+        $this->assertEquals(new \DateTime('2001-01-02'), $o->load(1)->get('date'));
     }
 
     public function testRelatedExpression()
@@ -275,9 +275,9 @@ class ReferenceSQLTest extends \atk4\schema\PhpunitTestCase
         // type was not set and is not inherited
         $this->assertNull($i->getField('total_net')->type);
 
-        $this->assertEquals(40, $i['total_net']);
-        $this->assertEquals(9.2, $i['total_vat']);
-        $this->assertEquals(49.2, $i['total_gross']);
+        $this->assertEquals(40, $i->get('total_net'));
+        $this->assertEquals(9.2, $i->get('total_vat'));
+        $this->assertEquals(49.2, $i->get('total_gross'));
 
         $i->ref('line')->import([
             ['total_net' => ($n = 1), 'total_vat' => ($n * $vat), 'total_gross' => ($n * ($vat + 1))],
@@ -285,18 +285,18 @@ class ReferenceSQLTest extends \atk4\schema\PhpunitTestCase
         ]);
         $i->reload();
 
-        $this->assertEquals($n = 43, $i['total_net']);
-        $this->assertEquals($n * $vat, $i['total_vat']);
-        $this->assertEquals($n * ($vat + 1), $i['total_gross']);
+        $this->assertEquals($n = 43, $i->get('total_net'));
+        $this->assertEquals($n * $vat, $i->get('total_vat'));
+        $this->assertEquals($n * ($vat + 1), $i->get('total_gross'));
 
         $i->ref('line')->import([
             ['total_net' => null, 'total_vat' => null, 'total_gross' => 1],
         ]);
         $i->reload();
 
-        $this->assertEquals($n = 43, $i['total_net']);
-        $this->assertEquals($n * $vat, $i['total_vat']);
-        $this->assertEquals($n * ($vat + 1) + 1, $i['total_gross']);
+        $this->assertEquals($n = 43, $i->get('total_net'));
+        $this->assertEquals($n * $vat, $i->get('total_vat'));
+        $this->assertEquals($n * ($vat + 1) + 1, $i->get('total_gross'));
     }
 
     public function testOtherAggregates()
@@ -332,24 +332,24 @@ class ReferenceSQLTest extends \atk4\schema\PhpunitTestCase
             ]);
         $l->load(1);
 
-        $this->assertEquals(2, $l['items_name']); // 2 not-null values
-        $this->assertEquals(1, $l['items_code']); // only 1 not-null value
-        $this->assertEquals(2, $l['items_star']); // 2 rows in total
-        $this->assertSame('Pork::Chicken', $l['items_c:']);
-        $this->assertSame('Pork-Chicken', $l['items_c-']);
-        $this->assertEquals(strlen('Chicken') + strlen('Pork'), $l['len']);
-        $this->assertEquals(strlen('Chicken') + strlen('Pork'), $l['len2']);
-        $this->assertEquals(10, $l['chicken5']);
+        $this->assertEquals(2, $l->get('items_name')); // 2 not-null values
+        $this->assertEquals(1, $l->get('items_code')); // only 1 not-null value
+        $this->assertEquals(2, $l->get('items_star')); // 2 rows in total
+        $this->assertSame('Pork::Chicken', $l->get('items_c:'));
+        $this->assertSame('Pork-Chicken', $l->get('items_c-'));
+        $this->assertEquals(strlen('Chicken') + strlen('Pork'), $l->get('len'));
+        $this->assertEquals(strlen('Chicken') + strlen('Pork'), $l->get('len2'));
+        $this->assertEquals(10, $l->get('chicken5'));
 
         $l->load(2);
-        $this->assertEquals(0, $l['items_name']);
-        $this->assertEquals(0, $l['items_code']);
-        $this->assertEquals(0, $l['items_star']);
-        $this->assertEquals('', $l['items_c:']);
-        $this->assertEquals('', $l['items_c-']);
-        $this->assertNull($l['len']);
-        $this->assertNull($l['len2']);
-        $this->assertNull($l['chicken5']);
+        $this->assertEquals(0, $l->get('items_name'));
+        $this->assertEquals(0, $l->get('items_code'));
+        $this->assertEquals(0, $l->get('items_star'));
+        $this->assertEquals('', $l->get('items_c:'));
+        $this->assertEquals('', $l->get('items_c-'));
+        $this->assertNull($l->get('len'));
+        $this->assertNull($l->get('len2'));
+        $this->assertNull($l->get('chicken5'));
     }
 
     public function testReferenceHook()
@@ -374,27 +374,27 @@ class ReferenceSQLTest extends \atk4\schema\PhpunitTestCase
             ->addField('address');
 
         $u->load(1);
-        $this->assertSame('John contact', $u['address']);
-        $this->assertSame('John contact', $u->ref('contact_id')['address']);
+        $this->assertSame('John contact', $u->get('address'));
+        $this->assertSame('John contact', $u->ref('contact_id')->get('address'));
 
         $u->load(2);
-        $this->assertNull($u['address']);
-        $this->assertNull($u['contact_id']);
-        $this->assertNull($u->ref('contact_id')['address']);
+        $this->assertNull($u->get('address'));
+        $this->assertNull($u->get('contact_id'));
+        $this->assertNull($u->ref('contact_id')->get('address'));
 
         $u->load(3);
-        $this->assertSame('Joe contact', $u['address']);
-        $this->assertSame('Joe contact', $u->ref('contact_id')['address']);
+        $this->assertSame('Joe contact', $u->get('address'));
+        $this->assertSame('Joe contact', $u->ref('contact_id')->get('address'));
 
         $u->load(2);
         $u->ref('contact_id')->save(['address' => 'Peters new contact']);
 
-        $this->assertNotNull($u['contact_id']);
-        $this->assertSame('Peters new contact', $u->ref('contact_id')['address']);
+        $this->assertNotNull($u->get('contact_id'));
+        $this->assertSame('Peters new contact', $u->ref('contact_id')->get('address'));
 
         $u->save()->reload();
-        $this->assertSame('Peters new contact', $u->ref('contact_id')['address']);
-        $this->assertSame('Peters new contact', $u['address']);
+        $this->assertSame('Peters new contact', $u->ref('contact_id')->get('address'));
+        $this->assertSame('Peters new contact', $u->get('address'));
     }
 
     /**
@@ -425,8 +425,8 @@ class ReferenceSQLTest extends \atk4\schema\PhpunitTestCase
 
         $p->load(2);
         $p->ref('Stadium')->import([['name' => 'Nou camp nou']]);
-        $this->assertSame('Nou camp nou', $p->ref('Stadium')['name']);
-        $this->assertSame('2', $p->ref('Stadium')['player_id']);
+        $this->assertSame('Nou camp nou', $p->ref('Stadium')->get('name'));
+        $this->assertSame('2', $p->ref('Stadium')->get('player_id'));
     }
 
     public function testModelProperty()

--- a/tests/ReferenceSQLTest.php
+++ b/tests/ReferenceSQLTest.php
@@ -36,19 +36,19 @@ class ReferenceSQLTest extends \atk4\schema\PhpunitTestCase
 
         $oo = $u->load(1)->ref('Orders');
         $oo->tryLoad(1);
-        $this->assertEquals(20, $oo['amount']);
+        $this->assertEquals(20, $oo->get('amount'));
         $oo->tryLoad(2);
-        $this->assertNull($oo['amount']);
+        $this->assertNull($oo->get('amount'));
         $oo->tryLoad(3);
-        $this->assertEquals(5, $oo['amount']);
+        $this->assertEquals(5, $oo->get('amount'));
 
         $oo = $u->load(2)->ref('Orders');
         $oo->tryLoad(1);
-        $this->assertNull($oo['amount']);
+        $this->assertNull($oo->get('amount'));
         $oo->tryLoad(2);
-        $this->assertEquals(15, $oo['amount']);
+        $this->assertEquals(15, $oo->get('amount'));
         $oo->tryLoad(3);
-        $this->assertNull($oo['amount']);
+        $this->assertNull($oo->get('amount'));
 
         $oo = $u->unload()->addCondition('id', '>', '1')->ref('Orders');
         if ($this->driverType === 'sqlite') {
@@ -98,11 +98,11 @@ class ReferenceSQLTest extends \atk4\schema\PhpunitTestCase
 
         $cc = $u->load(1)->ref('cur');
         $cc->tryLoadAny();
-        $this->assertSame('Euro', $cc['name']);
+        $this->assertSame('Euro', $cc->get('name'));
 
         $cc = $u->load(2)->ref('cur');
         $cc->tryLoadAny();
-        $this->assertSame('Pound', $cc['name']);
+        $this->assertSame('Pound', $cc->get('name'));
     }
 
     public function testLink2()
@@ -275,9 +275,9 @@ class ReferenceSQLTest extends \atk4\schema\PhpunitTestCase
         // type was not set and is not inherited
         $this->assertNull($i->getField('total_net')->type);
 
-        $this->assertEquals(40, $i['total_net']);
-        $this->assertEquals(9.2, $i['total_vat']);
-        $this->assertEquals(49.2, $i['total_gross']);
+        $this->assertEquals(40, $i->get('total_net'));
+        $this->assertEquals(9.2, $i->get('total_vat'));
+        $this->assertEquals(49.2, $i->get('total_gross'));
 
         $i->ref('line')->import([
             ['total_net' => ($n = 1), 'total_vat' => ($n * $vat), 'total_gross' => ($n * ($vat + 1))],
@@ -285,18 +285,18 @@ class ReferenceSQLTest extends \atk4\schema\PhpunitTestCase
         ]);
         $i->reload();
 
-        $this->assertEquals($n = 43, $i['total_net']);
-        $this->assertEquals($n * $vat, $i['total_vat']);
-        $this->assertEquals($n * ($vat + 1), $i['total_gross']);
+        $this->assertEquals($n = 43, $i->get('total_net'));
+        $this->assertEquals($n * $vat, $i->get('total_vat'));
+        $this->assertEquals($n * ($vat + 1), $i->get('total_gross'));
 
         $i->ref('line')->import([
             ['total_net' => null, 'total_vat' => null, 'total_gross' => 1],
         ]);
         $i->reload();
 
-        $this->assertEquals($n = 43, $i['total_net']);
-        $this->assertEquals($n * $vat, $i['total_vat']);
-        $this->assertEquals($n * ($vat + 1) + 1, $i['total_gross']);
+        $this->assertEquals($n = 43, $i->get('total_net'));
+        $this->assertEquals($n * $vat, $i->get('total_vat'));
+        $this->assertEquals($n * ($vat + 1) + 1, $i->get('total_gross'));
     }
 
     public function testOtherAggregates()
@@ -332,24 +332,24 @@ class ReferenceSQLTest extends \atk4\schema\PhpunitTestCase
             ]);
         $l->load(1);
 
-        $this->assertEquals(2, $l['items_name']); // 2 not-null values
-        $this->assertEquals(1, $l['items_code']); // only 1 not-null value
-        $this->assertEquals(2, $l['items_star']); // 2 rows in total
-        $this->assertSame('Pork::Chicken', $l['items_c:']);
-        $this->assertSame('Pork-Chicken', $l['items_c-']);
-        $this->assertEquals(strlen('Chicken') + strlen('Pork'), $l['len']);
-        $this->assertEquals(strlen('Chicken') + strlen('Pork'), $l['len2']);
-        $this->assertEquals(10, $l['chicken5']);
+        $this->assertEquals(2, $l->get('items_name')); // 2 not-null values
+        $this->assertEquals(1, $l->get('items_code')); // only 1 not-null value
+        $this->assertEquals(2, $l->get('items_star')); // 2 rows in total
+        $this->assertSame('Pork::Chicken', $l->get('items_c:'));
+        $this->assertSame('Pork-Chicken', $l->get('items_c-'));
+        $this->assertEquals(strlen('Chicken') + strlen('Pork'), $l->get('len'));
+        $this->assertEquals(strlen('Chicken') + strlen('Pork'), $l->get('len2'));
+        $this->assertEquals(10, $l->get('chicken5'));
 
         $l->load(2);
-        $this->assertEquals(0, $l['items_name']);
-        $this->assertEquals(0, $l['items_code']);
-        $this->assertEquals(0, $l['items_star']);
-        $this->assertEquals('', $l['items_c:']);
-        $this->assertEquals('', $l['items_c-']);
-        $this->assertNull($l['len']);
-        $this->assertNull($l['len2']);
-        $this->assertNull($l['chicken5']);
+        $this->assertEquals(0, $l->get('items_name'));
+        $this->assertEquals(0, $l->get('items_code'));
+        $this->assertEquals(0, $l->get('items_star'));
+        $this->assertEquals('', $l->get('items_c:'));
+        $this->assertEquals('', $l->get('items_c-'));
+        $this->assertNull($l->get('len'));
+        $this->assertNull($l->get('len2'));
+        $this->assertNull($l->get('chicken5'));
     }
 
     public function testReferenceHook()
@@ -374,27 +374,27 @@ class ReferenceSQLTest extends \atk4\schema\PhpunitTestCase
             ->addField('address');
 
         $u->load(1);
-        $this->assertSame('John contact', $u['address']);
+        $this->assertSame('John contact', $u->get('address'));
         $this->assertSame('John contact', $u->ref('contact_id')['address']);
 
         $u->load(2);
-        $this->assertNull($u['address']);
-        $this->assertNull($u['contact_id']);
+        $this->assertNull($u->get('address'));
+        $this->assertNull($u->get('contact_id'));
         $this->assertNull($u->ref('contact_id')['address']);
 
         $u->load(3);
-        $this->assertSame('Joe contact', $u['address']);
+        $this->assertSame('Joe contact', $u->get('address'));
         $this->assertSame('Joe contact', $u->ref('contact_id')['address']);
 
         $u->load(2);
         $u->ref('contact_id')->save(['address' => 'Peters new contact']);
 
-        $this->assertNotNull($u['contact_id']);
+        $this->assertNotNull($u->get('contact_id'));
         $this->assertSame('Peters new contact', $u->ref('contact_id')['address']);
 
         $u->save()->reload();
         $this->assertSame('Peters new contact', $u->ref('contact_id')['address']);
-        $this->assertSame('Peters new contact', $u['address']);
+        $this->assertSame('Peters new contact', $u->get('address'));
     }
 
     /**

--- a/tests/ReferenceSQLTest.php
+++ b/tests/ReferenceSQLTest.php
@@ -36,19 +36,19 @@ class ReferenceSQLTest extends \atk4\schema\PhpunitTestCase
 
         $oo = $u->load(1)->ref('Orders');
         $oo->tryLoad(1);
-        $this->assertEquals(20, $oo->get('amount'));
+        $this->assertEquals(20, $oo['amount']);
         $oo->tryLoad(2);
-        $this->assertNull($oo->get('amount'));
+        $this->assertNull($oo['amount']);
         $oo->tryLoad(3);
-        $this->assertEquals(5, $oo->get('amount'));
+        $this->assertEquals(5, $oo['amount']);
 
         $oo = $u->load(2)->ref('Orders');
         $oo->tryLoad(1);
-        $this->assertNull($oo->get('amount'));
+        $this->assertNull($oo['amount']);
         $oo->tryLoad(2);
-        $this->assertEquals(15, $oo->get('amount'));
+        $this->assertEquals(15, $oo['amount']);
         $oo->tryLoad(3);
-        $this->assertNull($oo->get('amount'));
+        $this->assertNull($oo['amount']);
 
         $oo = $u->unload()->addCondition('id', '>', '1')->ref('Orders');
         if ($this->driverType === 'sqlite') {
@@ -98,11 +98,11 @@ class ReferenceSQLTest extends \atk4\schema\PhpunitTestCase
 
         $cc = $u->load(1)->ref('cur');
         $cc->tryLoadAny();
-        $this->assertSame('Euro', $cc->get('name'));
+        $this->assertSame('Euro', $cc['name']);
 
         $cc = $u->load(2)->ref('cur');
         $cc->tryLoadAny();
-        $this->assertSame('Pound', $cc->get('name'));
+        $this->assertSame('Pound', $cc['name']);
     }
 
     public function testLink2()
@@ -275,9 +275,9 @@ class ReferenceSQLTest extends \atk4\schema\PhpunitTestCase
         // type was not set and is not inherited
         $this->assertNull($i->getField('total_net')->type);
 
-        $this->assertEquals(40, $i->get('total_net'));
-        $this->assertEquals(9.2, $i->get('total_vat'));
-        $this->assertEquals(49.2, $i->get('total_gross'));
+        $this->assertEquals(40, $i['total_net']);
+        $this->assertEquals(9.2, $i['total_vat']);
+        $this->assertEquals(49.2, $i['total_gross']);
 
         $i->ref('line')->import([
             ['total_net' => ($n = 1), 'total_vat' => ($n * $vat), 'total_gross' => ($n * ($vat + 1))],
@@ -285,18 +285,18 @@ class ReferenceSQLTest extends \atk4\schema\PhpunitTestCase
         ]);
         $i->reload();
 
-        $this->assertEquals($n = 43, $i->get('total_net'));
-        $this->assertEquals($n * $vat, $i->get('total_vat'));
-        $this->assertEquals($n * ($vat + 1), $i->get('total_gross'));
+        $this->assertEquals($n = 43, $i['total_net']);
+        $this->assertEquals($n * $vat, $i['total_vat']);
+        $this->assertEquals($n * ($vat + 1), $i['total_gross']);
 
         $i->ref('line')->import([
             ['total_net' => null, 'total_vat' => null, 'total_gross' => 1],
         ]);
         $i->reload();
 
-        $this->assertEquals($n = 43, $i->get('total_net'));
-        $this->assertEquals($n * $vat, $i->get('total_vat'));
-        $this->assertEquals($n * ($vat + 1) + 1, $i->get('total_gross'));
+        $this->assertEquals($n = 43, $i['total_net']);
+        $this->assertEquals($n * $vat, $i['total_vat']);
+        $this->assertEquals($n * ($vat + 1) + 1, $i['total_gross']);
     }
 
     public function testOtherAggregates()
@@ -332,24 +332,24 @@ class ReferenceSQLTest extends \atk4\schema\PhpunitTestCase
             ]);
         $l->load(1);
 
-        $this->assertEquals(2, $l->get('items_name')); // 2 not-null values
-        $this->assertEquals(1, $l->get('items_code')); // only 1 not-null value
-        $this->assertEquals(2, $l->get('items_star')); // 2 rows in total
-        $this->assertSame('Pork::Chicken', $l->get('items_c:'));
-        $this->assertSame('Pork-Chicken', $l->get('items_c-'));
-        $this->assertEquals(strlen('Chicken') + strlen('Pork'), $l->get('len'));
-        $this->assertEquals(strlen('Chicken') + strlen('Pork'), $l->get('len2'));
-        $this->assertEquals(10, $l->get('chicken5'));
+        $this->assertEquals(2, $l['items_name']); // 2 not-null values
+        $this->assertEquals(1, $l['items_code']); // only 1 not-null value
+        $this->assertEquals(2, $l['items_star']); // 2 rows in total
+        $this->assertSame('Pork::Chicken', $l['items_c:']);
+        $this->assertSame('Pork-Chicken', $l['items_c-']);
+        $this->assertEquals(strlen('Chicken') + strlen('Pork'), $l['len']);
+        $this->assertEquals(strlen('Chicken') + strlen('Pork'), $l['len2']);
+        $this->assertEquals(10, $l['chicken5']);
 
         $l->load(2);
-        $this->assertEquals(0, $l->get('items_name'));
-        $this->assertEquals(0, $l->get('items_code'));
-        $this->assertEquals(0, $l->get('items_star'));
-        $this->assertEquals('', $l->get('items_c:'));
-        $this->assertEquals('', $l->get('items_c-'));
-        $this->assertNull($l->get('len'));
-        $this->assertNull($l->get('len2'));
-        $this->assertNull($l->get('chicken5'));
+        $this->assertEquals(0, $l['items_name']);
+        $this->assertEquals(0, $l['items_code']);
+        $this->assertEquals(0, $l['items_star']);
+        $this->assertEquals('', $l['items_c:']);
+        $this->assertEquals('', $l['items_c-']);
+        $this->assertNull($l['len']);
+        $this->assertNull($l['len2']);
+        $this->assertNull($l['chicken5']);
     }
 
     public function testReferenceHook()
@@ -374,27 +374,27 @@ class ReferenceSQLTest extends \atk4\schema\PhpunitTestCase
             ->addField('address');
 
         $u->load(1);
-        $this->assertSame('John contact', $u->get('address'));
+        $this->assertSame('John contact', $u['address']);
         $this->assertSame('John contact', $u->ref('contact_id')['address']);
 
         $u->load(2);
-        $this->assertNull($u->get('address'));
-        $this->assertNull($u->get('contact_id'));
+        $this->assertNull($u['address']);
+        $this->assertNull($u['contact_id']);
         $this->assertNull($u->ref('contact_id')['address']);
 
         $u->load(3);
-        $this->assertSame('Joe contact', $u->get('address'));
+        $this->assertSame('Joe contact', $u['address']);
         $this->assertSame('Joe contact', $u->ref('contact_id')['address']);
 
         $u->load(2);
         $u->ref('contact_id')->save(['address' => 'Peters new contact']);
 
-        $this->assertNotNull($u->get('contact_id'));
+        $this->assertNotNull($u['contact_id']);
         $this->assertSame('Peters new contact', $u->ref('contact_id')['address']);
 
         $u->save()->reload();
         $this->assertSame('Peters new contact', $u->ref('contact_id')['address']);
-        $this->assertSame('Peters new contact', $u->get('address'));
+        $this->assertSame('Peters new contact', $u['address']);
     }
 
     /**

--- a/tests/ReferenceTest.php
+++ b/tests/ReferenceTest.php
@@ -24,8 +24,8 @@ class ReferenceTest extends AtkPhpunit\TestCase
         $user->hasMany('Orders', [$order, 'caption' => 'My Orders']);
         $o = $user->ref('Orders');
 
-        $this->assertSame(20, $o['amount']);
-        $this->assertSame(1, $o['user_id']);
+        $this->assertSame(20, $o->get('amount'));
+        $this->assertSame(1, $o->get('user_id'));
 
         $user->hasMany('BigOrders', function () {
             $m = new Model();

--- a/tests/ReferenceTest.php
+++ b/tests/ReferenceTest.php
@@ -24,8 +24,8 @@ class ReferenceTest extends AtkPhpunit\TestCase
         $user->hasMany('Orders', [$order, 'caption' => 'My Orders']);
         $o = $user->ref('Orders');
 
-        $this->assertSame(20, $o->get('amount'));
-        $this->assertSame(1, $o->get('user_id'));
+        $this->assertSame(20, $o['amount']);
+        $this->assertSame(1, $o['user_id']);
 
         $user->hasMany('BigOrders', function () {
             $m = new Model();

--- a/tests/ReferenceTest.php
+++ b/tests/ReferenceTest.php
@@ -24,8 +24,8 @@ class ReferenceTest extends AtkPhpunit\TestCase
         $user->hasMany('Orders', [$order, 'caption' => 'My Orders']);
         $o = $user->ref('Orders');
 
-        $this->assertSame(20, $o['amount']);
-        $this->assertSame(1, $o['user_id']);
+        $this->assertSame(20, $o->get('amount'));
+        $this->assertSame(1, $o->get('user_id'));
 
         $user->hasMany('BigOrders', function () {
             $m = new Model();
@@ -35,7 +35,7 @@ class ReferenceTest extends AtkPhpunit\TestCase
             return $m;
         });
 
-        $this->assertSame(100, $user->ref('BigOrders')['amount']);
+        $this->assertSame(100, $user->ref('BigOrders')->get('amount'));
     }
 
     /**

--- a/tests/SmboTransferTest.php
+++ b/tests/SmboTransferTest.php
@@ -64,7 +64,7 @@ class SmboTransferTest extends \atk4\schema\PhpunitTestCase
 
         $data = $t->export(['id', 'transfer_document_id']);
         usort($data, function ($e1, $e2) {
-            return $e1->get('id') < $e2->get('id') ? -1 : 1;
+            return $e1['id'] < $e2['id'] ? -1 : 1;
         });
         $this->assertSame([
             ['id' => '1', 'transfer_document_id' => '2'],
@@ -111,7 +111,7 @@ class SmboTransferTest extends \atk4\schema\PhpunitTestCase
     /*
     public function testBasicEntities()
     {
-        $db = Persistence::connect($GLOBALS->get('DB_DSN'), $GLOBALS->get('DB_USER'), $GLOBALS->get('DB_PASSWD'));
+        $db = Persistence::connect($GLOBALS['DB_DSN'], $GLOBALS['DB_USER'], $GLOBALS['DB_PASSWD']);
 
         // Create a new company
         $company = new Company($db);

--- a/tests/SmboTransferTest.php
+++ b/tests/SmboTransferTest.php
@@ -59,8 +59,8 @@ class SmboTransferTest extends \atk4\schema\PhpunitTestCase
 
         $t->save();
 
-        $this->assertEquals(-100, $aib->reload()['balance']);
-        $this->assertEquals(100, $boi->reload()['balance']);
+        $this->assertEquals(-100, $aib->reload()->get('balance'));
+        $this->assertEquals(100, $boi->reload()->get('balance'));
 
         $data = $t->export(['id', 'transfer_document_id']);
         usort($data, function ($e1, $e2) {

--- a/tests/SmboTransferTest.php
+++ b/tests/SmboTransferTest.php
@@ -64,7 +64,7 @@ class SmboTransferTest extends \atk4\schema\PhpunitTestCase
 
         $data = $t->export(['id', 'transfer_document_id']);
         usort($data, function ($e1, $e2) {
-            return $e1['id'] < $e2['id'] ? -1 : 1;
+            return $e1->get('id') < $e2->get('id') ? -1 : 1;
         });
         $this->assertSame([
             ['id' => '1', 'transfer_document_id' => '2'],
@@ -111,7 +111,7 @@ class SmboTransferTest extends \atk4\schema\PhpunitTestCase
     /*
     public function testBasicEntities()
     {
-        $db = Persistence::connect($GLOBALS['DB_DSN'], $GLOBALS['DB_USER'], $GLOBALS['DB_PASSWD']);
+        $db = Persistence::connect($GLOBALS->get('DB_DSN'), $GLOBALS->get('DB_USER'), $GLOBALS->get('DB_PASSWD'));
 
         // Create a new company
         $company = new Company($db);

--- a/tests/StaticPersistenceTest.php
+++ b/tests/StaticPersistenceTest.php
@@ -21,12 +21,12 @@ class StaticPersistenceTest extends AtkPhpunit\TestCase
         // default title field
         $m = new Model($p);
         $m->load(1);
-        $this->assertSame('world', $m['name']);
+        $this->assertSame('world', $m->get('name'));
 
         // custom title field and try loading from same static twice
         $m = new Model($p); //, ['title_field' => 'foo']);
         $m->load(1);
-        $this->assertSame('world', $m['name']); // still 'name' here not 'foo'
+        $this->assertSame('world', $m->get('name')); // still 'name' here not 'foo'
     }
 
     public function testArrayOfArrays()
@@ -36,9 +36,9 @@ class StaticPersistenceTest extends AtkPhpunit\TestCase
 
         $m->load(1);
 
-        $this->assertSame('world', $m['name']);
-        $this->assertSame('xy', $m['field1']);
-        $this->assertFalse($m['field2']);
+        $this->assertSame('world', $m->get('name'));
+        $this->assertSame('xy', $m->get('field1'));
+        $this->assertFalse($m->get('field2'));
     }
 
     public function testArrayOfHashes()
@@ -48,7 +48,7 @@ class StaticPersistenceTest extends AtkPhpunit\TestCase
 
         $m->load(1);
 
-        $this->assertSame('world', $m['foo']);
+        $this->assertSame('world', $m->get('foo'));
     }
 
     public function testIDArg()
@@ -58,7 +58,7 @@ class StaticPersistenceTest extends AtkPhpunit\TestCase
 
         $m->load(21);
 
-        $this->assertSame('world', $m['foo']);
+        $this->assertSame('world', $m->get('foo'));
     }
 
     public function testIDKey()
@@ -68,7 +68,7 @@ class StaticPersistenceTest extends AtkPhpunit\TestCase
 
         $m->load(21);
 
-        $this->assertSame('world', $m['foo']);
+        $this->assertSame('world', $m->get('foo'));
     }
 
     public function testEmpty()

--- a/tests/StaticPersistenceTest.php
+++ b/tests/StaticPersistenceTest.php
@@ -21,12 +21,12 @@ class StaticPersistenceTest extends AtkPhpunit\TestCase
         // default title field
         $m = new Model($p);
         $m->load(1);
-        $this->assertSame('world', $m->get('name'));
+        $this->assertSame('world', $m['name']);
 
         // custom title field and try loading from same static twice
         $m = new Model($p); //, ['title_field' => 'foo']);
         $m->load(1);
-        $this->assertSame('world', $m->get('name')); // still 'name' here not 'foo'
+        $this->assertSame('world', $m['name']); // still 'name' here not 'foo'
     }
 
     public function testArrayOfArrays()
@@ -36,9 +36,9 @@ class StaticPersistenceTest extends AtkPhpunit\TestCase
 
         $m->load(1);
 
-        $this->assertSame('world', $m->get('name'));
-        $this->assertSame('xy', $m->get('field1'));
-        $this->assertFalse($m->get('field2'));
+        $this->assertSame('world', $m['name']);
+        $this->assertSame('xy', $m['field1']);
+        $this->assertFalse($m['field2']);
     }
 
     public function testArrayOfHashes()
@@ -48,7 +48,7 @@ class StaticPersistenceTest extends AtkPhpunit\TestCase
 
         $m->load(1);
 
-        $this->assertSame('world', $m->get('foo'));
+        $this->assertSame('world', $m['foo']);
     }
 
     public function testIDArg()
@@ -58,7 +58,7 @@ class StaticPersistenceTest extends AtkPhpunit\TestCase
 
         $m->load(21);
 
-        $this->assertSame('world', $m->get('foo'));
+        $this->assertSame('world', $m['foo']);
     }
 
     public function testIDKey()
@@ -68,7 +68,7 @@ class StaticPersistenceTest extends AtkPhpunit\TestCase
 
         $m->load(21);
 
-        $this->assertSame('world', $m->get('foo'));
+        $this->assertSame('world', $m['foo']);
     }
 
     public function testEmpty()

--- a/tests/SubTypesTest.php
+++ b/tests/SubTypesTest.php
@@ -52,7 +52,7 @@ class STAccount extends Model
     {
         $out = $this->ref('Transactions:TransferOut')->save(['amount' => $amount]);
         $in = $account->ref('Transactions:TransferIn')->save(['amount' => $amount, 'link_id' => $out->id]);
-        $out['link_id'] = $in->id;
+        $out->set('link_id', $in->id);
         $out->save();
     }
 }
@@ -87,7 +87,7 @@ class STGenericTransaction extends Model
 
     public function getClassName()
     {
-        return __NAMESPACE__ . '\STTransaction_' . $this['type'];
+        return __NAMESPACE__ . '\STTransaction_' . $this->get('type');
     }
 }
 

--- a/tests/SubTypesTest.php
+++ b/tests/SubTypesTest.php
@@ -52,7 +52,7 @@ class STAccount extends Model
     {
         $out = $this->ref('Transactions:TransferOut')->save(['amount' => $amount]);
         $in = $account->ref('Transactions:TransferIn')->save(['amount' => $amount, 'link_id' => $out->id]);
-        $out->set('link_id', $in->id);
+        $out['link_id'] = $in->id;
         $out->save();
     }
 }
@@ -87,7 +87,7 @@ class STGenericTransaction extends Model
 
     public function getClassName()
     {
-        return __NAMESPACE__ . '\STTransaction_' . $this->get('type');
+        return __NAMESPACE__ . '\STTransaction_' . $this['type'];
     }
 }
 

--- a/tests/TransactionTest.php
+++ b/tests/TransactionTest.php
@@ -28,7 +28,7 @@ class TransactionTest extends \atk4\schema\PhpunitTestCase
         $m->onHook('afterSave', function ($m) {
             throw new \Exception('Awful thing happened');
         });
-        $m['name'] = 'XXX';
+        $m->set('name', 'XXX');
 
         try {
             $m->save();

--- a/tests/TransactionTest.php
+++ b/tests/TransactionTest.php
@@ -28,7 +28,7 @@ class TransactionTest extends \atk4\schema\PhpunitTestCase
         $m->onHook('afterSave', function ($m) {
             throw new \Exception('Awful thing happened');
         });
-        $m->set('name', 'XXX');
+        $m['name'] = 'XXX';
 
         try {
             $m->save();

--- a/tests/TypecastingTest.php
+++ b/tests/TypecastingTest.php
@@ -69,15 +69,15 @@ class TypecastingTest extends \atk4\schema\PhpunitTestCase
         $m->addField('array', ['type' => 'array']);
         $m->load(1);
 
-        $this->assertSame('foo', $m->get('string'));
-        $this->assertTrue($m->get('boolean'));
-        $this->assertSame(8.20, $m->get('money'));
-        $this->assertEquals(new \DateTime('2013-02-20'), $m->get('date'));
-        $this->assertEquals(new \DateTime('2013-02-20 20:00:12 UTC'), $m->get('datetime'));
-        $this->assertEquals(new \DateTime('1970-01-01 12:00:50'), $m->get('time'));
-        $this->assertSame(2940, $m->get('integer'));
-        $this->assertSame([1, 2, 3], $m->get('array'));
-        $this->assertSame(8.202343, $m->get('float'));
+        $this->assertSame('foo', $m['string']);
+        $this->assertTrue($m['boolean']);
+        $this->assertSame(8.20, $m['money']);
+        $this->assertEquals(new \DateTime('2013-02-20'), $m['date']);
+        $this->assertEquals(new \DateTime('2013-02-20 20:00:12 UTC'), $m['datetime']);
+        $this->assertEquals(new \DateTime('1970-01-01 12:00:50'), $m['time']);
+        $this->assertSame(2940, $m['integer']);
+        $this->assertSame([1, 2, 3], $m['array']);
+        $this->assertSame(8.202343, $m['float']);
 
         $m->duplicate()->save();
 
@@ -163,32 +163,32 @@ class TypecastingTest extends \atk4\schema\PhpunitTestCase
         $m->load(1);
 
         // Only
-        $this->assertSame('', $m->get('string'));
-        $this->assertSame('', $m->get('notype'));
-        $this->assertNull($m->get('date'));
-        $this->assertNull($m->get('datetime'));
-        $this->assertNull($m->get('time'));
-        $this->assertNull($m->get('boolean'));
-        $this->assertNull($m->get('integer'));
-        $this->assertNull($m->get('money'));
-        $this->assertNull($m->get('float'));
-        $this->assertNull($m->get('array'));
-        $this->assertNull($m->get('object'));
+        $this->assertSame('', $m['string']);
+        $this->assertSame('', $m['notype']);
+        $this->assertNull($m['date']);
+        $this->assertNull($m['datetime']);
+        $this->assertNull($m['time']);
+        $this->assertNull($m['boolean']);
+        $this->assertNull($m['integer']);
+        $this->assertNull($m['money']);
+        $this->assertNull($m['float']);
+        $this->assertNull($m['array']);
+        $this->assertNull($m['object']);
 
         unset($v['id']);
         $m->set($v);
 
-        $this->assertSame('', $m->get('string'));
-        $this->assertSame('', $m->get('notype'));
-        $this->assertNull($m->get('date'));
-        $this->assertNull($m->get('datetime'));
-        $this->assertNull($m->get('time'));
-        $this->assertNull($m->get('boolean'));
-        $this->assertNull($m->get('integer'));
-        $this->assertNull($m->get('money'));
-        $this->assertNull($m->get('float'));
-        $this->assertNull($m->get('array'));
-        $this->assertNull($m->get('object'));
+        $this->assertSame('', $m['string']);
+        $this->assertSame('', $m['notype']);
+        $this->assertNull($m['date']);
+        $this->assertNull($m['datetime']);
+        $this->assertNull($m['time']);
+        $this->assertNull($m['boolean']);
+        $this->assertNull($m['integer']);
+        $this->assertNull($m['money']);
+        $this->assertNull($m['float']);
+        $this->assertNull($m['array']);
+        $this->assertNull($m['object']);
         $this->assertSame([], $m->dirty);
 
         $m->save();
@@ -282,15 +282,15 @@ class TypecastingTest extends \atk4\schema\PhpunitTestCase
 
         $m->load(1);
 
-        $this->assertSame('hello world', $m->get('rot13'));
+        $this->assertSame('hello world', $m['rot13']);
         $this->assertSame(1, (int) $m->id);
-        $this->assertSame(1, (int) $m->get('id'));
-        $this->assertSame('2013-02-21 05:00:12.235689', (string) $m->get('datetime'));
-        $this->assertSame('2013-02-20', (string) $m->get('date'));
-        $this->assertSame('12:00:50.235689', (string) $m->get('time'));
+        $this->assertSame(1, (int) $m['id']);
+        $this->assertSame('2013-02-21 05:00:12.235689', (string) $m['datetime']);
+        $this->assertSame('2013-02-20', (string) $m['date']);
+        $this->assertSame('12:00:50.235689', (string) $m['time']);
 
-        $this->assertTrue($m->get('b1'));
-        $this->assertFalse($m->get('b2'));
+        $this->assertTrue($m['b1']);
+        $this->assertFalse($m['b2']);
 
         $m->duplicate()->save()->delete(1);
 
@@ -329,7 +329,7 @@ class TypecastingTest extends \atk4\schema\PhpunitTestCase
 
         $m->tryLoad(1);
 
-        $this->assertTrue($m->get('date') instanceof MyDate);
+        $this->assertTrue($m['date'] instanceof MyDate);
     }
 
     public function testTryLoadAny()
@@ -349,7 +349,7 @@ class TypecastingTest extends \atk4\schema\PhpunitTestCase
 
         $m->tryLoadAny();
 
-        $this->assertTrue($m->get('date') instanceof MyDate);
+        $this->assertTrue($m['date'] instanceof MyDate);
     }
 
     public function testTryLoadBy()
@@ -369,7 +369,7 @@ class TypecastingTest extends \atk4\schema\PhpunitTestCase
 
         $m->loadBy('id', 1);
 
-        $this->assertTrue($m->get('date') instanceof MyDate);
+        $this->assertTrue($m['date'] instanceof MyDate);
     }
 
     public function testLoadBy()
@@ -386,7 +386,7 @@ class TypecastingTest extends \atk4\schema\PhpunitTestCase
         $m = new Model($db, ['table' => 'types']);
         $m->addField('date', ['type' => 'date', 'dateTimeClass' => MyDate::class]);
         $m->loadAny();
-        $d = $m->get('date');
+        $d = $m['date'];
         $m->unload();
 
         $m->loadBy('date', $d)->unload();
@@ -460,7 +460,7 @@ class TypecastingTest extends \atk4\schema\PhpunitTestCase
         $m->loadAny();
 
         // must respect 'actual'
-        $this->assertNotNull($m->get('ts'));
+        $this->assertNotNull($m['ts']);
     }
 
     /**
@@ -500,7 +500,7 @@ class TypecastingTest extends \atk4\schema\PhpunitTestCase
         $m = new Model($db, ['table' => 'types']);
         $m->addField('ts', ['actual' => 'date', 'type' => 'datetime']);
         $m->loadAny();
-        $m->set('ts', clone $m->get('ts'));
+        $m['ts'] = clone $m['ts'];
 
         $this->assertFalse($m->isDirty('ts'));
     }
@@ -519,7 +519,7 @@ class TypecastingTest extends \atk4\schema\PhpunitTestCase
         $m = new Model($db, ['table' => 'types']);
         $m->addField('ts', ['actual' => 'date', 'type' => 'date']);
         $m->loadAny();
-        $m->set('ts', new \DateTime('2012-02-30'));
+        $m['ts'] = new \DateTime('2012-02-30');
         $m->save();
 
         // stores valid date.
@@ -536,13 +536,13 @@ class TypecastingTest extends \atk4\schema\PhpunitTestCase
         $m->data['i'] = 1;
         $this->assertSame([], $m->dirty);
 
-        $m->set('i', '1');
+        $m['i'] = '1';
         $this->assertSame([], $m->dirty);
 
-        $m->set('i', '2');
+        $m['i'] = '2';
         $this->assertSame(['i' => 1], $m->dirty);
 
-        $m->set('i', '1');
+        $m['i'] = '1';
         $this->assertSame([], $m->dirty);
 
         // same test without type integer
@@ -552,16 +552,16 @@ class TypecastingTest extends \atk4\schema\PhpunitTestCase
         $m->data['i'] = 1;
         $this->assertSame([], $m->dirty);
 
-        $m->set('i', '1');
+        $m['i'] = '1';
         $this->assertSame(1, $m->dirty['i']);
 
-        $m->set('i', '2');
+        $m['i'] = '2';
         $this->assertSame(1, $m->dirty['i']);
 
-        $m->set('i', '1');
+        $m['i'] = '1';
         $this->assertSame(1, $m->dirty['i']);
 
-        $m->set('i', 1);
+        $m['i'] = 1;
         $this->assertSame([], $m->dirty);
     }
 
@@ -583,13 +583,13 @@ class TypecastingTest extends \atk4\schema\PhpunitTestCase
         $m->addField('ts', ['actual' => 'date', 'type' => 'time']);
         $m->loadAny();
 
-        $m->set('ts', $sql_time_new);
+        $m['ts'] = $sql_time_new;
         $this->assertTrue($m->isDirty('ts'));
 
-        $m->set('ts', $sql_time);
+        $m['ts'] = $sql_time;
         $this->assertFalse($m->isDirty('ts'));
 
-        $m->set('ts', $sql_time_new);
+        $m['ts'] = $sql_time_new;
         $this->assertTrue($m->isDirty('ts'));
     }
 
@@ -611,16 +611,16 @@ class TypecastingTest extends \atk4\schema\PhpunitTestCase
         $m->addField('ts', ['actual' => 'date', 'type' => 'time']);
         $m->loadAny();
 
-        $m->set('ts', $sql_time);
+        $m['ts'] = $sql_time;
         $this->assertTrue($m->isDirty('ts'));
 
         $m->save();
         $m->reload();
 
-        $m->set('ts', $sql_time);
+        $m['ts'] = $sql_time;
         $this->assertFalse($m->isDirty('ts'));
 
-        $m->set('ts', $sql_time_new);
+        $m['ts'] = $sql_time_new;
         $this->assertTrue($m->isDirty('ts'));
     }
 }

--- a/tests/TypecastingTest.php
+++ b/tests/TypecastingTest.php
@@ -69,15 +69,15 @@ class TypecastingTest extends \atk4\schema\PhpunitTestCase
         $m->addField('array', ['type' => 'array']);
         $m->load(1);
 
-        $this->assertSame('foo', $m['string']);
-        $this->assertTrue($m['boolean']);
-        $this->assertSame(8.20, $m['money']);
-        $this->assertEquals(new \DateTime('2013-02-20'), $m['date']);
-        $this->assertEquals(new \DateTime('2013-02-20 20:00:12 UTC'), $m['datetime']);
-        $this->assertEquals(new \DateTime('1970-01-01 12:00:50'), $m['time']);
-        $this->assertSame(2940, $m['integer']);
-        $this->assertSame([1, 2, 3], $m['array']);
-        $this->assertSame(8.202343, $m['float']);
+        $this->assertSame('foo', $m->get('string'));
+        $this->assertTrue($m->get('boolean'));
+        $this->assertSame(8.20, $m->get('money'));
+        $this->assertEquals(new \DateTime('2013-02-20'), $m->get('date'));
+        $this->assertEquals(new \DateTime('2013-02-20 20:00:12 UTC'), $m->get('datetime'));
+        $this->assertEquals(new \DateTime('1970-01-01 12:00:50'), $m->get('time'));
+        $this->assertSame(2940, $m->get('integer'));
+        $this->assertSame([1, 2, 3], $m->get('array'));
+        $this->assertSame(8.202343, $m->get('float'));
 
         $m->duplicate()->save();
 
@@ -163,32 +163,32 @@ class TypecastingTest extends \atk4\schema\PhpunitTestCase
         $m->load(1);
 
         // Only
-        $this->assertSame('', $m['string']);
-        $this->assertSame('', $m['notype']);
-        $this->assertNull($m['date']);
-        $this->assertNull($m['datetime']);
-        $this->assertNull($m['time']);
-        $this->assertNull($m['boolean']);
-        $this->assertNull($m['integer']);
-        $this->assertNull($m['money']);
-        $this->assertNull($m['float']);
-        $this->assertNull($m['array']);
-        $this->assertNull($m['object']);
+        $this->assertSame('', $m->get('string'));
+        $this->assertSame('', $m->get('notype'));
+        $this->assertNull($m->get('date'));
+        $this->assertNull($m->get('datetime'));
+        $this->assertNull($m->get('time'));
+        $this->assertNull($m->get('boolean'));
+        $this->assertNull($m->get('integer'));
+        $this->assertNull($m->get('money'));
+        $this->assertNull($m->get('float'));
+        $this->assertNull($m->get('array'));
+        $this->assertNull($m->get('object'));
 
         unset($v['id']);
         $m->set($v);
 
-        $this->assertSame('', $m['string']);
-        $this->assertSame('', $m['notype']);
-        $this->assertNull($m['date']);
-        $this->assertNull($m['datetime']);
-        $this->assertNull($m['time']);
-        $this->assertNull($m['boolean']);
-        $this->assertNull($m['integer']);
-        $this->assertNull($m['money']);
-        $this->assertNull($m['float']);
-        $this->assertNull($m['array']);
-        $this->assertNull($m['object']);
+        $this->assertSame('', $m->get('string'));
+        $this->assertSame('', $m->get('notype'));
+        $this->assertNull($m->get('date'));
+        $this->assertNull($m->get('datetime'));
+        $this->assertNull($m->get('time'));
+        $this->assertNull($m->get('boolean'));
+        $this->assertNull($m->get('integer'));
+        $this->assertNull($m->get('money'));
+        $this->assertNull($m->get('float'));
+        $this->assertNull($m->get('array'));
+        $this->assertNull($m->get('object'));
         $this->assertSame([], $m->dirty);
 
         $m->save();
@@ -282,15 +282,15 @@ class TypecastingTest extends \atk4\schema\PhpunitTestCase
 
         $m->load(1);
 
-        $this->assertSame('hello world', $m['rot13']);
+        $this->assertSame('hello world', $m->get('rot13'));
         $this->assertSame(1, (int) $m->id);
-        $this->assertSame(1, (int) $m['id']);
-        $this->assertSame('2013-02-21 05:00:12.235689', (string) $m['datetime']);
-        $this->assertSame('2013-02-20', (string) $m['date']);
-        $this->assertSame('12:00:50.235689', (string) $m['time']);
+        $this->assertSame(1, (int) $m->get('id'));
+        $this->assertSame('2013-02-21 05:00:12.235689', (string) $m->get('datetime'));
+        $this->assertSame('2013-02-20', (string) $m->get('date'));
+        $this->assertSame('12:00:50.235689', (string) $m->get('time'));
 
-        $this->assertTrue($m['b1']);
-        $this->assertFalse($m['b2']);
+        $this->assertTrue($m->get('b1'));
+        $this->assertFalse($m->get('b2'));
 
         $m->duplicate()->save()->delete(1);
 
@@ -329,7 +329,7 @@ class TypecastingTest extends \atk4\schema\PhpunitTestCase
 
         $m->tryLoad(1);
 
-        $this->assertTrue($m['date'] instanceof MyDate);
+        $this->assertTrue($m->get('date') instanceof MyDate);
     }
 
     public function testTryLoadAny()
@@ -349,7 +349,7 @@ class TypecastingTest extends \atk4\schema\PhpunitTestCase
 
         $m->tryLoadAny();
 
-        $this->assertTrue($m['date'] instanceof MyDate);
+        $this->assertTrue($m->get('date') instanceof MyDate);
     }
 
     public function testTryLoadBy()
@@ -369,7 +369,7 @@ class TypecastingTest extends \atk4\schema\PhpunitTestCase
 
         $m->loadBy('id', 1);
 
-        $this->assertTrue($m['date'] instanceof MyDate);
+        $this->assertTrue($m->get('date') instanceof MyDate);
     }
 
     public function testLoadBy()
@@ -386,7 +386,7 @@ class TypecastingTest extends \atk4\schema\PhpunitTestCase
         $m = new Model($db, ['table' => 'types']);
         $m->addField('date', ['type' => 'date', 'dateTimeClass' => MyDate::class]);
         $m->loadAny();
-        $d = $m['date'];
+        $d = $m->get('date');
         $m->unload();
 
         $m->loadBy('date', $d)->unload();
@@ -460,7 +460,7 @@ class TypecastingTest extends \atk4\schema\PhpunitTestCase
         $m->loadAny();
 
         // must respect 'actual'
-        $this->assertNotNull($m['ts']);
+        $this->assertNotNull($m->get('ts'));
     }
 
     /**
@@ -500,7 +500,7 @@ class TypecastingTest extends \atk4\schema\PhpunitTestCase
         $m = new Model($db, ['table' => 'types']);
         $m->addField('ts', ['actual' => 'date', 'type' => 'datetime']);
         $m->loadAny();
-        $m['ts'] = clone $m['ts'];
+        $m->set('ts', clone $m->get('ts'));
 
         $this->assertFalse($m->isDirty('ts'));
     }
@@ -519,7 +519,7 @@ class TypecastingTest extends \atk4\schema\PhpunitTestCase
         $m = new Model($db, ['table' => 'types']);
         $m->addField('ts', ['actual' => 'date', 'type' => 'date']);
         $m->loadAny();
-        $m['ts'] = new \DateTime('2012-02-30');
+        $m->set('ts', new \DateTime('2012-02-30'));
         $m->save();
 
         // stores valid date.
@@ -536,13 +536,13 @@ class TypecastingTest extends \atk4\schema\PhpunitTestCase
         $m->data['i'] = 1;
         $this->assertSame([], $m->dirty);
 
-        $m['i'] = '1';
+        $m->set('i', '1');
         $this->assertSame([], $m->dirty);
 
-        $m['i'] = '2';
+        $m->set('i', '2');
         $this->assertSame(['i' => 1], $m->dirty);
 
-        $m['i'] = '1';
+        $m->set('i', '1');
         $this->assertSame([], $m->dirty);
 
         // same test without type integer
@@ -552,16 +552,16 @@ class TypecastingTest extends \atk4\schema\PhpunitTestCase
         $m->data['i'] = 1;
         $this->assertSame([], $m->dirty);
 
-        $m['i'] = '1';
+        $m->set('i', '1');
         $this->assertSame(1, $m->dirty['i']);
 
-        $m['i'] = '2';
+        $m->set('i', '2');
         $this->assertSame(1, $m->dirty['i']);
 
-        $m['i'] = '1';
+        $m->set('i', '1');
         $this->assertSame(1, $m->dirty['i']);
 
-        $m['i'] = 1;
+        $m->set('i', 1);
         $this->assertSame([], $m->dirty);
     }
 
@@ -583,13 +583,13 @@ class TypecastingTest extends \atk4\schema\PhpunitTestCase
         $m->addField('ts', ['actual' => 'date', 'type' => 'time']);
         $m->loadAny();
 
-        $m['ts'] = $sql_time_new;
+        $m->set('ts', $sql_time_new);
         $this->assertTrue($m->isDirty('ts'));
 
-        $m['ts'] = $sql_time;
+        $m->set('ts', $sql_time);
         $this->assertFalse($m->isDirty('ts'));
 
-        $m['ts'] = $sql_time_new;
+        $m->set('ts', $sql_time_new);
         $this->assertTrue($m->isDirty('ts'));
     }
 
@@ -611,16 +611,16 @@ class TypecastingTest extends \atk4\schema\PhpunitTestCase
         $m->addField('ts', ['actual' => 'date', 'type' => 'time']);
         $m->loadAny();
 
-        $m['ts'] = $sql_time;
+        $m->set('ts', $sql_time);
         $this->assertTrue($m->isDirty('ts'));
 
         $m->save();
         $m->reload();
 
-        $m['ts'] = $sql_time;
+        $m->set('ts', $sql_time);
         $this->assertFalse($m->isDirty('ts'));
 
-        $m['ts'] = $sql_time_new;
+        $m->set('ts', $sql_time_new);
         $this->assertTrue($m->isDirty('ts'));
     }
 }

--- a/tests/UserActionTest.php
+++ b/tests/UserActionTest.php
@@ -80,9 +80,9 @@ class UserActionTest extends \atk4\schema\PhpunitTestCase
         // load record, before executing, because scope is single record
         $client->load(1);
 
-        $this->assertNotTrue($client['reminder_sent']);
+        $this->assertNotTrue($client->get('reminder_sent'));
         $res = $act1->execute();
-        $this->assertTrue($client['reminder_sent']);
+        $this->assertTrue($client->get('reminder_sent'));
 
         $this->assertSame('sent reminder to John', $res);
         $client->unload();
@@ -106,14 +106,14 @@ class UserActionTest extends \atk4\schema\PhpunitTestCase
     {
         $client = new ACClient($this->pers);
         $client->addAction('say_name', function ($m) {
-            return $m['name'];
+            return $m->get('name');
         });
 
         $client->load(1);
         $this->assertSame('John', $client->getAction('say_name')->execute());
 
         $client->getAction('say_name')->preview = function ($m, $arg) {
-            return ($m instanceof ACClient) ? 'will say ' . $m['name'] : 'will fail';
+            return ($m instanceof ACClient) ? 'will say ' . $m->get('name') : 'will fail';
         };
         $this->assertSame('will say John', $client->getAction('say_name')->preview('x'));
 
@@ -210,10 +210,10 @@ class UserActionTest extends \atk4\schema\PhpunitTestCase
 
             $client->load(1);
 
-            $this->assertNotSame('Peter', $client['name']);
-            $client['name'] = 'Peter';
+            $this->assertNotSame('Peter', $client->get('name'));
+            $client->set('name', 'Peter');
             $a->execute();
-            $this->assertSame('Peter', $client['name']);
+            $this->assertSame('Peter', $client->get('name'));
         } catch (Exception $e) {
             echo $e->getColorfulText();
 
@@ -228,12 +228,12 @@ class UserActionTest extends \atk4\schema\PhpunitTestCase
 
         $client->load(1);
 
-        $this->assertNotSame('Peter', $client['name']);
-        $client['name'] = 'Peter';
-        $client['reminder_sent'] = true;
+        $this->assertNotSame('Peter', $client->get('name'));
+        $client->set('name', 'Peter');
+        $client->set('reminder_sent', true);
         $this->expectExceptionMessage('dirty fields');
         $a->execute();
-        $this->assertSame('Peter', $client['name']);
+        $this->assertSame('Peter', $client->get('name'));
     }
 
     public function testFieldsIncorrect()
@@ -243,11 +243,11 @@ class UserActionTest extends \atk4\schema\PhpunitTestCase
 
         $client->load(1);
 
-        $this->assertNotSame('Peter', $client['name']);
-        $client['name'] = 'Peter';
+        $this->assertNotSame('Peter', $client->get('name'));
+        $client->set('name', 'Peter');
         $this->expectExceptionMessage('array');
         $a->execute();
-        $this->assertSame('Peter', $client['name']);
+        $this->assertSame('Peter', $client->get('name'));
     }
 
     /**

--- a/tests/UserActionTest.php
+++ b/tests/UserActionTest.php
@@ -71,7 +71,7 @@ class UserActionTest extends \atk4\schema\PhpunitTestCase
         $this->assertSame(4, count($actions)); // don't return system actions here, but include add/edit/delete
         $this->assertSame(0, count($client->getActions(UserAction\Generic::ALL_RECORDS))); // don't return system actions here
 
-        $act1 = $actions->get('send_reminder');
+        $act1 = $actions['send_reminder'];
 
         // action takes no arguments. If it would, we should be able to find info about those
         $this->assertSame([], $act1->args);
@@ -80,9 +80,9 @@ class UserActionTest extends \atk4\schema\PhpunitTestCase
         // load record, before executing, because scope is single record
         $client->load(1);
 
-        $this->assertNotTrue($client->get('reminder_sent'));
+        $this->assertNotTrue($client['reminder_sent']);
         $res = $act1->execute();
-        $this->assertTrue($client->get('reminder_sent'));
+        $this->assertTrue($client['reminder_sent']);
 
         $this->assertSame('sent reminder to John', $res);
         $client->unload();
@@ -106,14 +106,14 @@ class UserActionTest extends \atk4\schema\PhpunitTestCase
     {
         $client = new ACClient($this->pers);
         $client->addAction('say_name', function ($m) {
-            return $m->get('name');
+            return $m['name'];
         });
 
         $client->load(1);
         $this->assertSame('John', $client->getAction('say_name')->execute());
 
         $client->getAction('say_name')->preview = function ($m, $arg) {
-            return ($m instanceof ACClient) ? 'will say ' . $m->get('name') : 'will fail';
+            return ($m instanceof ACClient) ? 'will say ' . $m['name'] : 'will fail';
         };
         $this->assertSame('will say John', $client->getAction('say_name')->preview('x'));
 
@@ -210,10 +210,10 @@ class UserActionTest extends \atk4\schema\PhpunitTestCase
 
             $client->load(1);
 
-            $this->assertNotSame('Peter', $client->get('name'));
-            $client->set('name', 'Peter');
+            $this->assertNotSame('Peter', $client['name']);
+            $client['name'] = 'Peter';
             $a->execute();
-            $this->assertSame('Peter', $client->get('name'));
+            $this->assertSame('Peter', $client['name']);
         } catch (Exception $e) {
             echo $e->getColorfulText();
 
@@ -228,12 +228,12 @@ class UserActionTest extends \atk4\schema\PhpunitTestCase
 
         $client->load(1);
 
-        $this->assertNotSame('Peter', $client->get('name'));
-        $client->set('name', 'Peter');
-        $client->set('reminder_sent', true);
+        $this->assertNotSame('Peter', $client['name']);
+        $client['name'] = 'Peter';
+        $client['reminder_sent'] = true;
         $this->expectExceptionMessage('dirty fields');
         $a->execute();
-        $this->assertSame('Peter', $client->get('name'));
+        $this->assertSame('Peter', $client['name']);
     }
 
     public function testFieldsIncorrect()
@@ -243,11 +243,11 @@ class UserActionTest extends \atk4\schema\PhpunitTestCase
 
         $client->load(1);
 
-        $this->assertNotSame('Peter', $client->get('name'));
-        $client->set('name', 'Peter');
+        $this->assertNotSame('Peter', $client['name']);
+        $client['name'] = 'Peter';
         $this->expectExceptionMessage('array');
         $a->execute();
-        $this->assertSame('Peter', $client->get('name'));
+        $this->assertSame('Peter', $client['name']);
     }
 
     /**

--- a/tests/UserActionTest.php
+++ b/tests/UserActionTest.php
@@ -71,7 +71,7 @@ class UserActionTest extends \atk4\schema\PhpunitTestCase
         $this->assertSame(4, count($actions)); // don't return system actions here, but include add/edit/delete
         $this->assertSame(0, count($client->getActions(UserAction\Generic::ALL_RECORDS))); // don't return system actions here
 
-        $act1 = $actions['send_reminder'];
+        $act1 = $actions->get('send_reminder');
 
         // action takes no arguments. If it would, we should be able to find info about those
         $this->assertSame([], $act1->args);
@@ -80,9 +80,9 @@ class UserActionTest extends \atk4\schema\PhpunitTestCase
         // load record, before executing, because scope is single record
         $client->load(1);
 
-        $this->assertNotTrue($client['reminder_sent']);
+        $this->assertNotTrue($client->get('reminder_sent'));
         $res = $act1->execute();
-        $this->assertTrue($client['reminder_sent']);
+        $this->assertTrue($client->get('reminder_sent'));
 
         $this->assertSame('sent reminder to John', $res);
         $client->unload();
@@ -106,14 +106,14 @@ class UserActionTest extends \atk4\schema\PhpunitTestCase
     {
         $client = new ACClient($this->pers);
         $client->addAction('say_name', function ($m) {
-            return $m['name'];
+            return $m->get('name');
         });
 
         $client->load(1);
         $this->assertSame('John', $client->getAction('say_name')->execute());
 
         $client->getAction('say_name')->preview = function ($m, $arg) {
-            return ($m instanceof ACClient) ? 'will say ' . $m['name'] : 'will fail';
+            return ($m instanceof ACClient) ? 'will say ' . $m->get('name') : 'will fail';
         };
         $this->assertSame('will say John', $client->getAction('say_name')->preview('x'));
 
@@ -210,10 +210,10 @@ class UserActionTest extends \atk4\schema\PhpunitTestCase
 
             $client->load(1);
 
-            $this->assertNotSame('Peter', $client['name']);
-            $client['name'] = 'Peter';
+            $this->assertNotSame('Peter', $client->get('name'));
+            $client->set('name', 'Peter');
             $a->execute();
-            $this->assertSame('Peter', $client['name']);
+            $this->assertSame('Peter', $client->get('name'));
         } catch (Exception $e) {
             echo $e->getColorfulText();
 
@@ -228,12 +228,12 @@ class UserActionTest extends \atk4\schema\PhpunitTestCase
 
         $client->load(1);
 
-        $this->assertNotSame('Peter', $client['name']);
-        $client['name'] = 'Peter';
-        $client['reminder_sent'] = true;
+        $this->assertNotSame('Peter', $client->get('name'));
+        $client->set('name', 'Peter');
+        $client->set('reminder_sent', true);
         $this->expectExceptionMessage('dirty fields');
         $a->execute();
-        $this->assertSame('Peter', $client['name']);
+        $this->assertSame('Peter', $client->get('name'));
     }
 
     public function testFieldsIncorrect()
@@ -243,11 +243,11 @@ class UserActionTest extends \atk4\schema\PhpunitTestCase
 
         $client->load(1);
 
-        $this->assertNotSame('Peter', $client['name']);
-        $client['name'] = 'Peter';
+        $this->assertNotSame('Peter', $client->get('name'));
+        $client->set('name', 'Peter');
         $this->expectExceptionMessage('array');
         $a->execute();
-        $this->assertSame('Peter', $client['name']);
+        $this->assertSame('Peter', $client->get('name'));
     }
 
     /**

--- a/tests/ValidationTest.php
+++ b/tests/ValidationTest.php
@@ -19,11 +19,11 @@ class MyValidationModel extends Model
     public function validate($intent = null)
     {
         $errors = [];
-        if ($this->get('name') === 'Python') {
-            $errors->set('name', 'Snakes are not allowed on this plane');
+        if ($this['name'] === 'Python') {
+            $errors['name'] = 'Snakes are not allowed on this plane';
         }
-        if ($this->get('domain') === 'example.com') {
-            $errors->set('domain', 'This domain is reserved for examples only');
+        if ($this['domain'] === 'example.com') {
+            $errors['domain'] = 'This domain is reserved for examples only';
         }
 
         return array_merge(parent::validate(), $errors);
@@ -110,14 +110,14 @@ class ValidationTests extends AtkPhpunit\TestCase
         $p = new Persistence\Array_($a);
         $m = new BadValidationModel($p);
 
-        $m->set('name', 'john');
+        $m['name'] = 'john';
         $m->save();
     }
 
     public function testValidateHook()
     {
         $this->m->onHook('validate', function ($m) {
-            if ($m->get('name') === 'C#') {
+            if ($m['name'] === 'C#') {
                 return ['name' => 'No sharp objects allowed'];
             }
         });

--- a/tests/ValidationTest.php
+++ b/tests/ValidationTest.php
@@ -19,10 +19,10 @@ class MyValidationModel extends Model
     public function validate($intent = null)
     {
         $errors = [];
-        if ($this['name'] === 'Python') {
+        if ($this->get('name') === 'Python') {
             $errors['name'] = 'Snakes are not allowed on this plane';
         }
-        if ($this['domain'] === 'example.com') {
+        if ($this->get('domain') === 'example.com') {
             $errors['domain'] = 'This domain is reserved for examples only';
         }
 
@@ -60,8 +60,8 @@ class ValidationTests extends AtkPhpunit\TestCase
 
     public function testValidate1()
     {
-        $this->m['name'] = 'john';
-        $this->m['domain'] = 'gmail.com';
+        $this->m->set('name', 'john');
+        $this->m->set('domain', 'gmail.com');
         $this->m->save();
     }
 
@@ -71,7 +71,7 @@ class ValidationTests extends AtkPhpunit\TestCase
      */
     public function testValidate2()
     {
-        $this->m['name'] = 'Python';
+        $this->m->set('name', 'Python');
         $this->m->save();
     }
 
@@ -81,16 +81,16 @@ class ValidationTests extends AtkPhpunit\TestCase
      */
     public function testValidate3()
     {
-        $this->m['name'] = 'Python';
-        $this->m['domain'] = 'example.com';
+        $this->m->set('name', 'Python');
+        $this->m->set('domain', 'example.com');
         $this->m->save();
     }
 
     public function testValidate4()
     {
         try {
-            $this->m['name'] = 'Python';
-            $this->m['domain'] = 'example.com';
+            $this->m->set('name', 'Python');
+            $this->m->set('domain', 'example.com');
             $this->m->save();
             $this->fail('Expected exception');
         } catch (\atk4\data\ValidationException $e) {
@@ -110,23 +110,23 @@ class ValidationTests extends AtkPhpunit\TestCase
         $p = new Persistence\Array_($a);
         $m = new BadValidationModel($p);
 
-        $m['name'] = 'john';
+        $m->set('name', 'john');
         $m->save();
     }
 
     public function testValidateHook()
     {
         $this->m->onHook('validate', function ($m) {
-            if ($m['name'] === 'C#') {
+            if ($m->get('name') === 'C#') {
                 return ['name' => 'No sharp objects allowed'];
             }
         });
 
-        $this->m['name'] = 'Swift';
+        $this->m->set('name', 'Swift');
         $this->m->save();
 
         try {
-            $this->m['name'] = 'C#';
+            $this->m->set('name', 'C#');
             $this->m->save();
             $this->fail('Expected exception');
         } catch (\atk4\data\ValidationException $e) {
@@ -134,8 +134,8 @@ class ValidationTests extends AtkPhpunit\TestCase
         }
 
         try {
-            $this->m['name'] = 'Python';
-            $this->m['domain'] = 'example.com';
+            $this->m->set('name', 'Python');
+            $this->m->set('domain', 'example.com');
             $this->m->save();
             $this->fail('Expected exception');
         } catch (\atk4\data\ValidationException $e) {

--- a/tests/ValidationTest.php
+++ b/tests/ValidationTest.php
@@ -19,11 +19,11 @@ class MyValidationModel extends Model
     public function validate($intent = null)
     {
         $errors = [];
-        if ($this['name'] === 'Python') {
-            $errors['name'] = 'Snakes are not allowed on this plane';
+        if ($this->get('name') === 'Python') {
+            $errors->set('name', 'Snakes are not allowed on this plane');
         }
-        if ($this['domain'] === 'example.com') {
-            $errors['domain'] = 'This domain is reserved for examples only';
+        if ($this->get('domain') === 'example.com') {
+            $errors->set('domain', 'This domain is reserved for examples only');
         }
 
         return array_merge(parent::validate(), $errors);
@@ -110,14 +110,14 @@ class ValidationTests extends AtkPhpunit\TestCase
         $p = new Persistence\Array_($a);
         $m = new BadValidationModel($p);
 
-        $m['name'] = 'john';
+        $m->set('name', 'john');
         $m->save();
     }
 
     public function testValidateHook()
     {
         $this->m->onHook('validate', function ($m) {
-            if ($m['name'] === 'C#') {
+            if ($m->get('name') === 'C#') {
                 return ['name' => 'No sharp objects allowed'];
             }
         });


### PR DESCRIPTION
->get('x'), ->set('x', 'v') are fully enough, originally also very unclear when to use when.

Also misleading as model is iterable on rows, not values (like you would expect when you iterate over an array).

For BC trait can be used or even the composer data installation can be patched to add this trait to Model by default.

This PR is big, but solely to isolate the ArrayAccess to make it optional, there is actually not additional different except presence/non-presence of the ArrayAccess impl. on Model.