### PR TITLE
Fix for updated dsql - rename Expression::get() to getRows()

### DIFF
--- a/src-schema/PhpunitTestCase.php
+++ b/src-schema/PhpunitTestCase.php
@@ -171,7 +171,7 @@ class PhpunitTestCase extends AtkPhpunit\TestCase
             $data2 = [];
 
             $s = $this->db->dsql();
-            $data = $s->table($table)->get();
+            $data = $s->table($table)->getRows();
 
             foreach ($data as &$row) {
                 foreach ($row as &$val) {

--- a/src/Persistence/Sql.php
+++ b/src/Persistence/Sql.php
@@ -823,7 +823,7 @@ class Sql extends Persistence
      */
     public function export(Model $model, array $fields = null, bool $typecast = true): array
     {
-        $data = $model->action('select', [$fields])->get();
+        $data = $model->action('select', [$fields])->getRows();
 
         if ($typecast) {
             $data = array_map(function ($row) use ($model) {

--- a/tests/ExpressionSqlTest.php
+++ b/tests/ExpressionSqlTest.php
@@ -220,23 +220,23 @@ class ExpressionSqlTest extends \atk4\schema\PhpunitTestCase
 
         // use alias as array key if it is set
         $q = $m->action('field', ['x', 'alias' => 'foo']);
-        $this->assertEquals([0 => ['foo' => 5]], $q->get());
+        $this->assertEquals([0 => ['foo' => 5]], $q->getRows());
 
         // if alias is not set, then use field name as key
         $q = $m->action('field', ['x']);
-        $this->assertEquals([0 => ['x' => 5]], $q->get());
+        $this->assertEquals([0 => ['x' => 5]], $q->getRows());
 
         // FX actions
         $q = $m->action('fx', ['sum', 'x', 'alias' => 'foo']);
-        $this->assertEquals([0 => ['foo' => 5]], $q->get());
+        $this->assertEquals([0 => ['foo' => 5]], $q->getRows());
 
         $q = $m->action('fx', ['sum', 'x']);
-        $this->assertEquals([0 => ['sum_x' => 5]], $q->get());
+        $this->assertEquals([0 => ['sum_x' => 5]], $q->getRows());
 
         $q = $m->action('fx0', ['sum', 'x', 'alias' => 'foo']);
-        $this->assertEquals([0 => ['foo' => 5]], $q->get());
+        $this->assertEquals([0 => ['foo' => 5]], $q->getRows());
 
         $q = $m->action('fx0', ['sum', 'x']);
-        $this->assertEquals([0 => ['sum_x' => 5]], $q->get());
+        $this->assertEquals([0 => ['sum_x' => 5]], $q->getRows());
     }
 }


### PR DESCRIPTION
for https://github.com/atk4/dsql/pull/271