### PR TITLE
Rename Persistence\Array_::get() method to getRows()

### DIFF
--- a/docs/sql.rst
+++ b/docs/sql.rst
@@ -357,7 +357,7 @@ Depending on the statement you can also use your statement to retrieve data::
 
     $data = $this->expr("call get_client_report_data([client_id])", [
         'client_id'=>$client_id
-    ])->get();
+    ])->getRows();
 
 This can be handy if you wish to create a method for your Model to abstract away
 the data::
@@ -375,7 +375,7 @@ the data::
             return $this->expr("call get_client_report_data([client_id, arg])", [
                 'arg'       => $arg,
                 'client_id' => $client_id,
-            ])->get();
+            ])->getRows();
         }
     }
 

--- a/src/Action/Iterator.php
+++ b/src/Action/Iterator.php
@@ -71,7 +71,7 @@ class Iterator
     public function aggregate($fx, $field, $coalesce = false)
     {
         $result = 0;
-        $column = array_column($this->get(), $field);
+        $column = array_column($this->getRows(), $field);
 
         switch (strtoupper($fx)) {
             case 'SUM':
@@ -226,7 +226,7 @@ class Iterator
      */
     public function order($fields)
     {
-        $data = $this->get();
+        $data = $this->getRows();
 
         // prepare arguments for array_multisort()
         $args = [];
@@ -252,7 +252,7 @@ class Iterator
      */
     public function limit(int $limit = null, int $offset = 0)
     {
-        $data = array_slice($this->get(), $offset, $limit, true);
+        $data = array_slice($this->getRows(), $offset, $limit, true);
 
         // put data back in generator
         $this->generator = new \ArrayIterator($data);
@@ -285,9 +285,19 @@ class Iterator
     }
 
     /**
-     * Return all data inside array.
+     * @deprecated use "getRows" method instead - will be removed in v2.5
      */
     public function get(): array
+    {
+        'trigger_error'('Method is deprecated. Use getRows instead', E_USER_DEPRECATED);
+
+        return $this->getRows();
+    }
+
+    /**
+     * Return all data inside array.
+     */
+    public function getRows(): array
     {
         return iterator_to_array($this->generator, true);
     }

--- a/src/Persistence/Array_.php
+++ b/src/Persistence/Array_.php
@@ -315,7 +315,7 @@ class Array_ extends Persistence
      */
     public function prepareIterator(Model $model): iterable
     {
-        return $model->action('select')->get();
+        return $model->action('select')->getRows();
     }
 
     /**
@@ -323,7 +323,7 @@ class Array_ extends Persistence
      */
     public function export(Model $model, array $fields = null, bool $typecast = true): array
     {
-        $data = $model->action('select', [$fields])->get();
+        $data = $model->action('select', [$fields])->getRows();
 
         if ($typecast) {
             $data = array_map(function ($row) use ($model) {

--- a/tests/PersistentArrayTest.php
+++ b/tests/PersistentArrayTest.php
@@ -351,7 +351,7 @@ class PersistentArrayTest extends AtkPhpunit\TestCase
 
         // case : str%
         $m->addCondition('country', 'LIKE', 'La%');
-        $result = $m->action('select')->get();
+        $result = $m->action('select')->getRows();
         $this->assertSame(3, count($result));
         $this->assertSame($dbData['countries'][3], $result[3]);
         $this->assertSame($dbData['countries'][7], $result[7]);
@@ -362,7 +362,7 @@ class PersistentArrayTest extends AtkPhpunit\TestCase
         // case : str% NOT LIKE
         $m->scope()->clear();
         $m->addCondition('country', 'NOT LIKE', 'La%');
-        $result = $m->action('select')->get();
+        $result = $m->action('select')->getRows();
         $this->assertSame(7, count($m->export()));
         $this->assertSame($dbData['countries'][1], $result[1]);
         $this->assertSame($dbData['countries'][2], $result[2]);
@@ -375,7 +375,7 @@ class PersistentArrayTest extends AtkPhpunit\TestCase
         // case : %str
         $m->scope()->clear();
         $m->addCondition('country', 'LIKE', '%ia');
-        $result = $m->action('select')->get();
+        $result = $m->action('select')->getRows();
         $this->assertSame(4, count($result));
         $this->assertSame($dbData['countries'][3], $result[3]);
         $this->assertSame($dbData['countries'][7], $result[7]);
@@ -387,7 +387,7 @@ class PersistentArrayTest extends AtkPhpunit\TestCase
         // case : %str%
         $m->scope()->clear();
         $m->addCondition('country', 'LIKE', '%a%');
-        $result = $m->action('select')->get();
+        $result = $m->action('select')->getRows();
         $this->assertSame(8, count($result));
         $this->assertSame($dbData['countries'][1], $result[1]);
         $this->assertSame($dbData['countries'][2], $result[2]);
@@ -467,7 +467,7 @@ class PersistentArrayTest extends AtkPhpunit\TestCase
 
         $m->scope()->clear();
         $m->addCondition('country', 'REGEXP', 'Ireland|UK');
-        $result = $m->action('select')->get();
+        $result = $m->action('select')->getRows();
         $this->assertSame(5, count($result));
         $this->assertSame($dbData['countries'][1], $result[1]);
         $this->assertSame($dbData['countries'][2], $result[2]);
@@ -479,7 +479,7 @@ class PersistentArrayTest extends AtkPhpunit\TestCase
 
         $m->scope()->clear();
         $m->addCondition('country', 'NOT REGEXP', 'Ireland|UK|Latvia');
-        $result = $m->action('select')->get();
+        $result = $m->action('select')->getRows();
         $this->assertSame(1, count($result));
         $this->assertSame($dbData['countries'][8], $result[8]);
         unset($result);
@@ -487,7 +487,7 @@ class PersistentArrayTest extends AtkPhpunit\TestCase
 
         $m->scope()->clear();
         $m->addCondition('code', '>', 18);
-        $result = $m->action('select')->get();
+        $result = $m->action('select')->getRows();
         $this->assertSame(1, count($result));
         $this->assertSame($dbData['countries'][9], $result[9]);
         unset($result);
@@ -495,7 +495,7 @@ class PersistentArrayTest extends AtkPhpunit\TestCase
 
         $m->scope()->clear();
         $m->addCondition('code', '>=', 18);
-        $result = $m->action('select')->get();
+        $result = $m->action('select')->getRows();
         $this->assertSame(2, count($result));
         $this->assertSame($dbData['countries'][8], $result[8]);
         $this->assertSame($dbData['countries'][9], $result[9]);
@@ -504,7 +504,7 @@ class PersistentArrayTest extends AtkPhpunit\TestCase
 
         $m->scope()->clear();
         $m->addCondition('code', '<', 12);
-        $result = $m->action('select')->get();
+        $result = $m->action('select')->getRows();
         $this->assertSame(1, count($result));
         $this->assertSame($dbData['countries'][1], $result[1]);
         unset($result);
@@ -512,7 +512,7 @@ class PersistentArrayTest extends AtkPhpunit\TestCase
 
         $m->scope()->clear();
         $m->addCondition('code', '<=', 12);
-        $result = $m->action('select')->get();
+        $result = $m->action('select')->getRows();
         $this->assertSame(2, count($result));
         $this->assertSame($dbData['countries'][1], $result[1]);
         $this->assertSame($dbData['countries'][2], $result[2]);
@@ -521,7 +521,7 @@ class PersistentArrayTest extends AtkPhpunit\TestCase
 
         $m->scope()->clear();
         $m->addCondition('code', [11, 12]);
-        $result = $m->action('select')->get();
+        $result = $m->action('select')->getRows();
         $this->assertSame(2, count($result));
         $this->assertSame($dbData['countries'][1], $result[1]);
         $this->assertSame($dbData['countries'][2], $result[2]);
@@ -530,14 +530,14 @@ class PersistentArrayTest extends AtkPhpunit\TestCase
 
         $m->scope()->clear();
         $m->addCondition('code', 'IN', []);
-        $result = $m->action('select')->get();
+        $result = $m->action('select')->getRows();
         $this->assertSame(0, count($result));
         unset($result);
         $m->unload();
 
         $m->scope()->clear();
         $m->addCondition('code', 'NOT IN', [11, 12, 13, 14, 15, 16, 17]);
-        $result = $m->action('select')->get();
+        $result = $m->action('select')->getRows();
         $this->assertSame(2, count($result));
         $this->assertSame($dbData['countries'][8], $result[8]);
         $this->assertSame($dbData['countries'][9], $result[9]);
@@ -546,7 +546,7 @@ class PersistentArrayTest extends AtkPhpunit\TestCase
 
         $m->scope()->clear();
         $m->addCondition('code', '!=', [11, 12, 13, 14, 15, 16, 17]);
-        $result = $m->action('select')->get();
+        $result = $m->action('select')->getRows();
         $this->assertSame(2, count($result));
         $this->assertSame($dbData['countries'][8], $result[8]);
         $this->assertSame($dbData['countries'][9], $result[9]);
@@ -812,7 +812,7 @@ class PersistentArrayTest extends AtkPhpunit\TestCase
         $m->addCondition('surname', 'Smith');
         $this->assertSame(1, $m->action('count')->getOne());
         $this->assertSame([4 => ['id' => 4, 'name' => 'Sarah', 'surname' => 'Smith']], $m->export());
-        $this->assertSame([4 => ['id' => 4, 'name' => 'Sarah', 'surname' => 'Smith']], $m->action('select')->get());
+        $this->assertSame([4 => ['id' => 4, 'name' => 'Sarah', 'surname' => 'Smith']], $m->action('select')->getRows());
 
         $m->addCondition('surname', 'Siiiith');
         $this->assertSame(0, $m->action('count')->getOne());


### PR DESCRIPTION
to be consistent with https://github.com/atk4/dsql/pull/271