### PR TITLE
Remove NameTrait trait from Model

### DIFF
--- a/src/Model.php
+++ b/src/Model.php
@@ -10,7 +10,6 @@ use atk4\core\DynamicMethodTrait;
 use atk4\core\FactoryTrait;
 use atk4\core\HookTrait;
 use atk4\core\InitializerTrait;
-use atk4\core\NameTrait;
 use atk4\core\ReadableCaptionTrait;
 use atk4\data\UserAction\Generic;
 use atk4\dsql\Query;
@@ -30,7 +29,6 @@ class Model implements \ArrayAccess, \IteratorAggregate
     use InitializerTrait {
         init as _init;
     }
-    use NameTrait;
     use DIContainerTrait;
     use FactoryTrait;
     use AppScopeTrait;


### PR DESCRIPTION
Added in https://github.com/atk4/data/commit/c3bd270fadbad7305fa8ca57559b404d45d8cf58 by @romaninsh

`NameTrait` is Model is extremely bad as it defines `name` property. `name` field is used a lot in database models and `name` property should not stop anyone doing so - it makes sense on in `ui`, more precisely in `View` class only.

## Incompatible code

``` php
$page->add('Model\User', 'model_abc');
$user = $page->getElement('model_abc');
```

## Better code

``` php
$user = new Model\User($app->db);
```