### PR TITLE
Scope improve usability - addCondition() should not wrap

### DIFF
--- a/src/Model/Scope/CompoundCondition.php
+++ b/src/Model/Scope/CompoundCondition.php
@@ -65,8 +65,10 @@ class CompoundCondition extends AbstractCondition
         foreach ($this->elements as $k => $nestedCondition) {
             $this->elements[$k] = clone $nestedCondition;
             $this->elements[$k]->owner = $this;
+            $this->elements[$k]->short_name = $nestedCondition->short_name;
         }
         $this->owner = null;
+        $this->short_name = null;
     }
 
     /**

--- a/src/Model/Scope/CompoundCondition.php
+++ b/src/Model/Scope/CompoundCondition.php
@@ -72,17 +72,17 @@ class CompoundCondition extends AbstractCondition
     }
 
     /**
-     * Add nested condition.
-     *
-     * @param mixed $field
-     * @param mixed $operator
-     * @param mixed $value
-     *
-     * @return static
+     * @return $this
      */
     public function addCondition($field, $operator = null, $value = null)
     {
-        $this->add(static::createAnd(func_get_args()));
+        if (!is_array($field) && !($field instanceof Scope\AbstractCondition)) {
+            $condition = new Condition(...func_get_args());
+        } else {
+            $condition = static::createAnd(func_get_args());
+        }
+
+        $this->add($condition);
 
         return $this;
     }

--- a/src/Model/Scope/CompoundCondition.php
+++ b/src/Model/Scope/CompoundCondition.php
@@ -76,10 +76,10 @@ class CompoundCondition extends AbstractCondition
      */
     public function addCondition($field, $operator = null, $value = null)
     {
-        if (func_get_args() === 1 && $field instanceof AbstractCondition) {
+        if (func_num_args() === 1 && $field instanceof AbstractCondition) {
             $condition = $field;
-        } elseif (func_get_args() === 1 && is_array($field)) {
-            $condition = new self($field);
+        } elseif (func_num_args() === 1 && is_array($field)) {
+            $condition = static::createAnd(func_get_args());
         } else {
             $condition = new Condition(...func_get_args());
         }

--- a/src/Model/Scope/CompoundCondition.php
+++ b/src/Model/Scope/CompoundCondition.php
@@ -56,7 +56,7 @@ class CompoundCondition extends AbstractCondition
                 }
             }
 
-            $this->add(clone $condition);
+            $this->add($condition);
         }
     }
 
@@ -66,6 +66,7 @@ class CompoundCondition extends AbstractCondition
             $this->elements[$k] = clone $nestedCondition;
             $this->elements[$k]->owner = $this;
         }
+        $this->owner = null;
     }
 
     /**

--- a/src/Model/Scope/CompoundCondition.php
+++ b/src/Model/Scope/CompoundCondition.php
@@ -76,12 +76,12 @@ class CompoundCondition extends AbstractCondition
      */
     public function addCondition($field, $operator = null, $value = null)
     {
-        if ($field instanceof AbstractCondition && func_get_args() === 1) {
+        if (func_get_args() === 1 && $field instanceof AbstractCondition) {
             $condition = $field;
-        } elseif (!is_array($field) && !($field instanceof AbstractCondition)) {
-            $condition = new Condition(...func_get_args());
+        } elseif (func_get_args() === 1 && is_array($field)) {
+            $condition = new self($field);
         } else {
-            $condition = static::createAnd(func_get_args());
+            $condition = new Condition(...func_get_args());
         }
 
         $this->add($condition);

--- a/src/Model/Scope/CompoundCondition.php
+++ b/src/Model/Scope/CompoundCondition.php
@@ -76,7 +76,9 @@ class CompoundCondition extends AbstractCondition
      */
     public function addCondition($field, $operator = null, $value = null)
     {
-        if (!is_array($field) && !($field instanceof Scope\AbstractCondition)) {
+        if ($field instanceof AbstractCondition && func_get_args() === 1) {
+            $condition = $field;
+        } elseif (!is_array($field) && !($field instanceof AbstractCondition)) {
             $condition = new Condition(...func_get_args());
         } else {
             $condition = static::createAnd(func_get_args());

--- a/src/Model/Scope/CompoundCondition.php
+++ b/src/Model/Scope/CompoundCondition.php
@@ -41,22 +41,22 @@ class CompoundCondition extends AbstractCondition
         $this->junction = $junction;
 
         foreach ($nestedConditions as $nestedCondition) {
-            $nestedCondition = is_string($nestedCondition) ? new Condition($nestedCondition) : $nestedCondition;
+            if ($nestedCondition instanceof AbstractCondition) {
+                $condition = $nestedCondition;
+            } else {
+                if (!is_array($nestedCondition)) {
+                    $nestedCondition = [$nestedCondition];
+                }
 
-            if (is_array($nestedCondition)) {
                 // array of OR nested conditions
-                if (count($nestedCondition) === 1 && isset($nestedCondition[0]) && is_array($nestedCondition[0])) {
-                    $nestedCondition = new self($nestedCondition[0], self::OR);
+                if (count($nestedCondition) === 1 && is_array(reset($nestedCondition))) {
+                    $condition = new self(reset($nestedCondition), self::OR);
                 } else {
-                    $nestedCondition = new Condition(...$nestedCondition);
+                    $condition = new Condition(...$nestedCondition);
                 }
             }
 
-            if ($nestedCondition->isEmpty()) {
-                continue;
-            }
-
-            $this->add(clone $nestedCondition);
+            $this->add(clone $condition);
         }
     }
 

--- a/src/Model/Scope/Condition.php
+++ b/src/Model/Scope/Condition.php
@@ -73,6 +73,10 @@ class Condition extends AbstractCondition
 
     public function __construct($key, $operator = null, $value = null)
     {
+        if ($key instanceof AbstractCondition) {
+            throw new Exception('Only Scope can contain another conditions');
+        }
+
         if (func_num_args() == 1 && is_bool($key)) {
             if ($key) {
                 return;

--- a/tests/ScopeTest.php
+++ b/tests/ScopeTest.php
@@ -301,6 +301,8 @@ class ScopeTest extends \atk4\schema\PhpunitTestCase
         // TODO once PHP7.3 support is dropped, we should use WeakRef for owner
         // and unset($compoundCondition); here
         // now we need a clone
+        // we should fix then also the short_name issue (if it was generated on adding
+        // to an owner but owner is removed, the short_name should be removed as well)
         $compoundCondition1 = clone $compoundCondition1;
         $compoundCondition2 = clone $compoundCondition2;
         $compoundCondition = CompoundCondition::createOr($compoundCondition1, $compoundCondition2);

--- a/tests/ScopeTest.php
+++ b/tests/ScopeTest.php
@@ -298,6 +298,11 @@ class ScopeTest extends \atk4\schema\PhpunitTestCase
 
         $this->assertEquals($compoundCondition->toWords($user), $user->scope()->toWords());
 
+        // TODO once PHP7.3 support is dropped, we should use WeakRef for owner
+        // and unset($compoundCondition); here
+        // now we need a clone
+        $compoundCondition1 = clone $compoundCondition1;
+        $compoundCondition2 = clone $compoundCondition2;
         $compoundCondition = CompoundCondition::createOr($compoundCondition1, $compoundCondition2);
 
         $compoundCondition->addCondition('country_code', 'BR');


### PR DESCRIPTION
makes even more sense with https://github.com/atk4/data/pull/663 as we use term "condition" for simple condition only

when you, at least I, add a condition, I want to add a simple one