### PR TITLE
Fix not rebound hooks after clone

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -77,10 +77,6 @@ jobs:
           if [ "${{ matrix.php }}" == "8.0" ]; then composer config platform.php 7.4.5 ; fi
           composer install --no-suggest --ansi --prefer-dist --no-interaction --no-progress --optimize-autoloader
 
-          # debug for https://github.com/atk4/data/pull/711, remove before merge
-          rm -R vendor/atk4/core
-          git clone -b hook_rebound https://github.com/atk4/core.git vendor/atk4/core
-
       - name: Init
         run: |
           mkdir -p build/logs

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -77,6 +77,10 @@ jobs:
           if [ "${{ matrix.php }}" == "8.0" ]; then composer config platform.php 7.4.5 ; fi
           composer install --no-suggest --ansi --prefer-dist --no-interaction --no-progress --optimize-autoloader
 
+          # debug for https://github.com/atk4/data/pull/711, remove before merge
+          rm -R vendor/atk4/core
+          git clone -b hook_rebound https://github.com/atk4/core.git vendor/atk4/core
+
       - name: Init
         run: |
           mkdir -p build/logs

--- a/docs/advanced.rst
+++ b/docs/advanced.rst
@@ -347,7 +347,7 @@ before and just slightly modifying it::
             }
         }
 
-        function softDelete($m) {
+        function softDelete(Model $m) {
             if (!$m->loaded()) {
                 throw (new \atk4\core\Exception('Model must be loaded before soft-deleting'))->addMoreInfo('model', $m);
             }
@@ -428,7 +428,7 @@ inside your model are unique::
             $this->owner->onHook(Model::HOOK_BEFORE_SAVE, \Closure::fromCallable([$this, 'beforeSave']));
         }
 
-        function beforeSave($m)
+        function beforeSave(Model $m)
         {
             foreach ($this->fields as $field) {
                 if ($m->dirty[$field]) {

--- a/docs/advanced.rst
+++ b/docs/advanced.rst
@@ -77,11 +77,11 @@ Another scenario which could benefit by type substitution would be::
 ATK Data allow class substitution during load and iteration by breaking "afterLoad"
 hook. Place the following inside Transaction::init()::
 
-    $this->onHook(Model::HOOK_AFTER_LOAD, function ($m) {
-        if (get_class($this) != $m->getClassName()) {
+    $this->onHookShort(Model::HOOK_AFTER_LOAD, function () {
+        if (get_class($this) != $this->getClassName()) {
             $cl = '\\'.$this->getClassName();
             $cl = new $cl($this->persistence);
-            $cl->load($m->getId());
+            $cl->load($this->getId());
 
             $this->breakHook($cl);
         }
@@ -517,11 +517,11 @@ Next we need to define reference. Inside Model_Invoice add::
         $j->hasOne('invoice_id', 'Model_Invoice');
     }, 'their_field'=>'invoice_id']);
 
-    $this->onHook(Model::HOOK_BEFORE_DELETE, function($m){
-        $m->ref('InvoicePayment')->action('delete')->execute();
+    $this->onHookShort(Model::HOOK_BEFORE_DELETE, function(){
+        $this->ref('InvoicePayment')->action('delete')->execute();
 
         // If you have important per-row hooks in InvoicePayment
-        // $payment = $m->ref('InvoicePayment'); $payment->each(function () use ($payment) { $payment->delete(); });
+        // $payment = $this->ref('InvoicePayment'); $payment->each(function () use ($payment) { $payment->delete(); });
     });
 
 You'll have to do a similar change inside Payment model. The code for '$j->'
@@ -652,23 +652,23 @@ Here is how to add them. First you need to create fields::
 I have declared those fields with never_persist so they will never be used by
 persistence layer to load or save anything. Next I need a beforeSave handler::
 
-    $this->onHook(Model::HOOK_BEFORE_SAVE, function($m) {
-        if($m->_isset($m['client_code') && !$m->_isset($m['client_id')) {
+    $this->onHookShort(Model::HOOK_BEFORE_SAVE, function() {
+        if($this->_isset($this['client_code') && !$this->_isset($this['client_id')) {
             $cl = $this->refModel('client_id');
-            $cl->addCondition('code',$m->get('client_code'));
-            $m->set('client_id', $cl->action('field',['id']));
+            $cl->addCondition('code',$this->get('client_code'));
+            $this->set('client_id', $cl->action('field',['id']));
         }
 
-        if($m->_isset('client_name') && !$m->_isset('client_id')) {
+        if($this->_isset('client_name') && !$this->_isset('client_id')) {
             $cl = $this->refModel('client_id');
-            $cl->addCondition('name', 'like', $m->get('client_name'));
-            $m->set('client_id', $cl->action('field',['id']));
+            $cl->addCondition('name', 'like', $this->get('client_name'));
+            $this->set('client_id', $cl->action('field',['id']));
         }
 
-        if($m->_isset('category') && !$m->_isset('category_id')) {
+        if($this->_isset('category') && !$this->_isset('category_id')) {
             $c = $this->refModel('category_id');
-            $c->addCondition($c->title_field, 'like', $m->get('category'));
-            $m->set('category_id', $c->action('field',['id']));
+            $c->addCondition($c->title_field, 'like', $this->get('category'));
+            $this->set('category_id', $c->action('field',['id']));
         }
     });
 
@@ -741,13 +741,13 @@ section. Add this into your Invoice Model::
 Next both payment and lines need to be added after invoice is actually created,
 so::
 
-    $this->onHook(Model::HOOK_AFTER_SAVE, function($m, $is_update){
-        if($m->_isset('payment')) {
-            $m->ref('Payment')->insert($m->get('payment'));
+    $this->onHookShort(Model::HOOK_AFTER_SAVE, function($is_update){
+        if($this->_isset('payment')) {
+            $this->ref('Payment')->insert($this->get('payment'));
         }
 
-        if($m->_isset('lines')) {
-            $m->ref('Line')->import($m->get('lines'));
+        if($this->_isset('lines')) {
+            $this->ref('Line')->import($this->get('lines'));
         }
     });
 

--- a/docs/advanced.rst
+++ b/docs/advanced.rst
@@ -653,7 +653,7 @@ I have declared those fields with never_persist so they will never be used by
 persistence layer to load or save anything. Next I need a beforeSave handler::
 
     $this->onHookShort(Model::HOOK_BEFORE_SAVE, function() {
-        if($this->_isset($this['client_code') && !$this->_isset($this['client_id')) {
+        if($this->_isset('client_code') && !$this->_isset('client_id')) {
             $cl = $this->refModel('client_id');
             $cl->addCondition('code',$this->get('client_code'));
             $this->set('client_id', $cl->action('field',['id']));

--- a/docs/design.rst
+++ b/docs/design.rst
@@ -338,10 +338,10 @@ Hooks can help you perform operations when object is being persisted::
             // addField() declaration
             // addExpression('is_password_expired')
 
-            $this->onHook(Model::HOOK_BEFORE_SAVE, function($m) {
-                if ($m->isDirty('password')) {
-                    $m->set('password', encrypt_password($m->get('password')));
-                    $m->set('password_change_date', $m->expr('now()'));
+            $this->onHookShort(Model::HOOK_BEFORE_SAVE, function() {
+                if ($this->isDirty('password')) {
+                    $this->set('password', encrypt_password($this->get('password')));
+                    $this->set('password_change_date', $this->expr('now()'));
                 }
             });
         }

--- a/docs/model.rst
+++ b/docs/model.rst
@@ -391,8 +391,8 @@ a hook::
 
    $this->addField('name');
 
-   $this->onHook(Model::HOOK_VALIDATE, function($m) {
-      if ($m->get('name') === 'C#') {
+   $this->onHookShort(Model::HOOK_VALIDATE, function() {
+      if ($this->get('name') === 'C#') {
          return ['name'=>'No sharp objects are allowed'];
       }
    });
@@ -437,8 +437,8 @@ action - `send_gift`.
 There are some advanced techniques like "SubTypes" or class substitution,
 for example, this hook may be placed in the "User" class init()::
 
-   $this->onHook(Model::HOOK_AFTER_LOAD, function($m) {
-      if ($m->get('purchases') > 1000) {
+   $this->onHookShort(Model::HOOK_AFTER_LOAD, function() {
+      if ($this->get('purchases') > 1000) {
          $this->breakHook($this->asModel(VipUser::class);
       }
    });

--- a/docs/persistence.rst
+++ b/docs/persistence.rst
@@ -491,14 +491,14 @@ this ref, how do you do it?
 
 Start by creating a beforeSave handler for Order::
 
-    $this->onHook(Model::HOOK_BEFORE_SAVE, function($m) {
+    $this->onHookShort(Model::HOOK_BEFORE_SAVE, function() {
         if ($this->isDirty('ref')) {
 
             if (
-                $m->newInstance()
-                    ->addCondition('client_id', $m->get('client_id')) // same client
-                    ->addCondition($m->id_field, '!=', $m->getId())   // has another order
-                    ->tryLoadBy('ref', $m->get('ref'))                // with same ref
+                $this->newInstance()
+                    ->addCondition('client_id', $this->get('client_id'))  // same client
+                    ->addCondition($this->id_field, '!=', $this->getId()) // has another order
+                    ->tryLoadBy('ref', $this->get('ref'))                 // with same ref
                     ->loaded()
             ) {
                 throw (new Exception('Order with ref already exists for this client'))
@@ -507,8 +507,6 @@ Start by creating a beforeSave handler for Order::
             }
         }
     });
-
-.. important:: Always use $m, don't use $this, or cloning models will glitch.
 
 So to review, we used newInstance() to create new copy of a current model. It
 is important to note that newInstance() is using get_class($this) to determine

--- a/src/Field.php
+++ b/src/Field.php
@@ -77,7 +77,7 @@ class Field implements Expressionable
     /**
      * Join object.
      *
-     * @var Join|null
+     * @var Model\Join|null
      */
     public $join;
 

--- a/src/Field.php
+++ b/src/Field.php
@@ -223,6 +223,21 @@ class Field implements Expressionable
         }
     }
 
+    protected function onHookToOwner(string $spot, \Closure $fx, array $args = [], int $priority = 5): int
+    {
+        $name = $this->short_name;
+
+        return $this->owner->onHookDynamic(
+            $spot,
+            static function (Model $owner) use ($name) {
+                return $owner->getField($name);
+            },
+            $fx,
+            $args,
+            $priority
+        );
+    }
+
     /**
      * Depending on the type of a current field, this will perform
      * some normalization for strict types. This method must also make

--- a/src/Field.php
+++ b/src/Field.php
@@ -225,7 +225,7 @@ class Field implements Expressionable
 
     protected function onHookToOwner(string $spot, \Closure $fx, array $args = [], int $priority = 5): int
     {
-        $name = $this->short_name;
+        $name = $this->short_name; // use static function to allow this object to be GCed
 
         return $this->owner->onHookDynamic(
             $spot,

--- a/src/Field/Callback.php
+++ b/src/Field/Callback.php
@@ -46,7 +46,7 @@ class Callback extends \atk4\data\Field
 
         $this->ui['table']['sortable'] = false;
 
-        $this->owner->onHook(Model::HOOK_AFTER_LOAD, function (Model $model) {
+        $this->onHookToOwner(Model::HOOK_AFTER_LOAD, function (Model $model) {
             $model->data[$this->short_name] = ($this->expr)($model);
         });
     }

--- a/src/FieldSql.php
+++ b/src/FieldSql.php
@@ -10,7 +10,7 @@ use atk4\dsql\Expressionable;
 /**
  * Class description?
  *
- * @property Join\Sql $join
+ * @property Persistence\Sql\Join $join
  */
 class FieldSql extends Field implements Expressionable
 {

--- a/src/FieldSqlExpression.php
+++ b/src/FieldSqlExpression.php
@@ -62,17 +62,15 @@ class FieldSqlExpression extends FieldSql
         }
 
         if ($this->concat) {
-            $this->owner->onHook(Model::HOOK_AFTER_SAVE, \Closure::fromCallable([$this, 'afterSave']));
+            $this->onHookToOwner(Model::HOOK_AFTER_SAVE, \Closure::fromCallable([$this, 'afterSave']));
         }
     }
 
     /**
      * Possibly that user will attempt to insert values here. If that is the case, then
      * we would need to inject it into related hasMany relationship.
-     *
-     * @param Model $m
      */
-    public function afterSave($m)
+    public function afterSave(Model $model)
     {
     }
 

--- a/src/Model.php
+++ b/src/Model.php
@@ -355,6 +355,9 @@ class Model implements \IteratorAggregate
         $this->_cloneCollection('elements');
         $this->_cloneCollection('fields');
         $this->_cloneCollection('userActions');
+
+        // check for clone errors immediately, otherwise not strictly needed
+        $this->_rebindHooksIfCloned();
     }
 
     /**

--- a/src/Model.php
+++ b/src/Model.php
@@ -298,6 +298,9 @@ class Model implements \IteratorAggregate
      */
     public $contained_in_root_model;
 
+    /** @var Reference Only for Reference class */
+    public $ownerReference;
+
     // }}}
 
     // {{{ Basic Functionality, field definition, set() and get()

--- a/src/Model.php
+++ b/src/Model.php
@@ -356,6 +356,13 @@ class Model implements \IteratorAggregate
         $this->_cloneCollection('fields');
         $this->_cloneCollection('userActions');
 
+        // update links with newly cloned joins
+        foreach ($this->fields as $field) {
+            if ($field->join !== null) {
+                $field->join = $this->getElement($field->join->short_name);
+            }
+        }
+
         // check for clone errors immediately, otherwise not strictly needed
         $this->_rebindHooksIfCloned();
     }

--- a/src/Model.php
+++ b/src/Model.php
@@ -418,35 +418,35 @@ class Model implements \IteratorAggregate
 
     private function initEntityHooks(): void
     {
-        $checkFx = function (self $model) {
-            if ($model->getId() === null) { // allow unload
+        $checkFx = function () {
+            if ($this->getId() === null) { // allow unload
                 return;
             }
 
-            if ($model->entityId === null) {
-                $model->entityId = $model->getId();
+            if ($this->entityId === null) {
+                $this->entityId = $this->getId();
             } else {
-                if (!$model->compare($this->id_field, $model->entityId)) {
-                    $newId = $model->getId();
-                    $model->unload(); // data for different ID were loaded, make sure to discard them
+                if (!$this->compare($this->id_field, $this->entityId)) {
+                    $newId = $this->getId();
+                    $this->unload(); // data for different ID were loaded, make sure to discard them
 
                     throw (new Exception('Model is loaded as an entity, ID can not be changed to a different one'))
-                        ->addMoreInfo('entityId', $model->entityId)
+                        ->addMoreInfo('entityId', $this->entityId)
                         ->addMoreInfo('newId', $newId);
                 }
             }
         };
 
-        $this->onHook(self::HOOK_BEFORE_LOAD, $checkFx, [], 10);
-        $this->onHook(self::HOOK_AFTER_LOAD, $checkFx, [], -10);
-        $this->onHook(self::HOOK_BEFORE_INSERT, $checkFx, [], 10);
-        $this->onHook(self::HOOK_AFTER_INSERT, $checkFx, [], -10);
-        $this->onHook(self::HOOK_BEFORE_UPDATE, $checkFx, [], 10);
-        $this->onHook(self::HOOK_AFTER_UPDATE, $checkFx, [], -10);
-        $this->onHook(self::HOOK_BEFORE_DELETE, $checkFx, [], 10);
-        $this->onHook(self::HOOK_AFTER_DELETE, $checkFx, [], -10);
-        $this->onHook(self::HOOK_BEFORE_SAVE, $checkFx, [], 10);
-        $this->onHook(self::HOOK_AFTER_SAVE, $checkFx, [], -10);
+        $this->onHookShort(self::HOOK_BEFORE_LOAD, $checkFx, [], 10);
+        $this->onHookShort(self::HOOK_AFTER_LOAD, $checkFx, [], -10);
+        $this->onHookShort(self::HOOK_BEFORE_INSERT, $checkFx, [], 10);
+        $this->onHookShort(self::HOOK_AFTER_INSERT, $checkFx, [], -10);
+        $this->onHookShort(self::HOOK_BEFORE_UPDATE, $checkFx, [], 10);
+        $this->onHookShort(self::HOOK_AFTER_UPDATE, $checkFx, [], -10);
+        $this->onHookShort(self::HOOK_BEFORE_DELETE, $checkFx, [], 10);
+        $this->onHookShort(self::HOOK_AFTER_DELETE, $checkFx, [], -10);
+        $this->onHookShort(self::HOOK_BEFORE_SAVE, $checkFx, [], 10);
+        $this->onHookShort(self::HOOK_AFTER_SAVE, $checkFx, [], -10);
     }
 
     /**
@@ -761,7 +761,7 @@ class Model implements \IteratorAggregate
     public function setNull(string $field)
     {
         // set temporary hook to disable any normalization (null validation)
-        $hookIndex = $this->onHook(self::HOOK_NORMALIZE, function () {
+        $hookIndex = $this->onHookShort(self::HOOK_NORMALIZE, static function () {
             throw new \atk4\core\HookBreaker(false);
         }, [], PHP_INT_MIN);
         try {

--- a/src/Model.php
+++ b/src/Model.php
@@ -1775,7 +1775,7 @@ class Model implements \IteratorAggregate
 
             // you can return false in afterLoad hook to prevent to yield this data row
             // use it like this:
-            // $model->onHook(self::HOOK_AFTER_LOAD, function ($m) {
+            // $model->onHook(self::HOOK_AFTER_LOAD, static function ($m) {
             //     if ($m->get('date') < $m->date_from) $m->breakHook(false);
             // })
 

--- a/src/Model/Join.php
+++ b/src/Model/Join.php
@@ -148,6 +148,21 @@ class Join
         }
     }
 
+    protected function onHookToOwner(string $spot, \Closure $fx, array $args = [], int $priority = 5): int
+    {
+        $name = $this->short_name;
+
+        return $this->owner->onHookDynamic(
+            $spot,
+            static function (Model $owner) use ($name) {
+                return $owner->getElement($name);
+            },
+            $fx,
+            $args,
+            $priority
+        );
+    }
+
     /**
      * Will use either foreign_alias or create #join_<table>.
      */

--- a/src/Model/Join.php
+++ b/src/Model/Join.php
@@ -150,7 +150,7 @@ class Join
 
     protected function onHookToOwner(string $spot, \Closure $fx, array $args = [], int $priority = 5): int
     {
-        $name = $this->short_name;
+        $name = $this->short_name; // use static function to allow this object to be GCed
 
         return $this->owner->onHookDynamic(
             $spot,

--- a/src/Model/Join.php
+++ b/src/Model/Join.php
@@ -211,7 +211,7 @@ class Join
             }
         }
 
-        $this->owner->onHook(Model::HOOK_AFTER_UNLOAD, \Closure::fromCallable([$this, 'afterUnload']));
+        $this->onHookToOwner(Model::HOOK_AFTER_UNLOAD, \Closure::fromCallable([$this, 'afterUnload']));
     }
 
     /**

--- a/src/Persistence/Array_/Join.php
+++ b/src/Persistence/Array_/Join.php
@@ -26,14 +26,14 @@ class Join extends Model\Join
 
         // Add necessary hooks
         if ($this->reverse) {
-            $this->owner->onHook(Model::HOOK_AFTER_INSERT, \Closure::fromCallable([$this, 'afterInsert']), [], -5);
-            $this->owner->onHook(Model::HOOK_BEFORE_UPDATE, \Closure::fromCallable([$this, 'beforeUpdate']), [], -5);
-            $this->owner->onHook(Model::HOOK_BEFORE_DELETE, \Closure::fromCallable([$this, 'doDelete']), [], -5);
+            $this->onHookToOwner(Model::HOOK_AFTER_INSERT, \Closure::fromCallable([$this, 'afterInsert']), [], -5);
+            $this->onHookToOwner(Model::HOOK_BEFORE_UPDATE, \Closure::fromCallable([$this, 'beforeUpdate']), [], -5);
+            $this->onHookToOwner(Model::HOOK_BEFORE_DELETE, \Closure::fromCallable([$this, 'doDelete']), [], -5);
         } else {
-            $this->owner->onHook(Model::HOOK_BEFORE_INSERT, \Closure::fromCallable([$this, 'beforeInsert']));
-            $this->owner->onHook(Model::HOOK_BEFORE_UPDATE, \Closure::fromCallable([$this, 'beforeUpdate']));
-            $this->owner->onHook(Model::HOOK_AFTER_DELETE, \Closure::fromCallable([$this, 'doDelete']));
-            $this->owner->onHook(Model::HOOK_AFTER_LOAD, \Closure::fromCallable([$this, 'afterLoad']));
+            $this->onHookToOwner(Model::HOOK_BEFORE_INSERT, \Closure::fromCallable([$this, 'beforeInsert']));
+            $this->onHookToOwner(Model::HOOK_BEFORE_UPDATE, \Closure::fromCallable([$this, 'beforeUpdate']));
+            $this->onHookToOwner(Model::HOOK_AFTER_DELETE, \Closure::fromCallable([$this, 'doDelete']));
+            $this->onHookToOwner(Model::HOOK_AFTER_LOAD, \Closure::fromCallable([$this, 'afterLoad']));
         }
     }
 

--- a/src/Persistence/Sql.php
+++ b/src/Persistence/Sql.php
@@ -177,9 +177,15 @@ class Sql extends Persistence
      */
     protected function initPersistence(Model $model): void
     {
-        $model->addMethod('expr', \Closure::fromCallable([$this, 'expr']));
-        $model->addMethod('dsql', \Closure::fromCallable([$this, 'dsql']));
-        $model->addMethod('exprNow', \Closure::fromCallable([$this, 'exprNow']));
+        $model->addMethod('expr', static function (Model $m, ...$args) {
+            return $m->persistence->expr($m, ...$args);
+        });
+        $model->addMethod('dsql', static function (Model $m, ...$args) {
+            return $m->persistence->dsql($m, ...$args);
+        });
+        $model->addMethod('exprNow', static function (Model $m, ...$args) {
+            return $m->persistence->exprNow($m, ...$args);
+        });
     }
 
     /**

--- a/src/Persistence/Sql/Join.php
+++ b/src/Persistence/Sql/Join.php
@@ -73,14 +73,14 @@ class Join extends Model\Join implements \atk4\dsql\Expressionable
             $this->foreign_alias = ($this->owner->table_alias ?: '') . $this->short_name;
         }
 
-        $this->owner->onHook(Persistence\Sql::HOOK_INIT_SELECT_QUERY, \Closure::fromCallable([$this, 'initSelectQuery']));
+        $this->onHookToOwner(Persistence\Sql::HOOK_INIT_SELECT_QUERY, \Closure::fromCallable([$this, 'initSelectQuery']));
 
         // Add necessary hooks
         if ($this->reverse) {
-            $this->owner->onHook(Model::HOOK_AFTER_INSERT, \Closure::fromCallable([$this, 'afterInsert']));
-            $this->owner->onHook(Model::HOOK_BEFORE_UPDATE, \Closure::fromCallable([$this, 'beforeUpdate']));
-            $this->owner->onHook(Model::HOOK_BEFORE_DELETE, \Closure::fromCallable([$this, 'doDelete']), [], -5);
-            $this->owner->onHook(Model::HOOK_AFTER_LOAD, \Closure::fromCallable([$this, 'afterLoad']));
+            $this->onHookToOwner(Model::HOOK_AFTER_INSERT, \Closure::fromCallable([$this, 'afterInsert']));
+            $this->onHookToOwner(Model::HOOK_BEFORE_UPDATE, \Closure::fromCallable([$this, 'beforeUpdate']));
+            $this->onHookToOwner(Model::HOOK_BEFORE_DELETE, \Closure::fromCallable([$this, 'doDelete']), [], -5);
+            $this->onHookToOwner(Model::HOOK_AFTER_LOAD, \Closure::fromCallable([$this, 'afterLoad']));
         } else {
             // Master field indicates ID of the joined item. In the past it had to be
             // defined as a physical field in the main table. Now it is a model field
@@ -98,10 +98,10 @@ class Join extends Model\Join implements \atk4\dsql\Expressionable
                 }
             }
 
-            $this->owner->onHook(Model::HOOK_BEFORE_INSERT, \Closure::fromCallable([$this, 'beforeInsert']), [], -5);
-            $this->owner->onHook(Model::HOOK_BEFORE_UPDATE, \Closure::fromCallable([$this, 'beforeUpdate']));
-            $this->owner->onHook(Model::HOOK_AFTER_DELETE, \Closure::fromCallable([$this, 'doDelete']));
-            $this->owner->onHook(Model::HOOK_AFTER_LOAD, \Closure::fromCallable([$this, 'afterLoad']));
+            $this->onHookToOwner(Model::HOOK_BEFORE_INSERT, \Closure::fromCallable([$this, 'beforeInsert']), [], -5);
+            $this->onHookToOwner(Model::HOOK_BEFORE_UPDATE, \Closure::fromCallable([$this, 'beforeUpdate']));
+            $this->onHookToOwner(Model::HOOK_AFTER_DELETE, \Closure::fromCallable([$this, 'doDelete']));
+            $this->onHookToOwner(Model::HOOK_AFTER_LOAD, \Closure::fromCallable([$this, 'afterLoad']));
         }
     }
 

--- a/src/Persistence/Static_.php
+++ b/src/Persistence/Static_.php
@@ -40,7 +40,7 @@ class Static_ extends Array_
         // chomp off first row, we will use it to deduct fields
         $row1 = reset($data);
 
-        $this->onHook(self::HOOK_AFTER_ADD, \Closure::fromCallable([$this, 'afterAdd']));
+        $this->onHookMethod(self::HOOK_AFTER_ADD, 'afterAdd');
 
         if (!is_array($row1)) {
             // convert array of strings into array of hashes
@@ -130,14 +130,13 @@ class Static_ extends Array_
 
     /**
      * Automatically adds missing model fields.
-     * Called from AfterAdd hook.
      *
-     * @param Static_ $persistence
+     * Called by HOOK_AFTER_ADD hook.
      */
-    public function afterAdd(self $persistence, Model $model)
+    public function afterAdd(Model $model)
     {
-        if ($persistence->titleForModel) {
-            $model->title_field = $persistence->titleForModel;
+        if ($this->titleForModel) {
+            $model->title_field = $this->titleForModel;
         }
 
         foreach ($this->fieldsForModel as $field => $def) {

--- a/src/Persistence/Static_.php
+++ b/src/Persistence/Static_.php
@@ -40,7 +40,9 @@ class Static_ extends Array_
         // chomp off first row, we will use it to deduct fields
         $row1 = reset($data);
 
-        $this->onHookMethod(self::HOOK_AFTER_ADD, 'afterAdd');
+        $this->onHookShort(self::HOOK_AFTER_ADD, function (...$args) {
+            $this->afterAdd(...$args);
+        });
 
         if (!is_array($row1)) {
             // convert array of strings into array of hashes

--- a/src/Reference.php
+++ b/src/Reference.php
@@ -101,7 +101,9 @@ class Reference
 
     protected function onHookToTheirModel(Model $model, string $spot, \Closure $fx, array $args = [], int $priority = 5): int
     {
-        // TODO is this even safe? is model guaranteed to be always unique here? (eg. always cloned?)
+        if ($model->ownerReference !== null && $model->ownerReference !== $this) {
+            throw new Exception('Model owner reference unexpectedly already set');
+        }
         $model->ownerReference = $this;
         $getThisFx = static function (Model $model) {
             return $model->ownerReference;
@@ -152,6 +154,8 @@ class Reference
     /**
      * Returns destination model that is linked through this reference. Will apply
      * necessary conditions.
+     *
+     * IMPORTANT: the returned model must be a fresh clone or freshly built from a seed
      */
     public function getTheirModel(array $defaults = []): Model
     {

--- a/src/Reference/ContainsMany.php
+++ b/src/Reference/ContainsMany.php
@@ -34,7 +34,7 @@ class ContainsMany extends ContainsOne
 
         // set some hooks for ref_model
         foreach ([Model::HOOK_AFTER_SAVE, Model::HOOK_AFTER_DELETE] as $spot) {
-            $theirModel->onHook($spot, function ($theirModel) {
+            $this->onHookToTheirModel($theirModel, $spot, function ($theirModel) {
                 $rows = $theirModel->persistence->getRawDataByTable($theirModel, $this->table_alias);
                 $this->getOurModel()->save([
                     $this->getOurFieldName() => $rows ?: null,

--- a/src/Reference/ContainsOne.php
+++ b/src/Reference/ContainsOne.php
@@ -94,7 +94,7 @@ class ContainsOne extends Reference
 
         // set some hooks for ref_model
         foreach ([Model::HOOK_AFTER_SAVE, Model::HOOK_AFTER_DELETE] as $spot) {
-            $theirModel->onHook($spot, function ($theirModel) {
+            $this->onHookToTheirModel($theirModel, $spot, function ($theirModel) {
                 $row = $theirModel->persistence->getRawDataByTable($theirModel, $this->table_alias);
                 $row = $row ? array_shift($row) : null; // get first and only one record from array persistence
                 $this->getOurModel()->save([$this->getOurFieldName() => $row]);

--- a/src/Reference/HasOne.php
+++ b/src/Reference/HasOne.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace atk4\data\Reference;
 
 use atk4\data\Field;
-use atk4\data\Join;
 use atk4\data\Model;
 use atk4\data\Reference;
 
@@ -36,7 +35,7 @@ class HasOne extends Reference
     /**
      * Points to the join if we are part of one.
      *
-     * @var Join|null
+     * @var Model\Join|null
      */
     protected $join;
 

--- a/src/Reference/HasOne.php
+++ b/src/Reference/HasOne.php
@@ -209,7 +209,7 @@ class HasOne extends Reference
         $theirModel = $this->getTheirModel($defaults);
 
         // add hook to set our_field = null when record of referenced model is deleted
-        $theirModel->onHook(Model::HOOK_AFTER_DELETE, function ($theirModel) {
+        $this->onHookToTheirModel($theirModel, Model::HOOK_AFTER_DELETE, function ($theirModel) {
             $this->getOurField()->setNull();
         });
 
@@ -225,7 +225,7 @@ class HasOne extends Reference
         // their model will be reloaded after saving our model to reflect changes in referenced fields
         $theirModel->reload_after_save = false;
 
-        $theirModel->onHook(Model::HOOK_AFTER_SAVE, function ($theirModel) {
+        $this->onHookToTheirModel($theirModel, Model::HOOK_AFTER_SAVE, function ($theirModel) {
             $theirValue = $this->their_field ? $theirModel->get($this->their_field) : $theirModel->getId();
 
             if ($this->getOurFieldValue() !== $theirValue) {

--- a/src/Reference/HasOneSql.php
+++ b/src/Reference/HasOneSql.php
@@ -64,7 +64,7 @@ class HasOneSql extends HasOne
         ));
 
         // Will try to execute last
-        $ourModel->onHook(Model::HOOK_BEFORE_SAVE, function (Model $ourModel) use ($ourFieldName, $theirFieldName) {
+        $this->onHookToOurModel($ourModel, Model::HOOK_BEFORE_SAVE, function (Model $ourModel) use ($ourFieldName, $theirFieldName) {
             // if title field is changed, but reference ID field (our_field)
             // is not changed, then update reference ID field value
             if ($ourModel->isDirty($ourFieldName) && !$ourModel->isDirty($this->our_field)) {
@@ -205,7 +205,7 @@ class HasOneSql extends HasOne
         ));
 
         // Will try to execute last
-        $ourModel->onHook(Model::HOOK_BEFORE_SAVE, function (Model $ourModel) use ($fieldName) {
+        $this->onHookToOurModel($ourModel, Model::HOOK_BEFORE_SAVE, function (Model $ourModel) use ($fieldName) {
             // if title field is changed, but reference ID field (our_field)
             // is not changed, then update reference ID field value
             if ($ourModel->isDirty($fieldName) && !$ourModel->isDirty($this->our_field)) {

--- a/tests/DeepCopyTest.php
+++ b/tests/DeepCopyTest.php
@@ -46,9 +46,9 @@ class DcInvoice extends Model
 
         $this->addField('is_paid', ['type' => 'boolean', 'default' => false]);
 
-        $this->onHook(DeepCopy::HOOK_AFTER_COPY, function ($m, $s) {
+        $this->onHookShort(DeepCopy::HOOK_AFTER_COPY, function ($s) {
             if (get_class($s) === static::class) {
-                $m->set('ref', $m->get('ref') . '_copy');
+                $this->set('ref', $this->get('ref') . '_copy');
             }
         });
     }

--- a/tests/DeepCopyTest.php
+++ b/tests/DeepCopyTest.php
@@ -277,7 +277,7 @@ class DeepCopyTest extends \atk4\schema\PhpunitTestCase
         $quote->loadAny();
 
         $invoice = new DcInvoice();
-        $invoice->onHook(DeepCopy::HOOK_AFTER_COPY, function ($m) {
+        $invoice->onHook(DeepCopy::HOOK_AFTER_COPY, static function ($m) {
             if (!$m->get('ref')) {
                 throw new \atk4\core\Exception('no ref');
             }
@@ -318,7 +318,7 @@ class DeepCopyTest extends \atk4\schema\PhpunitTestCase
         $quote->loadAny();
 
         $invoice = new DcInvoice();
-        $invoice->onHook(DeepCopy::HOOK_AFTER_COPY, function ($m) {
+        $invoice->onHook(DeepCopy::HOOK_AFTER_COPY, static function ($m) {
             if (!$m->get('ref')) {
                 throw new \atk4\core\Exception('no ref');
             }

--- a/tests/FieldTest.php
+++ b/tests/FieldTest.php
@@ -314,7 +314,7 @@ class FieldTest extends \atk4\schema\PhpunitTestCase
         $dbData['item'][1]['surname'] = 'Stalker';
         $this->assertEquals($dbData, $this->getDb());
 
-        $m->onHook(Model::HOOK_BEFORE_SAVE, function ($m) {
+        $m->onHook(Model::HOOK_BEFORE_SAVE, static function ($m) {
             if ($m->isDirty('name')) {
                 $m->set('surname', $m->get('name'));
                 $m->_unset('name');

--- a/tests/JoinSqlTest.php
+++ b/tests/JoinSqlTest.php
@@ -387,7 +387,7 @@ class JoinSqlTest extends \atk4\schema\PhpunitTestCase
         $j = $m_u->join('contact.test_id');
         $j->addField('contact_phone');
 
-        $m_u->onHook(Model::HOOK_AFTER_SAVE, function ($m) {
+        $m_u->onHook(Model::HOOK_AFTER_SAVE, static function ($m) {
             if ($m->get('contact_phone') !== '+123') {
                 $m->set('contact_phone', '+123');
                 $m->save();

--- a/tests/LookupSqlTest.php
+++ b/tests/LookupSqlTest.php
@@ -104,30 +104,30 @@ class LFriend extends Model
 
         // add or remove reverse friendships
         /*
-        $this->onHook(self::HOOK_AFTER_INSERT, function($m) {
-            if ($m->skip_reverse) {
+        $this->onHookShort(self::HOOK_AFTER_INSERT, function() {
+            if ($this->skip_reverse) {
                 return;
             }
 
-            $c = clone $m;
+            $c = clone $this;
             $c->skip_reverse = true;
             $this->insert([
-                'user_id'=>$m->get('friend_id'),
-                'friend_id'=>$m->get('user_id')
+                'user_id'=>$this->get('friend_id'),
+                'friend_id'=>$this->get('user_id')
             ]);
         });
 
-        $this->onHook(Model::HOOK_BEFORE_DELETE, function($m) {
-            if ($m->skip_reverse) {
+        $this->onHookShort(Model::HOOK_BEFORE_DELETE, function() {
+            if ($this->skip_reverse) {
                 return;
             }
 
-            $c = clone $m;
+            $c = clone $this;
             $c->skip_reverse = true;
 
             $c->loadBy([
-                'user_id'=>$m->get('friend_id'),
-                'friend_id'=>$m->get('user_id')
+                'user_id'=>$this->get('friend_id'),
+                'friend_id'=>$this->get('user_id')
             ])->delete();
 
 

--- a/tests/Model/Smbo/Transfer.php
+++ b/tests/Model/Smbo/Transfer.php
@@ -23,12 +23,12 @@ class Transfer extends Payment
 
         $this->addField('destination_account_id', ['never_persist' => true]);
 
-        $this->onHook(self::HOOK_BEFORE_SAVE, function ($m) {
+        $this->onHookShort(self::HOOK_BEFORE_SAVE, function () {
             // only for new records and when destination_account_id is set
-            if ($m->get('destination_account_id') && !$m->getId()) {
+            if ($this->get('destination_account_id') && !$this->getId()) {
                 // In this section we test if "clone" works ok
 
-                $this->other_leg_creation = $m2 = clone $m;
+                $this->other_leg_creation = $m2 = clone $this;
                 $m2->set('account_id', $m2->get('destination_account_id'));
                 $m2->set('amount', -$m2->get('amount'));
 
@@ -39,24 +39,24 @@ class Transfer extends Payment
                 // If clone is not working, then this is a current work-around
 
                 $this->other_leg_creation = $m2 = new Transfer($this->persistence);
-                $m2->set($m->get());
+                $m2->set($this->get());
                 $m2->unset('destination_account_id');
-                $m2->set('account_id', $m->get('destination_account_id'));
+                $m2->set('account_id', $this->get('destination_account_id'));
                 $m2->set('amount', -$m2->get('amount')); // neagtive amount
 
                 // */
 
                 $m2->reload_after_save = false; // avoid check
 
-                $m->set('transfer_document_id', $m2->save()->getId());
+                $this->set('transfer_document_id', $m2->save()->getId());
             }
         });
 
-        $this->onHook(self::HOOK_AFTER_SAVE, function ($m) {
-            if ($m->other_leg_creation) {
-                $m->other_leg_creation->set('transfer_document_id', $m->getId())->save();
+        $this->onHookShort(self::HOOK_AFTER_SAVE, function () {
+            if ($this->other_leg_creation) {
+                $this->other_leg_creation->set('transfer_document_id', $this->getId())->save();
             }
-            $m->other_leg_creation = null;
+            $this->other_leg_creation = null;
         });
     }
 }

--- a/tests/RandomTest.php
+++ b/tests/RandomTest.php
@@ -253,7 +253,7 @@ class RandomTest extends \atk4\schema\PhpunitTestCase
         $m->addField('name');
         $m->load(2);
 
-        $m->onHook(Persistence\Sql::HOOK_AFTER_UPDATE_QUERY, function ($m, $update, $st) {
+        $m->onHook(Persistence\Sql::HOOK_AFTER_UPDATE_QUERY, static function ($m, $update, $st) {
             // we can use afterUpdate to make sure that record was updated
 
             if (!$st->rowCount()) {
@@ -300,17 +300,17 @@ class RandomTest extends \atk4\schema\PhpunitTestCase
         $m = new Model($db, 'user');
         $m->addField('name');
 
-        $m->onHook(Model::HOOK_BEFORE_SAVE, function ($m) {
+        $m->onHook(Model::HOOK_BEFORE_SAVE, static function ($m) {
             $m->breakHook(false);
         });
 
-        $m->onHook(Model::HOOK_BEFORE_LOAD, function ($m, $id) {
+        $m->onHook(Model::HOOK_BEFORE_LOAD, static function ($m, $id) {
             $m->data = ['name' => 'rec #' . $id];
             $m->setId($id);
             $m->breakHook(false);
         });
 
-        $m->onHook(Model::HOOK_BEFORE_DELETE, function ($m, $id) {
+        $m->onHook(Model::HOOK_BEFORE_DELETE, static function ($m, $id) {
             $m->unload();
             $m->breakHook(false);
         });

--- a/tests/SubTypesTest.php
+++ b/tests/SubTypesTest.php
@@ -76,11 +76,11 @@ class StGenericTransaction extends Model
         }
         $this->addField('amount', ['type' => 'money']);
 
-        $this->onHook(Model::HOOK_AFTER_LOAD, function (self $m) {
-            if (static::class !== $m->getClassName()) {
-                $cl = $m->getClassName();
-                $cl = new $cl($m->persistence);
-                $cl->load($m->getId());
+        $this->onHookShort(Model::HOOK_AFTER_LOAD, function () {
+            if (static::class !== $this->getClassName()) {
+                $cl = $this->getClassName();
+                $cl = new $cl($this->persistence);
+                $cl->load($this->getId());
 
                 $this->breakHook($cl);
             }

--- a/tests/TransactionTest.php
+++ b/tests/TransactionTest.php
@@ -27,7 +27,7 @@ class TransactionTest extends \atk4\schema\PhpunitTestCase
         $m->addField('name');
         $m->load(2);
 
-        $m->onHook(Model::HOOK_AFTER_SAVE, function ($m) {
+        $m->onHook(Model::HOOK_AFTER_SAVE, static function ($m) {
             throw new \Exception('Awful thing happened');
         });
         $m->set('name', 'XXX');
@@ -39,7 +39,7 @@ class TransactionTest extends \atk4\schema\PhpunitTestCase
 
         $this->assertSame('Sue', $this->getDb()['item'][2]['name']);
 
-        $m->onHook(Model::HOOK_AFTER_DELETE, function ($m) {
+        $m->onHook(Model::HOOK_AFTER_DELETE, static function ($m) {
             throw new \Exception('Awful thing happened');
         });
 

--- a/tests/TransactionTest.php
+++ b/tests/TransactionTest.php
@@ -53,7 +53,6 @@ class TransactionTest extends \atk4\schema\PhpunitTestCase
 
     public function testBeforeSaveHook()
     {
-        $self = $this;
         $db = new Persistence\Sql($this->db->connection);
         $this->setDb([
             'item' => [
@@ -64,23 +63,22 @@ class TransactionTest extends \atk4\schema\PhpunitTestCase
         // test insert
         $m = new Model($db, 'item');
         $m->addField('name');
-        $m->onHook(Model::HOOK_BEFORE_SAVE, function ($model, $is_update) use ($self) {
-            $self->assertFalse($is_update);
+        $m->onHook(Model::HOOK_BEFORE_SAVE, function ($model, $is_update) {
+            $this->assertFalse($is_update);
         });
         $m->save(['name' => 'Foo']);
 
         // test update
         $m = new Model($db, 'item');
         $m->addField('name');
-        $m->onHook(Model::HOOK_AFTER_SAVE, function ($model, $is_update) use ($self) {
-            $self->assertTrue($is_update);
+        $m->onHook(Model::HOOK_AFTER_SAVE, function ($model, $is_update) {
+            $this->assertTrue($is_update);
         });
         $m->loadBy('name', 'John')->save(['name' => 'Foo']);
     }
 
     public function testAfterSaveHook()
     {
-        $self = $this;
         $db = new Persistence\Sql($this->db->connection);
         $this->setDb([
             'item' => [
@@ -91,23 +89,22 @@ class TransactionTest extends \atk4\schema\PhpunitTestCase
         // test insert
         $m = new Model($db, 'item');
         $m->addField('name');
-        $m->onHook(Model::HOOK_AFTER_SAVE, function ($model, $is_update) use ($self) {
-            $self->assertFalse($is_update);
+        $m->onHook(Model::HOOK_AFTER_SAVE, function ($model, $is_update) {
+            $this->assertFalse($is_update);
         });
         $m->save(['name' => 'Foo']);
 
         // test update
         $m = new Model($db, 'item');
         $m->addField('name');
-        $m->onHook(Model::HOOK_AFTER_SAVE, function ($model, $is_update) use ($self) {
-            $self->assertTrue($is_update);
+        $m->onHook(Model::HOOK_AFTER_SAVE, function ($model, $is_update) {
+            $this->assertTrue($is_update);
         });
         $m->loadBy('name', 'John')->save(['name' => 'Foo']);
     }
 
     public function testOnRollbackHook()
     {
-        $self = $this;
         $db = new Persistence\Sql($this->db->connection);
         $this->setDb([
             'item' => [

--- a/tests/ValidationTest.php
+++ b/tests/ValidationTest.php
@@ -111,7 +111,7 @@ class ValidationTests extends AtkPhpunit\TestCase
 
     public function testValidateHook()
     {
-        $this->m->onHook(Model::HOOK_VALIDATE, function ($m) {
+        $this->m->onHook(Model::HOOK_VALIDATE, static function ($m) {
             if ($m->get('name') === 'C#') {
                 return ['name' => 'No sharp objects allowed'];
             }


### PR DESCRIPTION
merge together with https://github.com/atk4/core/pull/272

BC break - if you clone object with hooks bounded to a different object, it throws correctly (but less strict now because of https://github.com/atk4/core/pull/275 PR)