### PR TITLE
Rename BasicCondition to Condition

### DIFF
--- a/docs/conditions.rst
+++ b/docs/conditions.rst
@@ -259,7 +259,7 @@ Model Scope
 -----------
 
 Using the Model::addCondition method is the basic way to limit the model scope of records. Under the hood
-Agile Data utilizes a special set of classes (BasicCondition and CompoundCondition) to apply the conditions as filters on records retrieved.
+Agile Data utilizes a special set of classes (Condition and CompoundCondition) to apply the conditions as filters on records retrieved.
 These classes can be used directly and independently from Model class.
 
 .. php:method:: scope()
@@ -270,9 +270,9 @@ This method provides access to the model scope enabling conditions to be added::
 
 .. php:namespace:: atk4\data\Model\Scope
 
-.. php:class:: BasicCondition
+.. php:class:: Condition
 
-BasicCondition represents a simple condition in a form [field, operation, value], similar to the functionality of the 
+Condition represents a simple condition in a form [field, operation, value], similar to the functionality of the 
 Model::addCondition method
 
 .. php:method:: __construct($key, $operator = null, $value = null);
@@ -290,11 +290,11 @@ If $value is omitted as argument then $operator is considered as $value and '=' 
 Negates the condition, e.g::
 
 	// results in 'name is not John'
-	$condition = (new BasicCondition('name', 'John'))->negate(); 
+	$condition = (new Condition('name', 'John'))->negate(); 
 
 .. php:method:: on(Model $model);
 
-Sets the model of BasicCondition to a clone of $model to avoid changes to the original object.::
+Sets the model of Condition to a clone of $model to avoid changes to the original object.::
 
    // uses the $contact model to conver the condition to human readable words
    $condition->toWords($contact);
@@ -304,32 +304,32 @@ Sets the model of BasicCondition to a clone of $model to avoid changes to the or
 Converts the condition object to human readable words. Model must be set first::
 
 	// results in 'Contact where Name is John'
-	(new BasicCondition('name', 'John'))->toWords($contactModel); 
+	(new Condition('name', 'John'))->toWords($contactModel); 
 
 .. php:class:: CompoundCondition
 
-CompoundCondition object has a single defined junction (AND or OR) and can contain multiple nested BasicCondition and/or CompoundCondition objects referred to as nested conditions.
+CompoundCondition object has a single defined junction (AND or OR) and can contain multiple nested Condition and/or CompoundCondition objects referred to as nested conditions.
 This makes creating Model scopes with deep nested conditions possible, 
 e.g ((Name like 'ABC%' and Country = 'US') or (Name like 'CDE%' and (Country = 'DE' or Surname = 'XYZ')))
 
-CompoundCondition can be created using new CompoundCondition() statement from an array or joining BasicCondition objects::
+CompoundCondition can be created using new CompoundCondition() statement from an array or joining Condition objects::
 
    // $condition1 will be used as child-component
-	$condition1 = new BasicCondition('name', 'like', 'ABC%');
+	$condition1 = new Condition('name', 'like', 'ABC%');
    
    // $condition2 will be used as child-component
-	$condition2 = new BasicCondition('country', 'US');
+	$condition2 = new Condition('country', 'US');
 	
    // $compoundCondition1 is created using AND as junction and $condition1 and $condition2 as nested conditions
 	$compoundCondition1 = CompoundCondition::createAnd($condition1, $condition2);
 	
-	$condition3 = new BasicCondition('country', 'DE');
-	$condition4 = new BasicCondition('surname', 'XYZ');
+	$condition3 = new Condition('country', 'DE');
+	$condition4 = new Condition('surname', 'XYZ');
 	
    // $compoundCondition2 is created using OR as junction and $condition3 and $condition4 as nested conditions
 	$compoundCondition2 = CompoundCondition::createOr($condition3, $condition4);
 
-	$condition5 = new BasicCondition('name', 'like', 'CDE%');
+	$condition5 = new Condition('name', 'like', 'CDE%');
 	
    // $compoundCondition3 is created using AND as junction and $condition5 and $compoundCondition2 as nested conditions
 	$compoundCondition3 = CompoundCondition::createAnd($condition5, $compoundCondition2);

--- a/src/Action/Iterator.php
+++ b/src/Action/Iterator.php
@@ -101,7 +101,7 @@ class Iterator
         $match = false;
 
         // simple condition
-        if ($condition instanceof Model\Scope\BasicCondition) {
+        if ($condition instanceof Model\Scope\Condition) {
             $args = $condition->toQueryArguments();
 
             $field = $args[0];

--- a/src/Model/Scope/CompoundCondition.php
+++ b/src/Model/Scope/CompoundCondition.php
@@ -41,14 +41,14 @@ class CompoundCondition extends AbstractCondition
         $this->junction = $junction;
 
         foreach ($nestedConditions as $nestedCondition) {
-            $nestedCondition = is_string($nestedCondition) ? new BasicCondition($nestedCondition) : $nestedCondition;
+            $nestedCondition = is_string($nestedCondition) ? new Condition($nestedCondition) : $nestedCondition;
 
             if (is_array($nestedCondition)) {
                 // array of OR nested conditions
                 if (count($nestedCondition) === 1 && isset($nestedCondition[0]) && is_array($nestedCondition[0])) {
                     $nestedCondition = new self($nestedCondition[0], self::OR);
                 } else {
-                    $nestedCondition = new BasicCondition(...$nestedCondition);
+                    $nestedCondition = new Condition(...$nestedCondition);
                 }
             }
 

--- a/src/Model/Scope/Condition.php
+++ b/src/Model/Scope/Condition.php
@@ -11,7 +11,7 @@ use atk4\data\Model;
 use atk4\dsql\Expression;
 use atk4\dsql\Expressionable;
 
-class BasicCondition extends AbstractCondition
+class Condition extends AbstractCondition
 {
     use ReadableCaptionTrait;
 

--- a/src/Persistence/Sql.php
+++ b/src/Persistence/Sql.php
@@ -366,7 +366,7 @@ class Sql extends Persistence
             $condition = $condition->simplify();
 
             // simple condition
-            if ($condition instanceof Model\Scope\BasicCondition) {
+            if ($condition instanceof Model\Scope\Condition) {
                 $query = $query->where(...$condition->toQueryArguments());
             }
 

--- a/tests/ScopeTest.php
+++ b/tests/ScopeTest.php
@@ -5,8 +5,8 @@ declare(strict_types=1);
 namespace atk4\data\tests;
 
 use atk4\data\Model;
-use atk4\data\Model\Scope\BasicCondition;
 use atk4\data\Model\Scope\CompoundCondition;
+use atk4\data\Model\Scope\Condition;
 use atk4\dsql\Expression;
 
 class SCountry extends Model
@@ -123,7 +123,7 @@ class ScopeTest extends \atk4\schema\PhpunitTestCase
     {
         $user = clone $this->user;
 
-        $condition = new BasicCondition('name', 'John');
+        $condition = new Condition('name', 'John');
 
         $user->scope()->add($condition);
 
@@ -136,37 +136,37 @@ class ScopeTest extends \atk4\schema\PhpunitTestCase
     {
         $user = clone $this->user;
 
-        $condition = new BasicCondition(new Expression('false'));
+        $condition = new Condition(new Expression('false'));
 
         $this->assertEquals('expression \'false\'', $condition->toWords($user));
 
-        $condition = new BasicCondition('country_id/code', 'US');
+        $condition = new Condition('country_id/code', 'US');
 
         $this->assertEquals('User that has reference Country Id where Code is equal to \'US\'', $condition->toWords($user));
 
-        $condition = new BasicCondition('country_id', 2);
+        $condition = new Condition('country_id', 2);
 
         $this->assertEquals('Country Id is equal to \'Latvia\'', $condition->toWords($user));
 
         if ($this->driverType == 'sqlite') {
-            $condition = new BasicCondition('name', $user->expr('[surname]'));
+            $condition = new Condition('name', $user->expr('[surname]'));
 
             $this->assertEquals('Name is equal to expression \'"user"."surname"\'', $condition->toWords($user));
         }
 
-        $condition = new BasicCondition('country_id', null);
+        $condition = new Condition('country_id', null);
 
         $this->assertEquals('Country Id is equal to empty', $condition->toWords($user));
 
-        $condition = new BasicCondition('name', '>', 'Test');
+        $condition = new Condition('name', '>', 'Test');
 
         $this->assertEquals('Name is greater than \'Test\'', $condition->toWords($user));
 
-        $condition = (new BasicCondition('country_id', 2))->negate();
+        $condition = (new Condition('country_id', 2))->negate();
 
         $this->assertEquals('Country Id is not equal to \'Latvia\'', $condition->toWords($user));
 
-        $condition = new BasicCondition($user->getField('surname'), $user->getField('name'));
+        $condition = new Condition($user->getField('surname'), $user->getField('name'));
 
         $this->assertEquals('Surname is equal to User Name', $condition->toWords($user));
 
@@ -275,11 +275,11 @@ class ScopeTest extends \atk4\schema\PhpunitTestCase
     {
         $user = clone $this->user;
 
-        $condition1 = new BasicCondition('name', 'John');
-        $condition2 = new BasicCondition('country_code', 'CA');
+        $condition1 = new Condition('name', 'John');
+        $condition2 = new Condition('country_code', 'CA');
 
-        $condition3 = new BasicCondition('surname', 'Doe');
-        $condition4 = new BasicCondition('country_code', 'LV');
+        $condition3 = new Condition('surname', 'Doe');
+        $condition4 = new Condition('country_code', 'LV');
 
         $compoundCondition1 = CompoundCondition::createAnd($condition1, $condition2);
         $compoundCondition2 = CompoundCondition::createAnd($condition3, $condition4);
@@ -315,11 +315,11 @@ class ScopeTest extends \atk4\schema\PhpunitTestCase
     {
         $user = clone $this->user;
 
-        $condition1 = new BasicCondition('name', 'Alain');
-        $condition2 = new BasicCondition('country_code', 'CA');
+        $condition1 = new Condition('name', 'Alain');
+        $condition2 = new Condition('country_code', 'CA');
 
         $compoundCondition1 = CompoundCondition::createAnd($condition1, $condition2);
-        $condition3 = (new BasicCondition('surname', 'Prost'))->negate();
+        $condition3 = (new Condition('surname', 'Prost'))->negate();
 
         $compoundCondition = CompoundCondition::createAnd($compoundCondition1, $condition3);
 
@@ -330,8 +330,8 @@ class ScopeTest extends \atk4\schema\PhpunitTestCase
     {
         $user = clone $this->user;
 
-        $condition1 = new BasicCondition('name', '!=', 'Alain');
-        $condition2 = new BasicCondition('country_code', '!=', 'FR');
+        $condition1 = new Condition('name', '!=', 'Alain');
+        $condition2 = new Condition('country_code', '!=', 'FR');
 
         $condition = CompoundCondition::createOr($condition1, $condition2)->negate();
 
@@ -346,12 +346,12 @@ class ScopeTest extends \atk4\schema\PhpunitTestCase
     {
         $user = clone $this->user;
 
-        $condition1 = new BasicCondition('name', 'Alain');
-        $condition2 = new BasicCondition('country_code', 'FR');
+        $condition1 = new Condition('name', 'Alain');
+        $condition2 = new Condition('country_code', 'FR');
 
         $compoundCondition = CompoundCondition::createAnd($condition1, $condition2);
 
-        $compoundCondition = CompoundCondition::createOr($compoundCondition, new BasicCondition('name', 'John'));
+        $compoundCondition = CompoundCondition::createOr($compoundCondition, new Condition('name', 'John'));
 
         $this->assertEquals('(Name is equal to \'Alain\' and Code is equal to \'FR\') or Name is equal to \'John\'', $compoundCondition->toWords($user));
     }
@@ -360,12 +360,12 @@ class ScopeTest extends \atk4\schema\PhpunitTestCase
     {
         $user = clone $this->user;
 
-        $condition1 = new BasicCondition('name', 'Alain');
-        $condition2 = new BasicCondition('country_code', 'FR');
+        $condition1 = new Condition('name', 'Alain');
+        $condition2 = new Condition('country_code', 'FR');
 
         $compoundCondition = CompoundCondition::createOr($condition1, $condition2);
 
-        $compoundCondition = CompoundCondition::createAnd($compoundCondition, new BasicCondition('name', 'John'));
+        $compoundCondition = CompoundCondition::createAnd($compoundCondition, new Condition('name', 'John'));
 
         $this->assertEquals('(Name is equal to \'Alain\' or Code is equal to \'FR\') and Name is equal to \'John\'', $compoundCondition->toWords($user));
     }
@@ -374,8 +374,8 @@ class ScopeTest extends \atk4\schema\PhpunitTestCase
     {
         $user = clone $this->user;
 
-        $condition1 = new BasicCondition('name', 'Alain');
-        $condition2 = new BasicCondition('country_code', 'FR');
+        $condition1 = new Condition('name', 'Alain');
+        $condition2 = new Condition('country_code', 'FR');
 
         $compoundCondition = CompoundCondition::createAnd($condition1, $condition2);
 
@@ -386,8 +386,8 @@ class ScopeTest extends \atk4\schema\PhpunitTestCase
     {
         $user = clone $this->user;
 
-        $condition1 = new BasicCondition('name', 'Alain');
-        $condition2 = new BasicCondition('country_code', 'FR');
+        $condition1 = new Condition('name', 'Alain');
+        $condition2 = new Condition('country_code', 'FR');
 
         $compoundCondition = CompoundCondition::createAnd($condition1, $condition2);
 


### PR DESCRIPTION
What is difference between CompoundCondition and Scope? Currently, Scope is topmost "scope". Everything else is "condition", but one is basic, onother is compound, ...

To simplify the terminology and reduce the number of terms, I propose to:

~~a) keep CompoundCondition more like an implementation detail and call collection of conditions a `Scope`. If it is part of Scope, we can call it `$subscope` or with specific name like `$customerScope`.~~

b) rename BasicCondition to `Condition`. Then if we speak about condition, we speak about the basic/simple one. Like in a real world, condition is undivisible
