### PR TITLE
Drop ID property in advance of standard row data, provide BC using magic

### DIFF
--- a/docs/persistence.rst
+++ b/docs/persistence.rst
@@ -117,7 +117,7 @@ However if you change the ID for record that was loaded, then your database
 record will also have its ID changed. Here is example::
 
     $m->load(123);
-    $m->set($m->id_field, 321);
+    $m->setId(321);
     $m->save();
 
 After this your database won't have a record with ID 123 anymore.

--- a/src/Model.php
+++ b/src/Model.php
@@ -847,11 +847,8 @@ class Model implements \IteratorAggregate
             $this->entityId = $value;
         }
 
-        // TODO - fix read only set and dirty issues related with set() below
+        // TODO make sure ID is in the data
         $this->data[$this->id_field] = $value;
-
-        return $this;
-        // TODO - fix read only set and dirty issues related with set() below
 
         if ($value === null) {
             return $this->setNull($this->id_field);

--- a/src/Model.php
+++ b/src/Model.php
@@ -376,6 +376,8 @@ class Model implements \IteratorAggregate
             return; // don't declare actions for model without id_field
         }
 
+        $this->initEntityHooks();
+
         if ($this->read_only) {
             return; // don't declare action for read-only model
         }
@@ -415,8 +417,6 @@ class Model implements \IteratorAggregate
             'system' => true, // don't show by default
             'args' => ['intent' => 'string'],
         ]);
-
-        $this->initEntityHooks();
     }
 
     private function initEntityHooks(): void

--- a/src/Model.php
+++ b/src/Model.php
@@ -851,11 +851,10 @@ class Model implements \IteratorAggregate
     {
         $this->assertHasIdField();
 
-//        if ($value === null) {
-//            return $this->setNull($this->id_field);
-//        } else {
-//            return $this->set($this->id_field, $value);
-//        }
+        // first set ID is entity ID
+        if ($this->entityId === null && $value !== null) {
+            $this->entityId = $value;
+        }
 
         $this->id = $value;
         $this->set($this->id_field, $this->id);

--- a/src/Model.php
+++ b/src/Model.php
@@ -1071,7 +1071,7 @@ class Model implements \IteratorAggregate
      */
     public function loaded(): bool
     {
-        return $this->id !== null;
+        return $this->id_field && $this->id !== null;
     }
 
     /**

--- a/src/Model.php
+++ b/src/Model.php
@@ -824,7 +824,7 @@ class Model implements \IteratorAggregate
 
     private function assertHasIdField(): void
     {
-        if (!is_string($this->id_field) || !$this->hasField($this->id_field)) {
+        if (!is_string($this->id_field) /*|| !$this->hasField($this->id_field)*/) {
             throw new Exception('ID field is not defined');
         }
     }
@@ -1110,7 +1110,7 @@ class Model implements \IteratorAggregate
      */
     public function loaded(): bool
     {
-        return $this->id_field && $this->id !== null;
+        return $this->id_field && $this->getId() !== null;
     }
 
     /**

--- a/src/Persistence/Csv.php
+++ b/src/Persistence/Csv.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace atk4\data\Persistence;
 
 use atk4\data\Exception;
-use atk4\data\Field;
 use atk4\data\Model;
 use atk4\data\Persistence;
 
@@ -84,7 +83,7 @@ class Csv extends Persistence
      *
      * @var array
      */
-    public $header = [];
+    public $header;
 
     public function __construct(string $file, array $defaults = [])
     {
@@ -92,9 +91,6 @@ class Csv extends Persistence
         $this->setDefaults($defaults);
     }
 
-    /**
-     * Destructor. close files correctly.
-     */
     public function __destruct()
     {
         $this->closeFile();
@@ -128,6 +124,7 @@ class Csv extends Persistence
         if ($this->handle) {
             fclose($this->handle);
             $this->handle = null;
+            $this->header = null;
         }
     }
 

--- a/src/Persistence/Csv.php
+++ b/src/Persistence/Csv.php
@@ -178,7 +178,7 @@ class Csv extends Persistence
 
         $header = [];
         foreach ($model->getFields() as $name => $field) {
-            if ($name === $model->id_field) {
+            if ($model->id_field && $name === $model->id_field) {
                 continue;
             }
 
@@ -208,15 +208,18 @@ class Csv extends Persistence
     public function typecastLoadRow(Model $model, array $row): array
     {
         $id = null;
-        if (isset($row[$model->id_field])) {
-            // temporary remove id field
-            $id = $row[$model->id_field];
-            unset($row[$model->id_field]);
-        } else {
-            $id = null;
+        if ($model->id_field) {
+            if (isset($row[$model->id_field])) {
+                // temporary remove id field
+                $id = $row[$model->id_field];
+                unset($row[$model->id_field]);
+            } else {
+                $id = null;
+            }
         }
+
         $row = array_combine($this->header, $row);
-        if (isset($id)) {
+        if ($model->id_field && isset($id)) {
             $row[$model->id_field] = $id;
         }
 
@@ -255,7 +258,9 @@ class Csv extends Persistence
         }
 
         $data = $this->typecastLoadRow($model, $data);
-        $data[$model->id_field] = $this->line;
+        if ($model->id_field) {
+            $data[$model->id_field] = $this->line;
+        }
 
         return $data;
     }
@@ -281,7 +286,9 @@ class Csv extends Persistence
                 break;
             }
             $data = $this->typecastLoadRow($model, $data);
-            $data[$model->id_field] = $this->line;
+            if ($model->id_field) {
+                $data[$model->id_field] = $this->line;
+            }
 
             yield $data;
         }
@@ -326,6 +333,10 @@ class Csv extends Persistence
         }
 
         $this->putLine($line);
+
+        if ($model->id_field) {
+            return $data[$model->id_field];
+        }
     }
 
     /**

--- a/src/Reference/ContainsMany.php
+++ b/src/Reference/ContainsMany.php
@@ -27,10 +27,8 @@ class ContainsMany extends ContainsOne
         $ourModel = $this->getOurModel();
 
         // get model
-        // will not use ID field (no, sorry, will have to use it)
         $theirModel = $this->getTheirModel(array_merge($defaults, [
             'contained_in_root_model' => $ourModel->contained_in_root_model ?: $ourModel,
-            //'id_field'              => false,
             'table' => $this->table_alias,
         ]));
 

--- a/src/Reference/ContainsOne.php
+++ b/src/Reference/ContainsOne.php
@@ -87,10 +87,8 @@ class ContainsOne extends Reference
         $ourModel = $this->getOurModel();
 
         // get model
-        // will not use ID field
         $theirModel = $this->getTheirModel(array_merge($defaults, [
             'contained_in_root_model' => $ourModel->contained_in_root_model ?: $ourModel,
-            // 'id_field' => false,
             'table' => $this->table_alias,
         ]));
 

--- a/src/Reference/ContainsOne.php
+++ b/src/Reference/ContainsOne.php
@@ -90,7 +90,7 @@ class ContainsOne extends Reference
         // will not use ID field
         $theirModel = $this->getTheirModel(array_merge($defaults, [
             'contained_in_root_model' => $ourModel->contained_in_root_model ?: $ourModel,
-            'id_field' => false,
+            // 'id_field' => false,
             'table' => $this->table_alias,
         ]));
 

--- a/tests/ContainsOneTest.php
+++ b/tests/ContainsOneTest.php
@@ -44,7 +44,7 @@ class Address1 extends Model
     {
         parent::init();
 
-        $this->hasOne('country_id', ['model' => [Country1::class]]);
+        $this->hasOne('country_id', ['model' => [Country1::class], 'type' => 'integer']);
 
         $this->addField('address');
         $this->addField('built_date', ['type' => 'datetime']);
@@ -142,7 +142,7 @@ class ContainsOneTest extends \atk4\schema\PhpunitTestCase
         $this->assertFalse($a->loaded());
 
         // now store some address
-        $a->setMulti($row = ['country_id' => 1, 'address' => 'foo', 'built_date' => new \DateTime('2019-01-01 UTC'), 'tags' => ['foo', 'bar'], 'door_code' => null]);
+        $a->setMulti($row = ['country_id' => 1, 'address' => 'foo', 'built_date' => new \DateTime('2019-01-01 UTC'), 'tags' => ['foo', 'bar'], 'door_code' => null, 'id' => 1]);
         $a->save();
 
         // now reload invoice and see if it is saved
@@ -156,7 +156,7 @@ class ContainsOneTest extends \atk4\schema\PhpunitTestCase
 
         // now add nested containsOne - DoorCode
         $c = $i->ref('addr')->ref('door_code');
-        $c->setMulti($row = ['code' => 'ABC', 'valid_till' => new \DateTime('2019-07-01 UTC')]);
+        $c->setMulti($row = ['code' => 'ABC', 'valid_till' => new \DateTime('2019-07-01 UTC'), 'id' => 1]);
         $c->save();
         $this->assertEquals($row, $i->ref('addr')->ref('door_code')->get());
 
@@ -175,7 +175,7 @@ class ContainsOneTest extends \atk4\schema\PhpunitTestCase
         // let's test how it all looks in persistence without typecasting
         $exp_addr = $i->setOrder('id')->export(null, null, false)[0]['addr'];
         $this->assertSame(
-            '{"country_id":"2","address":"bar","built_date":"2019-01-01T00:00:00+00:00","tags":"[\"foo\",\"bar\"]","door_code":"{\"code\":\"DEF\",\"valid_till\":\"2019-07-01T00:00:00+00:00\"}"}',
+            '{"id":1,"country_id":"2","address":"bar","built_date":"2019-01-01T00:00:00+00:00","tags":"[\"foo\",\"bar\"]","door_code":"{\"id\":1,\"code\":\"DEF\",\"valid_till\":\"2019-07-01T00:00:00+00:00\"}"}',
             $exp_addr
         );
 
@@ -202,7 +202,7 @@ class ContainsOneTest extends \atk4\schema\PhpunitTestCase
 
         // with address
         $a = $i->ref('addr');
-        $a->setMulti($row = ['country_id' => 1, 'address' => 'foo', 'built_date' => new \DateTime('2019-01-01'), 'tags' => [], 'door_code' => null]);
+        $a->setMulti($row = ['id' => 1, 'country_id' => 1, 'address' => 'foo', 'built_date' => new \DateTime('2019-01-01'), 'tags' => [], 'door_code' => null]);
         $a->save();
 
         // now let's add one more field in address model and save
@@ -210,7 +210,7 @@ class ContainsOneTest extends \atk4\schema\PhpunitTestCase
         $a->set('post_index', 'LV-1234');
         $a->save();
 
-        $this->assertSame(array_merge($row, ['post_index' => 'LV-1234']), $a->get());
+        $this->assertEquals(array_merge($row, ['post_index' => 'LV-1234']), $a->get());
 
         // now this one is a bit tricky
         // each time you call ref() it returns you new model object so it will not have post_index field

--- a/tests/ContainsOneTest.php
+++ b/tests/ContainsOneTest.php
@@ -142,7 +142,7 @@ class ContainsOneTest extends \atk4\schema\PhpunitTestCase
         $this->assertFalse($a->loaded());
 
         // now store some address
-        $a->setMulti($row = ['country_id' => 1, 'address' => 'foo', 'built_date' => new \DateTime('2019-01-01 UTC'), 'tags' => ['foo', 'bar'], 'door_code' => null, 'id' => 1]);
+        $a->setMulti($row = ['id' => 1, 'country_id' => 1, 'address' => 'foo', 'built_date' => new \DateTime('2019-01-01 UTC'), 'tags' => ['foo', 'bar'], 'door_code' => null]);
         $a->save();
 
         // now reload invoice and see if it is saved
@@ -156,7 +156,7 @@ class ContainsOneTest extends \atk4\schema\PhpunitTestCase
 
         // now add nested containsOne - DoorCode
         $c = $i->ref('addr')->ref('door_code');
-        $c->setMulti($row = ['code' => 'ABC', 'valid_till' => new \DateTime('2019-07-01 UTC'), 'id' => 1]);
+        $c->setMulti($row = ['id' => 1, 'code' => 'ABC', 'valid_till' => new \DateTime('2019-07-01 UTC')]);
         $c->save();
         $this->assertEquals($row, $i->ref('addr')->ref('door_code')->get());
 

--- a/tests/CsvTest.php
+++ b/tests/CsvTest.php
@@ -159,9 +159,10 @@ class CsvTest extends AtkPhpunit\TestCase
         $m = new Person($p);
 
         $m2 = $m->withPersistence($p2);
+        $m2->reload_after_save = false;
 
         foreach ($m as $row) {
-            $m2->save($row->get());
+            (clone $m2)->save($row->get());
         }
 
         fseek($this->file, 0);

--- a/tests/CsvTest.php
+++ b/tests/CsvTest.php
@@ -21,47 +21,62 @@ class CsvTest extends AtkPhpunit\TestCase
     {
         parent::setUp();
 
-        // better to skip this test on Windows, prevent permissions issues
-        // see also https://github.com/atk4/data/issues/271
-        if (strtoupper(substr(PHP_OS, 0, 3)) === 'WIN') {
-            $this->markTestSkipped('Skip on Windows');
-        }
-
-        $this->file = sys_get_temp_dir() . '/atk4_test__data__a.csv';
-        $this->file2 = sys_get_temp_dir() . '/atk4_test__data__b.csv';
+        $this->file = fopen('php://memory', 'w+');
+        $this->file2 = fopen('php://memory', 'w+');
     }
 
     protected function tearDown(): void
     {
         parent::tearDown();
 
-        if (file_exists($this->file)) {
-            unlink($this->file);
-        }
-        if (file_exists($this->file2)) {
-            unlink($this->file2);
-        }
+        fclose($this->file);
+        fclose($this->file2);
+    }
+
+    protected function makeCsvPersistence($fileHandle, array $defaults = []): Persistence\Csv
+    {
+        return new class($fileHandle, $defaults) extends Persistence\Csv {
+            private $handleUnloaded;
+
+            public function __construct($fileHandle, $defaults)
+            {
+                parent::__construct('', $defaults);
+                $this->handleUnloaded = $fileHandle;
+            }
+
+            public function openFile(string $mode = 'r'): void
+            {
+                $this->handle = $this->handleUnloaded;
+                fseek($this->handle, 0);
+            }
+
+            public function closeFile(): void
+            {
+                if ($this->handle && get_resource_type($this->handle) === 'stream') {
+                    $this->handle = null;
+                    $this->header = null;
+                }
+            }
+        };
     }
 
     protected function setDb($data): void
     {
-        $f = fopen($this->file, 'w');
-        fputcsv($f, array_keys(reset($data)));
+        ftruncate($this->file, 0);
+        fputcsv($this->file, array_keys(reset($data)));
         foreach ($data as $row) {
-            fputcsv($f, $row);
+            fputcsv($this->file, $row);
         }
-        fclose($f);
     }
 
     protected function getDb(): array
     {
-        $f = fopen($this->file, 'r');
-        $keys = fgetcsv($f);
+        fseek($this->file, 0);
+        $keys = fgetcsv($this->file);
         $data = [];
-        while ($row = fgetcsv($f)) {
+        while ($row = fgetcsv($this->file)) {
             $data[] = array_combine($keys, $row);
         }
-        fclose($f);
 
         return $data;
     }
@@ -90,7 +105,7 @@ class CsvTest extends AtkPhpunit\TestCase
 
         $this->setDb($data);
 
-        $p = new Persistence\Csv($this->file);
+        $p = $this->makeCsvPersistence($this->file);
         $m = new Model($p);
         $m->addField('name');
         $m->addField('surname');
@@ -109,7 +124,7 @@ class CsvTest extends AtkPhpunit\TestCase
 
         $this->setDb($data);
 
-        $p = new Persistence\Csv($this->file);
+        $p = $this->makeCsvPersistence($this->file);
         $m = new Model($p);
         $m->addField('name');
         $m->addField('surname');
@@ -136,8 +151,8 @@ class CsvTest extends AtkPhpunit\TestCase
 
         $this->setDb($data);
 
-        $p = new Persistence\Csv($this->file);
-        $p2 = new Persistence\Csv($this->file2);
+        $p = $this->makeCsvPersistence($this->file);
+        $p2 = $this->makeCsvPersistence($this->file2);
 
         $m = new Person($p);
 
@@ -147,9 +162,11 @@ class CsvTest extends AtkPhpunit\TestCase
             $m2->save($row->get());
         }
 
+        fseek($this->file, 0);
+        fseek($this->file2, 0);
         $this->assertSame(
-            file_get_contents($this->file2),
-            file_get_contents($this->file)
+            stream_get_contents($this->file),
+            stream_get_contents($this->file2)
         );
     }
 
@@ -164,7 +181,7 @@ class CsvTest extends AtkPhpunit\TestCase
         ];
         $this->setDb($data);
 
-        $p = new Persistence\Csv($this->file);
+        $p = $this->makeCsvPersistence($this->file);
         $m = new Model($p);
         $m->addField('name');
         $m->addField('surname');

--- a/tests/CsvTest.php
+++ b/tests/CsvTest.php
@@ -159,7 +159,7 @@ class CsvTest extends AtkPhpunit\TestCase
         $m = new Person($p);
 
         $m2 = $m->withPersistence($p2);
-        $m2->reload_after_save = false;
+        $m2->reload_after_save = false; // TODO should be not needed after https://github.com/atk4/data/pull/690 is merged
 
         foreach ($m as $row) {
             (clone $m2)->save($row->get());

--- a/tests/CsvTest.php
+++ b/tests/CsvTest.php
@@ -7,7 +7,7 @@ namespace atk4\data\tests;
 use atk4\core\AtkPhpunit;
 use atk4\data\Model;
 use atk4\data\Persistence;
-use atk4\data\tests\Model\Person as Person;
+use atk4\data\tests\Model\Person;
 
 /**
  * @coversDefaultClass \atk4\data\Model
@@ -67,6 +67,8 @@ class CsvTest extends AtkPhpunit\TestCase
         foreach ($data as $row) {
             fputcsv($this->file, $row);
         }
+
+        ftruncate($this->file2, 0);
     }
 
     protected function getDb(): array

--- a/tests/ModelWithoutIdTest.php
+++ b/tests/ModelWithoutIdTest.php
@@ -49,9 +49,23 @@ class ModelWithoutIdTest extends \atk4\schema\PhpunitTestCase
         $n = [];
         foreach ($this->m as $row) {
             $n[] = $row->get('name');
-            $this->assertNull($row->id);
         }
         $this->assertSame(['Sue', 'John'], $n);
+    }
+
+    public function testGetIdException()
+    {
+        $this->m->loadAny();
+        $this->expectException(Exception::class);
+        $this->expectErrorMessage('ID field is not defined');
+        $this->m->dummy = $this->m->id;
+    }
+
+    public function testSetIdException()
+    {
+        $this->expectException(Exception::class);
+        $this->expectErrorMessage('ID field is not defined');
+        $this->m->id = 1;
     }
 
     public function testFail1()
@@ -123,15 +137,5 @@ class ModelWithoutIdTest extends \atk4\schema\PhpunitTestCase
     {
         $this->expectException(Exception::class);
         $this->m->delete(4);
-    }
-
-    /**
-     * Additional checks are done if ID is manually set.
-     */
-    public function testFailDelete2()
-    {
-        $this->m->id = 4;
-        $this->expectException(Exception::class);
-        $this->m->delete();
     }
 }

--- a/tests/ModelWithoutIdTest.php
+++ b/tests/ModelWithoutIdTest.php
@@ -134,15 +134,4 @@ class ModelWithoutIdTest extends \atk4\schema\PhpunitTestCase
         $this->expectException(Exception::class);
         $this->m->delete();
     }
-
-    /**
-     * Additional checks are done if ID is manually set.
-     */
-    public function testFailUpdate()
-    {
-        $this->m->id = 1;
-        $this->m->set('name', 'foo');
-        $this->expectException(Exception::class);
-        $this->m->saveAndUnload();
-    }
 }

--- a/tests/PersistentSqlTest.php
+++ b/tests/PersistentSqlTest.php
@@ -121,7 +121,7 @@ class PersistentSqlTest extends \atk4\schema\PhpunitTestCase
         $this->assertSame('Doe', $m->get('surname'));
         $this->assertEquals(3, $m->id);
         // id field value is set with new id value even if reload_after_save = false
-        $this->assertEquals(3, $m->get($m->id_field));
+        $this->assertEquals(3, $m->getId());
     }
 
     public function testModelInsertRows()

--- a/tests/ReadOnlyModeTest.php
+++ b/tests/ReadOnlyModeTest.php
@@ -39,12 +39,12 @@ class ReadOnlyModeTest extends \atk4\schema\PhpunitTestCase
      */
     public function testBasic()
     {
-        $this->m->tryLoadAny();
-        $this->assertSame('John', $this->m->get('name'));
+        $mm = (clone $this->m)->tryLoadAny();
+        $this->assertSame('John', $mm->get('name'));
 
         $this->m->setOrder('name', 'desc');
-        $this->m->tryLoadAny();
-        $this->assertSame('Sue', $this->m->get('name'));
+        $mm = (clone $this->m)->tryLoadAny();
+        $this->assertSame('Sue', $mm->get('name'));
 
         $this->assertEquals([1 => 'John', 2 => 'Sue'], $this->m->getTitles());
     }

--- a/tests/ReferenceTest.php
+++ b/tests/ReferenceTest.php
@@ -17,10 +17,12 @@ class ReferenceTest extends AtkPhpunit\TestCase
     public function testBasicReferences()
     {
         $user = new Model(['table' => 'user']);
+        $user->addField('id');
         $user->addField('name');
         $user->id = 1;
 
         $order = new Model();
+        $order->addField('id');
         $order->addField('amount', ['default' => 20]);
         $order->addField('user_id');
 
@@ -47,10 +49,12 @@ class ReferenceTest extends AtkPhpunit\TestCase
     public function testModelCaption()
     {
         $user = new Model(['table' => 'user']);
+        $user->addField('id');
         $user->addField('name');
         $user->id = 1;
 
         $order = new Model();
+        $order->addField('id');
         $order->addField('amount', ['default' => 20]);
         $order->addField('user_id');
 

--- a/tests/UserActionTest.php
+++ b/tests/UserActionTest.php
@@ -205,21 +205,15 @@ class UserActionTest extends \atk4\schema\PhpunitTestCase
 
     public function testFields()
     {
-        try {
-            $client = new UaClient($this->pers);
-            $a = $client->addUserAction('change_details', ['callback' => 'save', 'fields' => ['name']]);
+        $client = new UaClient($this->pers);
+        $a = $client->addUserAction('change_details', ['callback' => 'save', 'fields' => ['name']]);
 
-            $client->load(1);
+        $client->load(1);
 
-            $this->assertNotSame('Peter', $client->get('name'));
-            $client->set('name', 'Peter');
-            $a->execute();
-            $this->assertSame('Peter', $client->get('name'));
-        } catch (Exception $e) {
-            echo $e->getColorfulText();
-
-            throw $e;
-        }
+        $this->assertNotSame('Peter', $client->get('name'));
+        $client->set('name', 'Peter');
+        $a->execute();
+        $this->assertSame('Peter', $client->get('name'));
     }
 
     public function testFieldsTooDirty1()


### PR DESCRIPTION
Labeling as a bug, as previously `get(id_field)` was very commonly have a different value than the actual id property.

Now, id property is implemented as magical one and data can never go out of sync.

Later, I think we should drop it in favor of getId() and setId(val) as we do not provide property access for other fields.