### PR TITLE
Drop driverType property

### DIFF
--- a/src/Persistence.php
+++ b/src/Persistence.php
@@ -32,7 +32,7 @@ class Persistence
         // parse DSN string
         $dsn = \atk4\dsql\Connection::normalizeDsn($dsn, $user, $password);
 
-        switch ($dsn['driverType']) {
+        switch ($dsn['driverSchema']) {
             case 'mysql':
             case 'oci':
             case 'oci12':

--- a/src/Persistence.php
+++ b/src/Persistence.php
@@ -21,9 +21,6 @@ class Persistence
     /** @const string */
     public const HOOK_AFTER_ADD = self::class . '@afterAdd';
 
-    /** @var string Connection driver name, for example, mysql, pgsql, oci etc. */
-    public $driverType;
-
     /**
      * Connects database.
      *
@@ -32,12 +29,10 @@ class Persistence
      */
     public static function connect($dsn, string $user = null, string $password = null, array $args = []): self
     {
-        // Process DSN string
+        // parse DSN string
         $dsn = \atk4\dsql\Connection::normalizeDsn($dsn, $user, $password);
 
-        $driverType = strtolower($args['driver']/*BC compatibility*/ ?? $args['driverType'] ?? $dsn['driverType']);
-
-        switch ($driverType) {
+        switch ($dsn['driverType']) {
             case 'mysql':
             case 'oci':
             case 'oci12':
@@ -51,11 +46,8 @@ class Persistence
                 // no break
             case 'pgsql':
             case 'sqlsrv':
-            case 'dumper':
-            case 'counter':
             case 'sqlite':
                 $db = new \atk4\data\Persistence\Sql($dsn['dsn'], $dsn['user'], $dsn['pass'], $args);
-                $db->driverType = $driverType;
 
                 return $db;
             default:

--- a/tests/ConditionSqlTest.php
+++ b/tests/ConditionSqlTest.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace atk4\data\tests;
 
 use atk4\data\Model;
+use Doctrine\DBAL\Platforms\PostgreSqlPlatform;
+use Doctrine\DBAL\Platforms\SqlitePlatform;
 
 /**
  * @coversDefaultClass \atk4\data\Model
@@ -36,7 +38,7 @@ class ConditionSqlTest extends \atk4\schema\PhpunitTestCase
         $mm->tryLoad(2);
         $this->assertNull($mm->get('name'));
 
-        if ($this->driverType === 'sqlite') {
+        if ($this->getDatabasePlatform() instanceof SqlitePlatform) {
             $this->assertSame(
                 'select "id","name","gender" from "user" where "gender" = :a',
                 $mm->action('select')->render()
@@ -418,7 +420,7 @@ class ConditionSqlTest extends \atk4\schema\PhpunitTestCase
      */
     public function testLikeCondition()
     {
-        if ($this->driverType === 'pgsql') {
+        if ($this->getDatabasePlatform() instanceof PostgreSqlPlatform) {
             $this->markTestIncomplete('PostgreSQL does not support "column LIKE variable" syntax');
         }
 

--- a/tests/DeepCopyTest.php
+++ b/tests/DeepCopyTest.php
@@ -7,6 +7,7 @@ namespace atk4\data\tests;
 use atk4\data\Model;
 use atk4\data\Util\DeepCopy;
 use atk4\data\Util\DeepCopyException;
+use Doctrine\DBAL\Platforms\SQLServerPlatform;
 
 class DcClient extends Model
 {
@@ -245,7 +246,7 @@ class DeepCopyTest extends \atk4\schema\PhpunitTestCase
         $this->assertEquals(1, $client3->ref('Quotes')->action('count')->getOne());
         $this->assertEquals(1, $client3->ref('Payments')->action('count')->getOne());
 
-        if ($this->driverType === 'sqlsrv') {
+        if ($this->getDatabasePlatform() instanceof SQLServerPlatform) {
             $this->markTestIncomplete('TODO - MSSQL: Cannot perform an aggregate function on an expression containing an aggregate or a subquery.');
         }
 

--- a/tests/JoinSqlTest.php
+++ b/tests/JoinSqlTest.php
@@ -7,6 +7,9 @@ namespace atk4\data\tests;
 use atk4\data\Exception;
 use atk4\data\Model;
 use atk4\data\Persistence;
+use Doctrine\DBAL\Platforms\OraclePlatform;
+use Doctrine\DBAL\Platforms\PostgreSqlPlatform;
+use Doctrine\DBAL\Platforms\SQLServerPlatform;
 
 /**
  * @coversDefaultClass \atk4\data\Model
@@ -55,7 +58,7 @@ class JoinSqlTest extends \atk4\schema\PhpunitTestCase
 
     public function testJoinSaving1()
     {
-        if ($this->driverType === 'pgsql' || $this->driverType === 'sqlsrv' || $this->driverType === 'oci') {
+        if ($this->getDatabasePlatform() instanceof PostgreSqlPlatform || $this->getDatabasePlatform() instanceof SQLServerPlatform || $this->getDatabasePlatform() instanceof OraclePlatform) {
             $this->markTestIncomplete('TODO - NULL PK not unset in INSERT');
         }
 
@@ -142,7 +145,7 @@ class JoinSqlTest extends \atk4\schema\PhpunitTestCase
 
         $this->db->connection->dsql()->table('contact')->where('id', 2)->delete();
 
-        if ($this->driverType === 'oci') { // TODO
+        if ($this->getDatabasePlatform() instanceof OraclePlatform) { // TODO
             $this->markTestIncomplete('TODO - for some reasons, result below has one different key');
         }
 
@@ -165,7 +168,7 @@ class JoinSqlTest extends \atk4\schema\PhpunitTestCase
 
     public function testJoinSaving3()
     {
-        if ($this->driverType === 'pgsql' || $this->driverType === 'sqlsrv' || $this->driverType === 'oci') {
+        if ($this->getDatabasePlatform() instanceof PostgreSqlPlatform || $this->getDatabasePlatform() instanceof SQLServerPlatform || $this->getDatabasePlatform() instanceof OraclePlatform) {
             $this->markTestIncomplete('TODO - NULL PK not unset in INSERT');
         }
 
@@ -231,7 +234,7 @@ class JoinSqlTest extends \atk4\schema\PhpunitTestCase
 
     public function testJoinUpdate()
     {
-        if ($this->driverType === 'pgsql' || $this->driverType === 'sqlsrv' || $this->driverType === 'oci') {
+        if ($this->getDatabasePlatform() instanceof PostgreSqlPlatform || $this->getDatabasePlatform() instanceof SQLServerPlatform || $this->getDatabasePlatform() instanceof OraclePlatform) {
             $this->markTestIncomplete('TODO - NULL PK not unset in INSERT');
         }
 
@@ -405,7 +408,7 @@ class JoinSqlTest extends \atk4\schema\PhpunitTestCase
 
     public function testDoubleJoin()
     {
-        if ($this->driverType === 'pgsql' || $this->driverType === 'sqlsrv' || $this->driverType === 'oci') {
+        if ($this->getDatabasePlatform() instanceof PostgreSqlPlatform || $this->getDatabasePlatform() instanceof SQLServerPlatform || $this->getDatabasePlatform() instanceof OraclePlatform) {
             $this->markTestIncomplete('TODO - NULL PK not unset in INSERT');
         }
 

--- a/tests/ModelWithoutIdTest.php
+++ b/tests/ModelWithoutIdTest.php
@@ -7,6 +7,7 @@ namespace atk4\data\tests;
 use atk4\data\Exception;
 use atk4\data\Model;
 use atk4\data\Persistence;
+use Doctrine\DBAL\Platforms\PostgreSqlPlatform;
 
 /**
  * @coversDefaultClass \atk4\data\Model
@@ -79,7 +80,7 @@ class ModelWithoutIdTest extends \atk4\schema\PhpunitTestCase
      */
     public function testInsert()
     {
-        if ($this->driverType === 'pgsql') {
+        if ($this->getDatabasePlatform() instanceof PostgreSqlPlatform) {
             $this->markTestIncomplete('PostgreSQL requires PK unspecified to use autoincrement');
         }
 
@@ -92,7 +93,7 @@ class ModelWithoutIdTest extends \atk4\schema\PhpunitTestCase
      */
     public function testSave1()
     {
-        if ($this->driverType === 'pgsql') {
+        if ($this->getDatabasePlatform() instanceof PostgreSqlPlatform) {
             $this->markTestIncomplete('PostgreSQL requires PK unspecified to use autoincrement');
         }
 
@@ -107,7 +108,7 @@ class ModelWithoutIdTest extends \atk4\schema\PhpunitTestCase
      */
     public function testSave2()
     {
-        if ($this->driverType === 'pgsql') {
+        if ($this->getDatabasePlatform() instanceof PostgreSqlPlatform) {
             $this->markTestIncomplete('PostgreSQL requires PK unspecified to use autoincrement');
         }
 

--- a/tests/RandomTest.php
+++ b/tests/RandomTest.php
@@ -7,6 +7,7 @@ namespace atk4\data\tests;
 use atk4\data\Exception;
 use atk4\data\Model;
 use atk4\data\Persistence;
+use Doctrine\DBAL\Platforms\SQLServerPlatform;
 
 class Model_Rate extends \atk4\data\Model
 {
@@ -499,7 +500,7 @@ class RandomTest extends \atk4\schema\PhpunitTestCase
 
     public function testTableNameDots()
     {
-        if ($this->driverType === 'sqlsrv') {
+        if ($this->getDatabasePlatform() instanceof SQLServerPlatform) {
             $this->markTestIncomplete('MSSQL uses asymetric escaping character');
         }
 

--- a/tests/ReferenceSqlTest.php
+++ b/tests/ReferenceSqlTest.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace atk4\data\tests;
 
 use atk4\data\Model;
+use Doctrine\DBAL\Platforms\PostgreSqlPlatform;
+use Doctrine\DBAL\Platforms\SQLServerPlatform;
 
 /**
  * @coversDefaultClass \atk4\data\Model
@@ -54,7 +56,7 @@ class ReferenceSqlTest extends \atk4\schema\PhpunitTestCase
 
         $oo = $u->unload()->addCondition('id', '>', '1')->ref('Orders');
 
-        if ($this->driverType === 'sqlsrv') {
+        if ($this->getDatabasePlatform() instanceof SQLServerPlatform) {
             $this->markTestIncomplete('MSSQL uses asymetric escaping character');
         }
 
@@ -70,7 +72,7 @@ class ReferenceSqlTest extends \atk4\schema\PhpunitTestCase
      */
     public function testLink()
     {
-        if ($this->driverType === 'sqlsrv') {
+        if ($this->getDatabasePlatform() instanceof SQLServerPlatform) {
             $this->markTestIncomplete('MSSQL uses asymetric escaping character');
         }
 
@@ -116,7 +118,7 @@ class ReferenceSqlTest extends \atk4\schema\PhpunitTestCase
 
     public function testLink2()
     {
-        if ($this->driverType === 'sqlsrv') {
+        if ($this->getDatabasePlatform() instanceof SQLServerPlatform) {
             $this->markTestIncomplete('MSSQL uses asymetric escaping character');
         }
 
@@ -166,7 +168,7 @@ class ReferenceSqlTest extends \atk4\schema\PhpunitTestCase
         $o->addCondition('amount', '>', 6);
         $o->addCondition('amount', '<', 9);
 
-        if ($this->driverType === 'sqlsrv') {
+        if ($this->getDatabasePlatform() instanceof SQLServerPlatform) {
             $this->markTestIncomplete('MSSQL uses asymetric escaping character');
         }
 
@@ -221,7 +223,7 @@ class ReferenceSqlTest extends \atk4\schema\PhpunitTestCase
 
     public function testRelatedExpression()
     {
-        if ($this->driverType === 'sqlsrv') {
+        if ($this->getDatabasePlatform() instanceof SQLServerPlatform) {
             $this->markTestIncomplete('MSSQL uses asymetric escaping character');
         }
 
@@ -319,9 +321,9 @@ class ReferenceSqlTest extends \atk4\schema\PhpunitTestCase
 
     public function testOtherAggregates()
     {
-        if ($this->driverType === 'pgsql') {
+        if ($this->getDatabasePlatform() instanceof PostgreSqlPlatform) {
             $this->markTestIncomplete('PostgreSQL does not support "SUM(variable)" syntax');
-        } elseif ($this->driverType === 'sqlsrv') {
+        } elseif ($this->getDatabasePlatform() instanceof SQLServerPlatform) {
             $this->markTestIncomplete('MSSQL does not support "LENGTH(variable)" function');
         }
 

--- a/tests/ScopeTest.php
+++ b/tests/ScopeTest.php
@@ -293,7 +293,7 @@ class ScopeTest extends \atk4\schema\PhpunitTestCase
         $user->addCondition('Tickets/user/country_id/Users/#', '>', 1);
         $user->addCondition('Tickets/user/country_id/Users/#', '>=', 2);
         $user->addCondition('Tickets/user/country_id/Users/country_id/Users/#', '>', 1);
-        if (! $this->getDatabasePlatform() instanceof SqlitePlatform) {
+        if (!$this->getDatabasePlatform() instanceof SqlitePlatform) {
             // not supported because of limitation/issue in Sqlite, the generated query fails
             // with error: "parser stack overflow"
             $user->addCondition('Tickets/user/country_id/Users/country_id/Users/name', '!=', null); // should be always true

--- a/tests/ScopeTest.php
+++ b/tests/ScopeTest.php
@@ -9,6 +9,7 @@ use atk4\data\Model;
 use atk4\data\Model\Scope;
 use atk4\data\Model\Scope\Condition;
 use atk4\dsql\Expression;
+use Doctrine\DBAL\Platforms\SqlitePlatform;
 
 class SCountry extends Model
 {
@@ -149,7 +150,7 @@ class ScopeTest extends \atk4\schema\PhpunitTestCase
 
         $this->assertEquals('Country Id is equal to \'Latvia\'', $condition->toWords($user));
 
-        if ($this->driverType === 'sqlite') {
+        if ($this->getDatabasePlatform() instanceof SqlitePlatform) {
             $condition = new Condition('name', $user->expr('[surname]'));
 
             $this->assertEquals('Name is equal to expression \'"user"."surname"\'', $condition->toWords($user));
@@ -292,7 +293,7 @@ class ScopeTest extends \atk4\schema\PhpunitTestCase
         $user->addCondition('Tickets/user/country_id/Users/#', '>', 1);
         $user->addCondition('Tickets/user/country_id/Users/#', '>=', 2);
         $user->addCondition('Tickets/user/country_id/Users/country_id/Users/#', '>', 1);
-        if ($this->driverType !== 'sqlite') {
+        if (! $this->getDatabasePlatform() instanceof SqlitePlatform) {
             // not supported because of limitation/issue in Sqlite, the generated query fails
             // with error: "parser stack overflow"
             $user->addCondition('Tickets/user/country_id/Users/country_id/Users/name', '!=', null); // should be always true

--- a/tests/TypecastingTest.php
+++ b/tests/TypecastingTest.php
@@ -7,6 +7,7 @@ namespace atk4\data\tests;
 use atk4\data\Exception;
 use atk4\data\Model;
 use atk4\data\Persistence;
+use Doctrine\DBAL\Platforms\OraclePlatform;
 
 class MyDate extends \DateTime
 {
@@ -126,7 +127,7 @@ class TypecastingTest extends \atk4\schema\PhpunitTestCase
     {
         // Oracle always converts empty string to null
         // see https://stackoverflow.com/questions/13278773/null-vs-empty-string-in-oracle#13278879
-        $emptyStringValue = $this->driverType === 'oci' ? null : '';
+        $emptyStringValue = $this->getDatabasePlatform() instanceof OraclePlatform ? null : '';
 
         $dbData = [
             'types' => [
@@ -193,7 +194,7 @@ class TypecastingTest extends \atk4\schema\PhpunitTestCase
         $this->assertNull($mm->get('float'));
         $this->assertNull($mm->get('array'));
         $this->assertNull($mm->get('object'));
-        if ($this->driverType !== 'oci') { // @TODO IMPORTANT we probably want to cast to string for Oracle on our own, so dirty array stay clean!
+        if (! $this->getDatabasePlatform() instanceof OraclePlatform) { // @TODO IMPORTANT we probably want to cast to string for Oracle on our own, so dirty array stay clean!
             $this->assertSame([], $mm->dirty);
         }
 

--- a/tests/TypecastingTest.php
+++ b/tests/TypecastingTest.php
@@ -194,7 +194,7 @@ class TypecastingTest extends \atk4\schema\PhpunitTestCase
         $this->assertNull($mm->get('float'));
         $this->assertNull($mm->get('array'));
         $this->assertNull($mm->get('object'));
-        if (! $this->getDatabasePlatform() instanceof OraclePlatform) { // @TODO IMPORTANT we probably want to cast to string for Oracle on our own, so dirty array stay clean!
+        if (!$this->getDatabasePlatform() instanceof OraclePlatform) { // @TODO IMPORTANT we probably want to cast to string for Oracle on our own, so dirty array stay clean!
             $this->assertSame([], $mm->dirty);
         }
 

--- a/tests/WithTest.php
+++ b/tests/WithTest.php
@@ -7,6 +7,7 @@ namespace atk4\data\tests;
 use atk4\data\Exception;
 use atk4\data\Model;
 use atk4\data\Persistence;
+use Doctrine\DBAL\Platforms\SQLServerPlatform;
 
 /**
  * @coversDefaultClass \atk4\data\Model
@@ -15,7 +16,7 @@ class WithTest extends \atk4\schema\PhpunitTestCase
 {
     public function testWith()
     {
-        if ($this->driverType === 'sqlsrv') {
+        if ($this->getDatabasePlatform() instanceof SQLServerPlatform) {
             $this->markTestIncomplete('TODO - add WITH support for MSSQL');
         }
 


### PR DESCRIPTION
for https://github.com/atk4/dsql/pull/261

BC break:
(for unknown reasons, there was) removed `Persistence::driverType` property