### PR TITLE
Add separate/explicit Model::setMulti() method, Model::set() no longer accepts array

### DIFF
--- a/docs/model.rst
+++ b/docs/model.rst
@@ -517,7 +517,7 @@ Populating Data
 
         $m_x = $m;
         $m_x->unload();
-        $m_x->set($row);
+        $m_x->setMulti($row);
         $m_x->save();
         return $m_x;
 
@@ -575,21 +575,26 @@ use the following syntax when accessing fields of an active record::
 
     $m->set('name', 'John');
     $m->set('surname', 'Peter');
+    // or
+    $m->setMulti(['name' => 'John', 'surname' => 'Peter']);
 
 When you modify active record, it keeps the original value in the $dirty array:
 
-.. php:method:: set
+.. php:method:: set($field, $value)
 
     Set field to a specified value. The original value will be stored in
-    $dirty property. If you pass non-array, then the value will be assigned
-    to the :ref:`title_field`.
+    $dirty property.
 
-.. php:method:: setNull
+.. php:method:: setMulti($fields)
+
+    Set multiple field values.
+
+.. php:method:: setNull($field)
 
     Set value of a specified field to NULL, temporarily ignoring normalization routine.
     Only use this if you intend to set a correct value shortly after.
 
-.. php:method:: unset
+.. php:method:: unset($field)
 
     Restore field value to it's original::
 

--- a/docs/persistence.rst
+++ b/docs/persistence.rst
@@ -64,17 +64,12 @@ There are several ways to link your model up with the persistence::
         $m->unload();
         $m->save(['name'=>'John']);
 
-    Save, like set() support title field::
-
-        $m->unload();
-        $m->save('John');
-
 .. php:method:: tryLoad
 
     Same as load() but will silently fail if record is not found::
 
         $m->tryLoad(10);
-        $m->set($data);
+        $m->setMulti($data);
 
         $m->save();     // will either create new record or update existing
 
@@ -621,7 +616,7 @@ method altogether::
     $o = new ActiveOrder($db);
     $o->load(123);
 
-    $o->set(['is_arhived', true])->saveAs('Order');
+    $o->set('is_arhived', true)->saveAs('Order');
 
 Currently the implementation of saveAs is rather trivial, but in the future
 versions of Agile Data you may be able to do this::

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -387,8 +387,8 @@ The `$dsn` can also be using the PEAR-style DSN format, such as:
 For some persistence classes, you should use constructor directly::
 
     $array = [];
-    $array->set(1, ['name'=>'John']);
-    $array->set(2, ['name'=>'Peter']);
+    $array[1] = ['name'=>'John'];
+    $array[2] = ['name'=>'Peter'];
 
     $db = new \atk4\data\Persistence\Array_($array);
     $m = new \atk4\data\Model($db);

--- a/src/Model.php
+++ b/src/Model.php
@@ -797,11 +797,7 @@ class Model implements \IteratorAggregate
     /**
      * Helper method to call self::set() for each input array element.
      *
-     * This method does not revert the data when an exception is thrown,
-     * it is presented more for easy fix of old code which relied on self::set()
-     * to accept an array which is no longer supported.
-     *
-     * Remove in the future or revert data properly.
+     * This method does not revert the data when an exception is thrown.
      *
      * @return $this
      */

--- a/src/Model.php
+++ b/src/Model.php
@@ -636,7 +636,7 @@ class Model implements \IteratorAggregate
     }
 
     /**
-     * Will return true if any the specified field is dirty.
+     * Will return true if specified field is dirty.
      */
     public function isDirty(string $field): bool
     {

--- a/src/Model.php
+++ b/src/Model.php
@@ -368,7 +368,7 @@ class Model implements \IteratorAggregate
      */
     public function __construct($persistence = null, $defaults = [])
     {
-        if (is_string($persistence) || is_array($persistence)) {
+        if ((is_string($persistence) || is_array($persistence)) && func_num_args() === 1) {
             $defaults = $persistence;
             $persistence = null;
         }
@@ -494,12 +494,11 @@ class Model implements \IteratorAggregate
     /**
      * Adds new field into model.
      *
-     * @param string       $name
      * @param array|object $seed
      *
      * @return Field
      */
-    public function addField($name, $seed = [])
+    public function addField(string $name, $seed = [])
     {
         if (is_object($seed)) {
             $field = $seed;
@@ -601,11 +600,9 @@ class Model implements \IteratorAggregate
     /**
      * Sets which fields we will select.
      *
-     * @param array $fields
-     *
      * @return $this
      */
-    public function onlyFields($fields = [])
+    public function onlyFields(array $fields = [])
     {
         $this->hook(self::HOOK_ONLY_FIELDS, [&$fields]);
         $this->only_fields = $fields;
@@ -639,22 +636,14 @@ class Model implements \IteratorAggregate
     }
 
     /**
-     * Will return true if any of the specified fields are dirty.
-     *
-     * @param string|array $field
+     * Will return true if any the specified field is dirty.
      */
-    public function isDirty($fields = []): bool
+    public function isDirty(string $field): bool
     {
-        if (!is_array($fields)) {
-            $fields = [$fields];
-        }
+        $this->checkOnlyFieldsField($field);
 
-        foreach ($fields as $field) {
-            $this->checkOnlyFieldsField($field);
-
-            if (array_key_exists($field, $this->dirty)) {
-                return true;
-            }
+        if (array_key_exists($field, $this->dirty)) {
+            return true;
         }
 
         return false;
@@ -663,7 +652,7 @@ class Model implements \IteratorAggregate
     /**
      * @param string|array|null $filter
      *
-     * @return array
+     * @return Field[]
      */
     public function getFields($filter = null)
     {
@@ -699,21 +688,12 @@ class Model implements \IteratorAggregate
     /**
      * Set field value.
      *
-     * @param string|array $field
-     * @param mixed        $value
+     * @param mixed $value
      *
      * @return $this
      */
-    public function set($field, $value = null)
+    public function set(string $field, $value)
     {
-        if (func_num_args() === 1) {
-            foreach ($field as $key => $value) {
-                $this->set($key, $value);
-            }
-
-            return $this;
-        }
-
         $this->checkOnlyFieldsField($field);
 
         $f = $this->getField($field);
@@ -796,11 +776,9 @@ class Model implements \IteratorAggregate
     /**
      * Unset field value even if null value is not allowed.
      *
-     * @param string|array|Model $field
-     *
      * @return $this
      */
-    public function setNull($field)
+    public function setNull(string $field)
     {
         // set temporary hook to disable any normalization (null validation)
         $hookIndex = $this->onHook(self::HOOK_NORMALIZE, function () {
@@ -820,11 +798,9 @@ class Model implements \IteratorAggregate
      * Returns field value.
      * If no field is passed, then returns array of all field values.
      *
-     * @param mixed $field
-     *
      * @return mixed
      */
-    public function get($field = null)
+    public function get(string $field = null)
     {
         if ($field === null) {
             // Collect list of eligible fields
@@ -921,11 +897,9 @@ class Model implements \IteratorAggregate
     /**
      * Remove current field value and use default.
      *
-     * @param string|array $name
-     *
      * @return $this
      */
-    public function _unset($name)
+    public function _unset(string $name)
     {
         $this->checkOnlyFieldsField($name);
 
@@ -1556,7 +1530,7 @@ class Model implements \IteratorAggregate
      */
     public $_dirty_after_reload = [];
 
-    public function save($data = [], Persistence $to_persistence = null)
+    public function save(array $data = [], Persistence $to_persistence = null)
     {
         if (!$to_persistence) {
             $to_persistence = $this->persistence;
@@ -1570,8 +1544,8 @@ class Model implements \IteratorAggregate
             throw new Exception('Model is read-only and cannot be saved');
         }
 
-        if ($data) {
-            $this->set($data);
+        foreach ($data as $k => $v) {
+            $this->set($k, $v);
         }
 
         return $this->atomic(function () use ($to_persistence) {
@@ -2232,12 +2206,11 @@ class Model implements \IteratorAggregate
     /**
      * Add expression field.
      *
-     * @param string                $name
      * @param string|array|callable $expression
      *
      * @return Field\Callback
      */
-    public function addExpression($name, $expression)
+    public function addExpression(string $name, $expression)
     {
         if (!is_array($expression)) {
             $expression = ['expr' => $expression];
@@ -2258,12 +2231,11 @@ class Model implements \IteratorAggregate
     /**
      * Add expression field which will calculate its value by using callback.
      *
-     * @param string                $name
      * @param string|array|callable $expression
      *
      * @return Field\Callback
      */
-    public function addCalculatedField($name, $expression)
+    public function addCalculatedField(string $name, $expression)
     {
         if (!is_array($expression)) {
             $expression = ['expr' => $expression];

--- a/src/Model.php
+++ b/src/Model.php
@@ -803,8 +803,8 @@ class Model implements \IteratorAggregate
      */
     public function setMulti(array $fields)
     {
-        foreach ($field as $key => $value) {
-            $this->set($key, $value);
+        foreach ($fields as $field => $value) {
+            $this->set($field, $value);
         }
 
         return $this;

--- a/src/Model.php
+++ b/src/Model.php
@@ -368,7 +368,7 @@ class Model implements \IteratorAggregate
      */
     public function __construct($persistence = null, $defaults = [])
     {
-        if (is_string($persistence) || is_array($persistence)) {
+        if ((is_string($persistence) || is_array($persistence)) && func_num_args() === 1) {
             $defaults = $persistence;
             $persistence = null;
         }
@@ -494,12 +494,11 @@ class Model implements \IteratorAggregate
     /**
      * Adds new field into model.
      *
-     * @param string       $name
      * @param array|object $seed
      *
      * @return Field
      */
-    public function addField($name, $seed = [])
+    public function addField(string $name, $seed = [])
     {
         if (is_object($seed)) {
             $field = $seed;
@@ -601,11 +600,9 @@ class Model implements \IteratorAggregate
     /**
      * Sets which fields we will select.
      *
-     * @param array $fields
-     *
      * @return $this
      */
-    public function onlyFields($fields = [])
+    public function onlyFields(array $fields = [])
     {
         $this->hook(self::HOOK_ONLY_FIELDS, [&$fields]);
         $this->only_fields = $fields;
@@ -639,22 +636,14 @@ class Model implements \IteratorAggregate
     }
 
     /**
-     * Will return true if any of the specified fields are dirty.
-     *
-     * @param string|array $field
+     * Will return true if any the specified field is dirty.
      */
-    public function isDirty($fields = []): bool
+    public function isDirty(string $field): bool
     {
-        if (!is_array($fields)) {
-            $fields = [$fields];
-        }
+        $this->checkOnlyFieldsField($field);
 
-        foreach ($fields as $field) {
-            $this->checkOnlyFieldsField($field);
-
-            if (array_key_exists($field, $this->dirty)) {
-                return true;
-            }
+        if (array_key_exists($field, $this->dirty)) {
+            return true;
         }
 
         return false;
@@ -663,7 +652,7 @@ class Model implements \IteratorAggregate
     /**
      * @param string|array|null $filter
      *
-     * @return array
+     * @return Field[]
      */
     public function getFields($filter = null)
     {
@@ -699,21 +688,12 @@ class Model implements \IteratorAggregate
     /**
      * Set field value.
      *
-     * @param string|array $field
-     * @param mixed        $value
+     * @param mixed $value
      *
      * @return $this
      */
-    public function set($field, $value = null)
+    public function set(string $field, $value)
     {
-        if (func_num_args() === 1) {
-            foreach ($field as $key => $value) {
-                $this->set($key, $value);
-            }
-
-            return $this;
-        }
-
         $this->checkOnlyFieldsField($field);
 
         $f = $this->getField($field);
@@ -796,11 +776,9 @@ class Model implements \IteratorAggregate
     /**
      * Unset field value even if null value is not allowed.
      *
-     * @param string|array|Model $field
-     *
      * @return $this
      */
-    public function setNull($field)
+    public function setNull(string $field)
     {
         // set temporary hook to disable any normalization (null validation)
         $hookIndex = $this->onHook(self::HOOK_NORMALIZE, function () {
@@ -840,11 +818,9 @@ class Model implements \IteratorAggregate
      * Returns field value.
      * If no field is passed, then returns array of all field values.
      *
-     * @param mixed $field
-     *
      * @return mixed
      */
-    public function get($field = null)
+    public function get(string $field = null)
     {
         if ($field === null) {
             // Collect list of eligible fields
@@ -941,11 +917,9 @@ class Model implements \IteratorAggregate
     /**
      * Remove current field value and use default.
      *
-     * @param string|array $name
-     *
      * @return $this
      */
-    public function _unset($name)
+    public function _unset(string $name)
     {
         $this->checkOnlyFieldsField($name);
 
@@ -1576,7 +1550,7 @@ class Model implements \IteratorAggregate
      */
     public $_dirty_after_reload = [];
 
-    public function save($data = [], Persistence $to_persistence = null)
+    public function save(array $data = [], Persistence $to_persistence = null)
     {
         if (!$to_persistence) {
             $to_persistence = $this->persistence;
@@ -1590,9 +1564,7 @@ class Model implements \IteratorAggregate
             throw new Exception('Model is read-only and cannot be saved');
         }
 
-        if ($data) {
-            $this->set($data);
-        }
+        $this->setMulti($data);
 
         return $this->atomic(function () use ($to_persistence) {
             if (($errors = $this->validate('save')) !== []) {
@@ -2252,12 +2224,11 @@ class Model implements \IteratorAggregate
     /**
      * Add expression field.
      *
-     * @param string                $name
      * @param string|array|callable $expression
      *
      * @return Field\Callback
      */
-    public function addExpression($name, $expression)
+    public function addExpression(string $name, $expression)
     {
         if (!is_array($expression)) {
             $expression = ['expr' => $expression];
@@ -2278,12 +2249,11 @@ class Model implements \IteratorAggregate
     /**
      * Add expression field which will calculate its value by using callback.
      *
-     * @param string                $name
      * @param string|array|callable $expression
      *
      * @return Field\Callback
      */
-    public function addCalculatedField($name, $expression)
+    public function addCalculatedField(string $name, $expression)
     {
         if (!is_array($expression)) {
             $expression = ['expr' => $expression];

--- a/src/Model.php
+++ b/src/Model.php
@@ -817,6 +817,26 @@ class Model implements \IteratorAggregate
     }
 
     /**
+     * Helper method to call self::set() for each input array element.
+     *
+     * This method does not revert the data when an exception is thrown,
+     * it is presented more for easy fix of old code which relied on self::set()
+     * to accept an array which is no longer supported.
+     *
+     * Remove in the future or revert data properly.
+     *
+     * @return $this
+     */
+    public function setMulti(array $fields)
+    {
+        foreach ($field as $key => $value) {
+            $this->set($key, $value);
+        }
+
+        return $this;
+    }
+
+    /**
      * Returns field value.
      * If no field is passed, then returns array of all field values.
      *

--- a/tests/BusinessModelTest.php
+++ b/tests/BusinessModelTest.php
@@ -53,7 +53,7 @@ class BusinessModelTest extends AtkPhpunit\TestCase
     {
         $m = new Model();
         $this->expectException(Exception::class);
-        $m->set(['name' => 5]);
+        $m->set('name', 5);
     }
 
     public function testDirty()
@@ -178,7 +178,7 @@ class BusinessModelTest extends AtkPhpunit\TestCase
         $m->set('name', 'foo');
         $this->assertSame('foo', $m->get('name'));
 
-        $m->set(['name' => 'baz']);
+        $m->set('name', 'baz');
         $this->assertSame('baz', $m->get('name'));
     }
 
@@ -220,16 +220,6 @@ class BusinessModelTest extends AtkPhpunit\TestCase
         $m = new Model();
         $this->expectException(Exception::class);
         $m->set('', 'foo');
-    }
-
-    /**
-     * Fields can't be numeric.
-     */
-    public function testException2d()
-    {
-        $m = new Model();
-        $this->expectException(\Error::class);
-        $m->set(['foo', 'bar']);
     }
 
     public function testException3()

--- a/tests/BusinessModelTest.php
+++ b/tests/BusinessModelTest.php
@@ -53,7 +53,7 @@ class BusinessModelTest extends AtkPhpunit\TestCase
     {
         $m = new Model();
         $this->expectException(Exception::class);
-        $m->set('name', 5);
+        $m->set(['name' => 5]);
     }
 
     public function testDirty()
@@ -178,7 +178,7 @@ class BusinessModelTest extends AtkPhpunit\TestCase
         $m->set('name', 'foo');
         $this->assertSame('foo', $m->get('name'));
 
-        $m->set('name', 'baz');
+        $m->set(['name' => 'baz']);
         $this->assertSame('baz', $m->get('name'));
     }
 
@@ -228,8 +228,8 @@ class BusinessModelTest extends AtkPhpunit\TestCase
     public function testException2d()
     {
         $m = new Model();
-        $this->expectException(Exception::class);
-        $m->set('foo', 'bar');
+        $this->expectException(\Error::class);
+        $m->set(['foo', 'bar']);
     }
 
     public function testException3()

--- a/tests/BusinessModelTest.php
+++ b/tests/BusinessModelTest.php
@@ -53,7 +53,7 @@ class BusinessModelTest extends AtkPhpunit\TestCase
     {
         $m = new Model();
         $this->expectException(Exception::class);
-        $m->set(['name' => 5]);
+        $m->set('name', 5);
     }
 
     public function testDirty()
@@ -178,7 +178,7 @@ class BusinessModelTest extends AtkPhpunit\TestCase
         $m->set('name', 'foo');
         $this->assertSame('foo', $m->get('name'));
 
-        $m->set(['name' => 'baz']);
+        $m->set('name', 'baz');
         $this->assertSame('baz', $m->get('name'));
     }
 
@@ -228,8 +228,8 @@ class BusinessModelTest extends AtkPhpunit\TestCase
     public function testException2d()
     {
         $m = new Model();
-        $this->expectException(\Error::class);
-        $m->set(['foo', 'bar']);
+        $this->expectException(Exception::class);
+        $m->set('foo', 'bar');
     }
 
     public function testException3()

--- a/tests/ContainsOneTest.php
+++ b/tests/ContainsOneTest.php
@@ -142,7 +142,7 @@ class ContainsOneTest extends \atk4\schema\PhpunitTestCase
         $this->assertFalse($a->loaded());
 
         // now store some address
-        $a->set($row = ['country_id' => 1, 'address' => 'foo', 'built_date' => new \DateTime('2019-01-01 UTC'), 'tags' => ['foo', 'bar'], 'door_code' => null]);
+        $a->setMulti(['country_id' => 1, 'address' => 'foo', 'built_date' => new \DateTime('2019-01-01 UTC'), 'tags' => ['foo', 'bar'], 'door_code' => null]);
         $a->save();
 
         // now reload invoice and see if it is saved
@@ -156,7 +156,7 @@ class ContainsOneTest extends \atk4\schema\PhpunitTestCase
 
         // now add nested containsOne - DoorCode
         $c = $i->ref('addr')->ref('door_code');
-        $c->set($row = ['code' => 'ABC', 'valid_till' => new \DateTime('2019-07-01 UTC')]);
+        $c->setMulti(['code' => 'ABC', 'valid_till' => new \DateTime('2019-07-01 UTC')]);
         $c->save();
         $this->assertEquals($row, $i->ref('addr')->ref('door_code')->get());
 
@@ -202,7 +202,7 @@ class ContainsOneTest extends \atk4\schema\PhpunitTestCase
 
         // with address
         $a = $i->ref('addr');
-        $a->set($row = ['country_id' => 1, 'address' => 'foo', 'built_date' => new \DateTime('2019-01-01'), 'tags' => [], 'door_code' => null]);
+        a->setMulti(['country_id' => 1, 'address' => 'foo', 'built_date' => new \DateTime('2019-01-01'), 'tags' => [], 'door_code' => null]);
         $a->save();
 
         // now let's add one more field in address model and save

--- a/tests/ContainsOneTest.php
+++ b/tests/ContainsOneTest.php
@@ -142,7 +142,7 @@ class ContainsOneTest extends \atk4\schema\PhpunitTestCase
         $this->assertFalse($a->loaded());
 
         // now store some address
-        $a->setMulti(['country_id' => 1, 'address' => 'foo', 'built_date' => new \DateTime('2019-01-01 UTC'), 'tags' => ['foo', 'bar'], 'door_code' => null]);
+        $a->setMulti($row = ['country_id' => 1, 'address' => 'foo', 'built_date' => new \DateTime('2019-01-01 UTC'), 'tags' => ['foo', 'bar'], 'door_code' => null]);
         $a->save();
 
         // now reload invoice and see if it is saved
@@ -156,7 +156,7 @@ class ContainsOneTest extends \atk4\schema\PhpunitTestCase
 
         // now add nested containsOne - DoorCode
         $c = $i->ref('addr')->ref('door_code');
-        $c->setMulti(['code' => 'ABC', 'valid_till' => new \DateTime('2019-07-01 UTC')]);
+        $c->setMulti($row = ['code' => 'ABC', 'valid_till' => new \DateTime('2019-07-01 UTC')]);
         $c->save();
         $this->assertEquals($row, $i->ref('addr')->ref('door_code')->get());
 
@@ -202,7 +202,7 @@ class ContainsOneTest extends \atk4\schema\PhpunitTestCase
 
         // with address
         $a = $i->ref('addr');
-        $a->setMulti(['country_id' => 1, 'address' => 'foo', 'built_date' => new \DateTime('2019-01-01'), 'tags' => [], 'door_code' => null]);
+        $a->setMulti($row = ['country_id' => 1, 'address' => 'foo', 'built_date' => new \DateTime('2019-01-01'), 'tags' => [], 'door_code' => null]);
         $a->save();
 
         // now let's add one more field in address model and save

--- a/tests/ContainsOneTest.php
+++ b/tests/ContainsOneTest.php
@@ -202,7 +202,7 @@ class ContainsOneTest extends \atk4\schema\PhpunitTestCase
 
         // with address
         $a = $i->ref('addr');
-        a->setMulti(['country_id' => 1, 'address' => 'foo', 'built_date' => new \DateTime('2019-01-01'), 'tags' => [], 'door_code' => null]);
+        $a->setMulti(['country_id' => 1, 'address' => 'foo', 'built_date' => new \DateTime('2019-01-01'), 'tags' => [], 'door_code' => null]);
         $a->save();
 
         // now let's add one more field in address model and save

--- a/tests/ContainsOneTest.php
+++ b/tests/ContainsOneTest.php
@@ -142,7 +142,10 @@ class ContainsOneTest extends \atk4\schema\PhpunitTestCase
         $this->assertFalse($a->loaded());
 
         // now store some address
-        $a->set($row = ['country_id' => 1, 'address' => 'foo', 'built_date' => new \DateTime('2019-01-01 UTC'), 'tags' => ['foo', 'bar'], 'door_code' => null]);
+        $row = ['country_id' => 1, 'address' => 'foo', 'built_date' => new \DateTime('2019-01-01 UTC'), 'tags' => ['foo', 'bar'], 'door_code' => null];
+        foreach ($row as $k => $v) {
+            $a->set($k, $v);
+        }
         $a->save();
 
         // now reload invoice and see if it is saved
@@ -156,7 +159,10 @@ class ContainsOneTest extends \atk4\schema\PhpunitTestCase
 
         // now add nested containsOne - DoorCode
         $c = $i->ref('addr')->ref('door_code');
-        $c->set($row = ['code' => 'ABC', 'valid_till' => new \DateTime('2019-07-01 UTC')]);
+        $row = ['code' => 'ABC', 'valid_till' => new \DateTime('2019-07-01 UTC')];
+        foreach ($row as $k => $v) {
+            $c->set($k, $v);
+        }
         $c->save();
         $this->assertEquals($row, $i->ref('addr')->ref('door_code')->get());
 
@@ -202,7 +208,10 @@ class ContainsOneTest extends \atk4\schema\PhpunitTestCase
 
         // with address
         $a = $i->ref('addr');
-        $a->set($row = ['country_id' => 1, 'address' => 'foo', 'built_date' => new \DateTime('2019-01-01'), 'tags' => [], 'door_code' => null]);
+        $row = ['country_id' => 1, 'address' => 'foo', 'built_date' => new \DateTime('2019-01-01'), 'tags' => [], 'door_code' => null];
+        foreach ($row as $k => $v) {
+            $a->set($k, $v);
+        }
         $a->save();
 
         // now let's add one more field in address model and save

--- a/tests/ContainsOneTest.php
+++ b/tests/ContainsOneTest.php
@@ -142,10 +142,7 @@ class ContainsOneTest extends \atk4\schema\PhpunitTestCase
         $this->assertFalse($a->loaded());
 
         // now store some address
-        $row = ['country_id' => 1, 'address' => 'foo', 'built_date' => new \DateTime('2019-01-01 UTC'), 'tags' => ['foo', 'bar'], 'door_code' => null];
-        foreach ($row as $k => $v) {
-            $a->set($k, $v);
-        }
+        $a->set($row = ['country_id' => 1, 'address' => 'foo', 'built_date' => new \DateTime('2019-01-01 UTC'), 'tags' => ['foo', 'bar'], 'door_code' => null]);
         $a->save();
 
         // now reload invoice and see if it is saved
@@ -159,10 +156,7 @@ class ContainsOneTest extends \atk4\schema\PhpunitTestCase
 
         // now add nested containsOne - DoorCode
         $c = $i->ref('addr')->ref('door_code');
-        $row = ['code' => 'ABC', 'valid_till' => new \DateTime('2019-07-01 UTC')];
-        foreach ($row as $k => $v) {
-            $c->set($k, $v);
-        }
+        $c->set($row = ['code' => 'ABC', 'valid_till' => new \DateTime('2019-07-01 UTC')]);
         $c->save();
         $this->assertEquals($row, $i->ref('addr')->ref('door_code')->get());
 
@@ -208,10 +202,7 @@ class ContainsOneTest extends \atk4\schema\PhpunitTestCase
 
         // with address
         $a = $i->ref('addr');
-        $row = ['country_id' => 1, 'address' => 'foo', 'built_date' => new \DateTime('2019-01-01'), 'tags' => [], 'door_code' => null];
-        foreach ($row as $k => $v) {
-            $a->set($k, $v);
-        }
+        $a->set($row = ['country_id' => 1, 'address' => 'foo', 'built_date' => new \DateTime('2019-01-01'), 'tags' => [], 'door_code' => null]);
         $a->save();
 
         // now let's add one more field in address model and save

--- a/tests/PersistentArrayOfStringsTest.php
+++ b/tests/PersistentArrayOfStringsTest.php
@@ -37,7 +37,7 @@ class PersistentArrayOfStringsTest extends AtkPhpunit\TestCase
         $m->addField('array', ['type' => 'array']);
         $m->addField('object', ['type' => 'object']);
 
-        foreach ([
+        $m->set([
             'string' => "Two\r\nLines  ",
             'text' => "Two\r\nLines  ",
             'integer' => 123,
@@ -50,9 +50,7 @@ class PersistentArrayOfStringsTest extends AtkPhpunit\TestCase
             'time' => new \DateTime('2019-01-20T12:23:34+00:00'),
             'array' => ['foo' => 'bar', 'int' => 123, 'rows' => ['a', 'b']],
             'object' => (object) ['foo' => 'bar', 'int' => 123, 'rows' => ['a', 'b']],
-        ] as $k => $v) {
-            $m->set($k, $v);
-        }
+        ]);
         $m->saveAndUnload();
 
         // no typecasting option set in export()

--- a/tests/PersistentArrayOfStringsTest.php
+++ b/tests/PersistentArrayOfStringsTest.php
@@ -37,7 +37,7 @@ class PersistentArrayOfStringsTest extends AtkPhpunit\TestCase
         $m->addField('array', ['type' => 'array']);
         $m->addField('object', ['type' => 'object']);
 
-        $m->set([
+        foreach ([
             'string' => "Two\r\nLines  ",
             'text' => "Two\r\nLines  ",
             'integer' => 123,
@@ -50,7 +50,9 @@ class PersistentArrayOfStringsTest extends AtkPhpunit\TestCase
             'time' => new \DateTime('2019-01-20T12:23:34+00:00'),
             'array' => ['foo' => 'bar', 'int' => 123, 'rows' => ['a', 'b']],
             'object' => (object) ['foo' => 'bar', 'int' => 123, 'rows' => ['a', 'b']],
-        ]);
+        ] as $k => $v) {
+            $m->set($k, $v);
+        }
         $m->saveAndUnload();
 
         // no typecasting option set in export()

--- a/tests/PersistentArrayOfStringsTest.php
+++ b/tests/PersistentArrayOfStringsTest.php
@@ -37,7 +37,7 @@ class PersistentArrayOfStringsTest extends AtkPhpunit\TestCase
         $m->addField('array', ['type' => 'array']);
         $m->addField('object', ['type' => 'object']);
 
-        $m->set([
+        $m->setMulti([
             'string' => "Two\r\nLines  ",
             'text' => "Two\r\nLines  ",
             'integer' => 123,

--- a/tests/PersistentArrayTest.php
+++ b/tests/PersistentArrayTest.php
@@ -145,7 +145,8 @@ class PersistentArrayTest extends AtkPhpunit\TestCase
         ], $this->getInternalPersistenceData($p));
 
         $m->unload();
-        $m->set(['name' => 'Foo', 'surname' => 'Bar']);
+        $m->set('name', 'Foo');
+        $m->set('surname', 'Bar');
         $m->save();
 
         $this->assertEquals([

--- a/tests/PersistentArrayTest.php
+++ b/tests/PersistentArrayTest.php
@@ -145,7 +145,7 @@ class PersistentArrayTest extends AtkPhpunit\TestCase
         ], $this->getInternalPersistenceData($p));
 
         $m->unload();
-        $m->set(['name' => 'Foo', 'surname' => 'Bar']);
+        $m->setMulti(['name' => 'Foo', 'surname' => 'Bar']);
         $m->save();
 
         $this->assertEquals([

--- a/tests/PersistentArrayTest.php
+++ b/tests/PersistentArrayTest.php
@@ -145,8 +145,7 @@ class PersistentArrayTest extends AtkPhpunit\TestCase
         ], $this->getInternalPersistenceData($p));
 
         $m->unload();
-        $m->set('name', 'Foo');
-        $m->set('surname', 'Bar');
+        $m->set(['name' => 'Foo', 'surname' => 'Bar']);
         $m->save();
 
         $this->assertEquals([

--- a/tests/TransactionTest.php
+++ b/tests/TransactionTest.php
@@ -129,8 +129,7 @@ class TransactionTest extends \atk4\schema\PhpunitTestCase
         });
 
         // this will fail because field foo is not in DB and call onRollback hook
-        $m->set('name', 'Jane');
-        $m->set('foo', 'bar');
+        $m->set(['name' => 'Jane', 'foo' => 'bar']);
         $m->save();
 
         $this->assertTrue($hook_called);

--- a/tests/TransactionTest.php
+++ b/tests/TransactionTest.php
@@ -129,7 +129,8 @@ class TransactionTest extends \atk4\schema\PhpunitTestCase
         });
 
         // this will fail because field foo is not in DB and call onRollback hook
-        $m->set(['name' => 'Jane', 'foo' => 'bar']);
+        $m->set('name', 'Jane');
+        $m->set('foo', 'bar');
         $m->save();
 
         $this->assertTrue($hook_called);

--- a/tests/TransactionTest.php
+++ b/tests/TransactionTest.php
@@ -129,7 +129,7 @@ class TransactionTest extends \atk4\schema\PhpunitTestCase
         });
 
         // this will fail because field foo is not in DB and call onRollback hook
-        $m->set(['name' => 'Jane', 'foo' => 'bar']);
+        $m->setMulti(['name' => 'Jane', 'foo' => 'bar']);
         $m->save();
 
         $this->assertTrue($hook_called);

--- a/tests/TypecastingTest.php
+++ b/tests/TypecastingTest.php
@@ -129,7 +129,7 @@ class TypecastingTest extends \atk4\schema\PhpunitTestCase
 
         $a = [
             'types' => [
-                1 => $v = [
+                1 => $row = [
                     'id' => 1,
                     'string' => '',
                     'notype' => '',
@@ -178,8 +178,8 @@ class TypecastingTest extends \atk4\schema\PhpunitTestCase
         $this->assertNull($m->get('array'));
         $this->assertNull($m->get('object'));
 
-        unset($v['id']);
-        $m->set($v);
+        unset($row['id']);
+        $m->setMulti($row);
 
         $this->assertSame('', $m->get('string'));
         $this->assertSame('', $m->get('notype'));
@@ -225,7 +225,7 @@ class TypecastingTest extends \atk4\schema\PhpunitTestCase
 
         $a = [
             'test' => [
-                1 => $v = ['id' => '1', 'a' => 1, 'b' => '', 'c' => null],
+                1 => $row = ['id' => '1', 'a' => 1, 'b' => '', 'c' => null],
             ],
         ];
         $this->setDb($a);
@@ -236,11 +236,11 @@ class TypecastingTest extends \atk4\schema\PhpunitTestCase
         $m->addField('b');
         $m->addField('c');
 
-        unset($v['id']);
-        $m->set($v);
+        unset($row['id']);
+        $m->setMulti($row);
         $m->save();
 
-        $a['test'][2] = array_merge(['id' => '2'], $v);
+        $a['test'][2] = array_merge(['id' => '2'], $row);
 
         $this->assertEquals($a, $this->getDb());
     }

--- a/tests/TypecastingTest.php
+++ b/tests/TypecastingTest.php
@@ -129,7 +129,7 @@ class TypecastingTest extends \atk4\schema\PhpunitTestCase
 
         $a = [
             'types' => [
-                1 => $row = [
+                1 => $v = [
                     'id' => 1,
                     'string' => '',
                     'notype' => '',
@@ -178,10 +178,8 @@ class TypecastingTest extends \atk4\schema\PhpunitTestCase
         $this->assertNull($m->get('array'));
         $this->assertNull($m->get('object'));
 
-        unset($row['id']);
-        foreach ($row as $k => $v) {
-            $m->set($k, $v);
-        }
+        unset($v['id']);
+        $m->set($v);
 
         $this->assertSame('', $m->get('string'));
         $this->assertSame('', $m->get('notype'));
@@ -227,7 +225,7 @@ class TypecastingTest extends \atk4\schema\PhpunitTestCase
 
         $a = [
             'test' => [
-                1 => $row = ['id' => '1', 'a' => 1, 'b' => '', 'c' => null],
+                1 => $v = ['id' => '1', 'a' => 1, 'b' => '', 'c' => null],
             ],
         ];
         $this->setDb($a);
@@ -238,13 +236,11 @@ class TypecastingTest extends \atk4\schema\PhpunitTestCase
         $m->addField('b');
         $m->addField('c');
 
-        unset($row['id']);
-        foreach ($row as $k => $v) {
-            $m->set($k, $v);
-        }
+        unset($v['id']);
+        $m->set($v);
         $m->save();
 
-        $a['test'][2] = array_merge(['id' => '2'], $row);
+        $a['test'][2] = array_merge(['id' => '2'], $v);
 
         $this->assertEquals($a, $this->getDb());
     }

--- a/tests/TypecastingTest.php
+++ b/tests/TypecastingTest.php
@@ -129,7 +129,7 @@ class TypecastingTest extends \atk4\schema\PhpunitTestCase
 
         $a = [
             'types' => [
-                1 => $v = [
+                1 => $row = [
                     'id' => 1,
                     'string' => '',
                     'notype' => '',
@@ -178,8 +178,10 @@ class TypecastingTest extends \atk4\schema\PhpunitTestCase
         $this->assertNull($m->get('array'));
         $this->assertNull($m->get('object'));
 
-        unset($v['id']);
-        $m->set($v);
+        unset($row['id']);
+        foreach ($row as $k => $v) {
+            $m->set($k, $v);
+        }
 
         $this->assertSame('', $m->get('string'));
         $this->assertSame('', $m->get('notype'));
@@ -225,7 +227,7 @@ class TypecastingTest extends \atk4\schema\PhpunitTestCase
 
         $a = [
             'test' => [
-                1 => $v = ['id' => '1', 'a' => 1, 'b' => '', 'c' => null],
+                1 => $row = ['id' => '1', 'a' => 1, 'b' => '', 'c' => null],
             ],
         ];
         $this->setDb($a);
@@ -236,11 +238,13 @@ class TypecastingTest extends \atk4\schema\PhpunitTestCase
         $m->addField('b');
         $m->addField('c');
 
-        unset($v['id']);
-        $m->set($v);
+        unset($row['id']);
+        foreach ($row as $k => $v) {
+            $m->set($k, $v);
+        }
         $m->save();
 
-        $a['test'][2] = array_merge(['id' => '2'], $v);
+        $a['test'][2] = array_merge(['id' => '2'], $row);
 
         $this->assertEquals($a, $this->getDb());
     }


### PR DESCRIPTION
merge after https://github.com/atk4/ui/pull/1364

No method should accept different dimenisonality of the input data.