### PR TITLE
Unify Model::addCondition() and CompoundCondition::addCondition()

### DIFF
--- a/src/Model.php
+++ b/src/Model.php
@@ -965,7 +965,7 @@ class Model implements \IteratorAggregate
      */
     public function addCondition($field, $operator = null, $value = null)
     {
-        $this->scope()->add(new Model\Scope\CompoundCondition([func_get_args()]));
+        $this->scope()->addCondition(...func_get_args());
 
         return $this;
     }

--- a/src/Model/Scope/CompoundCondition.php
+++ b/src/Model/Scope/CompoundCondition.php
@@ -79,7 +79,7 @@ class CompoundCondition extends AbstractCondition
      */
     public function addCondition($field, $operator = null, $value = null)
     {
-        $this->add(new self([func_get_args()]));
+        $this->add(static::createAnd(func_get_args()));
 
         return $this;
     }


### PR DESCRIPTION
Revert to using `self` in `CompoundCondition::createXx` methods due to unpredictable behavior otherwise.
Using `static::createXx` within scope object results in creating `Scope` object and not `CompoundCondition` as intended