### PR TITLE
Allow to save read only models in another persistence

### DIFF
--- a/src/Model.php
+++ b/src/Model.php
@@ -1477,7 +1477,7 @@ class Model implements \IteratorAggregate
             throw new Exception('Model is not associated with any database');
         }
 
-        if ($this->read_only) {
+        if ($this->read_only && $to_persistence === $this->persistence) {
             throw new Exception('Model is read-only and cannot be saved');
         }
 


### PR DESCRIPTION
Tiny fix to allow saving read only model in another persistence.
Think about this another persistence as some kind of _backup persistence_.