### PR TITLE
Fix comment - PostgreSQL requires PK specified in SQL to use autoincrement

### DIFF
--- a/tests/ModelWithoutIdTest.php
+++ b/tests/ModelWithoutIdTest.php
@@ -7,7 +7,6 @@ namespace atk4\data\tests;
 use atk4\data\Exception;
 use atk4\data\Model;
 use atk4\data\Persistence;
-use Doctrine\DBAL\Platforms\PostgreSQLPlatform;
 
 /**
  * @coversDefaultClass \atk4\data\Model
@@ -80,10 +79,6 @@ class ModelWithoutIdTest extends \atk4\schema\PhpunitTestCase
      */
     public function testInsert()
     {
-        if ($this->getDatabasePlatform() instanceof PostgreSQLPlatform) {
-            $this->markTestIncomplete('PostgreSQL requires PK unspecified to use autoincrement');
-        }
-
         $this->m->insert(['name' => 'Joe']);
         $this->assertEquals(3, $this->m->action('count')->getOne());
     }
@@ -93,10 +88,6 @@ class ModelWithoutIdTest extends \atk4\schema\PhpunitTestCase
      */
     public function testSave1()
     {
-        if ($this->getDatabasePlatform() instanceof PostgreSQLPlatform) {
-            $this->markTestIncomplete('PostgreSQL requires PK unspecified to use autoincrement');
-        }
-
         $this->m->tryLoadAny();
         $this->m->saveAndUnload();
 
@@ -108,10 +99,6 @@ class ModelWithoutIdTest extends \atk4\schema\PhpunitTestCase
      */
     public function testSave2()
     {
-        if ($this->getDatabasePlatform() instanceof PostgreSQLPlatform) {
-            $this->markTestIncomplete('PostgreSQL requires PK unspecified to use autoincrement');
-        }
-
         $this->m->tryLoadAny();
         $this->m->save();
 

--- a/tests/ModelWithoutIdTest.php
+++ b/tests/ModelWithoutIdTest.php
@@ -7,6 +7,7 @@ namespace atk4\data\tests;
 use atk4\data\Exception;
 use atk4\data\Model;
 use atk4\data\Persistence;
+use Doctrine\DBAL\Platforms\PostgreSQLPlatform;
 
 /**
  * @coversDefaultClass \atk4\data\Model
@@ -79,6 +80,10 @@ class ModelWithoutIdTest extends \atk4\schema\PhpunitTestCase
      */
     public function testInsert()
     {
+        if ($this->getDatabasePlatform() instanceof PostgreSQLPlatform) {
+            $this->markTestIncomplete('PostgreSQL requires PK unspecified to use autoincrement');
+        }
+
         $this->m->insert(['name' => 'Joe']);
         $this->assertEquals(3, $this->m->action('count')->getOne());
     }
@@ -88,6 +93,10 @@ class ModelWithoutIdTest extends \atk4\schema\PhpunitTestCase
      */
     public function testSave1()
     {
+        if ($this->getDatabasePlatform() instanceof PostgreSQLPlatform) {
+            $this->markTestIncomplete('PostgreSQL requires PK unspecified to use autoincrement');
+        }
+
         $this->m->tryLoadAny();
         $this->m->saveAndUnload();
 
@@ -99,6 +108,10 @@ class ModelWithoutIdTest extends \atk4\schema\PhpunitTestCase
      */
     public function testSave2()
     {
+        if ($this->getDatabasePlatform() instanceof PostgreSQLPlatform) {
+            $this->markTestIncomplete('PostgreSQL requires PK unspecified to use autoincrement');
+        }
+
         $this->m->tryLoadAny();
         $this->m->save();
 

--- a/tests/ModelWithoutIdTest.php
+++ b/tests/ModelWithoutIdTest.php
@@ -81,7 +81,7 @@ class ModelWithoutIdTest extends \atk4\schema\PhpunitTestCase
     public function testInsert()
     {
         if ($this->getDatabasePlatform() instanceof PostgreSQLPlatform) {
-            $this->markTestIncomplete('PostgreSQL requires PK unspecified to use autoincrement');
+            $this->markTestIncomplete('PostgreSQL requires ID specified in SQL to use autoincrement');
         }
 
         $this->m->insert(['name' => 'Joe']);
@@ -94,7 +94,7 @@ class ModelWithoutIdTest extends \atk4\schema\PhpunitTestCase
     public function testSave1()
     {
         if ($this->getDatabasePlatform() instanceof PostgreSQLPlatform) {
-            $this->markTestIncomplete('PostgreSQL requires PK unspecified to use autoincrement');
+            $this->markTestIncomplete('PostgreSQL requires ID specified in SQL to use autoincrement');
         }
 
         $this->m->tryLoadAny();
@@ -109,7 +109,7 @@ class ModelWithoutIdTest extends \atk4\schema\PhpunitTestCase
     public function testSave2()
     {
         if ($this->getDatabasePlatform() instanceof PostgreSQLPlatform) {
-            $this->markTestIncomplete('PostgreSQL requires PK unspecified to use autoincrement');
+            $this->markTestIncomplete('PostgreSQL requires ID specified in SQL to use autoincrement');
         }
 
         $this->m->tryLoadAny();

--- a/tests/ModelWithoutIdTest.php
+++ b/tests/ModelWithoutIdTest.php
@@ -81,7 +81,7 @@ class ModelWithoutIdTest extends \atk4\schema\PhpunitTestCase
     public function testInsert()
     {
         if ($this->getDatabasePlatform() instanceof PostgreSQLPlatform) {
-            $this->markTestIncomplete('PostgreSQL requires ID specified in SQL to use autoincrement');
+            $this->markTestIncomplete('PostgreSQL requires PK specified in SQL to use autoincrement');
         }
 
         $this->m->insert(['name' => 'Joe']);
@@ -94,7 +94,7 @@ class ModelWithoutIdTest extends \atk4\schema\PhpunitTestCase
     public function testSave1()
     {
         if ($this->getDatabasePlatform() instanceof PostgreSQLPlatform) {
-            $this->markTestIncomplete('PostgreSQL requires ID specified in SQL to use autoincrement');
+            $this->markTestIncomplete('PostgreSQL requires PK specified in SQL to use autoincrement');
         }
 
         $this->m->tryLoadAny();
@@ -109,7 +109,7 @@ class ModelWithoutIdTest extends \atk4\schema\PhpunitTestCase
     public function testSave2()
     {
         if ($this->getDatabasePlatform() instanceof PostgreSQLPlatform) {
-            $this->markTestIncomplete('PostgreSQL requires ID specified in SQL to use autoincrement');
+            $this->markTestIncomplete('PostgreSQL requires PK specified in SQL to use autoincrement');
         }
 
         $this->m->tryLoadAny();

--- a/tests/ModelWithoutIdTest.php
+++ b/tests/ModelWithoutIdTest.php
@@ -79,9 +79,6 @@ class ModelWithoutIdTest extends \atk4\schema\PhpunitTestCase
      */
     public function testInsert()
     {
-        $this->m->id_field = 'id';
-        $this->m->addField('id');
-
         $this->m->insert(['name' => 'Joe']);
         $this->assertEquals(3, $this->m->action('count')->getOne());
     }
@@ -91,10 +88,7 @@ class ModelWithoutIdTest extends \atk4\schema\PhpunitTestCase
      */
     public function testSave1()
     {
-        $this->m->id_field = 'id';
-        $this->m->addField('id');
-
-//        $this->m->tryLoadAny();
+        $this->m->tryLoadAny();
         $this->m->saveAndUnload();
 
         $this->assertEquals(3, $this->m->action('count')->getOne());
@@ -105,10 +99,7 @@ class ModelWithoutIdTest extends \atk4\schema\PhpunitTestCase
      */
     public function testSave2()
     {
-        $this->m->id_field = 'id';
-        $this->m->addField('id');
-
-//        $this->m->tryLoadAny();
+        $this->m->tryLoadAny();
         $this->m->save();
 
         $this->assertEquals(3, $this->m->action('count')->getOne());

--- a/tests/ModelWithoutIdTest.php
+++ b/tests/ModelWithoutIdTest.php
@@ -79,6 +79,9 @@ class ModelWithoutIdTest extends \atk4\schema\PhpunitTestCase
      */
     public function testInsert()
     {
+        $this->m->id_field = 'id';
+        $this->m->addField('id');
+
         $this->m->insert(['name' => 'Joe']);
         $this->assertEquals(3, $this->m->action('count')->getOne());
     }
@@ -88,7 +91,10 @@ class ModelWithoutIdTest extends \atk4\schema\PhpunitTestCase
      */
     public function testSave1()
     {
-        $this->m->tryLoadAny();
+        $this->m->id_field = 'id';
+        $this->m->addField('id');
+
+//        $this->m->tryLoadAny();
         $this->m->saveAndUnload();
 
         $this->assertEquals(3, $this->m->action('count')->getOne());
@@ -99,7 +105,10 @@ class ModelWithoutIdTest extends \atk4\schema\PhpunitTestCase
      */
     public function testSave2()
     {
-        $this->m->tryLoadAny();
+        $this->m->id_field = 'id';
+        $this->m->addField('id');
+
+//        $this->m->tryLoadAny();
         $this->m->save();
 
         $this->assertEquals(3, $this->m->action('count')->getOne());


### PR DESCRIPTION
I think we do not need to support this usecase on PostgreSQL...

Actually, we even want to think about requiring ID field in Model.