### PR TITLE
Implicit ID have default type of integer and is required by default

### DIFF
--- a/src/Model.php
+++ b/src/Model.php
@@ -372,7 +372,7 @@ class Model extends Model\Base implements \IteratorAggregate
         $this->_init();
 
         if ($this->id_field) {
-            $this->addField($this->id_field, ['system' => true]);
+            $this->addField($this->id_field, ['type' => 'integer', 'system' => true]);
         } else {
             return; // don't declare actions for model without id_field
         }

--- a/src/Model.php
+++ b/src/Model.php
@@ -372,7 +372,7 @@ class Model extends Model\Base implements \IteratorAggregate
         $this->_init();
 
         if ($this->id_field) {
-            $this->addField($this->id_field, ['type' => 'integer', 'system' => true]);
+            $this->addField($this->id_field, ['type' => 'integer', 'required' => true, 'system' => true]);
         } else {
             return; // don't declare actions for model without id_field
         }

--- a/tests-schema/ModelTest.php
+++ b/tests-schema/ModelTest.php
@@ -145,7 +145,7 @@ class ModelTest extends PhpunitTestCase
             ['blob', 'MIXEDcase'],
         ));
 
-        $this->assertSame([['id' => '1'], ['id' => '2']], $model->export(['id']));
+        $this->assertSame([['id' => 1], ['id' => 2]], $model->export(['id']));
     }
 }
 

--- a/tests/RandomTest.php
+++ b/tests/RandomTest.php
@@ -182,7 +182,7 @@ class RandomTest extends \Atk4\Schema\PhpunitTestCase
         $m = new Model_Item($db, 'item');
 
         $this->assertSame(
-            ['id' => '3', 'name' => 'Smith', 'parent_item_id' => '2', 'parent_item' => 'Sue'],
+            ['id' => 3, 'name' => 'Smith', 'parent_item_id' => '2', 'parent_item' => 'Sue'],
             $m->load(3)->get()
         );
     }
@@ -206,7 +206,7 @@ class RandomTest extends \Atk4\Schema\PhpunitTestCase
         $m = new Model_Item2($db, 'item');
 
         $this->assertSame(
-            ['id' => '3', 'name' => 'Smith', 'parent_item_id' => '2', 'parent_item' => 'Sue'],
+            ['id' => 3, 'name' => 'Smith', 'parent_item_id' => '2', 'parent_item' => 'Sue'],
             $m->load(3)->get()
         );
     }

--- a/tests/SmboTransferTest.php
+++ b/tests/SmboTransferTest.php
@@ -64,8 +64,8 @@ class SmboTransferTest extends \Atk4\Schema\PhpunitTestCase
             return $e1['id'] < $e2['id'] ? -1 : 1;
         });
         $this->assertSame([
-            ['id' => '1', 'transfer_document_id' => '2'],
-            ['id' => '2', 'transfer_document_id' => '1'],
+            ['id' => 1, 'transfer_document_id' => '2'],
+            ['id' => 2, 'transfer_document_id' => '1'],
         ], $data);
     }
 


### PR DESCRIPTION
slightly a BC break, but not in standard cases