### PR TITLE
[fix] Their_field property access

### DIFF
--- a/src/Reference.php
+++ b/src/Reference.php
@@ -80,6 +80,11 @@ class Reference
         $this->link = $link;
     }
 
+    public function getTheirField()
+    {
+        return $this->their_field ?? $this->model->id_field;
+    }
+
     protected function onHookToOurModel(Model $model, string $spot, \Closure $fx, array $args = [], int $priority = 5): int
     {
         $name = $this->short_name; // use static function to allow this object to be GCed


### PR DESCRIPTION
Property their_field is need for properly building ScopeBuilder dropdwon item.