### PR TITLE
Convert callables to closures and move hook names to constants

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -71,6 +71,7 @@ jobs:
           if [ "${{ matrix.type }}" != "Phpunit" ]; then composer remove --no-interaction --no-update phpunit/phpunit phpunit/dbunit phpunit/phpcov --dev ; fi
           if [ "${{ matrix.type }}" != "CodingStyle" ]; then composer remove --no-interaction --no-update friendsofphp/php-cs-fixer --dev ; fi
           composer install --no-suggest --ansi --prefer-dist --no-interaction --no-progress --optimize-autoloader
+          (cd vendor/atk4 && rm -R core && git clone https://github.com/atk4/core.git && cd core && git fetch origin pull/196/head && git checkout FETCH_HEAD)
 
       - name: Init
         run: |

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -71,7 +71,6 @@ jobs:
           if [ "${{ matrix.type }}" != "Phpunit" ]; then composer remove --no-interaction --no-update phpunit/phpunit phpunit/dbunit phpunit/phpcov --dev ; fi
           if [ "${{ matrix.type }}" != "CodingStyle" ]; then composer remove --no-interaction --no-update friendsofphp/php-cs-fixer --dev ; fi
           composer install --no-suggest --ansi --prefer-dist --no-interaction --no-progress --optimize-autoloader
-          (cd vendor/atk4 && rm -R core && git clone https://github.com/atk4/core.git && cd core && git fetch origin pull/196/head && git checkout FETCH_HEAD)
 
       - name: Init
         run: |

--- a/docs/advanced.rst
+++ b/docs/advanced.rst
@@ -166,7 +166,7 @@ which I want to define like this::
 
         $this->owner->addField('updated_dts', ['type'=>'datetime']);
 
-        $this->owner->onHook('beforeUpdate', function($m, $data) {
+        $this->owner->onHook(Model::HOOK_BEFORE_UPDATE, function($m, $data) {
             if(isset($this->app->user) and $this->app->user->loaded()) {
                 $data['updated_by'] = $this->app->user->id;
             }
@@ -343,7 +343,7 @@ before and just slightly modifying it::
                 $this->owner->addMethod('restore', \Closure::fromCallable([$this, 'restore']));
             } else {
                 $this->owner->addCondition('is_deleted', false);
-                $this->owner->onHook('beforeDelete', \Closure::fromCallable([$this, 'softDelete']), null, 100);
+                $this->owner->onHook(Model::HOOK_BEFORE_DELETE, \Closure::fromCallable([$this, 'softDelete']), null, 100);
             }
         }
 
@@ -359,7 +359,7 @@ before and just slightly modifying it::
             $m->save(['is_deleted'=>true])->unload();
             $m->reload_after_save = $rs;
 
-            $m->hook('afterDelete', [$id]);
+            $m->hook(Model::HOOK_AFTER_DELETE, [$id]);
 
             $m->breakHook(false); // this will cancel original delete()
         }
@@ -515,7 +515,7 @@ Next we need to define reference. Inside Model_Invoice add::
         $j->hasOne('invoice_id', 'Model_Invoice');
     }, 'their_field'=>'invoice_id']);
 
-    $this->onHook('beforeDelete',function($m){
+    $this->onHook(Model::HOOK_BEFORE_DELETE, function($m){
         $m->ref('InvoicePayment')->action('delete')->execute();
 
         // If you have important per-row hooks in InvoicePayment

--- a/docs/advanced.rst
+++ b/docs/advanced.rst
@@ -231,10 +231,10 @@ Start by creating a class::
 
             if (isset($this->owner->deleted_only)) {
                 $this->owner->addCondition('is_deleted', true);
-                $this->owner->addMethod('restore', [$this, 'restore']);
-            }else{
+                $this->owner->addMethod('restore', \Closure::fromCallable([$this, 'restore']));
+            } else {
                 $this->owner->addCondition('is_deleted', false);
-                $this->owner->addMethod('softDelete', [$this, 'softDelete']);
+                $this->owner->addMethod('softDelete', \Closure::fromCallable([$this, 'softDelete']));
             }
         }
 
@@ -340,7 +340,7 @@ before and just slightly modifying it::
 
             if (isset($this->owner->deleted_only)) {
                 $this->owner->addCondition('is_deleted', true);
-                $this->owner->addMethod('restore', [$this, 'restore']);
+                $this->owner->addMethod('restore', \Closure::fromCallable([$this, 'restore']));
             } else {
                 $this->owner->addCondition('is_deleted', false);
                 $this->owner->onHook('beforeDelete', [$this, 'softDelete'], null, 100);

--- a/docs/advanced.rst
+++ b/docs/advanced.rst
@@ -343,7 +343,7 @@ before and just slightly modifying it::
                 $this->owner->addMethod('restore', \Closure::fromCallable([$this, 'restore']));
             } else {
                 $this->owner->addCondition('is_deleted', false);
-                $this->owner->onHook('beforeDelete', [$this, 'softDelete'], null, 100);
+                $this->owner->onHook('beforeDelete', \Closure::fromCallable([$this, 'softDelete']), null, 100);
             }
         }
 
@@ -425,7 +425,7 @@ inside your model are unique::
                 $this->fields = [$this->owner->title_field];
             }
 
-            $this->owner->onHook('beforeSave', $this);
+            $this->owner->onHook('beforeSave', \Closure::fromCallable([$this, 'beforeSave']));
         }
 
         function beforeSave($m)

--- a/docs/advanced.rst
+++ b/docs/advanced.rst
@@ -77,7 +77,7 @@ Another scenario which could benefit by type substitution would be::
 ATK Data allow class substitution during load and iteration by breaking "afterLoad"
 hook. Place the following inside Transaction::init()::
 
-    $this->onHook('afterLoad', function ($m) {
+    $this->onHook(Model::HOOK_AFTER_LOAD, function ($m) {
         if (get_class($this) != $m->getClassName()) {
             $cl = '\\'.$this->getClassName();
             $cl = new $cl($this->persistence);
@@ -98,7 +98,7 @@ of the record. Finally to help with performance, you can implement a switch::
         ..
 
         if ($this->typeSubstitution) {
-            $this->onHook('afterLoad',
+            $this->onHook(Model::HOOK_AFTER_LOAD,
                 ..........
             )
         }

--- a/docs/advanced.rst
+++ b/docs/advanced.rst
@@ -425,7 +425,7 @@ inside your model are unique::
                 $this->fields = [$this->owner->title_field];
             }
 
-            $this->owner->onHook('beforeSave', \Closure::fromCallable([$this, 'beforeSave']));
+            $this->owner->onHook(Model::HOOK_BEFORE_SAVE, \Closure::fromCallable([$this, 'beforeSave']));
         }
 
         function beforeSave($m)
@@ -650,7 +650,7 @@ Here is how to add them. First you need to create fields::
 I have declared those fields with never_persist so they will never be used by
 persistence layer to load or save anything. Next I need a beforeSave handler::
 
-    $this->onHook('beforeSave', function($m) {
+    $this->onHook(Model::HOOK_BEFORE_SAVE, function($m) {
         if(isset($m['client_code']) && !isset($m['client_id'])) {
             $cl = $this->refModel('client_id');
             $cl->addCondition('code',$m['client_code']);
@@ -739,7 +739,7 @@ section. Add this into your Invoice Model::
 Next both payment and lines need to be added after invoice is actually created,
 so::
 
-    $this->onHook('afterSave', function($m, $is_update){
+    $this->onHook(Model::HOOK_AFTER_SAVE, function($m, $is_update){
         if(isset($m['payment'])) {
             $m->ref('Payment')->insert($m['payment']);
         }

--- a/docs/design.rst
+++ b/docs/design.rst
@@ -338,7 +338,7 @@ Hooks can help you perform operations when object is being persisted::
             // addField() declaration
             // addExpression('is_password_expired')
 
-            $this->onHook('beforeSave', function($m) {
+            $this->onHook(Model::HOOK_BEFORE_SAVE, function($m) {
                 if ($m->isDirty('password')) {
                     $m['password'] = encrypt_password($m['password']);
                     $m['password_change_date'] = $m->expr('now()');

--- a/docs/hooks.rst
+++ b/docs/hooks.rst
@@ -52,7 +52,7 @@ Example with beforeSave
 The next code snippet demonstrates a basic usage of a `beforeSave` hook.
 This one will update field values just before record is saved::
 
-    $m->onHook('beforeSave', function($m) {
+    $m->onHook(Model::HOOK_BEFORE_SAVE, function($m) {
         $m['name'] = strtoupper($m['name']);
         $m['surname'] = strtoupper($m['surname']);
     });
@@ -136,7 +136,7 @@ of save.
 
 You may actually drop validation exception inside save, insert or update hooks::
 
-    $m->onHook('beforeSave', function($m) {
+    $m->onHook(Model::HOOK_BEFORE_SAVE, function($m) {
         if ($m['name'] = 'Yagi') {
             throw new \atk4\data\ValidationException(['name'=>"We don't serve like you"]);
         }

--- a/docs/hooks.rst
+++ b/docs/hooks.rst
@@ -85,7 +85,7 @@ model will assume the operation was successful.
 
 You can also break beforeLoad hook which can be used to skip rows::
 
-    $model->onHook('afterLoad', function ($m) {
+    $model->onHook(Model::HOOK_AFTER_LOAD, function ($m) {
         if ($m['date'] < $m->date_from) {
             $m->breakHook(false); // will not yield such data row
         }
@@ -213,7 +213,7 @@ In some cases you want to prevent default actions from executing.
 Suppose you want to check 'memcache' before actually loading the record from
 the database. Here is how you can implement this functionality::
 
-    $m->onHook('beforeLoad',function($m, $id) {
+    $m->onHook(Model::HOOK_BEFORE_LOAD, function($m, $id) {
         $data = $m->app->cacheFetch($m->table, $id);
         if ($data) {
             $m->data = $data;

--- a/docs/hooks.rst
+++ b/docs/hooks.rst
@@ -193,7 +193,7 @@ and your update() may not actually update anything. This does not normally
 generate an error, however if you want to actually make sure that update() was
 effective, you can implement this through a hook::
 
-    $m->onHook('afterUpdateQuery',function($m, $update, $st) {
+    $m->onHook(Persistence\SQL::HOOK_AFTER_UPDATE_QUERY, function($m, $update, $st) {
         if (!$st->rowCount()) {
             throw new \atk4\core\Exception([
                 'Update didn\'t affect any records',

--- a/docs/hooks.rst
+++ b/docs/hooks.rst
@@ -239,13 +239,13 @@ This can be used in various situations.
 
 Save information into auditLog about failure:
 
-    $m->onHook('onRollback', function($m){ 
+    $m->onHook(Model::HOOK_ROLLBACK, function($m){ 
         $m->auditLog->registerFailure();
     });
 
 Upgrade schema:
 
-    $m->onHook('onRollback', function($m, $exception) { 
+    $m->onHook(Model::HOOK_ROLLBACK, function($m, $exception) { 
         if ($exception instanceof \PDOException) {
             $m->schema->upgrade();
             $m->breakHook(false); // exception will not be thrown

--- a/docs/model.rst
+++ b/docs/model.rst
@@ -187,7 +187,7 @@ To invoke code from `init()` methods of ALL models (for example soft-delete logi
 you use Persistence's "afterAdd" hook. This will not affect ALL models but just models
 which are associated with said persistence::
 
-   $db->onHook('afterAdd', function($p, $m) use($acl) {
+   $db->onHook(Persistence::HOOK_AFTER_ADD, function($p, $m) use($acl) {
 
       $fields = $m->getFields();
 

--- a/docs/model.rst
+++ b/docs/model.rst
@@ -391,7 +391,7 @@ a hook::
 
    $this->addField('name');
 
-   $this->onHook(self::HOOK_VALIDATE, function($m) {
+   $this->onHook(Model::HOOK_VALIDATE, function($m) {
       if ($m['name'] == 'C#') {
          return ['name'=>'No sharp objects are allowed'];
       }

--- a/docs/model.rst
+++ b/docs/model.rst
@@ -391,7 +391,7 @@ a hook::
 
    $this->addField('name');
 
-   $this->onHook('validate', function($m) {
+   $this->onHook(self::HOOK_VALIDATE, function($m) {
       if ($m['name'] == 'C#') {
          return ['name'=>'No sharp objects are allowed'];
       }

--- a/docs/model.rst
+++ b/docs/model.rst
@@ -437,7 +437,7 @@ action - `send_gift`.
 There are some advanced techniques like "SubTypes" or class substitution,
 for example, this hook may be placed in the "User" class init()::
 
-   $this->onHook('afterLoad', function($m) {
+   $this->onHook(Model::HOOK_AFTER_LOAD, function($m) {
       if ($m['purchases'] > 1000) {
          $this->breakHook($this->asModel(VIPUser::class);
       }

--- a/docs/overview.rst
+++ b/docs/overview.rst
@@ -166,7 +166,7 @@ If your persistence does not support expressions (e.g. you are using Redis or
 MongoDB), you would need to define the field differently::
 
     $model->addField('gross');
-    $model->onHook('beforeSave', function($m) {
+    $model->onHook(Model::HOOK_BEFORE_SAVE, function($m) {
         $m['gross'] = $m['net'] + $m['vat'];
     });
 
@@ -186,7 +186,7 @@ you want it to work with NoSQL, then your solution might be::
 
         // persistence does not support expressions
         $model->addField('gross');
-        $model->onHook('beforeSave', function($m) {
+        $model->onHook(Model::HOOK_BEFORE_SAVE, function($m) {
             $m['gross'] = $m['net'] + $m['vat'];
         });
 

--- a/docs/persistence.rst
+++ b/docs/persistence.rst
@@ -688,7 +688,7 @@ application::
             $m->withPersistence($this->sql)->save();
         });
 
-        $m->onHook('beforeDelete', function($m){
+        $m->onHook(Model::HOOK_BEFORE_DELETE, function($m){
             $m->withPersistence($this->sql)->delete();
         });
 
@@ -733,7 +733,7 @@ also::
         $m->withPersistence($this->sql)->save();
     });
 
-    $m->onHook('beforeDelete', function($m){
+    $m->onHook(Model::HOOK_BEFORE_DELETE, function($m){
         $m->withPersistence($this->sql)->delete();
     });
 

--- a/docs/persistence.rst
+++ b/docs/persistence.rst
@@ -496,7 +496,7 @@ this ref, how do you do it?
 
 Start by creating a beforeSave handler for Order::
 
-    $this->onHook('beforeSave', function($m) {
+    $this->onHook(Model::HOOK_BEFORE_SAVE, function($m) {
         if ($this->isDirty('ref')) {
 
             if (
@@ -684,7 +684,7 @@ application::
             $m = $m->withPersistence($this->mdb)->replace();
         }
 
-        $m->onHook('beforeSave', function($m){
+        $m->onHook(Model::HOOK_BEFORE_SAVE, function($m){
             $m->withPersistence($this->sql)->save();
         });
 
@@ -729,7 +729,7 @@ records.
 The last two hooks are in order to replicate any changes into the SQL database
 also::
 
-    $m->onHook('beforeSave', function($m){
+    $m->onHook(Model::HOOK_BEFORE_SAVE, function($m){
         $m->withPersistence($this->sql)->save();
     });
 
@@ -784,7 +784,7 @@ Archive Copies into different persistence
 If you wish that every time you save your model the copy is also stored inside
 some other database (for archive purposes) you can implement it like this::
 
-    $m->onHook('beforeSave', function($m) {
+    $m->onHook(Model::HOOK_BEFORE_SAVE, function($m) {
         $arc = $this->withPersistence($m->app->archive_db, false);
 
         // add some audit fields

--- a/src/Field/Callback.php
+++ b/src/Field/Callback.php
@@ -3,6 +3,7 @@
 namespace atk4\data\Field;
 
 use atk4\core\InitializerTrait;
+use atk4\data\Model;
 
 /**
  * Evaluate php expression after load.

--- a/src/Field/Callback.php
+++ b/src/Field/Callback.php
@@ -43,7 +43,7 @@ class Callback extends \atk4\data\Field
 
         $this->ui['table']['sortable'] = false;
 
-        $this->owner->onHook('afterLoad', function ($m) {
+        $this->owner->onHook(Model::HOOK_AFTER_LOAD, function ($m) {
             $m->data[$this->short_name] = call_user_func($this->expr, $m);
         });
     }

--- a/src/Field_SQL_Expression.php
+++ b/src/Field_SQL_Expression.php
@@ -59,7 +59,7 @@ class Field_SQL_Expression extends Field_SQL
         }
 
         if ($this->concat) {
-            $this->owner->onHook('afterSave', \Closure::fromCallable([$this, 'afterSave']));
+            $this->owner->onHook(Model::HOOK_AFTER_SAVE, \Closure::fromCallable([$this, 'afterSave']));
         }
     }
 

--- a/src/Field_SQL_Expression.php
+++ b/src/Field_SQL_Expression.php
@@ -59,7 +59,7 @@ class Field_SQL_Expression extends Field_SQL
         }
 
         if ($this->concat) {
-            $this->owner->onHook('afterSave', $this);
+            $this->owner->onHook('afterSave', \Closure::fromCallable([$this, 'afterSave']));
         }
     }
 

--- a/src/Join.php
+++ b/src/Join.php
@@ -202,7 +202,7 @@ class Join
             }
         }
 
-        $this->owner->onHook('afterUnload', \Closure::fromCallable([$this, 'afterUnload']));
+        $this->owner->onHook(Model::HOOK_AFTER_UNLOAD, \Closure::fromCallable([$this, 'afterUnload']));
     }
 
     /**
@@ -477,10 +477,8 @@ class Join
 
     /**
      * Clears id and save buffer.
-     *
-     * @todo CHECK IF WE ACTUALLY USE THIS METHOD SOMEWHERE
      */
-    public function afterUnload()
+    protected function afterUnload()
     {
         $this->id = null;
         $this->save_buffer = [];

--- a/src/Join.php
+++ b/src/Join.php
@@ -202,7 +202,7 @@ class Join
             }
         }
 
-        $this->owner->onHook('afterUnload', $this);
+        $this->owner->onHook('afterUnload', \Closure::fromCallable([$this, 'afterUnload']));
     }
 
     /**

--- a/src/Join/Array_.php
+++ b/src/Join/Array_.php
@@ -32,7 +32,7 @@ class Array_ extends Join
             $this->owner->onHook('beforeInsert', \Closure::fromCallable([$this, 'beforeInsert']));
             $this->owner->onHook('beforeUpdate', \Closure::fromCallable([$this, 'beforeUpdate']));
             $this->owner->onHook('afterDelete', \Closure::fromCallable([$this, 'doDelete']));
-            $this->owner->onHook('afterLoad', \Closure::fromCallable([$this, 'afterLoad']));
+            $this->owner->onHook(Model::HOOK_AFTER_LOAD, \Closure::fromCallable([$this, 'afterLoad']));
         }
     }
 

--- a/src/Join/Array_.php
+++ b/src/Join/Array_.php
@@ -25,14 +25,14 @@ class Array_ extends Join
 
         // Add necessary hooks
         if ($this->reverse) {
-            $this->owner->onHook('afterInsert', $this, [], -5);
-            $this->owner->onHook('beforeUpdate', $this, [], -5);
-            $this->owner->onHook('beforeDelete', [$this, 'doDelete'], [], -5);
+            $this->owner->onHook('afterInsert', \Closure::fromCallable([$this, 'afterInsert']), [], -5);
+            $this->owner->onHook('beforeUpdate', \Closure::fromCallable([$this, 'beforeUpdate']), [], -5);
+            $this->owner->onHook('beforeDelete', \Closure::fromCallable([$this, 'doDelete']), [], -5);
         } else {
-            $this->owner->onHook('beforeInsert', $this);
-            $this->owner->onHook('beforeUpdate', $this);
-            $this->owner->onHook('afterDelete', [$this, 'doDelete']);
-            $this->owner->onHook('afterLoad', $this);
+            $this->owner->onHook('beforeInsert', \Closure::fromCallable([$this, 'beforeInsert']));
+            $this->owner->onHook('beforeUpdate', \Closure::fromCallable([$this, 'beforeUpdate']));
+            $this->owner->onHook('afterDelete', \Closure::fromCallable([$this, 'doDelete']));
+            $this->owner->onHook('afterLoad', \Closure::fromCallable([$this, 'afterLoad']));
         }
     }
 

--- a/src/Join/Array_.php
+++ b/src/Join/Array_.php
@@ -25,13 +25,13 @@ class Array_ extends Join
 
         // Add necessary hooks
         if ($this->reverse) {
-            $this->owner->onHook('afterInsert', \Closure::fromCallable([$this, 'afterInsert']), [], -5);
-            $this->owner->onHook('beforeUpdate', \Closure::fromCallable([$this, 'beforeUpdate']), [], -5);
-            $this->owner->onHook('beforeDelete', \Closure::fromCallable([$this, 'doDelete']), [], -5);
+            $this->owner->onHook(Model::HOOK_AFTER_INSERT, \Closure::fromCallable([$this, 'afterInsert']), [], -5);
+            $this->owner->onHook(Model::HOOK_BEFORE_UPDATE, \Closure::fromCallable([$this, 'beforeUpdate']), [], -5);
+            $this->owner->onHook(Model::HOOK_BEFORE_DELETE, \Closure::fromCallable([$this, 'doDelete']), [], -5);
         } else {
-            $this->owner->onHook('beforeInsert', \Closure::fromCallable([$this, 'beforeInsert']));
-            $this->owner->onHook('beforeUpdate', \Closure::fromCallable([$this, 'beforeUpdate']));
-            $this->owner->onHook('afterDelete', \Closure::fromCallable([$this, 'doDelete']));
+            $this->owner->onHook(Model::HOOK_BEFORE_INSERT, \Closure::fromCallable([$this, 'beforeInsert']));
+            $this->owner->onHook(Model::HOOK_BEFORE_UPDATE, \Closure::fromCallable([$this, 'beforeUpdate']));
+            $this->owner->onHook(Model::HOOK_AFTER_DELETE, \Closure::fromCallable([$this, 'doDelete']));
             $this->owner->onHook(Model::HOOK_AFTER_LOAD, \Closure::fromCallable([$this, 'afterLoad']));
         }
     }

--- a/src/Join/SQL.php
+++ b/src/Join/SQL.php
@@ -71,14 +71,14 @@ class SQL extends Join implements \atk4\dsql\Expressionable
             $this->foreign_alias = ($this->owner->table_alias ?: '') . $this->short_name;
         }
 
-        $this->owner->onHook('initSelectQuery', $this);
+        $this->owner->onHook('initSelectQuery', \Closure::fromCallable([$this, 'initSelectQuery']));
 
         // Add necessary hooks
         if ($this->reverse) {
-            $this->owner->onHook('afterInsert', $this);
-            $this->owner->onHook('beforeUpdate', $this);
-            $this->owner->onHook('beforeDelete', [$this, 'doDelete'], [], -5);
-            $this->owner->onHook('afterLoad', $this);
+            $this->owner->onHook('afterInsert', \Closure::fromCallable([$this, 'afterInsert']));
+            $this->owner->onHook('beforeUpdate', \Closure::fromCallable([$this, 'beforeUpdate']));
+            $this->owner->onHook('beforeDelete', \Closure::fromCallable([$this, 'doDelete']), [], -5);
+            $this->owner->onHook('afterLoad', \Closure::fromCallable([$this, 'afterLoad']));
         } else {
             // Master field indicates ID of the joined item. In the past it had to be
             // defined as a physical field in the main table. Now it is a model field
@@ -97,10 +97,10 @@ class SQL extends Join implements \atk4\dsql\Expressionable
                 }
             }
 
-            $this->owner->onHook('beforeInsert', $this, [], -5);
-            $this->owner->onHook('beforeUpdate', $this);
-            $this->owner->onHook('afterDelete', [$this, 'doDelete']);
-            $this->owner->onHook('afterLoad', $this);
+            $this->owner->onHook('beforeInsert', \Closure::fromCallable([$this, 'beforeInsert']), [], -5);
+            $this->owner->onHook('beforeUpdate', \Closure::fromCallable([$this, 'beforeUpdate']));
+            $this->owner->onHook('afterDelete', \Closure::fromCallable([$this, 'doDelete']));
+            $this->owner->onHook('afterLoad', \Closure::fromCallable([$this, 'afterLoad']));
         }
     }
 

--- a/src/Join/SQL.php
+++ b/src/Join/SQL.php
@@ -4,12 +4,13 @@ namespace atk4\data\Join;
 
 use atk4\data\Join;
 use atk4\data\Model;
+use atk4\data\Persistence;
 
 /**
  * Join\SQL class.
  *
- * @property \atk4\data\Persistence\SQL $persistence
- * @property SQL                        $join
+ * @property Persistence\SQL $persistence
+ * @property SQL             $join
  */
 class SQL extends Join implements \atk4\dsql\Expressionable
 {
@@ -71,7 +72,7 @@ class SQL extends Join implements \atk4\dsql\Expressionable
             $this->foreign_alias = ($this->owner->table_alias ?: '') . $this->short_name;
         }
 
-        $this->owner->onHook('initSelectQuery', \Closure::fromCallable([$this, 'initSelectQuery']));
+        $this->owner->onHook(Persistence\SQL::HOOK_INIT_SELECT_QUERY, \Closure::fromCallable([$this, 'initSelectQuery']));
 
         // Add necessary hooks
         if ($this->reverse) {

--- a/src/Join/SQL.php
+++ b/src/Join/SQL.php
@@ -75,9 +75,9 @@ class SQL extends Join implements \atk4\dsql\Expressionable
 
         // Add necessary hooks
         if ($this->reverse) {
-            $this->owner->onHook('afterInsert', \Closure::fromCallable([$this, 'afterInsert']));
-            $this->owner->onHook('beforeUpdate', \Closure::fromCallable([$this, 'beforeUpdate']));
-            $this->owner->onHook('beforeDelete', \Closure::fromCallable([$this, 'doDelete']), [], -5);
+            $this->owner->onHook(Model::HOOK_AFTER_INSERT, \Closure::fromCallable([$this, 'afterInsert']));
+            $this->owner->onHook(Model::HOOK_BEFORE_UPDATE, \Closure::fromCallable([$this, 'beforeUpdate']));
+            $this->owner->onHook(Model::HOOK_BEFORE_DELETE, \Closure::fromCallable([$this, 'doDelete']), [], -5);
             $this->owner->onHook(Model::HOOK_AFTER_LOAD, \Closure::fromCallable([$this, 'afterLoad']));
         } else {
             // Master field indicates ID of the joined item. In the past it had to be
@@ -97,9 +97,9 @@ class SQL extends Join implements \atk4\dsql\Expressionable
                 }
             }
 
-            $this->owner->onHook('beforeInsert', \Closure::fromCallable([$this, 'beforeInsert']), [], -5);
-            $this->owner->onHook('beforeUpdate', \Closure::fromCallable([$this, 'beforeUpdate']));
-            $this->owner->onHook('afterDelete', \Closure::fromCallable([$this, 'doDelete']));
+            $this->owner->onHook(Model::HOOK_BEFORE_INSERT, \Closure::fromCallable([$this, 'beforeInsert']), [], -5);
+            $this->owner->onHook(Model::HOOK_BEFORE_UPDATE, \Closure::fromCallable([$this, 'beforeUpdate']));
+            $this->owner->onHook(Model::HOOK_AFTER_DELETE, \Closure::fromCallable([$this, 'doDelete']));
             $this->owner->onHook(Model::HOOK_AFTER_LOAD, \Closure::fromCallable([$this, 'afterLoad']));
         }
     }

--- a/src/Join/SQL.php
+++ b/src/Join/SQL.php
@@ -78,7 +78,7 @@ class SQL extends Join implements \atk4\dsql\Expressionable
             $this->owner->onHook('afterInsert', \Closure::fromCallable([$this, 'afterInsert']));
             $this->owner->onHook('beforeUpdate', \Closure::fromCallable([$this, 'beforeUpdate']));
             $this->owner->onHook('beforeDelete', \Closure::fromCallable([$this, 'doDelete']), [], -5);
-            $this->owner->onHook('afterLoad', \Closure::fromCallable([$this, 'afterLoad']));
+            $this->owner->onHook(Model::HOOK_AFTER_LOAD, \Closure::fromCallable([$this, 'afterLoad']));
         } else {
             // Master field indicates ID of the joined item. In the past it had to be
             // defined as a physical field in the main table. Now it is a model field
@@ -100,7 +100,7 @@ class SQL extends Join implements \atk4\dsql\Expressionable
             $this->owner->onHook('beforeInsert', \Closure::fromCallable([$this, 'beforeInsert']), [], -5);
             $this->owner->onHook('beforeUpdate', \Closure::fromCallable([$this, 'beforeUpdate']));
             $this->owner->onHook('afterDelete', \Closure::fromCallable([$this, 'doDelete']));
-            $this->owner->onHook('afterLoad', \Closure::fromCallable([$this, 'afterLoad']));
+            $this->owner->onHook(Model::HOOK_AFTER_LOAD, \Closure::fromCallable([$this, 'afterLoad']));
         }
     }
 

--- a/src/Model.php
+++ b/src/Model.php
@@ -12,7 +12,6 @@ use atk4\core\HookTrait;
 use atk4\core\InitializerTrait;
 use atk4\core\NameTrait;
 use atk4\core\ReadableCaptionTrait;
-use atk4\data\UserAction\Generic;
 use atk4\dsql\Query;
 
 /**
@@ -71,6 +70,8 @@ class Model implements \ArrayAccess, \IteratorAggregate
     public const HOOK_NORMALIZE = self::class . '@normalize';
     /** @const string Executed when self::validate() method is called. */
     public const HOOK_VALIDATE = self::class . '@validate';
+    /** @const string Executed when self::onlyFields() method is called. */
+    public const HOOK_ONLY_FIELDS = self::class . '@onlyFields';
 
     // {{{ Properties of the class
 
@@ -655,7 +656,7 @@ class Model implements \ArrayAccess, \IteratorAggregate
      */
     public function onlyFields($fields = [])
     {
-        $this->hook('onlyFields', [&$fields]);
+        $this->hook(self::HOOK_ONLY_FIELDS, [&$fields]);
         $this->only_fields = $fields;
 
         return $this;

--- a/src/Model.php
+++ b/src/Model.php
@@ -37,10 +37,13 @@ class Model implements \ArrayAccess, \IteratorAggregate
     use CollectionTrait;
     use ReadableCaptionTrait;
 
-    /** @const string */
+    /** @const string Executed for every field set using self::set() method. */
     public const HOOK_NORMALIZE = self::class . '@normalize';
-    /** @const string */
+    /** @const string Executed when self::validate() method is called. */
     public const HOOK_VALIDATE = self::class . '@validate';
+
+    /** @const string */
+    public const HOOK_ROLLBACK = self::class . '@rollback';
 
     // {{{ Properties of the class
 
@@ -2248,7 +2251,7 @@ class Model implements \ArrayAccess, \IteratorAggregate
         try {
             return $persistence->atomic($f);
         } catch (\Exception $e) {
-            if ($this->hook('onRollback', [$this, $e]) !== false) {
+            if ($this->hook(self::HOOK_ROLLBACK, [$this, $e]) !== false) {
                 throw $e;
             }
         }

--- a/src/Model.php
+++ b/src/Model.php
@@ -46,11 +46,23 @@ class Model implements \ArrayAccess, \IteratorAggregate
     public const HOOK_BEFORE_LOAD = self::class . '@beforeLoad';
     /** @const string */
     public const HOOK_AFTER_LOAD = self::class . '@afterLoad';
-
     /** @const string */
     public const HOOK_BEFORE_UNLOAD = self::class . '@beforeUnload';
     /** @const string */
     public const HOOK_AFTER_UNLOAD = self::class . '@afterUnload';
+
+    /** @const string */
+    public const HOOK_BEFORE_INSERT = self::class . '@beforeInsert';
+    /** @const string */
+    public const HOOK_AFTER_INSERT = self::class . '@afterInsert';
+    /** @const string */
+    public const HOOK_BEFORE_UPDATE = self::class . '@beforeUpdate';
+    /** @const string */
+    public const HOOK_AFTER_UPDATE = self::class . '@afterUpdate';
+    /** @const string */
+    public const HOOK_BEFORE_DELETE = self::class . '@beforeDelete';
+    /** @const string */
+    public const HOOK_AFTER_DELETE = self::class . '@afterDelete';
 
     /** @const string Executed when execution of self::atomic() failed. */
     public const HOOK_ROLLBACK = self::class . '@rollback';
@@ -1886,13 +1898,13 @@ class Model implements \ArrayAccess, \IteratorAggregate
                     return $this;
                 }
 
-                if ($this->hook('beforeUpdate', [&$data]) === false) {
+                if ($this->hook(self::HOOK_BEFORE_UPDATE, [&$data]) === false) {
                     return $this;
                 }
 
                 $to_persistence->update($this, $this->id, $data);
 
-                $this->hook('afterUpdate', [&$data]);
+                $this->hook(self::HOOK_AFTER_UPDATE, [&$data]);
             } else {
                 $data = [];
                 foreach ($this->get() as $name => $value) {
@@ -1909,7 +1921,7 @@ class Model implements \ArrayAccess, \IteratorAggregate
                     }
                 }
 
-                if ($this->hook('beforeInsert', [&$data]) === false) {
+                if ($this->hook(self::HOOK_BEFORE_INSERT, [&$data]) === false) {
                     return $this;
                 }
 
@@ -1920,12 +1932,12 @@ class Model implements \ArrayAccess, \IteratorAggregate
                     // Model inserted without any ID fields. Theoretically
                     // we should ignore $this->id even if it was returned.
                     $this->id = null;
-                    $this->hook('afterInsert', [null]);
+                    $this->hook(self::HOOK_AFTER_INSERT, [null]);
 
                     $this->dirty = [];
                 } elseif ($this->id) {
                     $this->set($this->id_field, $this->id);
-                    $this->hook('afterInsert', [$this->id]);
+                    $this->hook(self::HOOK_AFTER_INSERT, [$this->id]);
 
                     if ($this->reload_after_save !== false) {
                         $d = $this->dirty;
@@ -2229,11 +2241,11 @@ class Model implements \ArrayAccess, \IteratorAggregate
 
                 return $this;
             } elseif ($this->loaded()) {
-                if ($this->hook('beforeDelete', [$this->id]) === false) {
+                if ($this->hook(self::HOOK_BEFORE_DELETE, [$this->id]) === false) {
                     return $this;
                 }
                 $this->persistence->delete($this, $this->id);
-                $this->hook('afterDelete', [$this->id]);
+                $this->hook(self::HOOK_AFTER_DELETE, [$this->id]);
                 $this->unload();
 
                 return $this;

--- a/src/Model.php
+++ b/src/Model.php
@@ -37,20 +37,6 @@ class Model implements \ArrayAccess, \IteratorAggregate
     use CollectionTrait;
     use ReadableCaptionTrait;
 
-    /** @const string Executed for every field set using self::set() method. */
-    public const HOOK_NORMALIZE = self::class . '@normalize';
-    /** @const string Executed when self::validate() method is called. */
-    public const HOOK_VALIDATE = self::class . '@validate';
-
-    /** @const string */
-    public const HOOK_BEFORE_LOAD = self::class . '@beforeLoad';
-    /** @const string */
-    public const HOOK_AFTER_LOAD = self::class . '@afterLoad';
-    /** @const string */
-    public const HOOK_BEFORE_UNLOAD = self::class . '@beforeUnload';
-    /** @const string */
-    public const HOOK_AFTER_UNLOAD = self::class . '@afterUnload';
-
     /** @const string */
     public const HOOK_BEFORE_INSERT = self::class . '@beforeInsert';
     /** @const string */
@@ -64,8 +50,22 @@ class Model implements \ArrayAccess, \IteratorAggregate
     /** @const string */
     public const HOOK_AFTER_DELETE = self::class . '@afterDelete';
 
+    /** @const string */
+    public const HOOK_BEFORE_LOAD = self::class . '@beforeLoad';
+    /** @const string */
+    public const HOOK_AFTER_LOAD = self::class . '@afterLoad';
+    /** @const string */
+    public const HOOK_BEFORE_UNLOAD = self::class . '@beforeUnload';
+    /** @const string */
+    public const HOOK_AFTER_UNLOAD = self::class . '@afterUnload';
+
     /** @const string Executed when execution of self::atomic() failed. */
     public const HOOK_ROLLBACK = self::class . '@rollback';
+
+    /** @const string Executed for every field set using self::set() method. */
+    public const HOOK_NORMALIZE = self::class . '@normalize';
+    /** @const string Executed when self::validate() method is called. */
+    public const HOOK_VALIDATE = self::class . '@validate';
 
     // {{{ Properties of the class
 

--- a/src/Model.php
+++ b/src/Model.php
@@ -38,6 +38,15 @@ class Model implements \ArrayAccess, \IteratorAggregate
     use ReadableCaptionTrait;
 
     /** @const string */
+    public const HOOK_BEFORE_LOAD = self::class . '@beforeLoad';
+    /** @const string */
+    public const HOOK_AFTER_LOAD = self::class . '@afterLoad';
+    /** @const string */
+    public const HOOK_BEFORE_UNLOAD = self::class . '@beforeUnload';
+    /** @const string */
+    public const HOOK_AFTER_UNLOAD = self::class . '@afterUnload';
+
+    /** @const string */
     public const HOOK_BEFORE_INSERT = self::class . '@beforeInsert';
     /** @const string */
     public const HOOK_AFTER_INSERT = self::class . '@afterInsert';
@@ -51,13 +60,9 @@ class Model implements \ArrayAccess, \IteratorAggregate
     public const HOOK_AFTER_DELETE = self::class . '@afterDelete';
 
     /** @const string */
-    public const HOOK_BEFORE_LOAD = self::class . '@beforeLoad';
+    public const HOOK_BEFORE_SAVE = self::class . '@beforeSave';
     /** @const string */
-    public const HOOK_AFTER_LOAD = self::class . '@afterLoad';
-    /** @const string */
-    public const HOOK_BEFORE_UNLOAD = self::class . '@beforeUnload';
-    /** @const string */
-    public const HOOK_AFTER_UNLOAD = self::class . '@afterUnload';
+    public const HOOK_AFTER_SAVE = self::class . '@afterSave';
 
     /** @const string Executed when execution of self::atomic() failed. */
     public const HOOK_ROLLBACK = self::class . '@rollback';
@@ -1868,7 +1873,7 @@ class Model implements \ArrayAccess, \IteratorAggregate
                 throw new ValidationException($errors, $this);
             }
             $is_update = $this->loaded();
-            if ($this->hook('beforeSave', [$is_update]) === false) {
+            if ($this->hook(Model::HOOK_BEFORE_SAVE, [$is_update]) === false) {
                 return $this;
             }
 
@@ -1949,7 +1954,7 @@ class Model implements \ArrayAccess, \IteratorAggregate
                 }
             }
 
-            $this->hook('afterSave', [$is_update]);
+            $this->hook(self::HOOK_AFTER_SAVE, [$is_update]);
 
             if ($this->loaded()) {
                 $this->dirty = $this->_dirty_after_reload;

--- a/src/Model.php
+++ b/src/Model.php
@@ -37,6 +37,11 @@ class Model implements \ArrayAccess, \IteratorAggregate
     use CollectionTrait;
     use ReadableCaptionTrait;
 
+    /** @const string */
+    public const HOOK_NORMALIZE = self::class . '@normalize';
+    /** @const string */
+    public const HOOK_VALIDATE = self::class . '@validate';
+
     // {{{ Properties of the class
 
     /**
@@ -462,7 +467,7 @@ class Model implements \ArrayAccess, \IteratorAggregate
     public function validate($intent = null)
     {
         $errors = [];
-        foreach ($this->hook('validate', [$intent]) as $handler_error) {
+        foreach ($this->hook(self::HOOK_VALIDATE, [$intent]) as $handler_error) {
             if ($handler_error) {
                 $errors = array_merge($errors, $handler_error);
             }
@@ -780,7 +785,7 @@ class Model implements \ArrayAccess, \IteratorAggregate
         $f = $this->hasField($field);
 
         try {
-            if ($f && $this->hook('normalize', [$f, $value]) !== false) {
+            if ($f && $this->hook(self::HOOK_NORMALIZE, [$f, $value]) !== false) {
                 $value = $f->normalize($value);
             }
         } catch (Exception $e) {
@@ -879,14 +884,14 @@ class Model implements \ArrayAccess, \IteratorAggregate
     public function setNull($field)
     {
         // set temporary hook to disable any normalization (null validation)
-        $hookIndex = $this->onHook('normalize', function () {
+        $hookIndex = $this->onHook(self::HOOK_NORMALIZE, function () {
             throw new \atk4\core\HookBreaker(false);
         }, [], PHP_INT_MIN);
 
         try {
             $this->set($field, null);
         } finally {
-            $this->removeHook('normalize', $hookIndex, true);
+            $this->removeHook(self::HOOK_NORMALIZE, $hookIndex, true);
         }
 
         return $this;

--- a/src/Model.php
+++ b/src/Model.php
@@ -43,6 +43,11 @@ class Model implements \ArrayAccess, \IteratorAggregate
     public const HOOK_VALIDATE = self::class . '@validate';
 
     /** @const string */
+    public const HOOK_BEFORE_UNLOAD = self::class . '@beforeUnload';
+    /** @const string */
+    public const HOOK_AFTER_UNLOAD = self::class . '@afterUnload';
+
+    /** @const string Executed when execution of self::atomic() failed. */
     public const HOOK_ROLLBACK = self::class . '@rollback';
 
     // {{{ Properties of the class
@@ -51,7 +56,7 @@ class Model implements \ArrayAccess, \IteratorAggregate
      * The class used by addField() method.
      *
      * @todo use Field::class here and refactor addField() method to not use namespace prefixes.
-     *       but because that's backward incomatible change, then we can do that only in next
+     *       but because that's backward incompatible change, then we can do that only in next
      *       major version.
      *
      * @var string|array
@@ -1382,11 +1387,11 @@ class Model implements \ArrayAccess, \IteratorAggregate
      */
     public function unload()
     {
-        $this->hook('beforeUnload');
+        $this->hook(self::HOOK_BEFORE_UNLOAD);
         $this->id = null;
         $this->data = [];
         $this->dirty = [];
-        $this->hook('afterUnload');
+        $this->hook(self::HOOK_AFTER_UNLOAD);
 
         return $this;
     }

--- a/src/Model.php
+++ b/src/Model.php
@@ -1874,7 +1874,7 @@ class Model implements \ArrayAccess, \IteratorAggregate
                 throw new ValidationException($errors, $this);
             }
             $is_update = $this->loaded();
-            if ($this->hook(Model::HOOK_BEFORE_SAVE, [$is_update]) === false) {
+            if ($this->hook(self::HOOK_BEFORE_SAVE, [$is_update]) === false) {
                 return $this;
             }
 

--- a/src/Model.php
+++ b/src/Model.php
@@ -43,6 +43,11 @@ class Model implements \ArrayAccess, \IteratorAggregate
     public const HOOK_VALIDATE = self::class . '@validate';
 
     /** @const string */
+    public const HOOK_BEFORE_LOAD = self::class . '@beforeLoad';
+    /** @const string */
+    public const HOOK_AFTER_LOAD = self::class . '@afterLoad';
+
+    /** @const string */
     public const HOOK_BEFORE_UNLOAD = self::class . '@beforeUnload';
     /** @const string */
     public const HOOK_AFTER_UNLOAD = self::class . '@afterUnload';
@@ -1417,7 +1422,7 @@ class Model implements \ArrayAccess, \IteratorAggregate
             $this->unload();
         }
 
-        if ($this->hook('beforeLoad', [$id]) === false) {
+        if ($this->hook(self::HOOK_BEFORE_LOAD, [$id]) === false) {
             return $this;
         }
 
@@ -1426,7 +1431,7 @@ class Model implements \ArrayAccess, \IteratorAggregate
             $this->id = $id;
         }
 
-        $ret = $this->hook('afterLoad');
+        $ret = $this->hook(self::HOOK_AFTER_LOAD);
         if ($ret === false) {
             return $this->unload();
         } elseif (is_object($ret)) {
@@ -1649,7 +1654,7 @@ class Model implements \ArrayAccess, \IteratorAggregate
         if ($this->data) {
             $this->id = $id;
 
-            $ret = $this->hook('afterLoad');
+            $ret = $this->hook(self::HOOK_AFTER_LOAD);
             if ($ret === false) {
                 return $this->unload();
             } elseif (is_object($ret)) {
@@ -1687,7 +1692,7 @@ class Model implements \ArrayAccess, \IteratorAggregate
                 $this->id = $this->data[$this->id_field];
             }
 
-            $ret = $this->hook('afterLoad');
+            $ret = $this->hook(self::HOOK_AFTER_LOAD);
             if ($ret === false) {
                 return $this->unload();
             } elseif (is_object($ret)) {
@@ -1728,7 +1733,7 @@ class Model implements \ArrayAccess, \IteratorAggregate
                 }
             }
 
-            $ret = $this->hook('afterLoad');
+            $ret = $this->hook(self::HOOK_AFTER_LOAD);
             if ($ret === false) {
                 return $this->unload();
             } elseif (is_object($ret)) {
@@ -2136,14 +2141,14 @@ class Model implements \ArrayAccess, \IteratorAggregate
 
             // you can return false in afterLoad hook to prevent to yield this data row
             // use it like this:
-            // $model->onHook('afterLoad', function ($m) {
+            // $model->onHook(self::HOOK_AFTER_LOAD, function ($m) {
             //     if ($m['date'] < $m->date_from) $m->breakHook(false);
             // })
 
             // you can also use breakHook() with specific object which will then be returned
             // as a next iterator value
 
-            $ret = $this->hook('afterLoad');
+            $ret = $this->hook(self::HOOK_AFTER_LOAD);
 
             if ($ret === false) {
                 continue;

--- a/src/Persistence.php
+++ b/src/Persistence.php
@@ -17,6 +17,9 @@ class Persistence
     use \atk4\core\NameTrait;
     use \atk4\core\DIContainerTrait;
 
+    /** @const string */
+    public const HOOK_AFTER_ADD = self::class . '@afterAdd';
+
     /** @var string Connection driver name, for example, mysql, pgsql, oci etc. */
     public $driverType;
 
@@ -112,7 +115,7 @@ class Persistence
         $this->initPersistence($m);
         $m = $this->_add($m);
 
-        $this->hook('afterAdd', [$m]);
+        $this->hook(self::HOOK_AFTER_ADD, [$m]);
 
         return $m;
     }

--- a/src/Persistence/SQL.php
+++ b/src/Persistence/SQL.php
@@ -28,8 +28,6 @@ class SQL extends Persistence
     public const HOOK_AFTER_UPDATE_QUERY = self::class . '@afterUpdateQuery';
     /** @const string */
     public const HOOK_BEFORE_DELETE_QUERY = self::class . '@beforeDeleteQuery';
-    /** @const string */
-    public const HOOK_AFTER_DELETE_QUERY = self::class . '@afterDeleteQuery';
 
     /**
      * Connection object.

--- a/src/Persistence/SQL.php
+++ b/src/Persistence/SQL.php
@@ -171,9 +171,9 @@ class SQL extends Persistence
      */
     protected function initPersistence(Model $m)
     {
-        $m->addMethod('expr', [$this, 'expr']);
-        $m->addMethod('dsql', [$this, 'dsql']);
-        $m->addMethod('exprNow', [$this, 'exprNow']);
+        $m->addMethod('expr', \Closure::fromCallable([$this, 'expr']));
+        $m->addMethod('dsql', \Closure::fromCallable([$this, 'dsql']));
+        $m->addMethod('exprNow', \Closure::fromCallable([$this, 'exprNow']));
     }
 
     /**

--- a/src/Persistence/SQL.php
+++ b/src/Persistence/SQL.php
@@ -16,6 +16,19 @@ use atk4\dsql\Query;
  */
 class SQL extends Persistence
 {
+    /** @const string */
+    public const HOOK_BEFORE_INSERT_QUERY = self::class . '@beforeInsertQuery';
+    /** @const string */
+    public const HOOK_AFTER_INSERT_QUERY = self::class . '@afterInsertQuery';
+    /** @const string */
+    public const HOOK_BEFORE_UPDATE_QUERY = self::class . '@beforeUpdateQuery';
+    /** @const string */
+    public const HOOK_AFTER_UPDATE_QUERY = self::class . '@afterUpdateQuery';
+    /** @const string */
+    public const HOOK_BEFORE_DELETE_QUERY = self::class . '@beforeDeleteQuery';
+    /** @const string */
+    public const HOOK_AFTER_DELETE_QUERY = self::class . '@afterDeleteQuery';
+
     /**
      * Connection object.
      *
@@ -859,7 +872,7 @@ class SQL extends Persistence
         $st = null;
 
         try {
-            $m->hook('beforeInsertQuery', [$insert]);
+            $m->hook(self::HOOK_BEFORE_INSERT_QUERY, [$insert]);
             $st = $insert->execute();
         } catch (\PDOException $e) {
             throw new Exception([
@@ -871,7 +884,7 @@ class SQL extends Persistence
             ], 0, $e);
         }
 
-        $m->hook('afterInsertQuery', [$insert, $st]);
+        $m->hook(self::HOOK_AFTER_INSERT_QUERY, [$insert, $st]);
 
         return $m->lastInsertID();
     }
@@ -943,7 +956,7 @@ class SQL extends Persistence
         $st = null;
 
         try {
-            $m->hook('beforeUpdateQuery', [$update]);
+            $m->hook(self::HOOK_BEFORE_UPDATE_QUERY, [$update]);
             if ($data) {
                 $st = $update->execute();
             }
@@ -962,7 +975,7 @@ class SQL extends Persistence
             $m->id = $data[$m->id_field];
         }
 
-        $m->hook('afterUpdateQuery', [$update, $st]);
+        $m->hook(self::HOOK_AFTER_UPDATE_QUERY, [$update, $st]);
 
         // if any rows were updated in database, and we had expressions, reload
         if ($m->reload_after_save === true && (!$st || $st->rowCount())) {
@@ -987,7 +1000,7 @@ class SQL extends Persistence
         $delete = $this->initQuery($m);
         $delete->mode('delete');
         $delete->where($m->id_field, $id);
-        $m->hook('beforeDeleteQuery', [$delete]);
+        $m->hook(self::HOOK_BEFORE_DELETE_QUERY, [$delete]);
 
         try {
             $delete->execute();

--- a/src/Persistence/SQL.php
+++ b/src/Persistence/SQL.php
@@ -17,6 +17,8 @@ use atk4\dsql\Query;
 class SQL extends Persistence
 {
     /** @const string */
+    public const HOOK_INIT_SELECT_QUERY = self::class . '@initSelectQuery';
+    /** @const string */
     public const HOOK_BEFORE_INSERT_QUERY = self::class . '@beforeInsertQuery';
     /** @const string */
     public const HOOK_AFTER_INSERT_QUERY = self::class . '@afterInsertQuery';
@@ -634,7 +636,7 @@ class SQL extends Persistence
             case 'delete':
                 $q->mode('delete');
                 $this->initQueryConditions($m, $q);
-                $m->hook('initSelectQuery', [$q, $type]);
+                $m->hook(self::HOOK_INIT_SELECT_QUERY, [$q, $type]);
 
                 return $q;
             case 'select':
@@ -643,7 +645,7 @@ class SQL extends Persistence
                 break;
             case 'count':
                 $this->initQueryConditions($m, $q);
-                $m->hook('initSelectQuery', [$q]);
+                $m->hook(self::HOOK_INIT_SELECT_QUERY, [$q]);
                 if (isset($args['alias'])) {
                     $q->reset('field')->field('count(*)', $args['alias']);
                 } else {
@@ -660,7 +662,7 @@ class SQL extends Persistence
                 }
 
                 $field = is_string($args[0]) ? $m->getField($args[0]) : $args[0];
-                $m->hook('initSelectQuery', [$q, $type]);
+                $m->hook(self::HOOK_INIT_SELECT_QUERY, [$q, $type]);
                 if (isset($args['alias'])) {
                     $q->reset('field')->field($field, $args['alias']);
                 } elseif ($field instanceof Field_SQL_Expression) {
@@ -684,7 +686,7 @@ class SQL extends Persistence
                 $fx = $args[0];
                 $field = is_string($args[1]) ? $m->getField($args[1]) : $args[1];
                 $this->initQueryConditions($m, $q);
-                $m->hook('initSelectQuery', [$q, $type]);
+                $m->hook(self::HOOK_INIT_SELECT_QUERY, [$q, $type]);
 
                 if ($type === 'fx') {
                     $expr = "{$fx}([])";
@@ -710,7 +712,7 @@ class SQL extends Persistence
 
         $this->initQueryConditions($m, $q);
         $this->setLimitOrder($m, $q);
-        $m->hook('initSelectQuery', [$q, $type]);
+        $m->hook(self::HOOK_INIT_SELECT_QUERY, [$q, $type]);
 
         return $q;
     }

--- a/src/Persistence/Static_.php
+++ b/src/Persistence/Static_.php
@@ -43,7 +43,7 @@ class Static_ extends Array_
         // chomp off first row, we will use it to deduct fields
         $row1 = reset($data);
 
-        $this->onHook('afterAdd', [$this, 'afterAdd']);
+        $this->onHook('afterAdd', \Closure::fromCallable([$this, 'afterAdd']));
 
         if (!is_array($row1)) {
             // We are dealing with array of strings. Convert it into array of hashes

--- a/src/Persistence/Static_.php
+++ b/src/Persistence/Static_.php
@@ -43,7 +43,7 @@ class Static_ extends Array_
         // chomp off first row, we will use it to deduct fields
         $row1 = reset($data);
 
-        $this->onHook('afterAdd', \Closure::fromCallable([$this, 'afterAdd']));
+        $this->onHook(self::HOOK_AFTER_ADD, \Closure::fromCallable([$this, 'afterAdd']));
 
         if (!is_array($row1)) {
             // We are dealing with array of strings. Convert it into array of hashes

--- a/src/Reference/ContainsMany.php
+++ b/src/Reference/ContainsMany.php
@@ -62,10 +62,12 @@ class ContainsMany extends ContainsOne
         ]));
 
         // set some hooks for ref_model
-        $m->onHook(['afterSave', 'afterDelete'], function ($model) {
-            $rows = $model->persistence->data[$this->table_alias];
-            $this->owner->save([$this->our_field => $rows ?: null]);
-        });
+        foreach (['afterSave', 'afterDelete'] as $spot) {
+            $m->onHook($spot, function ($model) {
+                $rows = $model->persistence->data[$this->table_alias];
+                $this->owner->save([$this->our_field => $rows ?: null]);
+            });
+        }
 
         return $m;
     }

--- a/src/Reference/ContainsMany.php
+++ b/src/Reference/ContainsMany.php
@@ -62,7 +62,7 @@ class ContainsMany extends ContainsOne
         ]));
 
         // set some hooks for ref_model
-        foreach (['afterSave', 'afterDelete'] as $spot) {
+        foreach ([Model::HOOK_AFTER_SAVE, Model::HOOK_AFTER_DELETE] as $spot) {
             $m->onHook($spot, function ($model) {
                 $rows = $model->persistence->data[$this->table_alias];
                 $this->owner->save([$this->our_field => $rows ?: null]);

--- a/src/Reference/ContainsOne.php
+++ b/src/Reference/ContainsOne.php
@@ -115,7 +115,7 @@ class ContainsOne extends Reference
         ]));
 
         // set some hooks for ref_model
-        foreach (['afterSave', 'afterDelete'] as $spot) {
+        foreach ([Model::HOOK_AFTER_SAVE, Model::HOOK_AFTER_DELETE] as $spot) {
             $m->onHook($spot, function ($model) {
                 $row = $model->persistence->data[$this->table_alias];
                 $row = $row ? array_shift($row) : null; // get first and only one record from array persistence

--- a/src/Reference/ContainsOne.php
+++ b/src/Reference/ContainsOne.php
@@ -115,11 +115,13 @@ class ContainsOne extends Reference
         ]));
 
         // set some hooks for ref_model
-        $m->onHook(['afterSave', 'afterDelete'], function ($model) {
-            $row = $model->persistence->data[$this->table_alias];
-            $row = $row ? array_shift($row) : null; // get first and only one record from array persistence
-            $this->owner->save([$this->our_field => $row]);
-        });
+        foreach (['afterSave', 'afterDelete'] as $spot) {
+            $m->onHook($spot, function ($model) {
+                $row = $model->persistence->data[$this->table_alias];
+                $row = $row ? array_shift($row) : null; // get first and only one record from array persistence
+                $this->owner->save([$this->our_field => $row]);
+            });
+        }
 
         // try to load any (actually only one possible) record
         $m->tryLoadAny();

--- a/src/Reference/HasOne.php
+++ b/src/Reference/HasOne.php
@@ -216,7 +216,7 @@ class HasOne extends Reference
         $m = $this->getModel($defaults);
 
         // add hook to set our_field = null when record of referenced model is deleted
-        $m->onHook('afterDelete', function ($m) {
+        $m->onHook(Model::HOOK_AFTER_DELETE, function ($m) {
             $this->owner[$this->our_field] = null;
         });
 

--- a/src/Reference/HasOne.php
+++ b/src/Reference/HasOne.php
@@ -226,7 +226,7 @@ class HasOne extends Reference
                 $m->tryLoadBy($this->their_field, $this->owner[$this->our_field]);
             }
 
-            $m->onHook('afterSave', function ($m) {
+            $m->onHook(Model::HOOK_AFTER_SAVE, function ($m) {
                 $this->owner[$this->our_field] = $m[$this->their_field];
             });
         } else {
@@ -234,7 +234,7 @@ class HasOne extends Reference
                 $m->tryLoad($this->owner[$this->our_field]);
             }
 
-            $m->onHook('afterSave', function ($m) {
+            $m->onHook(Model::HOOK_AFTER_SAVE, function ($m) {
                 $this->owner[$this->our_field] = $m->id;
             });
         }

--- a/src/Reference/HasOne_SQL.php
+++ b/src/Reference/HasOne_SQL.php
@@ -61,7 +61,7 @@ class HasOne_SQL extends HasOne
         $e->never_save = true;
 
         // Will try to execute last
-        $this->owner->onHook('beforeSave', function (Model $m) use ($field, $their_field) {
+        $this->owner->onHook(Model::HOOK_BEFORE_SAVE, function (Model $m) use ($field, $their_field) {
             // if title field is changed, but reference ID field (our_field)
             // is not changed, then update reference ID field value
             if ($m->isDirty($field) && !$m->isDirty($this->our_field)) {
@@ -236,7 +236,7 @@ class HasOne_SQL extends HasOne
         ));
 
         // Will try to execute last
-        $this->owner->onHook('beforeSave', function (Model $m) use ($field) {
+        $this->owner->onHook(Model::HOOK_BEFORE_SAVE, function (Model $m) use ($field) {
             // if title field is changed, but reference ID field (our_field)
             // is not changed, then update reference ID field value
             if ($m->isDirty($field) && !$m->isDirty($this->our_field)) {

--- a/src/Util/DeepCopy.php
+++ b/src/Util/DeepCopy.php
@@ -21,6 +21,9 @@ class DeepCopy
 {
     use \atk4\core\DebugTrait;
 
+    /** @const string */
+    public const HOOK_AFTER_COPY = self::class . '@afterCopy';
+
     /**
      * @var \atk4\data\Model from which we want to copy records
      */
@@ -225,7 +228,7 @@ class DeepCopy
                     }
                 }
             }
-            $destination->hook('afterCopy', [$source]);
+            $destination->hook(self::HOOK_AFTER_COPY, [$source]);
 
             // Look for hasOne references that needs to be mapped. Make sure records can be mapped, or copy them
             foreach ($this->extractKeys($references) as $ref_key => $ref_val) {

--- a/tests/DeepCopyTest.php
+++ b/tests/DeepCopyTest.php
@@ -43,7 +43,7 @@ class DCInvoice extends Model
 
         $this->addField('is_paid', ['type' => 'boolean', 'default' => false]);
 
-        $this->onHook('afterCopy', function ($m, $s) {
+        $this->onHook(DeepCopy::HOOK_AFTER_COPY, function ($m, $s) {
             if (get_class($s) === static::class) {
                 $m['ref'] = $m['ref'] . '_copy';
             }
@@ -273,7 +273,7 @@ class DeepCopyTest extends \atk4\schema\PhpunitTestCase
         $quote->loadAny();
 
         $invoice = new DCInvoice();
-        $invoice->onHook('afterCopy', function ($m) {
+        $invoice->onHook(DeepCopy::HOOK_AFTER_COPY, function ($m) {
             if (!$m['ref']) {
                 throw new \atk4\core\Exception('no ref');
             }
@@ -315,7 +315,7 @@ class DeepCopyTest extends \atk4\schema\PhpunitTestCase
         $quote->loadAny();
 
         $invoice = new DCInvoice();
-        $invoice->onHook('afterCopy', function ($m) {
+        $invoice->onHook(DeepCopy::HOOK_AFTER_COPY, function ($m) {
             if (!$m['ref']) {
                 throw new \atk4\core\Exception('no ref');
             }

--- a/tests/FieldTest.php
+++ b/tests/FieldTest.php
@@ -339,7 +339,7 @@ class FieldTest extends \atk4\schema\PhpunitTestCase
         $a['item'][1]['surname'] = 'Stalker';
         $this->assertEquals($a, $this->getDB());
 
-        $m->onHook('beforeSave', function ($m) {
+        $m->onHook(Model::HOOK_BEFORE_SAVE, function ($m) {
             if ($m->isDirty('name')) {
                 $m['surname'] = $m['name'];
                 unset($m['name']);

--- a/tests/JoinSQLTest.php
+++ b/tests/JoinSQLTest.php
@@ -383,7 +383,7 @@ class JoinSQLTest extends \atk4\schema\PhpunitTestCase
         $j = $m_u->join('contact.test_id');
         $j->addField('contact_phone');
 
-        $m_u->onHook('afterSave', function ($m) {
+        $m_u->onHook(Model::HOOK_AFTER_SAVE, function ($m) {
             if ($m['contact_phone'] !== '+123') {
                 $m['contact_phone'] = '+123';
                 $m->save();

--- a/tests/LookupSQLTest.php
+++ b/tests/LookupSQLTest.php
@@ -102,7 +102,7 @@ class LFriend extends Model
 
         // add or remove reverse friendships
         /*
-        $this->onHook('afterInsert', function($m) {
+        $this->onHook(self::HOOK_AFTER_INSERT, function($m) {
             if ($m->skip_reverse) {
                 return;
             }
@@ -115,7 +115,7 @@ class LFriend extends Model
             ]);
         });
 
-        $this->onHook('beforeDelete', function($m) {
+        $this->onHook(Model::HOOK_BEFORE_DELETE, function($m) {
             if ($m->skip_reverse) {
                 return;
             }

--- a/tests/Model/Smbo/Transfer.php
+++ b/tests/Model/Smbo/Transfer.php
@@ -21,7 +21,7 @@ class Transfer extends Payment
 
         $this->addField('destination_account_id', ['never_persist' => true]);
 
-        $this->onHook('beforeSave', function ($m) {
+        $this->onHook(self::HOOK_BEFORE_SAVE, function ($m) {
             // only for new records and when destination_account_id is set
             if ($m['destination_account_id'] && !$m->id) {
                 // In this section we test if "clone" works ok
@@ -50,7 +50,7 @@ class Transfer extends Payment
             }
         });
 
-        $this->onHook('afterSave', function ($m) {
+        $this->onHook(self::HOOK_AFTER_SAVE, function ($m) {
             if ($m->other_leg_creation) {
                 $m->other_leg_creation->set('transfer_document_id', $m->id)->save();
             }

--- a/tests/RandomTest.php
+++ b/tests/RandomTest.php
@@ -322,7 +322,7 @@ class RandomTest extends \atk4\schema\PhpunitTestCase
             $m->breakHook(false);
         });
 
-        $m->onHook('beforeLoad', function ($m, $id) {
+        $m->onHook(Model::HOOK_BEFORE_LOAD, function ($m, $id) {
             $m->data = ['name' => 'rec #' . $id];
             $m->id = $id;
             $m->breakHook(false);

--- a/tests/RandomTest.php
+++ b/tests/RandomTest.php
@@ -270,7 +270,7 @@ class RandomTest extends \atk4\schema\PhpunitTestCase
         $m->addField('name');
         $m->load(2);
 
-        $m->onHook('afterUpdateQuery', function ($m, $update, $st) {
+        $m->onHook(Persistence\SQL::HOOK_AFTER_UPDATE_QUERY, function ($m, $update, $st) {
             // we can use afterUpdate to make sure that record was updated
 
             if (!$st->rowCount()) {
@@ -328,7 +328,7 @@ class RandomTest extends \atk4\schema\PhpunitTestCase
             $m->breakHook(false);
         });
 
-        $m->onHook('beforeDelete', function ($m, $id) {
+        $m->onHook(Model::HOOK_BEFORE_DELETE, function ($m, $id) {
             $m->unload();
             $m->breakHook(false);
         });

--- a/tests/RandomTest.php
+++ b/tests/RandomTest.php
@@ -318,7 +318,7 @@ class RandomTest extends \atk4\schema\PhpunitTestCase
         $m = new Model($db, 'user');
         $m->addField('name');
 
-        $m->onHook('beforeSave', function ($m) {
+        $m->onHook(Model::HOOK_BEFORE_SAVE, function ($m) {
             $m->breakHook(false);
         });
 

--- a/tests/SubTypesTest.php
+++ b/tests/SubTypesTest.php
@@ -74,7 +74,7 @@ class STGenericTransaction extends Model
         }
         $this->addField('amount');
 
-        $this->onHook('afterLoad', function (self $m) {
+        $this->onHook(Model::HOOK_AFTER_LOAD, function (self $m) {
             if (static::class !== $m->getClassName()) {
                 $cl = '\\' . $this->getClassName();
                 $cl = new $cl($this->persistence);

--- a/tests/TransactionTest.php
+++ b/tests/TransactionTest.php
@@ -120,7 +120,7 @@ class TransactionTest extends \atk4\schema\PhpunitTestCase
 
         $hook_called = false;
         $values = [];
-        $m->onHook('onRollback', function ($mm, $e) use (&$hook_called, &$values) {
+        $m->onHook(Model::HOOK_ROLLBACK, function ($mm, $e) use (&$hook_called, &$values) {
             $hook_called = true;
             $values = $mm->get(); // model field values are still the same no matter we rolled back
             $mm->breakHook(false); // if we break hook and return false then exception is not thrown, but rollback still happens

--- a/tests/TransactionTest.php
+++ b/tests/TransactionTest.php
@@ -25,7 +25,7 @@ class TransactionTest extends \atk4\schema\PhpunitTestCase
         $m->addField('name');
         $m->load(2);
 
-        $m->onHook('afterSave', function ($m) {
+        $m->onHook(Model::HOOK_AFTER_SAVE, function ($m) {
             throw new \Exception('Awful thing happened');
         });
         $m['name'] = 'XXX';
@@ -62,7 +62,7 @@ class TransactionTest extends \atk4\schema\PhpunitTestCase
         // test insert
         $m = new Model($db, 'item');
         $m->addField('name');
-        $m->onHook('beforeSave', function ($model, $is_update) use ($self) {
+        $m->onHook(Model::HOOK_BEFORE_SAVE, function ($model, $is_update) use ($self) {
             $self->assertFalse($is_update);
         });
         $m->save(['name' => 'Foo']);
@@ -70,7 +70,7 @@ class TransactionTest extends \atk4\schema\PhpunitTestCase
         // test update
         $m = new Model($db, 'item');
         $m->addField('name');
-        $m->onHook('afterSave', function ($model, $is_update) use ($self) {
+        $m->onHook(Model::HOOK_AFTER_SAVE, function ($model, $is_update) use ($self) {
             $self->assertTrue($is_update);
         });
         $m->loadBy('name', 'John')->save(['name' => 'Foo']);
@@ -89,7 +89,7 @@ class TransactionTest extends \atk4\schema\PhpunitTestCase
         // test insert
         $m = new Model($db, 'item');
         $m->addField('name');
-        $m->onHook('afterSave', function ($model, $is_update) use ($self) {
+        $m->onHook(Model::HOOK_AFTER_SAVE, function ($model, $is_update) use ($self) {
             $self->assertFalse($is_update);
         });
         $m->save(['name' => 'Foo']);
@@ -97,7 +97,7 @@ class TransactionTest extends \atk4\schema\PhpunitTestCase
         // test update
         $m = new Model($db, 'item');
         $m->addField('name');
-        $m->onHook('afterSave', function ($model, $is_update) use ($self) {
+        $m->onHook(Model::HOOK_AFTER_SAVE, function ($model, $is_update) use ($self) {
             $self->assertTrue($is_update);
         });
         $m->loadBy('name', 'John')->save(['name' => 'Foo']);

--- a/tests/TransactionTest.php
+++ b/tests/TransactionTest.php
@@ -37,7 +37,7 @@ class TransactionTest extends \atk4\schema\PhpunitTestCase
 
         $this->assertSame('Sue', $this->getDB()['item'][2]['name']);
 
-        $m->onHook('afterDelete', function ($m) {
+        $m->onHook(Model::HOOK_AFTER_DELETE, function ($m) {
             throw new \Exception('Awful thing happened');
         });
 

--- a/tests/ValidationTest.php
+++ b/tests/ValidationTest.php
@@ -116,7 +116,7 @@ class ValidationTests extends AtkPhpunit\TestCase
 
     public function testValidateHook()
     {
-        $this->m->onHook('validate', function ($m) {
+        $this->m->onHook(Model::HOOK_VALIDATE, function ($m) {
             if ($m['name'] === 'C#') {
                 return ['name' => 'No sharp objects allowed'];
             }


### PR DESCRIPTION
related with https://github.com/atk4/core/pull/196

BC break as you have to use the new constants instead of the old/short hook names like `afterInsert`

## Example Old Code

``` php
$model->addHook('beforeSave', function() {});
```

## Example New code

``` php
$model->addHook(\atk4\data\Model::HOOK_BEFORE_SAVE, function() {});
```

## More info

Regex to locate old names:
```
['"](beforeLoad|afterLoad|beforeUnload|afterUnload|beforeInsert|afterInsert|beforeUpdate|afterUpdate|beforeDelete|afterDelete|beforeSave|afterSave|rollback|normalize|validate|onlyFields|afterAdd|initSelectQuery|beforeInsertQuery|afterInsertQuery|beforeUpdateQuery|afterUpdateQuery|beforeDeleteQuery|afterCopy)['"]
```

New hook names:
```
\atk4\data\Model::
'beforeLoad' => HOOK_BEFORE_LOAD
'afterLoad' => HOOK_AFTER_LOAD
'beforeUnload' => HOOK_BEFORE_UNLOAD
'afterUnload' => HOOK_AFTER_UNLOAD
'beforeInsert' => HOOK_BEFORE_INSERT
'afterInsert' => HOOK_AFTER_INSERT
'beforeUpdate' => HOOK_BEFORE_UPDATE
'afterUpdate' => HOOK_AFTER_UPDATE
'beforeDelete' => HOOK_BEFORE_DELETE
'afterDelete' => HOOK_AFTER_DELETE
'beforeSave' => HOOK_BEFORE_SAVE
'afterSave' => HOOK_AFTER_SAVE
'rollback' => HOOK_ROLLBACK
'normalize' => HOOK_NORMALIZE
'validate' => HOOK_VALIDATE
'onlyFields' => HOOK_ONLY_FIELDS

\atk4\data\Persistence::
'afterAdd' => HOOK_AFTER_ADD

\atk4\data\Persistence\SQL::
'initSelectQuery' => HOOK_INIT_SELECT_QUERY
'beforeInsertQuery' => HOOK_BEFORE_INSERT_QUERY
'afterInsertQuery' => HOOK_AFTER_INSERT_QUERY
'beforeUpdateQuery' => HOOK_BEFORE_UPDATE_QUERY
'afterUpdateQuery' => HOOK_AFTER_UPDATE_QUERY
'beforeDeleteQuery' => HOOK_BEFORE_DELETE_QUERY

\atk4\data\Util\DeepCopy::
'afterCopy' => HOOK_AFTER_COPY
```