### PR TITLE
Fix generated caption for anonymous classes

### DIFF
--- a/src/Model.php
+++ b/src/Model.php
@@ -872,7 +872,9 @@ class Model implements \IteratorAggregate
      */
     public function getModelCaption()
     {
-        return $this->caption ?: $this->readableCaption(static::class);
+        return $this->caption ?: $this->readableCaption(
+            strpos(static::class, 'class@anonymous') === 0 ? get_parent_class(static::class) : static::class
+        );
     }
 
     /**


### PR DESCRIPTION
Table name can be secret, so we should not use it as a fallback data