### PR TITLE
Move record related to separate Record class

### DIFF
--- a/src/Model.php
+++ b/src/Model.php
@@ -224,7 +224,7 @@ class Model implements \IteratorAggregate
      *
      * @var array
      */
-    public $data = [];
+    // mapped to $this->_recordProps['data'] public $data = [];
 
     /**
      * After loading an active record from DataSet it will be stored in
@@ -240,7 +240,15 @@ class Model implements \IteratorAggregate
      *
      * @var array
      */
-    public $dirty = [];
+    // mapped to $this->_recordProps['dirty'] public $dirty = [];
+
+    /**
+     * Contains ID of the current record. If the value is null then the record
+     * is considered to be new.
+     *
+     * @var mixed
+     */
+    // mapped to $this->_recordProps['id'] public $id;
 
     /**
      * Setting model as read_only will protect you from accidentally
@@ -253,14 +261,6 @@ class Model implements \IteratorAggregate
      * @var bool
      */
     public $read_only = false;
-
-    /**
-     * Contains ID of the current record. If the value is null then the record
-     * is considered to be new.
-     *
-     * @var mixed
-     */
-    public $id;
 
     /**
      * While in most cases your id field will be called 'id', sometimes
@@ -2273,6 +2273,55 @@ class Model implements \IteratorAggregate
         }
 
         return $this->addField($name, new Field\Callback($expression));
+    }
+
+    // }}}
+
+    // {{{ Record related methods
+
+    /** array Values for record related magic properties */
+    private $_recordProps = [
+        'data' => [],
+        'dirty' => [],
+        'id' => null,
+    ];
+
+    public function __isset(string $name): bool
+    {
+        if (array_key_exists($name, $this->_recordProps)) {
+            return true;
+        }
+
+        return isset($this->{$name}); // default behaviour
+    }
+
+    public function &__get(string $name)
+    {
+        if (array_key_exists($name, $this->_recordProps)) {
+            return $this->_recordProps[$name];
+        }
+
+        return $this->{$name}; // default behaviour
+    }
+
+    public function __set(string $name, $value): void
+    {
+        if (array_key_exists($name, $this->_recordProps)) {
+            $this->_recordProps[$name] = $value;
+
+            return;
+        }
+
+        $this->{$name} = $value; // default behaviour
+    }
+
+    public function __unset(string $name): void
+    {
+        if (array_key_exists($name, $this->_recordProps)) {
+            throw new Exception('Record related magic properties are not allowed to be unset');
+        }
+
+        unset($this->{$name}); // default behaviour
     }
 
     // }}}

--- a/src/Model.php
+++ b/src/Model.php
@@ -1200,7 +1200,10 @@ class Model implements \IteratorAggregate
             return $ret;
         }
 
-        return $this;
+        $this->_record = $this->createRecord();
+        $this->_record->id = $this->id;
+
+        return $this->_record;
     }
 
     /**
@@ -1213,7 +1216,7 @@ class Model implements \IteratorAggregate
         $id = $this->id;
         $this->unload();
 
-        return $this->load($id);
+        return $this->load($id)->_model;
     }
 
     /**

--- a/src/Record.php
+++ b/src/Record.php
@@ -1,0 +1,102 @@
+<?php
+
+declare(strict_types=1);
+
+namespace atk4\data;
+
+/**
+ * Currently very coupled with Model, but all record related/loaded data should be stored here.
+ */
+class Record
+{
+    /** @var Model To be used from Model class only, later remove in advance of WeakMap in model */
+    private $_model;
+
+    /**
+     * @param mixed $id
+     */
+    public function __construct(Model $model, $id = null)
+    {
+        $this->_model = $model;
+
+        $isNew = func_num_args() === 1;
+    }
+
+    // {{{ Model related magic methods - map unported properties/methods to owning model
+
+    public function __isset(string $name): bool
+    {
+        if (!property_exists($this, $name) && $this->_model->__isset($name)) {
+            return true;
+        }
+
+        return isset($this->{$name});
+    }
+
+    /**
+     * @return mixed
+     */
+    public function &__get(string $name)
+    {
+        if (!property_exists($this, $name) && $this->_model->__isset($name)) {
+            $model = $this->_model;
+
+            return \Closure::bind(static function &() use ($model, $name) {
+                return $model->{$name};
+            }, null, $model)();
+        }
+
+        return $this->{$name};
+    }
+
+    /**
+     * @param mixed $value
+     */
+    public function __set(string $name, $value): void
+    {
+        if (!property_exists($this, $name) && $this->_model->__isset($name)) {
+            $model = $this->_model;
+
+            \Closure::bind(static function () use ($model, $name, $value) {
+                $model->{$name} = $value;
+            }, null, $model)();
+
+            return;
+        }
+
+        $this->{$name} = $value;
+    }
+
+    public function __unset(string $name): void
+    {
+        if (!property_exists($this, $name) && $this->_model->__isset($name)) {
+            throw new Exception('Model related magic properties are not allowed to be unset');
+        }
+
+        unset($this->{$name});
+    }
+
+    /**
+     * @return mixed
+     */
+    public function __call(string $name, $args)
+    {
+        $nameMigr = '_migrtorecord_' . $name;
+        if (method_exists($this->_model, $nameMigr)) {
+            $name = $nameMigr;
+        }
+        unset($nameMigr);
+
+        if (method_exists($this->_model, $name)) {
+            $model = $this->_model;
+
+            return \Closure::bind(static function () use ($model, $name, $args) {
+                return $model->{$name}(...$args);
+            }, null, $model)();
+        }
+
+        throw new Exception('Method "' . $name . '" does not exist');
+    }
+
+    // }}}
+}

--- a/tests/DeepCopyTest.php
+++ b/tests/DeepCopyTest.php
@@ -220,7 +220,7 @@ class DeepCopyTest extends \atk4\schema\PhpunitTestCase
 
         $dc = new DeepCopy();
         $client3 = $dc
-            ->from((new DcClient($this->db))->load(1))
+            ->from((new DcClient($this->db))->load(1)->_model)
             ->to(new DcClient())
             ->with([
                 // Invoices are copied, but unless we also copy lines, totals won't be there!


### PR DESCRIPTION
I prepared Model to be splitted between Model and Record. All Model properties/methods are also available virtually thru Record. Full BC, all unit tests are passing.

The goal is to separate row/record data from model - see last commit - one very simple example how load() will return data later - a Record, instead of Model. This is "still softly BC" (because all properties/methods can fallback to Model) except the returned object is no longer instance of Model (thus it can not be passed to methods when Model type is expected in their declaration).

Later, we can isolate the Model/Record logic even more to some manager and make Models more like immutable objects - data sources with defined source and conditions.

also Model foreach should return a Record then