### PR TITLE
correct fix for merging properties

### DIFF
--- a/src/Field.php
+++ b/src/Field.php
@@ -210,7 +210,7 @@ class Field implements Expressionable
     {
         foreach ($defaults as $key => $val) {
             if (is_array($val)) {
-                $this->{$key} = array_merge_recursive(is_array($this->{$key} ?? null) ? $this->{$key} : [], $val);
+                $this->{$key} = array_replace_recursive(is_array($this->{$key} ?? null) ? $this->{$key} : [], $val);
             } else {
                 $this->{$key} = $val;
             }

--- a/src/Reference/ContainsOne.php
+++ b/src/Reference/ContainsOne.php
@@ -65,7 +65,7 @@ class ContainsOne extends Reference
                 'reference' => $this,
                 'system' => $this->system,
                 'caption' => $this->caption, // it's ref models caption, but we can use it here for field too
-                'ui' => array_merge_recursive([
+                'ui' => array_replace_recursive([
                     'visible' => false, // not visible in UI Table, Grid and Crud
                     'editable' => true, // but should be editable in UI Form
                 ], $this->ui),

--- a/src/Reference/ContainsOne.php
+++ b/src/Reference/ContainsOne.php
@@ -65,7 +65,7 @@ class ContainsOne extends Reference
                 'reference' => $this,
                 'system' => $this->system,
                 'caption' => $this->caption, // it's ref models caption, but we can use it here for field too
-                'ui' => array_replace_recursive([
+                'ui' => array_merge([
                     'visible' => false, // not visible in UI Table, Grid and Crud
                     'editable' => true, // but should be editable in UI Form
                 ], $this->ui),


### PR DESCRIPTION
It should be array_replace_recursive there.

```
$a = ['form' => ['MyForm', 'color'=>'red'], 'table' => ['color'=>'blue']];
$b = ['form' => ['color'=>'green'], 'table'=>['MyTable']];
print_r($c = array_merge_recursive($a,$b)); // will create color as array [red, green] :(
print_r($d = array_replace_recursive($a,$b)); // will correctly replace color
assert($d, ['form' => ['MyForm', 'color'=>'green'], 'table' => ['MyTable', 'color'=>'blue']]);
```