### PR TITLE
Fix Array persistence with Datetime fields

### DIFF
--- a/tests/PersistentArrayTest.php
+++ b/tests/PersistentArrayTest.php
@@ -232,6 +232,52 @@ class PersistentArrayTest extends AtkPhpunit\TestCase
         $this->expectException(Exception::class);
         $m->tryLoad(1);
     }
+    
+    /**
+     * different to other field types, date, time and datetime fields return an
+     * object, not a scalar value to work with. Make sure Array persistence handles them correctly.
+     */
+    public function testDateTimeFields() {
+        $p = new Persistence\Array_();
+        $m = new Model($p);
+        $m->addField('date', ['type' => 'date']);
+        $m->addField('time', ['type' => 'time']);
+        $m->addField('datetime', ['type' => 'datetime']);
+        $m->save();
+
+        //try setting DateTime Object
+        $dateTime = \DateTime::createFromFormat('Y-m-d H:i:s', '2020-01-01 11:11:11');
+        $m->set('date', $dateTime);
+        $m->set('time', $dateTime);
+        $m->set('datetime', $dateTime);
+        $m->save();
+
+        self::assertInstanceOf(
+            \DateTime::class,
+            $m->get('date')
+        );
+        self::assertInstanceOf(
+            \DateTime::class,
+            $m->get('time')
+        );
+        self::assertInstanceOf(
+            \DateTime::class,
+            $m->get('datetime')
+        );
+
+        self::assertEquals(
+            '2020-01-01',
+            $m->get('date')->format('Y-m-d')
+        );
+        self::assertEquals(
+            '11:11:11',
+            $m->get('time')->format('H:i:s')
+        );
+        self::assertEquals(
+            '2020-01-01 11:11:11',
+            $m->get('date')->format('Y-m-d H:i:s')
+        );
+    }
 
     /**
      * Some persistences don't support loadAny() method.


### PR DESCRIPTION
Currently, the added test fails and produces this error message:

```
Error : Object of class DateTime could not be converted to string
 /var/www/html/atk/data/src/Field.php:539
 /var/www/html/atk/data/src/Field.php:542
 /var/www/html/atk/data/src/Model.php:710
 /var/www/html/atk/data/tests/PersistentArrayTest.php:212
 
```

The objective of this PR is to fix this issue. As no fix is provided yet, just a draft.