### PR TITLE
Add Session persistence

### DIFF
--- a/docs/persistence.rst
+++ b/docs/persistence.rst
@@ -802,13 +802,9 @@ Store a specific record
 
 If you are using authentication mechanism to log a user in and you wish to
 store his details into Session, so that you don't have to reload every time,
-you can implement it like this::
+you can use Session persistence and implement it like this::
 
-    if (!isset($_SESSION['ad'])) {
-        $_SESSION['ad'] = []; // initialize
-    }
-
-    $sess = new \atk4\data\Persistence\Array_($_SESSION['ad']);
+    $sess = new \atk4\data\Persistence\Session();
     $logged_user = new User($sess);
     $logged_user->load('active_user');
 
@@ -819,8 +815,7 @@ user record that I'm going to store there.
 How to add record inside session, e.g. log the user in? Here is the code::
 
     $u = new User($db);
-    $u->load(123);
-
+    // this will save record with id='active_user' into session persistence
     $u->withPersistence($sess, 'active_user')->save();
 
 .. _Action:

--- a/src/Model.php
+++ b/src/Model.php
@@ -13,6 +13,7 @@ use atk4\core\InitializerTrait;
 use atk4\core\NameTrait;
 use atk4\core\ReadableCaptionTrait;
 use atk4\data\UserAction\Generic;
+use atk4\data\Persistence;
 use atk4\dsql\Query;
 
 /**
@@ -145,7 +146,7 @@ class Model implements \ArrayAccess, \IteratorAggregate
     public $sequence;
 
     /**
-     * Persistence driver inherited from atk4\data\Persistence.
+     * Persistence driver inherited from Persistence.
      *
      * @var Persistence
      */
@@ -1568,26 +1569,17 @@ class Model implements \ArrayAccess, \IteratorAggregate
      * If you wish to fully copy the data from one
      * model to another you should use:
      *
-     * $m->withPersistence($p2, false)->set($m)->save();
+     * $m->withPersistence($p2, false)->set($m->get())->save();
      *
      * See https://github.com/atk4/data/issues/111 for
      * use-case examples.
      *
-     * @param Persistence $persistence
      * @param mixed       $id
-     * @param string      $class
      *
      * @return $this
      */
-    public function withPersistence($persistence, $id = null, string $class = null)
+    public function withPersistence(Persistence $persistence, $id = null, string $class = null)
     {
-        if (!$persistence instanceof Persistence) {
-            throw new Exception([
-                'Please supply valid persistence',
-                'arg' => $persistence,
-            ]);
-        }
-
         if (!$class) {
             $class = static::class;
         }

--- a/src/Model.php
+++ b/src/Model.php
@@ -13,7 +13,6 @@ use atk4\core\InitializerTrait;
 use atk4\core\NameTrait;
 use atk4\core\ReadableCaptionTrait;
 use atk4\data\UserAction\Generic;
-use atk4\data\Persistence;
 use atk4\dsql\Query;
 
 /**
@@ -1574,7 +1573,7 @@ class Model implements \ArrayAccess, \IteratorAggregate
      * See https://github.com/atk4/data/issues/111 for
      * use-case examples.
      *
-     * @param mixed       $id
+     * @param mixed $id
      *
      * @return $this
      */

--- a/src/Persistence/ArrayOfStrings.php
+++ b/src/Persistence/ArrayOfStrings.php
@@ -3,7 +3,6 @@
 namespace atk4\data\Persistence;
 
 use atk4\data\Field;
-use atk4\data\Persistence;
 
 /**
  * Array persistence which will always typecast all values to strings.

--- a/src/Persistence/Array_.php
+++ b/src/Persistence/Array_.php
@@ -461,4 +461,12 @@ class Array_ extends Persistence
                 ]);
         }
     }
+
+    /**
+     * Deletes all data.
+     */
+    public function clearData()
+    {
+        $this->data = [];
+    }
 }

--- a/src/Persistence/Session.php
+++ b/src/Persistence/Session.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace atk4\data\Persistence;
+
+/**
+ * Array persistence which will store model data in session.
+ */
+class Session extends Array_
+{
+    /**
+     * Session container key.
+     *
+     * @var string
+     */
+    protected $session_key = '__atk_session';
+
+    /**
+     * Constructor. Can pass array of data in parameters.
+     */
+    public function __construct(&$data = [], ?string $key = null)
+    {
+        $key = $key ?? $this->name ?? get_class($this);
+
+        parent::__construct($data);
+        $_SESSION[$this->session_key][$key] = &$this->data;
+    }
+}

--- a/src/Persistence/Session.php
+++ b/src/Persistence/Session.php
@@ -17,9 +17,9 @@ class Session extends Array_
     /**
      * Constructor. Can pass array of data in parameters.
      */
-    public function __construct(&$data = [], ?string $key = null)
+    public function __construct(&$data = [], string $key = null)
     {
-        $key = $key ?? $this->name ?? get_class($this);
+        $key = $key ?? $this->name ?? static::class;
 
         parent::__construct($data);
         $_SESSION[$this->session_key][$key] = &$this->data;

--- a/tests/PersistentSessionTest.php
+++ b/tests/PersistentSessionTest.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace atk4\data\tests;
+
+use atk4\core\AtkPhpunit;
+use atk4\data\Model;
+use atk4\data\Persistence;
+
+/**
+ * @coversDefaultClass \atk4\data\Persistence\Session
+ */
+class PersistentSessionTest extends AtkPhpunit\TestCase
+{
+    /**
+     * Tests.
+     */
+    public function testSession()
+    {
+        $a = [
+            'user' => [
+                1 => ['name' => 'John'],
+                2 => ['name' => 'Sarah'],
+            ],
+        ];
+
+        $p = new Persistence\Session($a);
+        $this->assertSame($a, $p->data);
+
+        $m = new Model($p, 'user');
+        $m->addField('name');
+        $this->assertSame($a, $p->data);
+        $this->assertSame($a[$m->table], $m->export());
+
+        $m->load(1);
+        $this->assertSame('John', $m['name']);
+
+        $m->load(2);
+        $m['name'] = 'Jane';
+        $m->save();
+
+        $m->load(2);
+        $this->assertSame('Jane', $m['name']);
+        $this->assertSame($a, $p->data);
+        $this->assertSame($a[$m->table], $m->export());
+
+        // now clear data
+        $p->clearData();
+        $this->assertTrue(empty($p->data));
+        $this->assertTrue(empty($a));
+    }
+}


### PR DESCRIPTION
Implements simple session persistence which will store model data in local session.

P.S. @mvorisek it will then be used in https://github.com/atk4/ui/blob/3fd37f0bee0d43f01e9eccb41e96b9dc3466d5ca/src/TableColumn/FilterModel/Generic.php#L15 to get rid of sessionTrait and $model->name usage there.