### PR TITLE
Fix PostgreSQL CI errors

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -80,9 +80,8 @@ jobs:
         if: matrix.type == 'Phpunit'
         run: "vendor/bin/phpunit --configuration phpunit-mysql.xml.dist \"$(if [ -n \"$LOG_COVERAGE\" ]; then echo '--coverage-text'; else echo '--no-coverage'; fi)\" -v"
 
-      - name: "Run tests: PostgreSQL (expected errors) (only for Phpunit)"
+      - name: "Run tests: PostgreSQL (only for Phpunit)"
         if: matrix.type == 'Phpunit'
-        continue-on-error: true
         run: "vendor/bin/phpunit --configuration phpunit-pgsql.xml.dist \"$(if [ -n \"$LOG_COVERAGE\" ]; then echo '--coverage-text'; else echo '--no-coverage'; fi)\" -v"
 
       - name: Lint / check syntax (only for CodingStyle)

--- a/docs/persistence.rst
+++ b/docs/persistence.rst
@@ -57,7 +57,7 @@ There are several ways to link your model up with the persistence::
 
         $m->load(10);
         $m->set('name', 'John');
-        $$m->save();
+        $m->save();
 
     You can pass argument to save() to set() and save()::
 

--- a/src/Persistence/Sql.php
+++ b/src/Persistence/Sql.php
@@ -783,9 +783,10 @@ class Sql extends Persistence
     {
         $insert = $model->action('insert');
 
-        // don't set id field at all if it's NULL
-        if ($model->id_field && array_key_exists($model->id_field, $data) && $data[$model->id_field] === null) {
+        if ($model->id_field && !isset($data[$model->id_field])) {
             unset($data[$model->id_field]);
+
+            $this->syncIdSequence($model);
         }
 
         $insert->set($this->typecastSaveRow($model, $data));

--- a/src/Persistence/Sql.php
+++ b/src/Persistence/Sql.php
@@ -802,9 +802,11 @@ class Sql extends Persistence
                 ->addMoreInfo('scope', $model->scope()->toWords());
         }
 
+        $id = $model->persistence->lastInsertId($model);
+
         $model->hook(self::HOOK_AFTER_INSERT_QUERY, [$insert, $st]);
 
-        return $model->persistence->lastInsertId($model);
+        return $id;
     }
 
     /**

--- a/src/Persistence/Sql.php
+++ b/src/Persistence/Sql.php
@@ -802,7 +802,11 @@ class Sql extends Persistence
                 ->addMoreInfo('scope', $model->scope()->toWords());
         }
 
-        $id = $model->persistence->lastInsertId($model);
+        if ($model->id_field && isset($data[$model->id_field])) {
+            $id = $data[$model->id_field];
+        } else {
+            $id = $model->persistence->lastInsertId($model);
+        }
 
         $model->hook(self::HOOK_AFTER_INSERT_QUERY, [$insert, $st]);
 

--- a/src/Persistence/Sql.php
+++ b/src/Persistence/Sql.php
@@ -807,7 +807,7 @@ class Sql extends Persistence
 
             $this->syncIdSequence($model);
         } else {
-            $id = $model->persistence->lastInsertId($model);
+            $id = $this->lastInsertId($model);
         }
 
         $model->hook(self::HOOK_AFTER_INSERT_QUERY, [$insert, $st]);

--- a/src/Persistence/Sql.php
+++ b/src/Persistence/Sql.php
@@ -977,9 +977,8 @@ class Sql extends Persistence
         // PostgreSQL sequence must be manually synchronized if a row with explicit ID was inserted
         if ($this->connection instanceof \atk4\dsql\Postgresql\Connection) {
             $this->connection->expr(
-                // @TODO soft-escape
-                'select setval(pg_get_serial_sequence([], []), coalesce(max(' . $model->id_field . '), 0) + 1, false) from "' . $model->table . '"',
-                [$model->table, $model->id_field]
+                'select setval([], coalesce(max({}), 0) + 1, false) from {}',
+                [$this->getIdSequenceName($model), $model->id_field, $model->table]
             )->execute();
         }
     }

--- a/src/Persistence/Sql.php
+++ b/src/Persistence/Sql.php
@@ -776,10 +776,8 @@ class Sql extends Persistence
 
     /**
      * Inserts record in database and returns new record ID.
-     *
-     * @return mixed
      */
-    public function insert(Model $model, array $data)
+    public function insert(Model $model, array $data): string
     {
         $insert = $model->action('insert');
 
@@ -804,7 +802,7 @@ class Sql extends Persistence
         }
 
         if ($model->id_field && isset($data[$model->id_field])) {
-            $id = $data[$model->id_field];
+            $id = (string) $data[$model->id_field];
 
             $this->syncIdSequence($model);
         } else {

--- a/tests/ConditionSqlTest.php
+++ b/tests/ConditionSqlTest.php
@@ -429,6 +429,10 @@ class ConditionSqlTest extends \atk4\schema\PhpunitTestCase
      */
     public function testLikeCondition()
     {
+        if ($this->driverType === 'pgsql') {
+            $this->markTestIncomplete('This test is not supported on PostgreSQL');
+        }
+
         $this->setDb([
             'user' => [
                 1 => ['id' => 1, 'name' => 'John', 'active' => 1, 'created' => '2020-01-01 15:00:30'],

--- a/tests/ConditionSqlTest.php
+++ b/tests/ConditionSqlTest.php
@@ -227,10 +227,6 @@ class ConditionSqlTest extends \atk4\schema\PhpunitTestCase
 
     public function testExpressionJoin()
     {
-        if ($this->driverType === 'pgsql') {
-            $this->markTestIncomplete('This test is not supported on PostgreSQL');
-        }
-
         $this->setDb([
             'user' => [
                 1 => ['id' => 1, 'name' => 'John', 'surname' => 'Smith', 'gender' => 'M', 'contact_id' => 1],
@@ -269,7 +265,7 @@ class ConditionSqlTest extends \atk4\schema\PhpunitTestCase
         $this->assertFalse($mm->loaded());
 
         $mm = clone $m;
-        $mm->addCondition($mm->expr('"+123 smiths" = [contact_phone]'));
+        $mm->addCondition($mm->expr('\'+123 smiths\' = [contact_phone]'));
         $mmm = (clone $mm)->tryLoad(1);
         $this->assertSame('John', $mmm->get('name'));
         $this->assertSame('+123 smiths', $mmm->get('contact_phone'));
@@ -430,7 +426,7 @@ class ConditionSqlTest extends \atk4\schema\PhpunitTestCase
     public function testLikeCondition()
     {
         if ($this->driverType === 'pgsql') {
-            $this->markTestIncomplete('This test is not supported on PostgreSQL');
+            $this->markTestIncomplete('PostgreSQL does not support "column LIKE variable" syntax');
         }
 
         $this->setDb([

--- a/tests/ContainsManyTest.php
+++ b/tests/ContainsManyTest.php
@@ -267,7 +267,7 @@ class ContainsManyTest extends \atk4\schema\PhpunitTestCase
         $this->assertSame(24.2 * 15 / 100 + 86.25 * 20 / 100, $i->get('discounts_total_sum')); // =20.88
 
         // let's test how it all looks in persistence without typecasting
-        $exp_lines = $i->export(null, null, false)[0]['lines'];
+        $exp_lines = $i->setOrder('id')->export(null, null, false)[0]['lines'];
         $this->assertSame(
             json_encode([
                 '1' => [

--- a/tests/ContainsOneTest.php
+++ b/tests/ContainsOneTest.php
@@ -173,7 +173,7 @@ class ContainsOneTest extends \atk4\schema\PhpunitTestCase
         $this->assertSame('United Kingdom', $c->get('name'));
 
         // let's test how it all looks in persistence without typecasting
-        $exp_addr = $i->export(null, null, false)[0]['addr'];
+        $exp_addr = $i->setOrder('id')->export(null, null, false)[0]['addr'];
         $this->assertSame(
             '{"country_id":"2","address":"bar","built_date":"2019-01-01T00:00:00+00:00","tags":"[\"foo\",\"bar\"]","door_code":"{\"code\":\"DEF\",\"valid_till\":\"2019-07-01T00:00:00+00:00\"}"}',
             $exp_addr

--- a/tests/DeepCopyTest.php
+++ b/tests/DeepCopyTest.php
@@ -88,7 +88,7 @@ class DcInvoiceLine extends Model
 
         $this->addField('qty', ['type' => 'integer', 'mandatory' => true]);
         $this->addField('price', ['type' => 'money']);
-        $this->addField('vat', ['type' => 'numeric', 'default' => 0.21]);
+        $this->addField('vat', ['type' => 'float', 'default' => 0.21]);
 
         // total is calculated with VAT
         $this->addExpression('total', '[qty]*[price]*(1+[vat])');

--- a/tests/FieldTest.php
+++ b/tests/FieldTest.php
@@ -137,10 +137,6 @@ class FieldTest extends \atk4\schema\PhpunitTestCase
 
     public function testMandatory4()
     {
-        if ($this->driverType === 'pgsql') {
-            $this->markTestIncomplete('This test is not supported on PostgreSQL');
-        }
-
         $db = new Persistence\Sql($this->db->connection);
         $this->setDb([
             'user' => [
@@ -347,10 +343,6 @@ class FieldTest extends \atk4\schema\PhpunitTestCase
 
     public function testTitle()
     {
-        if ($this->driverType === 'pgsql') {
-            $this->markTestIncomplete('This test is not supported on PostgreSQL');
-        }
-
         $db = new Persistence\Sql($this->db->connection);
         $this->setDb([
             'user' => [
@@ -401,10 +393,6 @@ class FieldTest extends \atk4\schema\PhpunitTestCase
 
     public function testActual()
     {
-        if ($this->driverType === 'pgsql') {
-            $this->markTestIncomplete('This test is not supported on PostgreSQL');
-        }
-
         $db = new Persistence\Sql($this->db->connection);
         $this->setDb([
             'user' => [

--- a/tests/JoinSqlTest.php
+++ b/tests/JoinSqlTest.php
@@ -56,7 +56,7 @@ class JoinSqlTest extends \atk4\schema\PhpunitTestCase
     public function testJoinSaving1()
     {
         if ($this->driverType === 'pgsql') {
-            $this->markTestIncomplete('This test is not supported on PostgreSQL');
+            $this->markTestIncomplete('TODO - NULL PK not unset in INSERT');
         }
 
         $db = new Persistence\Sql($this->db->connection);
@@ -162,7 +162,7 @@ class JoinSqlTest extends \atk4\schema\PhpunitTestCase
     public function testJoinSaving3()
     {
         if ($this->driverType === 'pgsql') {
-            $this->markTestIncomplete('This test is not supported on PostgreSQL');
+            $this->markTestIncomplete('TODO - NULL PK not unset in INSERT');
         }
 
         $db = new Persistence\Sql($this->db->connection);
@@ -228,7 +228,7 @@ class JoinSqlTest extends \atk4\schema\PhpunitTestCase
     public function testJoinUpdate()
     {
         if ($this->driverType === 'pgsql') {
-            $this->markTestIncomplete('This test is not supported on PostgreSQL');
+            $this->markTestIncomplete('TODO - NULL PK not unset in INSERT');
         }
 
         $this->setDb([
@@ -402,7 +402,7 @@ class JoinSqlTest extends \atk4\schema\PhpunitTestCase
     public function testDoubleJoin()
     {
         if ($this->driverType === 'pgsql') {
-            $this->markTestIncomplete('This test is not supported on PostgreSQL');
+            $this->markTestIncomplete('TODO - NULL PK not unset in INSERT');
         }
 
         $this->setDb([

--- a/tests/ModelWithoutIdTest.php
+++ b/tests/ModelWithoutIdTest.php
@@ -66,7 +66,7 @@ class ModelWithoutIdTest extends \atk4\schema\PhpunitTestCase
     public function testInsert()
     {
         if ($this->driverType === 'pgsql') {
-            $this->markTestIncomplete('This test is not supported on PostgreSQL');
+            $this->markTestIncomplete('PostgreSQL requires PK unspecified to use autoincrement');
         }
 
         $this->m->insert(['name' => 'Joe']);
@@ -79,7 +79,7 @@ class ModelWithoutIdTest extends \atk4\schema\PhpunitTestCase
     public function testSave1()
     {
         if ($this->driverType === 'pgsql') {
-            $this->markTestIncomplete('This test is not supported on PostgreSQL');
+            $this->markTestIncomplete('PostgreSQL requires PK unspecified to use autoincrement');
         }
 
         $this->m->tryLoadAny();
@@ -94,7 +94,7 @@ class ModelWithoutIdTest extends \atk4\schema\PhpunitTestCase
     public function testSave2()
     {
         if ($this->driverType === 'pgsql') {
-            $this->markTestIncomplete('This test is not supported on PostgreSQL');
+            $this->markTestIncomplete('PostgreSQL requires PK unspecified to use autoincrement');
         }
 
         $this->m->tryLoadAny();

--- a/tests/RandomTest.php
+++ b/tests/RandomTest.php
@@ -114,10 +114,6 @@ class RandomTest extends \atk4\schema\PhpunitTestCase
 
     public function testAddFields()
     {
-        if ($this->driverType === 'pgsql') {
-            $this->markTestIncomplete('This test is not supported on PostgreSQL');
-        }
-
         $this->setDb([
             'user' => [
                 1 => ['name' => 'John', 'login' => 'john@example.com'],
@@ -142,10 +138,6 @@ class RandomTest extends \atk4\schema\PhpunitTestCase
 
     public function testAddFields2()
     {
-        if ($this->driverType === 'pgsql') {
-            $this->markTestIncomplete('This test is not supported on PostgreSQL');
-        }
-
         $this->setDb([
             'user' => [
                 1 => ['name' => 'John', 'last_name' => null, 'login' => null, 'salary' => null, 'tax' => null, 'vat' => null],
@@ -178,16 +170,12 @@ class RandomTest extends \atk4\schema\PhpunitTestCase
 
     public function testSameTable()
     {
-        if ($this->driverType === 'pgsql') {
-            $this->markTestIncomplete('This test is not supported on PostgreSQL');
-        }
-
         $db = new Persistence\Sql($this->db->connection);
         $this->setDb([
             'item' => [
-                1 => ['id' => 1, 'name' => 'John', 'parent_item_id' => '1'],
-                2 => ['id' => 2, 'name' => 'Sue', 'parent_item_id' => '1'],
-                3 => ['id' => 3, 'name' => 'Smith', 'parent_item_id' => '2'],
+                1 => ['id' => 1, 'name' => 'John', 'parent_item_id' => 1],
+                2 => ['id' => 2, 'name' => 'Sue', 'parent_item_id' => 1],
+                3 => ['id' => 3, 'name' => 'Smith', 'parent_item_id' => 2],
             ],
         ]);
 
@@ -201,10 +189,6 @@ class RandomTest extends \atk4\schema\PhpunitTestCase
 
     public function testSameTable2()
     {
-        if ($this->driverType === 'pgsql') {
-            $this->markTestIncomplete('This test is not supported on PostgreSQL');
-        }
-
         $db = new Persistence\Sql($this->db->connection);
         $this->setDb([
             'item' => [
@@ -213,9 +197,9 @@ class RandomTest extends \atk4\schema\PhpunitTestCase
                 3 => ['id' => 3, 'name' => 'Smith'],
             ],
             'item2' => [
-                1 => ['id' => 1, 'item_id' => 1, 'parent_item_id' => '1'],
-                2 => ['id' => 2, 'item_id' => 2, 'parent_item_id' => '1'],
-                3 => ['id' => 3, 'item_id' => 3, 'parent_item_id' => '2'],
+                1 => ['id' => 1, 'item_id' => 1, 'parent_item_id' => 1],
+                2 => ['id' => 2, 'item_id' => 2, 'parent_item_id' => 1],
+                3 => ['id' => 3, 'item_id' => 3, 'parent_item_id' => 2],
             ],
         ]);
 
@@ -229,10 +213,6 @@ class RandomTest extends \atk4\schema\PhpunitTestCase
 
     public function testSameTable3()
     {
-        if ($this->driverType === 'pgsql') {
-            $this->markTestIncomplete('This test is not supported on PostgreSQL');
-        }
-
         $db = new Persistence\Sql($this->db->connection);
         $this->setDb([
             'item' => [
@@ -241,16 +221,16 @@ class RandomTest extends \atk4\schema\PhpunitTestCase
                 3 => ['id' => 3, 'name' => 'Smith', 'age' => 24],
             ],
             'item2' => [
-                1 => ['id' => 1, 'item_id' => 1, 'parent_item_id' => '1'],
-                2 => ['id' => 2, 'item_id' => 2, 'parent_item_id' => '1'],
-                3 => ['id' => 3, 'item_id' => 3, 'parent_item_id' => '2'],
+                1 => ['id' => 1, 'item_id' => 1, 'parent_item_id' => 1],
+                2 => ['id' => 2, 'item_id' => 2, 'parent_item_id' => 1],
+                3 => ['id' => 3, 'item_id' => 3, 'parent_item_id' => 2],
             ],
         ]);
 
         $m = new Model_Item3($db, 'item');
 
         $this->assertEquals(
-            ['id' => '2', 'name' => 'Sue', 'parent_item_id' => '1', 'parent_item' => 'John', 'age' => '20', 'child_age' => 24],
+            ['id' => '2', 'name' => 'Sue', 'parent_item_id' => 1, 'parent_item' => 'John', 'age' => '20', 'child_age' => 24],
             $m->load(2)->get()
         );
 
@@ -387,15 +367,11 @@ class RandomTest extends \atk4\schema\PhpunitTestCase
 
     public function testGetTitle()
     {
-        if ($this->driverType === 'pgsql') {
-            $this->markTestIncomplete('This test is not supported on PostgreSQL');
-        }
-
         $db = new Persistence\Sql($this->db->connection);
         $this->setDb([
             'item' => [
-                1 => ['id' => 1, 'name' => 'John', 'parent_item_id' => '1'],
-                2 => ['id' => 2, 'name' => 'Sue', 'parent_item_id' => '1'],
+                1 => ['id' => 1, 'name' => 'John', 'parent_item_id' => 1],
+                2 => ['id' => 2, 'name' => 'Sue', 'parent_item_id' => 1],
             ],
         ]);
 

--- a/tests/ReferenceSqlTest.php
+++ b/tests/ReferenceSqlTest.php
@@ -299,6 +299,10 @@ class ReferenceSqlTest extends \atk4\schema\PhpunitTestCase
 
     public function testOtherAggregates()
     {
+        if ($this->driverType === 'pgsql') {
+            $this->markTestIncomplete('This test is not supported on PostgreSQL');
+        }
+
         $vat = 0.23;
 
         $this->setDb([

--- a/tests/ReferenceSqlTest.php
+++ b/tests/ReferenceSqlTest.php
@@ -300,7 +300,7 @@ class ReferenceSqlTest extends \atk4\schema\PhpunitTestCase
     public function testOtherAggregates()
     {
         if ($this->driverType === 'pgsql') {
-            $this->markTestIncomplete('This test is not supported on PostgreSQL');
+            $this->markTestIncomplete('PostgreSQL does not support "SUM(variable)" syntax');
         }
 
         $vat = 0.23;

--- a/tests/SmboTransferTest.php
+++ b/tests/SmboTransferTest.php
@@ -34,7 +34,7 @@ class SmboTransferTest extends \atk4\schema\PhpunitTestCase
             ->field('contact_from_id')
             ->field('contact_to_id')
             ->field('doc_type')
-            ->field('amount', ['type' => 'decimal(8,2)'])
+            ->field('amount', ['type' => 'float'])
             ->create();
 
         $x = clone $s;
@@ -44,7 +44,7 @@ class SmboTransferTest extends \atk4\schema\PhpunitTestCase
             ->field('account_id', ['type' => 'integer'])
             ->field('cheque_no')
             //->field('misc_payment', ['type' => 'enum(\'N\',\'Y\')'])
-            ->field('misc_payment', ['type' => 'varchar(2)'])
+            ->field('misc_payment')
             ->field('transfer_document_id')
             ->create();
     }

--- a/tests/SubTypesTest.php
+++ b/tests/SubTypesTest.php
@@ -74,7 +74,7 @@ class StGenericTransaction extends Model
         if ($this->type) {
             $this->addCondition('type', $this->type);
         }
-        $this->addField('amount');
+        $this->addField('amount', ['type' => 'money']);
 
         $this->onHook(Model::HOOK_AFTER_LOAD, function (self $m) {
             if (static::class !== $m->getClassName()) {

--- a/tests/TypecastingTest.php
+++ b/tests/TypecastingTest.php
@@ -124,10 +124,6 @@ class TypecastingTest extends \atk4\schema\PhpunitTestCase
 
     public function testEmptyValues()
     {
-        if ($this->driverType === 'pgsql') {
-            $this->markTestIncomplete('This test is not supported on PostgreSQL');
-        }
-
         $dbData = [
             'types' => [
                 1 => $row = [
@@ -220,10 +216,6 @@ class TypecastingTest extends \atk4\schema\PhpunitTestCase
 
     public function testTypecastNull()
     {
-        if ($this->driverType === 'pgsql') {
-            $this->markTestIncomplete('This test is not supported on PostgreSQL');
-        }
-
         $dbData = [
             'test' => [
                 1 => $row = ['id' => '1', 'a' => 1, 'b' => '', 'c' => null],


### PR DESCRIPTION
fixes https://github.com/atk4/data/issues/705

PostgreSQL SEQUENCE is not incremented if ID is explicitly set.
```
CREATE SEQUENCE seq;

create table target(
   id integer,
   name varchar(100),
   CONSTRAINT pk PRIMARY KEY (id)
);

INSERT INTO target (id, name) values (seq.nextval, 'test');
INSERT INTO target (id, name) values (3, 'test');
INSERT INTO target (id, name) values (seq.nextval, 'test');
INSERT INTO target (id, name) values (2, 'test');
INSERT INTO target (id, name) values (seq.nextval, 'test');
```

Using PostgreSQL SERIAL is NOT a solution, as it only a sugar for SEQUENCE.
```
create table target(
   id SERIAL PRIMARY KEY,
   name varchar(100)
);

INSERT INTO target (name) values ('test');
INSERT INTO target (id, name) values (3, 'test');
INSERT INTO target (name) values ('test');
INSERT INTO target (id, name) values (2, 'test');
INSERT INTO target (name) values ('test');
```

Oracle should support AI like:
```
create table target(
   id INTEGER GENERATED ALWAYS AS IDENTITY (START WITH 1 INCREMENT BY 1) NOT NULL,
   name varchar(100),
   CONSTRAINT pk PRIMARY KEY (id)
);

INSERT INTO target (name) values ('test');
INSERT INTO target (id, name) values (3, 'test');
INSERT INTO target (name) values ('test');
INSERT INTO target (id, name) values (2, 'test');
INSERT INTO target (name) values ('test');
```

but I am not sure if that has the same issue or not (I have no access to Oracle DB, related with https://github.com/atk4/dsql/issues/241 ).