### PR TITLE
Add loadany() to Array_ Persistence

### DIFF
--- a/src/Persistence/Array_.php
+++ b/src/Persistence/Array_.php
@@ -145,6 +145,21 @@ class Array_ extends Persistence
     }
 
     /**
+     * Tries to load first available record and return data record.
+     */
+    public function loadAny(Model $model, string $table = null): ?array
+    {
+        $row = $this->tryLoadAny($model, $table);
+        if ($row === null) {
+            throw (new Exception('No matching records were found', 404))
+                ->addMoreInfo('model', $model)
+                ->addMoreInfo('scope', $model->scope()->toWords());
+        }
+
+        return $row;
+    }
+
+    /**
      * Tries to load model and return data record.
      * Doesn't throw exception if model can't be loaded.
      *

--- a/tests/PersistentArrayTest.php
+++ b/tests/PersistentArrayTest.php
@@ -954,6 +954,6 @@ class PersistentArrayTest extends AtkPhpunit\TestCase
         $m->addField('name');
         $m->addField('surname');
         $m->tryLoadAny();
-        $this->assertSame(2, $m->id);
+        $this->assertSame(2, $m->getId());
     }
 }

--- a/tests/PersistentArrayTest.php
+++ b/tests/PersistentArrayTest.php
@@ -854,4 +854,38 @@ class PersistentArrayTest extends AtkPhpunit\TestCase
         $cc = (clone $country)->load(2);
         $this->assertSame(1, $cc->ref('Users')->action('count')->getOne());
     }
+
+    public function testLoadAnyThrowsExceptionOnRecordNotFound()
+    {
+        $p = new Persistence\Array_();
+        $m = new Model($p);
+        $m->addField('name');
+        $this->expectExceptionCode(404);
+        $m->loadAny();
+    }
+
+    public function testTryLoadAnyNotThrowsExceptionOnRecordNotFound()
+    {
+        $p = new Persistence\Array_();
+        $m = new Model($p);
+        $m->addField('name');
+        $m->addField('surname');
+        $m->tryLoadAny();
+        $this->assertFalse($m->loaded());
+    }
+
+    public function testTryLoadAnyReturnsFirstRecord()
+    {
+        $a = [
+            2 => ['name' => 'John', 'surname' => 'Smith'],
+            3 => ['name' => 'Sarah', 'surname' => 'Jones'],
+        ];
+
+        $p = new Persistence\Array_($a);
+        $m = new Model($p);
+        $m->addField('name');
+        $m->addField('surname');
+        $m->tryLoadAny();
+        $this->assertSame(2, $m->id);
+    }
 }


### PR DESCRIPTION
merge after https://github.com/atk4/data/pull/690 or close (if https://github.com/atk4/data/pull/690 adds `loadAny`)

This method has somehow been missing from Persistence\Array_. This PR adds it and adds a few tests.

However, I see there should be some cleaning up done in PersistenceArrayTest.php in another PR:
Some functions in there are general Persistence tests and have nothing to do with Persistence\Array_.
My proposal is to move PersistenceArrayTest and PersistenceSQLTest to a new directory tests/Persistence/ to meet the structure in /src dir.
