### PR TITLE
[fix] - Enable Callback missing argument

### DIFF
--- a/src/Model/UserAction.php
+++ b/src/Model/UserAction.php
@@ -126,7 +126,7 @@ class UserAction
 
     protected function validateBeforeExecute(): void
     {
-        if ($this->enabled === false || ($this->enabled instanceof \Closure && ($this->enabled)() === false)) {
+        if ($this->enabled === false || ($this->enabled instanceof \Closure && ($this->enabled)($this->getOwner()) === false)) {
             throw new Exception('This action is disabled');
         }
 


### PR DESCRIPTION
Fixed issue when an action uses a callback function to determine if action can execute or not. 

For example. The model action below will fail when running the `validateBeforeExecute()` method.

```
        $model->addUserAction('pay_invoice', [
            'caption' => 'Pay Full Invoice Amount',
            'description' => 'Pay',
            'enabled' => function($m) {
              return $m->get('balance') > 0;
            },
            'modifier' =>UserAction::MODIFIER_UPDATE,
            'appliesTo' => UserAction::APPLIES_TO_SINGLE_RECORD,
            'args' => [
                'method' => ['required' => true, 'default' => 'cash', 'enum' => ['cash', 'debit', 'credit']],
            ],
        ]);
````