### PR TITLE
Revert "fix phpdoc of _hasReference"

### DIFF
--- a/src/Model/Join.php
+++ b/src/Model/Join.php
@@ -305,12 +305,11 @@ class Join
     /**
      * Creates reference based on a field from the join.
      *
-     * @param string $link
-     * @param array  $defaults
+     * @param array $defaults
      *
      * @return Reference\HasOne
      */
-    public function hasOne($link, $defaults = [])
+    public function hasOne(string $link, $defaults = [])
     {
         if (!is_array($defaults)) {
             $defaults = ['model' => $defaults ?: 'Model_' . $link];
@@ -324,12 +323,11 @@ class Join
     /**
      * Creates reference based on the field from the join.
      *
-     * @param string $link
-     * @param array  $defaults
+     * @param array $defaults
      *
      * @return Reference\HasMany
      */
-    public function hasMany($link, $defaults = [])
+    public function hasMany(string $link, $defaults = [])
     {
         if (!is_array($defaults)) {
             $defaults = ['model' => $defaults ?: 'Model_' . $link];

--- a/src/Model/Join.php
+++ b/src/Model/Join.php
@@ -130,11 +130,6 @@ class Join
      */
     protected $save_buffer = [];
 
-    /**
-     * Default constructor. Will copy argument into properties.
-     *
-     * @param array $defaults
-     */
     public function __construct($foreign_table = null)
     {
         if ($foreign_table !== null) {

--- a/src/Model/ReferencesTrait.php
+++ b/src/Model/ReferencesTrait.php
@@ -15,44 +15,43 @@ trait ReferencesTrait
     /**
      * The seed used by addRef() method.
      *
-     * @var string|array
+     * @var array
      */
     public $_default_seed_addRef = [Reference::class];
 
     /**
      * The seed used by hasOne() method.
      *
-     * @var string|array
+     * @var array
      */
     public $_default_seed_hasOne = [Reference\HasOne::class];
 
     /**
      * The seed used by hasMany() method.
      *
-     * @var string|array
+     * @var array
      */
     public $_default_seed_hasMany = [Reference\HasMany::class];
 
     /**
      * The seed used by containsOne() method.
      *
-     * @var string|array
+     * @var array
      */
     public $_default_seed_containsOne = [Reference\ContainsOne::class];
 
     /**
      * The seed used by containsMany() method.
      *
-     * @var string
+     * @var array
      */
     public $_default_seed_containsMany = [Reference\ContainsMany::class];
 
     /**
-     * @param string         $className Class name
-     * @param string         $link      Link
-     * @param array|\Closure $defaults  Properties which we will pass to Reference object constructor
+     * @param string         $link     Link
+     * @param array|\Closure $defaults Properties which we will pass to Reference object constructor
      */
-    protected function _hasReference($className, $link, $defaults = []): Reference
+    protected function _hasReference(array $seed, $link, $defaults = []): Reference
     {
         if (!is_array($defaults)) {
             $defaults = ['model' => $defaults ?: 'Model_' . $link];
@@ -63,7 +62,7 @@ trait ReferencesTrait
 
         $defaults[0] = $link;
 
-        $reference = Reference::fromSeed($className, $defaults);
+        $reference = Reference::fromSeed($seed, $defaults);
 
         // if reference with such name already exists, then throw exception
         if ($this->hasElement($name = $reference->getDesiredName())) {

--- a/src/Model/ReferencesTrait.php
+++ b/src/Model/ReferencesTrait.php
@@ -15,44 +15,44 @@ trait ReferencesTrait
     /**
      * The seed used by addRef() method.
      *
-     * @var string|array|object
+     * @var string|array
      */
     public $_default_seed_addRef = [Reference::class];
 
     /**
      * The seed used by hasOne() method.
      *
-     * @var string|array|object
+     * @var string|array
      */
     public $_default_seed_hasOne = [Reference\HasOne::class];
 
     /**
      * The seed used by hasMany() method.
      *
-     * @var string|array|object
+     * @var string|array
      */
     public $_default_seed_hasMany = [Reference\HasMany::class];
 
     /**
      * The seed used by containsOne() method.
      *
-     * @var string|array|object
+     * @var string|array
      */
     public $_default_seed_containsOne = [Reference\ContainsOne::class];
 
     /**
      * The seed used by containsMany() method.
      *
-     * @var string|array|object
+     * @var string
      */
     public $_default_seed_containsMany = [Reference\ContainsMany::class];
 
     /**
-     * @param array|string|object $seed     The first element specifies a class name, other elements are seed
-     * @param string              $link
-     * @param array|\Closure      $defaults Properties which we will pass to Reference object constructor
+     * @param string         $className Class name
+     * @param string         $link      Link
+     * @param array|\Closure $defaults  Properties which we will pass to Reference object constructor
      */
-    protected function _hasReference($seed, $link, $defaults = []): Reference
+    protected function _hasReference($className, $link, $defaults = []): Reference
     {
         if (!is_array($defaults)) {
             $defaults = ['model' => $defaults ?: 'Model_' . $link];
@@ -63,7 +63,7 @@ trait ReferencesTrait
 
         $defaults[0] = $link;
 
-        $reference = Reference::fromSeed($seed, $defaults);
+        $reference = Reference::fromSeed($className, $defaults);
 
         // if reference with such name already exists, then throw exception
         if ($this->hasElement($name = $reference->getDesiredName())) {

--- a/src/Model/ReferencesTrait.php
+++ b/src/Model/ReferencesTrait.php
@@ -48,10 +48,9 @@ trait ReferencesTrait
     public $_default_seed_containsMany = [Reference\ContainsMany::class];
 
     /**
-     * @param string         $link     Link
      * @param array|\Closure $defaults Properties which we will pass to Reference object constructor
      */
-    protected function _hasReference(array $seed, $link, $defaults = []): Reference
+    protected function _hasReference(array $seed, string $link, $defaults = []): Reference
     {
         if (!is_array($defaults)) {
             $defaults = ['model' => $defaults ?: 'Model_' . $link];
@@ -78,10 +77,9 @@ trait ReferencesTrait
     /**
      * Add generic relation. Provide your own call-back that will return the model.
      *
-     * @param string         $link Link
-     * @param array|\Closure $fx   Callback
+     * @param array|\Closure $fx Callback
      */
-    public function addRef($link, $fx): Reference
+    public function addRef(string $link, $fx): Reference
     {
         return $this->_hasReference($this->_default_seed_addRef, $link, $fx);
     }
@@ -89,12 +87,11 @@ trait ReferencesTrait
     /**
      * Add hasOne reference.
      *
-     * @param string $link
-     * @param array  $defaults
+     * @param array $defaults
      *
      * @return Reference\HasOne
      */
-    public function hasOne($link, $defaults = []): Reference
+    public function hasOne(string $link, $defaults = []): Reference
     {
         return $this->_hasReference($this->_default_seed_hasOne, $link, $defaults);
     }
@@ -102,12 +99,11 @@ trait ReferencesTrait
     /**
      * Add hasMany reference.
      *
-     * @param string $link
-     * @param array  $defaults
+     * @param array $defaults
      *
      * @return Reference\HasMany
      */
-    public function hasMany($link, $defaults = []): Reference
+    public function hasMany(string $link, $defaults = []): Reference
     {
         return $this->_hasReference($this->_default_seed_hasMany, $link, $defaults);
     }
@@ -115,12 +111,11 @@ trait ReferencesTrait
     /**
      * Add containsOne reference.
      *
-     * @param string $link
-     * @param array  $defaults
+     * @param array $defaults
      *
      * @return Reference\ContainsOne
      */
-    public function containsOne($link, $defaults = []): Reference
+    public function containsOne(string $link, $defaults = []): Reference
     {
         return $this->_hasReference($this->_default_seed_containsOne, $link, $defaults);
     }
@@ -128,12 +123,11 @@ trait ReferencesTrait
     /**
      * Add containsMany reference.
      *
-     * @param string $link
-     * @param array  $defaults
+     * @param array $defaults
      *
      * @return Reference\ContainsMany
      */
-    public function containsMany($link, $defaults = []): Reference
+    public function containsMany(string $link, $defaults = []): Reference
     {
         return $this->_hasReference($this->_default_seed_containsMany, $link, $defaults);
     }
@@ -141,12 +135,11 @@ trait ReferencesTrait
     /**
      * Traverse to related model.
      *
-     * @param string $link
-     * @param array  $defaults
+     * @param array $defaults
      *
      * @return \atk4\data\Model
      */
-    public function ref($link, $defaults = []): self
+    public function ref(string $link, $defaults = []): self
     {
         return $this->getRef($link)->ref($defaults);
     }
@@ -154,12 +147,11 @@ trait ReferencesTrait
     /**
      * Return related model.
      *
-     * @param string $link
-     * @param array  $defaults
+     * @param array $defaults
      *
      * @return \atk4\data\Model
      */
-    public function refModel($link, $defaults = []): self
+    public function refModel(string $link, $defaults = []): self
     {
         return $this->getRef($link)->refModel($defaults);
     }
@@ -167,22 +159,19 @@ trait ReferencesTrait
     /**
      * Returns model that can be used for generating sub-query actions.
      *
-     * @param string $link
-     * @param array  $defaults
+     * @param array $defaults
      *
      * @return \atk4\data\Model
      */
-    public function refLink($link, $defaults = []): self
+    public function refLink(string $link, $defaults = []): self
     {
         return $this->getRef($link)->refLink($defaults);
     }
 
     /**
      * Returns the reference.
-     *
-     * @param string $link
      */
-    public function getRef($link): Reference
+    public function getRef(string $link): Reference
     {
         return $this->getElement('#ref_' . $link);
     }
@@ -204,10 +193,8 @@ trait ReferencesTrait
 
     /**
      * Returns true if reference exists.
-     *
-     * @param string $link
      */
-    public function hasRef($link): bool
+    public function hasRef(string $link): bool
     {
         return $this->hasElement('#ref_' . $link);
     }

--- a/src/Reference.php
+++ b/src/Reference.php
@@ -74,12 +74,7 @@ class Reference
      */
     public $caption;
 
-    /**
-     * Default constructor. Will copy argument into properties.
-     *
-     * @param string $link a short_name component
-     */
-    public function __construct($link)
+    public function __construct(string $link)
     {
         $this->link = $link;
     }


### PR DESCRIPTION
Reverts atk4/data#762 + some new fixes

ping @PhilippGrashoff

I think we can fix there: `array *\$defaults(?! = \[)` (in Model constructor, the `$defaults` with string should probably stay for now)