### PR TITLE
Remove support of relative class names

### DIFF
--- a/docs/fields.rst
+++ b/docs/fields.rst
@@ -278,7 +278,7 @@ Password (after 1.5.0 release)
 Without this class your password will be stored **unencrypted**.
 Here is how to use it properly::
 
-    $user->addField('mypass', ['Password']);
+    $user->addField('mypass', [\atk4\ui\FormField\Password::class]);
 
     $user->set('mypass', 'secret');
     $user->save();

--- a/src/Field/Email.php
+++ b/src/Field/Email.php
@@ -9,10 +9,10 @@ use atk4\data\ValidationException;
  * Stores valid email(s) as per configuration.
  *
  * Usage:
- *  $user->addField('email', ['Email']);
- *  $user->addField('email_mx_check', ['Email', 'dns_check'=>true]);
- *  $user->addField('email_with_name', ['Email', 'include_names'=>true]);
- *  $user->addField('emails', ['Email', 'allow_multiple'=>true, 'separator'=>[',',';']]);
+ *  $user->addField('email', [Field\Email::class]);
+ *  $user->addField('email_mx_check', [Field\Email::class, 'dns_check'=>true]);
+ *  $user->addField('email_with_name', [Field\Email::class, 'include_names'=>true]);
+ *  $user->addField('emails', [Field\Email::class, 'allow_multiple'=>true, 'separator'=>[',',';']]);
  *
  * Various options can also be combined.
  */

--- a/src/Model.php
+++ b/src/Model.php
@@ -560,7 +560,7 @@ class Model implements \IteratorAggregate
         );
 
         /** @var Field $field */
-        $field = $this->factory($seed, null, Field::class);
+        $field = $this->factory($seed);
 
         return $field;
     }

--- a/tests/FieldTypesTest.php
+++ b/tests/FieldTypesTest.php
@@ -3,6 +3,7 @@
 namespace atk4\data\tests;
 
 use atk4\data\Model;
+use atk4\data\Field;
 use atk4\data\Persistence\Static_ as Persistence_Static;
 
 /**
@@ -25,7 +26,7 @@ class FieldTypesTest extends \atk4\schema\PhpunitTestCase
     public function testEmail1()
     {
         $m = new Model($this->pers);
-        $m->addField('email', \atk4\data\Field\Email::class);
+        $m->addField('email', Field\Email::class);
 
         $m->set('email', ' foo@example.com');
         $m->save();
@@ -40,8 +41,8 @@ class FieldTypesTest extends \atk4\schema\PhpunitTestCase
     public function testEmail2()
     {
         $m = new Model($this->pers);
-        $m->addField('email', [\atk4\data\Field\Email::class]);
-        $m->addField('emails', [\atk4\data\Field\Email::class, 'allow_multiple' => true]);
+        $m->addField('email', [Field\Email::class]);
+        $m->addField('emails', [Field\Email::class, 'allow_multiple' => true]);
 
         $m->set('emails', 'bar@exampe.com ,foo@example.com');
         $this->assertSame('bar@exampe.com, foo@example.com', $m->get('emails'));
@@ -53,7 +54,7 @@ class FieldTypesTest extends \atk4\schema\PhpunitTestCase
     public function testEmail3()
     {
         $m = new Model($this->pers);
-        $m->addField('email', [\atk4\data\Field\Email::class, 'dns_check' => true]);
+        $m->addField('email', [Field\Email::class, 'dns_check' => true]);
 
         $m->set('email', ' foo@gmail.com');
 
@@ -66,10 +67,10 @@ class FieldTypesTest extends \atk4\schema\PhpunitTestCase
     public function testEmail4()
     {
         $m = new Model($this->pers);
-        $m->addField('email_name', [\atk4\data\Field\Email::class, 'include_names' => true]);
-        $m->addField('email_names', [\atk4\data\Field\Email::class, 'include_names' => true, 'allow_multiple' => true, 'dns_check' => true, 'separator' => [',', ';']]);
-        $m->addField('email_idn', [\atk4\data\Field\Email::class, 'dns_check' => true]);
-        $m->addField('email', [\atk4\data\Field\Email::class]);
+        $m->addField('email_name', [Field\Email::class, 'include_names' => true]);
+        $m->addField('email_names', [Field\Email::class, 'include_names' => true, 'allow_multiple' => true, 'dns_check' => true, 'separator' => [',', ';']]);
+        $m->addField('email_idn', [Field\Email::class, 'dns_check' => true]);
+        $m->addField('email', [Field\Email::class]);
 
         $m->set('email_name', 'Romans <me@gmail.com>');
         $m->set('email_names', 'Romans1 <me1@gmail.com>, Romans2 <me2@gmail.com>; Romans3 <me3@gmail.com>');

--- a/tests/FieldTypesTest.php
+++ b/tests/FieldTypesTest.php
@@ -25,7 +25,7 @@ class FieldTypesTest extends \atk4\schema\PhpunitTestCase
     public function testEmail1()
     {
         $m = new Model($this->pers);
-        $m->addField('email', ['Email']);
+        $m->addField('email', \atk4\data\Field\Email::class);
 
         $m->set('email', ' foo@example.com');
         $m->save();
@@ -40,8 +40,8 @@ class FieldTypesTest extends \atk4\schema\PhpunitTestCase
     public function testEmail2()
     {
         $m = new Model($this->pers);
-        $m->addField('email', ['Email']);
-        $m->addField('emails', ['Email', 'allow_multiple' => true]);
+        $m->addField('email', [\atk4\data\Field\Email::class]);
+        $m->addField('emails', [\atk4\data\Field\Email::class, 'allow_multiple' => true]);
 
         $m->set('emails', 'bar@exampe.com ,foo@example.com');
         $this->assertSame('bar@exampe.com, foo@example.com', $m->get('emails'));
@@ -53,7 +53,7 @@ class FieldTypesTest extends \atk4\schema\PhpunitTestCase
     public function testEmail3()
     {
         $m = new Model($this->pers);
-        $m->addField('email', ['Email', 'dns_check' => true]);
+        $m->addField('email', [\atk4\data\Field\Email::class, 'dns_check' => true]);
 
         $m->set('email', ' foo@gmail.com');
 
@@ -66,10 +66,10 @@ class FieldTypesTest extends \atk4\schema\PhpunitTestCase
     public function testEmail4()
     {
         $m = new Model($this->pers);
-        $m->addField('email_name', ['Email', 'include_names' => true]);
-        $m->addField('email_names', ['Email', 'include_names' => true, 'allow_multiple' => true, 'dns_check' => true, 'separator' => [',', ';']]);
-        $m->addField('email_idn', ['Email', 'dns_check' => true]);
-        $m->addField('email', ['Email']);
+        $m->addField('email_name', [\atk4\data\Field\Email::class, 'include_names' => true]);
+        $m->addField('email_names', [\atk4\data\Field\Email::class, 'include_names' => true, 'allow_multiple' => true, 'dns_check' => true, 'separator' => [',', ';']]);
+        $m->addField('email_idn', [\atk4\data\Field\Email::class, 'dns_check' => true]);
+        $m->addField('email', [\atk4\data\Field\Email::class]);
 
         $m->set('email_name', 'Romans <me@gmail.com>');
         $m->set('email_names', 'Romans1 <me1@gmail.com>, Romans2 <me2@gmail.com>; Romans3 <me3@gmail.com>');

--- a/tests/FieldTypesTest.php
+++ b/tests/FieldTypesTest.php
@@ -2,8 +2,8 @@
 
 namespace atk4\data\tests;
 
-use atk4\data\Model;
 use atk4\data\Field;
+use atk4\data\Model;
 use atk4\data\Persistence\Static_ as Persistence_Static;
 
 /**


### PR DESCRIPTION
## Obsolete code example

``` php
$user->addField('mypass', ['Password']);
```

## Change to 
``` php
$user->addField('mypass', [\atk4\ui\FormField\Password::class]);
```

## More info

To fix your projects check the results of regex (for bests result use case-sensitive matching mode):

- `atk4\data\Field`
   ```
   ['"]([^'" ]+\\)?(Boolean|Callback|Email)['"]
   ```