### PR TITLE
Introduce traversing ref links and aggregates in Model::get

### DIFF
--- a/src/Field.php
+++ b/src/Field.php
@@ -539,7 +539,9 @@ class Field implements Expressionable
      */
     public function getCaption(): string
     {
-        return $this->caption ?? $this->ui['caption'] ?? $this->readableCaption($this->short_name);
+        $caption = $this->caption ?? $this->ui['caption'] ?? $this->readableCaption($this->short_name);
+
+        return $caption instanceof \Closure ? $caption($this) : $caption;
     }
 
     // }}}

--- a/src/Model.php
+++ b/src/Model.php
@@ -813,13 +813,11 @@ class Model implements \IteratorAggregate
             }
 
             // aggregate function
-            if (str_contains($fieldName, '(')) {
-                $args = [];
-                if (preg_match('/^([\w ]+)\(([\w \*]*)/', $fieldName, $args)) {
-                    array_shift($args);
+            $args = [];
+            if (preg_match('~^(\w+)\(([\w*]*)\)$~', $fieldName, $args)) {
+                array_shift($args);
 
-                    return $this->action('fx', $args)->getOne();
-                }
+                return $this->action('fx', $args)->getOne();
             }
         }
 

--- a/src/Model.php
+++ b/src/Model.php
@@ -798,6 +798,11 @@ class Model implements \IteratorAggregate
 
         // if field is not existing maybe it is a traversing link or aggregate function
         if (!$this->hasField($fieldName)) {
+            // alias for count aggregate, consistent with Model scopes
+            if ($fieldName === '#') {
+                $fieldName = 'count(*)';
+            }
+
             // traverses relationships and returns value from a referenced model, e.g contact/company/name
             if (str_contains($fieldName, '/')) {
                 $refs = explode('/', $fieldName);

--- a/src/Model/ReferencesTrait.php
+++ b/src/Model/ReferencesTrait.php
@@ -185,6 +185,15 @@ trait ReferencesTrait
      */
     public function getRef($link): Reference
     {
+        // support for relationship traversing link, e.g contact/company/customers
+        if (str_contains($link, '/')) {
+            $link = explode('/', $link);
+
+            $directLink = array_shift($link);
+
+            return $this->ref($directLink)->getRef(implode('/', $link));
+        }
+
         return $this->getElement('#ref_' . $link);
     }
 

--- a/src/Persistence/Array_.php
+++ b/src/Persistence/Array_.php
@@ -374,8 +374,8 @@ class Array_ extends Persistence
                         ->addMoreInfo('action', $type);
                 }
 
-                $fx = $args[0];
-                $field = $args[1];
+                [$fx, $field] = $args;
+
                 $action = $this->initAction($model, $field);
                 $this->applyScope($model, $action);
                 $this->setLimitOrder($model, $action);

--- a/src/Persistence/Sql.php
+++ b/src/Persistence/Sql.php
@@ -634,6 +634,14 @@ class Sql extends Persistence
 
                 [$fx, $field] = $args;
 
+                if (is_string($field)) {
+                    if ($model->hasField($field)) {
+                        $field = $model->getField($field);
+                    } else {
+                        $field = new Expression($field);
+                    }
+                }
+
                 $this->initQueryConditions($model, $query);
                 $model->hook(self::HOOK_INIT_SELECT_QUERY, [$query, $type]);
 

--- a/src/Persistence/Sql.php
+++ b/src/Persistence/Sql.php
@@ -367,7 +367,7 @@ class Sql extends Persistence
 
             // simple condition
             if ($condition instanceof Model\Scope\Condition) {
-                $query = $query->where(...$condition->toQueryArguments());
+                $query->where(...$condition->toQueryArguments());
             }
 
             // nested conditions
@@ -378,7 +378,7 @@ class Sql extends Persistence
                     $this->initQueryConditions($model, $expression, $nestedCondition);
                 }
 
-                $query = $query->where($expression);
+                $query->where($expression);
             }
         }
     }
@@ -632,8 +632,8 @@ class Sql extends Persistence
                         ->addMoreInfo('action', $type);
                 }
 
-                $fx = $args[0];
-                $field = is_string($args[1]) ? $model->getField($args[1]) : $args[1];
+                [$fx, $field] = $args;
+
                 $this->initQueryConditions($model, $query);
                 $model->hook(self::HOOK_INIT_SELECT_QUERY, [$query, $type]);
 

--- a/src/Persistence/Sql.php
+++ b/src/Persistence/Sql.php
@@ -620,6 +620,10 @@ class Sql extends Persistence
                 $this->initQueryConditions($model, $query);
                 $this->setLimitOrder($model, $query);
 
+                if ($model->loaded()) {
+                    $query->where($model->id_field, $model->id);
+                }
+
                 return $query;
             case 'fx':
             case 'fx0':

--- a/src/Reference.php
+++ b/src/Reference.php
@@ -191,31 +191,29 @@ class Reference
     /**
      * Adds model to persistence.
      *
-     * @param Model $model
+     * @param Model $theirModel
      * @param array $defaults
      */
-    protected function addToPersistence($model, $defaults = []): Model
+    protected function addToPersistence($theirModel, $defaults = []): Model
     {
-        if (!$model->persistence && $persistence = $this->getDefaultPersistence($model)) {
-            $persistence->add($model, $defaults);
+        if (!$theirModel->persistence && $persistence = $this->getDefaultPersistence($theirModel)) {
+            $persistence->add($theirModel, $defaults);
         }
 
         // set model caption
         if ($this->caption !== null) {
-            $model->caption = $this->caption;
+            $theirModel->caption = $this->caption;
         }
 
-        return $model;
+        return $theirModel;
     }
 
     /**
-     * Returns default persistence.
-     *
-     * @param Model $model Referenced model
+     * Returns default persistence for theirModel.
      *
      * @return Persistence|false
      */
-    protected function getDefaultPersistence($model)
+    protected function getDefaultPersistence(Model $theirModel)
     {
         $ourModel = $this->getOurModel();
 

--- a/src/Reference.php
+++ b/src/Reference.php
@@ -159,6 +159,21 @@ class Reference
         return $this->addToPersistence($theirModel, $defaults);
     }
 
+    protected function getOurField(): Field
+    {
+        return $this->getOurModel()->getField($this->getOurFieldName());
+    }
+
+    protected function getOurFieldName(): string
+    {
+        return $this->our_field ?: $this->getOurModel()->id_field;
+    }
+
+    protected function getOurFieldValue()
+    {
+        return $this->getOurField()->get();
+    }
+
     protected function initTableAlias(): void
     {
         if (!$this->table_alias) {

--- a/src/Reference/ContainsMany.php
+++ b/src/Reference/ContainsMany.php
@@ -23,25 +23,9 @@ class ContainsMany extends ContainsOne
      */
     protected function getDefaultPersistence($model)
     {
-        $ourModel = $this->getOurModel();
-
-        // model should be loaded
-        /* Imants: it looks that this is not actually required - disabling
-        if (!$ourModel->loaded()) {
-            throw (new Exception('Model should be loaded!'))
-                ->addMoreInfo('model', get_class($ourModel));
-        }
-        */
-
-        // set data source of referenced array persistence
-        $rows = $ourModel->get($this->our_field) ?: [];
-        /*
-        foreach ($rows as $id=>$row) {
-            $rows[$id] = $ourModel->persistence->typecastLoadRow($ourModel, $row); // we need this typecasting because we set persistence data directly
-        }
-        */
-
-        return new Persistence\ArrayOfStrings([$this->table_alias => $rows ?: []]);
+        return new Persistence\ArrayOfStrings([
+            $this->table_alias => $this->getOurFieldValue() ?: [],
+        ]);
     }
 
     /**
@@ -65,7 +49,9 @@ class ContainsMany extends ContainsOne
         foreach ([Model::HOOK_AFTER_SAVE, Model::HOOK_AFTER_DELETE] as $spot) {
             $theirModel->onHook($spot, function ($theirModel) {
                 $rows = $theirModel->persistence->getRawDataByTable($this->table_alias);
-                $this->getOurModel()->save([$this->our_field => $rows ?: null]);
+                $this->getOurModel()->save([
+                    $this->getOurFieldName() => $rows ?: null,
+                ]);
             });
         }
 

--- a/src/Reference/ContainsMany.php
+++ b/src/Reference/ContainsMany.php
@@ -12,16 +12,7 @@ use atk4\data\Persistence;
  */
 class ContainsMany extends ContainsOne
 {
-    /**
-     * Returns default persistence. It will be empty at this point.
-     *
-     * @see ref()
-     *
-     * @param Model $model Referenced model
-     *
-     * @return Persistence|false
-     */
-    protected function getDefaultPersistence($model)
+    protected function getDefaultPersistence(Model $theirModel)
     {
         return new Persistence\ArrayOfStrings([
             $this->table_alias => $this->getOurFieldValue() ?: [],

--- a/src/Reference/ContainsOne.php
+++ b/src/Reference/ContainsOne.php
@@ -72,16 +72,7 @@ class ContainsOne extends Reference
         }
     }
 
-    /**
-     * Returns default persistence. It will be empty at this point.
-     *
-     * @see ref()
-     *
-     * @param Model $model Referenced model
-     *
-     * @return Persistence
-     */
-    protected function getDefaultPersistence($model)
+    protected function getDefaultPersistence(Model $theirModel)
     {
         return new Persistence\ArrayOfStrings([
             $this->table_alias => $this->getOurFieldValue() ? [1 => $this->getOurFieldValue()] : [],

--- a/src/Reference/ContainsOne.php
+++ b/src/Reference/ContainsOne.php
@@ -79,25 +79,13 @@ class ContainsOne extends Reference
      *
      * @param Model $model Referenced model
      *
-     * @return Persistence|false
+     * @return Persistence
      */
     protected function getDefaultPersistence($model)
     {
-        $ourModel = $this->getOurModel();
-
-        // model should be loaded
-        /* Imants: it looks that this is not actually required - disabling
-        if (!$ourModel->loaded()) {
-            throw (new Exception('Model should be loaded!'))
-                ->addMoreInfo('model', get_class($ourModel));
-        }
-        */
-
-        // set data source of referenced array persistence
-        $row = $ourModel->get($this->our_field) ?: [];
-        //$row = $ourModel->persistence->typecastLoadRow($ourModel, $row); // we need this typecasting because we set persistence data directly
-
-        return new Persistence\ArrayOfStrings([$this->table_alias => $row ? [1 => $row] : []]);
+        return new Persistence\ArrayOfStrings([
+            $this->table_alias => $this->getOurFieldValue() ? [1 => $this->getOurFieldValue()] : [],
+        ]);
     }
 
     /**
@@ -122,7 +110,7 @@ class ContainsOne extends Reference
             $theirModel->onHook($spot, function ($theirModel) {
                 $row = $theirModel->persistence->getRawDataByTable($this->table_alias);
                 $row = $row ? array_shift($row) : null; // get first and only one record from array persistence
-                $this->getOurModel()->save([$this->our_field => $row]);
+                $this->getOurModel()->save([$this->getOurFieldName() => $row]);
             });
         }
 

--- a/src/Reference/HasMany.php
+++ b/src/Reference/HasMany.php
@@ -31,7 +31,7 @@ class HasMany extends Reference
 
         // create expression based on existing conditions
         return $ourModel->action('field', [
-            $this->our_field ?: $ourModel->id_field,
+            $this->getOurFieldName(),
         ]);
     }
 
@@ -44,7 +44,7 @@ class HasMany extends Reference
 
         $ourModel->persistence_data['use_table_prefixes'] = true;
 
-        return $ourModel->getField($this->our_field ?: $ourModel->id_field);
+        return $this->getOurField();
     }
 
     /**

--- a/src/Reference/HasOne.php
+++ b/src/Reference/HasOne.php
@@ -225,10 +225,15 @@ class HasOne extends Reference
             }
         }
 
+        // their model will be reloaded after saving our model to reflect changes in referenced fields
+        $theirModel->reload_after_save = false;
+
         $theirModel->onHook(Model::HOOK_AFTER_SAVE, function ($theirModel) {
             $theirValue = $this->their_field ? $theirModel->get($this->their_field) : $theirModel->id;
 
-            $this->getOurField()->set($theirValue);
+            $this->getOurField()->set($theirValue)->owner->save();
+
+            $theirModel->reload();
         });
 
         return $theirModel;

--- a/src/Reference/HasOne.php
+++ b/src/Reference/HasOne.php
@@ -196,7 +196,7 @@ class HasOne extends Reference
     {
         $this->getOurModel()->persistence_data['use_table_prefixes'] = true;
 
-        return $this->getOurModel()->getField($this->our_field);
+        return $this->getOurField();
     }
 
     /**
@@ -213,10 +213,10 @@ class HasOne extends Reference
 
         // add hook to set our_field = null when record of referenced model is deleted
         $theirModel->onHook(Model::HOOK_AFTER_DELETE, function ($theirModel) {
-            $this->getOurModel()->set($this->our_field, null);
+            $this->getOurField()->setNull();
         });
 
-        if ($ourValue = $this->getOurModel()->get($this->our_field)) {
+        if ($ourValue = $this->getOurFieldValue()) {
             // if our model is loaded, then try to load referenced model
             if ($this->their_field) {
                 $theirModel->tryLoadBy($this->their_field, $ourValue);
@@ -226,9 +226,9 @@ class HasOne extends Reference
         }
 
         $theirModel->onHook(Model::HOOK_AFTER_SAVE, function ($theirModel) {
-            $ourValue = $this->their_field ? $theirModel->get($this->their_field) : $theirModel->id;
+            $theirValue = $this->their_field ? $theirModel->get($this->their_field) : $theirModel->id;
 
-            $this->getOurModel()->set($this->our_field, $ourValue);
+            $this->getOurField()->set($theirValue);
         });
 
         return $theirModel;

--- a/src/Reference/HasOneSql.php
+++ b/src/Reference/HasOneSql.php
@@ -61,11 +61,14 @@ class HasOneSql extends HasOne
                     return $ourModel->refLink($this->link)->action('field', [$theirFieldName])->reset('order');
                 },
             ],
-            $defaults
+            $defaults,
+            [
+                // to be able to change field, but not save it
+                // afterSave hook will take care of the rest
+                'read_only' => false,
+                'never_save' => true,
+            ]
         ));
-
-        $fieldExpression->read_only = false;
-        $fieldExpression->never_save = true;
 
         // Will try to execute last
         $ourModel->onHook(Model::HOOK_BEFORE_SAVE, function (Model $ourModel) use ($ourFieldName, $theirFieldName) {

--- a/src/Reference/HasOneSql.php
+++ b/src/Reference/HasOneSql.php
@@ -20,7 +20,7 @@ class HasOneSql extends HasOne
      *
      * Returns Expression in case you want to do something else with it.
      *
-     * @param string|Field|array $ourFieldName or [$field, ..defaults]
+     * @param string|Field|array $ourFieldName   or [$field, ..defaults]
      * @param string|\Closure    $theirFieldName
      */
     public function addField($ourFieldName, $theirFieldName = null): FieldSqlExpression

--- a/src/Reference/HasOneSql.php
+++ b/src/Reference/HasOneSql.php
@@ -163,24 +163,20 @@ class HasOneSql extends HasOne
         $theirField = $this->their_field ?: $theirModel->id_field;
         $ourField = $this->getOurField();
 
-        // If model is not loaded, then we are probably doing deep traversal
-        if (!$ourModel->loaded()) {
-            $values = $ourModel->action('field', [$ourField]);
-
-            return $theirModel->addCondition($theirField, $values);
-        }
-
         // At this point the reference
         // if our_field is the id_field and is being used in the reference
         // we should persist the relation in condtition
         // example - $model->load(1)->ref('refLink')->import($rows);
         if ($ourModel->loaded() && !$theirModel->loaded()) {
             if ($ourModel->id_field === $this->getOurFieldName()) {
-                $theirModel->addCondition($theirField, $this->getOurFieldValue());
+                return $theirModel->addCondition($theirField, $this->getOurFieldValue());
             }
         }
 
-        return $theirModel;
+        // handles the deep traversal using an expression
+        $ourFieldExpression = $ourModel->action('field', [$ourField]);
+
+        return $theirModel->addCondition($theirField, $ourFieldExpression);
     }
 
     /**

--- a/tests/RandomTest.php
+++ b/tests/RandomTest.php
@@ -347,7 +347,7 @@ class RandomTest extends \atk4\schema\PhpunitTestCase
         $db = new Persistence\Sql($this->db->connection);
         $m = new Model_Item($db);
 
-        $this->expectException(Exception::class);
+        $this->expectException(\atk4\core\Exception::class);
         $m->hasOne('foo', ['model' => [Model_Item::class]])
             ->addTitle(); // field foo already exists, so we can't add title with same name
     }

--- a/tests/RandomTest.php
+++ b/tests/RandomTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace atk4\data\tests;
 
-use atk4\data\Exception;
 use atk4\data\Model;
 use atk4\data\Persistence;
 

--- a/tests/ReferenceTest.php
+++ b/tests/ReferenceTest.php
@@ -118,6 +118,7 @@ class ReferenceTest extends \atk4\schema\PhpunitTestCase
         $this->assertEquals(20, $user->get('Company/Orders/amount')); // 'amount' default value
         $this->assertEquals(65, $user->get('Company/Orders/sum(amount)'));
         $this->assertEquals(2, $user->get('Company/Orders/count(*)'));
+        $this->assertEquals(2, $user->get('Company/Orders/#'));
         $this->assertEquals(1, $user->get('Company/count(*)'));
     }
 

--- a/tests/ReferenceTest.php
+++ b/tests/ReferenceTest.php
@@ -26,8 +26,9 @@ class ReferenceTest extends \atk4\schema\PhpunitTestCase
         ],
         'order' => [
             ['company_id' => 1, 'description' => 'Vinny Company Order 1', 'amount' => 50.0],
-            ['company_id' => 2, 'description' => 'Zoe Company Order', 'amount' => 10.0],
+            ['company_id' => 2, 'description' => 'Zoe Company Order 1', 'amount' => 10.0],
             ['company_id' => 1, 'description' => 'Vinny Company Order 2', 'amount' => 15.0],
+            ['company_id' => 1, 'description' => 'Zoe Company Order 2', 'amount' => null],
         ],
     ];
 
@@ -117,8 +118,9 @@ class ReferenceTest extends \atk4\schema\PhpunitTestCase
         $this->assertEquals($user->ref('Company')->ref('Orders'), $user->ref('Company/Orders'));
         $this->assertEquals(20, $user->get('Company/Orders/amount')); // 'amount' default value
         $this->assertEquals(65, $user->get('Company/Orders/sum(amount)'));
-        $this->assertEquals(2, $user->get('Company/Orders/count(*)'));
-        $this->assertEquals(2, $user->get('Company/Orders/#'));
+        $this->assertEquals(3, $user->get('Company/Orders/count(*)'));
+        $this->assertEquals(3, $user->get('Company/Orders/#'));
+        $this->assertEquals(2, $user->get('Company/Orders/count(amount)'));
         $this->assertEquals(1, $user->get('Company/count(*)'));
     }
 

--- a/tests/ReferenceTest.php
+++ b/tests/ReferenceTest.php
@@ -115,10 +115,10 @@ class ReferenceTest extends \atk4\schema\PhpunitTestCase
         $company->hasMany('Orders', [$order]);
 
         $this->assertEquals($user->ref('Company')->ref('Orders'), $user->ref('Company/Orders'));
-        $this->assertSame(20, $user->get('Company/Orders/amount')); // 'amount' default value
-        $this->assertSame('65', $user->get('Company/Orders/sum(amount)'));
-        $this->assertSame('2', $user->get('Company/Orders/count(*)'));
-        $this->assertSame('1', $user->get('Company/count(*)'));
+        $this->assertEquals(20, $user->get('Company/Orders/amount')); // 'amount' default value
+        $this->assertEquals(65, $user->get('Company/Orders/sum(amount)'));
+        $this->assertEquals(2, $user->get('Company/Orders/count(*)'));
+        $this->assertEquals(1, $user->get('Company/count(*)'));
     }
 
     public function testRefName1()


### PR DESCRIPTION
- cleanup and align Model References further f8a56a7, 2c381345
- fix an issue on recursion on self-referencing models when fields added in init method e13afc8c7d, 2dd281a4
- call `HasOneSql::addField` from `HasOneSql::addTitle` and avoid duplicate code 2dd281a4
- introduce support for resolving traversing links in `Reference::getRef` 1d72c68568
- fix issue with improper loading/saving of referenced models 2d9d817f
- introduce link traversing and aggregates in `Model::get` 27d2b8b599
- update tests to include new functionality 9ab574ab2

Major bug fixes and new functionality introduced:
```
$user->load(1);
$user->get('Company/Orders/amount'); // 'amount' default value
$user->get('Company/Orders/sum(amount)')); // returns sum of all order amounts for the company of user 1
$user->get('Company/Orders/count(*)'); // returns number of orders for the company of user 1
$user->get('Company/count(*)'); // returns number of companies of user 1
```
