### PR TITLE
Introduce getQueryArguments in Field

### DIFF
--- a/src/Field.php
+++ b/src/Field.php
@@ -7,6 +7,7 @@ namespace atk4\data;
 use atk4\core\DiContainerTrait;
 use atk4\core\ReadableCaptionTrait;
 use atk4\core\TrackableTrait;
+use atk4\data\Model\Scope;
 use atk4\dsql\Expression;
 use atk4\dsql\Expressionable;
 
@@ -513,19 +514,19 @@ class Field implements Expressionable
     /**
      * Returns arguments to be used for query on this field based on the condition.
      *
-     * @param string|null $operator one of Model\Scope\Condition operators
+     * @param string|null $operator one of Scope\Condition operators
      * @param mixed       $value    the condition value to be handled
      *
      * @todo: value is array
      */
-    public function getQueryArguments(Model\Scope\Condition $condition, $operator, $value): array
+    public function getQueryArguments($operator, $value): array
     {
         if ($persistence = $this->owner->persistence) {
             $skipValueTypecast = [
-                Model\Scope\Condition::OPERATOR_LIKE,
-                Model\Scope\Condition::OPERATOR_NOT_LIKE,
-                Model\Scope\Condition::OPERATOR_REGEXP,
-                Model\Scope\Condition::OPERATOR_NOT_REGEXP,
+                Scope\Condition::OPERATOR_LIKE,
+                Scope\Condition::OPERATOR_NOT_LIKE,
+                Scope\Condition::OPERATOR_REGEXP,
+                Scope\Condition::OPERATOR_NOT_REGEXP,
             ];
 
             if (!in_array($operator, $skipValueTypecast, true)) {

--- a/src/Field.php
+++ b/src/Field.php
@@ -521,17 +521,15 @@ class Field implements Expressionable
      */
     public function getQueryArguments($operator, $value): array
     {
-        if ($persistence = $this->owner->persistence) {
-            $skipValueTypecast = [
-                Scope\Condition::OPERATOR_LIKE,
-                Scope\Condition::OPERATOR_NOT_LIKE,
-                Scope\Condition::OPERATOR_REGEXP,
-                Scope\Condition::OPERATOR_NOT_REGEXP,
-            ];
+        $skipValueTypecast = [
+            Scope\Condition::OPERATOR_LIKE,
+            Scope\Condition::OPERATOR_NOT_LIKE,
+            Scope\Condition::OPERATOR_REGEXP,
+            Scope\Condition::OPERATOR_NOT_REGEXP,
+        ];
 
-            if (!in_array($operator, $skipValueTypecast, true)) {
-                $value = $persistence->typecastSaveField($this, $value);
-            }
+        if (!in_array($operator, $skipValueTypecast, true)) {
+            $value = $this->owner->persistence->typecastSaveField($this, $value);
         }
 
         return [$this, $operator, $value];

--- a/src/Field.php
+++ b/src/Field.php
@@ -516,8 +516,6 @@ class Field implements Expressionable
      *
      * @param string|null $operator one of Scope\Condition operators
      * @param mixed       $value    the condition value to be handled
-     *
-     * @todo: value is array
      */
     public function getQueryArguments($operator, $value): array
     {
@@ -529,7 +527,13 @@ class Field implements Expressionable
         ];
 
         if (!in_array($operator, $skipValueTypecast, true)) {
-            $value = $this->owner->persistence->typecastSaveField($this, $value);
+            if (is_array($value)) {
+                foreach ($value as &$option) {
+                    $option = $this->owner->persistence->typecastSaveField($this, $option);
+                }
+            } else {
+                $value = $this->owner->persistence->typecastSaveField($this, $value);
+            }
         }
 
         return [$this, $operator, $value];

--- a/src/Field.php
+++ b/src/Field.php
@@ -528,9 +528,9 @@ class Field implements Expressionable
 
         if (!in_array($operator, $skipValueTypecast, true)) {
             if (is_array($value)) {
-                foreach ($value as &$option) {
-                    $option = $this->owner->persistence->typecastSaveField($this, $option);
-                }
+                $value = array_map(function ($option) {
+                    return $this->owner->persistence->typecastSaveField($this, $option);
+                }, $value);
             } else {
                 $value = $this->owner->persistence->typecastSaveField($this, $value);
             }

--- a/src/Field.php
+++ b/src/Field.php
@@ -508,6 +508,36 @@ class Field implements Expressionable
 
     // }}}
 
+    // {{{ Scope condition
+
+    /**
+     * Returns arguments to be used for query on this field based on the condition.
+     *
+     * @param string|null $operator one of Model\Scope\Condition operators
+     * @param mixed       $value    the condition value to be handled
+     *
+     * @todo: value is array
+     */
+    public function getQueryArguments(Model\Scope\Condition $condition, $operator, $value): array
+    {
+        if ($persistence = $this->owner->persistence) {
+            $skipValueTypecast = [
+                Model\Scope\Condition::OPERATOR_LIKE,
+                Model\Scope\Condition::OPERATOR_NOT_LIKE,
+                Model\Scope\Condition::OPERATOR_REGEXP,
+                Model\Scope\Condition::OPERATOR_NOT_REGEXP,
+            ];
+
+            if (!in_array($operator, $skipValueTypecast, true)) {
+                $value = $persistence->typecastSaveField($this, $value);
+            }
+        }
+
+        return [$this, $operator, $value];
+    }
+
+    // }}}
+
     // {{{ Handy methods used by UI
 
     /**

--- a/src/Model/Scope/Condition.php
+++ b/src/Model/Scope/Condition.php
@@ -193,7 +193,7 @@ class Condition extends AbstractScope
 
             // handle the query arguments using field
             if ($field instanceof Field) {
-                [$field, $operator, $value] = $field->getQueryArguments($this, $operator, $value);
+                [$field, $operator, $value] = $field->getQueryArguments($operator, $value);
             }
 
             // only expression contained in $field

--- a/src/Model/Scope/Condition.php
+++ b/src/Model/Scope/Condition.php
@@ -98,13 +98,6 @@ class Condition extends AbstractScope
         ],
     ];
 
-    protected static $skipValueTypecast = [
-        self::OPERATOR_LIKE,
-        self::OPERATOR_NOT_LIKE,
-        self::OPERATOR_REGEXP,
-        self::OPERATOR_NOT_REGEXP,
-    ];
-
     public function __construct($key, $operator = null, $value = null)
     {
         if ($key instanceof AbstractScope) {
@@ -198,10 +191,9 @@ class Condition extends AbstractScope
                 }
             }
 
-            // @todo: value is array
-            // convert the value using the typecasting of persistence
-            if ($field instanceof Field && $model->persistence && !in_array($operator, self::$skipValueTypecast, true)) {
-                $value = $model->persistence->typecastSaveField($field, $value);
+            // handle the query arguments using field
+            if ($field instanceof Field) {
+                [$field, $operator, $value] = $field->getQueryArguments($this, $operator, $value);
             }
 
             // only expression contained in $field

--- a/src/Model/Scope/Condition.php
+++ b/src/Model/Scope/Condition.php
@@ -128,6 +128,24 @@ class Condition extends AbstractScope
                     ->addMoreInfo('operator', $operator);
             }
         }
+
+        if (is_array($value)) {
+            if (array_filter($value, 'is_array')) {
+                throw (new Exception('Multi-dimensional array as condition value is not supported'))
+                    ->addMoreInfo('value', $value);
+            }
+
+            if (!in_array($this->operator, [
+                self::OPERATOR_EQUALS,
+                self::OPERATOR_IN,
+                self::OPERATOR_DOESNOT_EQUAL,
+                self::OPERATOR_NOT_IN,
+            ], true)) {
+                throw (new Exception('Operator is not supported for array condition value'))
+                    ->addMoreInfo('operator', $operator)
+                    ->addMoreInfo('value', $value);
+            }
+        }
     }
 
     protected function onChangeModel(): void

--- a/tests/ScopeTest.php
+++ b/tests/ScopeTest.php
@@ -183,7 +183,6 @@ class ScopeTest extends \atk4\schema\PhpunitTestCase
         $condition = new Condition('name', 'abc');
 
         $this->expectException(Exception::class);
-
         $condition->toWords();
     }
 
@@ -192,7 +191,6 @@ class ScopeTest extends \atk4\schema\PhpunitTestCase
         $country = clone $this->country;
 
         $this->expectException(Exception::class);
-
         $country->addCondition('name', '==', 'abc');
     }
 
@@ -201,7 +199,6 @@ class ScopeTest extends \atk4\schema\PhpunitTestCase
         $condition = new Condition(new Expression('false'));
 
         $this->expectException(Exception::class);
-
         $condition->negate();
     }
 
@@ -210,7 +207,6 @@ class ScopeTest extends \atk4\schema\PhpunitTestCase
         $country = clone $this->country;
 
         $this->expectException(Exception::class);
-
         $country->scope()->negate();
     }
 
@@ -445,14 +441,12 @@ class ScopeTest extends \atk4\schema\PhpunitTestCase
     public function testInvalid1()
     {
         $this->expectException(Exception::class);
-
         new Condition('name', '>', ['a', 'b']);
     }
 
     public function testInvalid2()
     {
         $this->expectException(Exception::class);
-
         new Condition('name', ['a', 'b' => ['c']]);
     }
 }

--- a/tests/ScopeTest.php
+++ b/tests/ScopeTest.php
@@ -441,14 +441,14 @@ class ScopeTest extends \atk4\schema\PhpunitTestCase
 
         $this->assertEmpty($scope->toWords($user));
     }
-    
+
     public function testInvalid1()
     {
         $this->expectException(Exception::class);
 
         new Condition('name', '>', ['a', 'b']);
     }
-    
+
     public function testInvalid2()
     {
         $this->expectException(Exception::class);

--- a/tests/ScopeTest.php
+++ b/tests/ScopeTest.php
@@ -441,4 +441,18 @@ class ScopeTest extends \atk4\schema\PhpunitTestCase
 
         $this->assertEmpty($scope->toWords($user));
     }
+    
+    public function testInvalid1()
+    {
+        $this->expectException(Exception::class);
+
+        new Condition('name', '>', ['a', 'b']);
+    }
+    
+    public function testInvalid2()
+    {
+        $this->expectException(Exception::class);
+
+        new Condition('name', ['a', 'b' => ['c']]);
+    }
 }


### PR DESCRIPTION
Let Field object handle conversion to query arguments.
Default functionality remains of Field typecasting the condition value using persistence.

The method can be extended in child field classes to handle different logic, e.g
a new class extending Field for saving multiple values can be set up to save them in persistence like an encoded string `__value1__value2__`.
Then a `new Condition('name', 'value1')` can be converted to query `'name' LIKE '\_\_value1\_\_'` by the Field object enabling conditions on single values

TODO: the question remains what to do with default behavior if the value is an array:
- typecast each element (in case operator is '=')?
- how to handle in case of other operators?

Functionality is important for enhancing atk4/login to handle user multiple roles!