### PR TITLE
Should use recursive merging

### DIFF
--- a/src/Field.php
+++ b/src/Field.php
@@ -210,7 +210,7 @@ class Field implements Expressionable
     {
         foreach ($defaults as $key => $val) {
             if (is_array($val)) {
-                $this->{$key} = array_merge(is_array($this->{$key} ?? null) ? $this->{$key} : [], $val);
+                $this->{$key} = array_merge_recursive(is_array($this->{$key} ?? null) ? $this->{$key} : [], $val);
             } else {
                 $this->{$key} = $val;
             }


### PR DESCRIPTION
Should use recursive merging otherwise ui or any other array property cant be extended only overwritten.

For example, if you already have set some default properties and constructor also sets some, then constructor completely override the default ones.
If default one is `ui => [editable => true]` and you call constructor with `ui => [visible => true]` then you ended up with just `ui => [visible => true]` not `ui => [editable => true, visible => true]` as expected.
That's especially important in case of UI Multiline field which didn't work well because of this.