### PR TITLE
Require array in reference/join defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ class JobReport extends Job {
     $invoice_lines = $invoice->ref('Lines');
 
     // Build relation between job and invoice line
-    $this->hasMany('InvoiceLines', $invoice_lines)
+    $this->hasMany('InvoiceLines', ['model' => $invoice_lines])
       ->addField('invoiced', ['aggregate'=>'sum', 'field'=>'total', 'type'=>'money']);
 
     // Next we need to see how much is reported through timesheets
@@ -152,7 +152,7 @@ class JobReport extends Job {
     $timesheet->addExpression('cost', '[hours]*[hourly_rate]');
 
     // Build relation between Job and Timesheets
-    $this->hasMany('Timesheets', $timesheet)
+    $this->hasMany('Timesheets', ['model' => $timesheet])
       ->addField('reported', ['aggregate'=>'sum', 'field'=>'cost', 'type'=>'money']);
 
 	// Finally lets calculate profit
@@ -356,7 +356,7 @@ class Client extends \Atk4\Data\Model {
 
     $this->addFields(['name','address']);
 
-    $this->hasMany('Project', new Project());
+    $this->hasMany('Project', ['model' => [Project::class]]);
   }
 }
 ```

--- a/docs/advanced.rst
+++ b/docs/advanced.rst
@@ -29,7 +29,7 @@ store extra fields there. In your code::
 As you implement single Account and multiple Transaction types, you want to relate
 both::
 
-    $account->hasMany('Transactions', new Transaction());
+    $account->hasMany('Transactions', ['model' => [Transaction::class]]);
 
 There are however two difficulties here:
 
@@ -42,9 +42,9 @@ Best practice for specifying relation type
 Although there is no magic behind it, I recommend that you use the following
 code pattern when dealing with multiple types::
 
-    $account->hasMany('Transactions', new Transaction());
-    $account->hasMany('Transactions:Deposit', new Transaction\Deposit());
-    $account->hasMany('Transactions:Transfer', new Transaction\Transfer());
+    $account->hasMany('Transactions', ['model' => [Transaction::class]]);
+    $account->hasMany('Transactions:Deposit', ['model' => [Transaction\Deposit::class]]);
+    $account->hasMany('Transactions:Transfer', ['model' => [Transaction\Transfer::class]]);
 
 You can then use type-specific reference::
 
@@ -510,12 +510,12 @@ Next we need to define reference. Inside Model_Invoice add::
 
     $this->hasMany('InvoicePayment');
 
-    $this->hasMany('Payment', [function($m) {
+    $this->hasMany('Payment', ['model' => function($m) {
         $p = new Model_Payment($m->persistence);
         $j = $p->join('invoice_payment.payment_id');
         $j->addField('amount_closed');
         $j->hasOne('invoice_id', 'Model_Invoice');
-    }, 'their_field'=>'invoice_id']);
+    }, 'their_field' => 'invoice_id']);
 
     $this->onHookShort(Model::HOOK_BEFORE_DELETE, function(){
         $this->ref('InvoicePayment')->action('delete')->execute();
@@ -776,7 +776,7 @@ define Model_Document::
 One option here is to move 'Model_Contact' into model property, which will be
 different for the extended class::
 
-    $this->hasOne('client_id', $this->client_class);
+    $this->hasOne('client_id', ['model' => [$this->client_class]]);
 
 Alternatively you can replace model in the init() method of Model_Invoice::
 
@@ -797,9 +797,9 @@ field only to offer payments made by the same client. Inside Model_Invoice add::
 
     $this->hasOne('client_id', 'Client');
 
-    $this->hasOne('payment_invoice_id', function($m){
+    $this->hasOne('payment_invoice_id', ['model' => function($m){
         return $m->ref('client_id')->ref('Payment');
-    });
+    }]);
 
     /// how to use
 
@@ -825,9 +825,9 @@ Agile Data allow you to define multiple references between same entities, but
 sometimes that can be quite useful. Consider adding this inside your Model_Contact::
 
     $this->hasMany('Invoice', 'Model_Invoice');
-    $this->hasMany('OverdueInvoice', function($m){
+    $this->hasMany('OverdueInvoice', ['model' => function($m){
         return $m->ref('Invoice')->addCondition('due','<',date('Y-m-d'))
-    });
+    }]);
 
 This way if you extend your class into 'Model_Client' and modify the 'Invoice'
 reference to use different model::

--- a/docs/design.rst
+++ b/docs/design.rst
@@ -236,7 +236,7 @@ Code (add inside `init()`)::
         protected function init(): void {
             parent::init();
 
-            $this->hasMany('Order', new Model_Order());
+            $this->hasMany('Order', ['model' => [Model_Order::class]]);
         }
     }
 
@@ -244,7 +244,7 @@ Code (add inside `init()`)::
         protected function init(): void {
             parent::init();
 
-            $this->hasOne('Client', new Model_Client());
+            $this->hasOne('Client', ['model' => [Model_Client::class]]);
 
             // addField declarations
         }

--- a/docs/sql.rst
+++ b/docs/sql.rst
@@ -56,12 +56,12 @@ SQL Reference
 
     Allows importing field from a referenced model::
 
-        $model->hasOne('country_id', new Country())
+        $model->hasOne('country_id', ['model' => [Country::class]])
             ->addField('country_name', 'name');
 
     Second argument could be array containing additional settings for the field::
 
-        $model->hasOne('account_id', new Account())
+        $model->hasOne('account_id', ['model' => [Account::class]])
             ->addField('account_balance', ['balance', 'type'=>'money']);
 
     Returns new field object.
@@ -70,12 +70,12 @@ SQL Reference
 
     Allows importing multiple fields::
 
-        $model->hasOne('country_id', new Country())
+        $model->hasOne('country_id', ['model' => [Country::class]])
             ->addFields(['country_name', 'country_code']);
 
     You can specify defaults to be applied on all fields::
 
-        $model->hasOne('account_id', new Account())
+        $model->hasOne('account_id', ['model' => [Account::class]])
             ->addFields([
                 'opening_balance',
                 'balance'
@@ -83,7 +83,7 @@ SQL Reference
 
     You can also specify aliases::
 
-        $model->hasOne('account_id', new Account())
+        $model->hasOne('account_id', ['model' => [Account::class]])
             ->addFields([
                 'opening_balance',
                 'account_balance'=>'balance'
@@ -91,7 +91,7 @@ SQL Reference
 
     If you need to pass more details to individual field, you can also use sub-array::
 
-        $model->hasOne('account_id', new Account())
+        $model->hasOne('account_id', ['model' => [Account::class]])
             ->addFields([
             [
                 ['opening_balance', 'caption'=>'The Opening Balance'],
@@ -119,14 +119,14 @@ SQL Reference
     Similar to addField, but will import "title" field and will come up with
     good name for it::
 
-        $model->hasOne('country_id', new Country())
+        $model->hasOne('country_id', ['model' => [Country::class]])
             ->addTitle();
 
         // creates 'country' field as sub-query for country.name
 
     You may pass defaults::
 
-        $model->hasOne('country_id', new Country())
+        $model->hasOne('country_id', ['model' => [Country::class]])
             ->addTitle(['caption'=>'Country Name']);
 
     Returns new field object.
@@ -414,7 +414,7 @@ fetching like this::
         function init(): void {
             parent::init();
 
-            $this->hasOne('parent_id', new self());
+            $this->hasOne('parent_id', ['model' => [self::class]]);
             $this->addField('name');
 
             $this->addExpression('path', 'get_path([id])');

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -19,10 +19,6 @@ parameters:
         # TODO remove once https://github.com/atk4/ui/issues/1548 is resolved
         - '~^Class Atk4\\Ui\\(Button|Icon) not found\.$~'
 
-        # TODO do we want to allow to pass an Model instance?
-        - '~^Parameter #2 \$defaults of method Atk4\\Data\\Model::(hasOne|hasMany)\(\) expects array, .+ given\.$~'
-        - '~^Parameter #2 \$defaults of method Atk4\\Data\\Model\\Join::(hasOne|hasMany)\(\) expects array, .+ given\.$~'
-
         # TODO these rules are generated, this ignores should be fixed in the code
         # for src-schema/PhpunitTestCase.php
         - '~^Access to an undefined property Atk4\\Data\\Persistence\:\:\$connection\.$~'

--- a/src/Model/Join.php
+++ b/src/Model/Join.php
@@ -8,6 +8,7 @@ use Atk4\Core\DiContainerTrait;
 use Atk4\Core\InitializerTrait;
 use Atk4\Core\TrackableTrait;
 use Atk4\Data\Exception;
+use Atk4\Data\Field;
 use Atk4\Data\Model;
 use Atk4\Data\Persistence;
 use Atk4\Data\Reference;
@@ -216,17 +217,9 @@ class Join
      * Adding field into join will automatically associate that field
      * with this join. That means it won't be loaded from $table, but
      * form the join instead.
-     *
-     * @param string $name
-     * @param array  $seed
-     *
-     * @return \Atk4\Data\Field
      */
-    public function addField($name, $seed = [])
+    public function addField(string $name, array $seed = []): Field
     {
-        if ($seed && !is_array($seed)) {
-            $seed = [$seed];
-        }
         $seed['joinName'] = $this->short_name;
 
         return $this->getOwner()->addField($this->prefix . $name, $seed);
@@ -257,15 +250,10 @@ class Join
     /**
      * Another join will be attached to a current join.
      *
-     * @param array $defaults
-     *
      * @return self
      */
-    public function join(string $foreign_table, $defaults = [])
+    public function join(string $foreign_table, array $defaults = [])
     {
-        if (!is_array($defaults)) {
-            $defaults = ['master_field' => $defaults];
-        }
         $defaults['joinName'] = $this->short_name;
 
         return $this->getOwner()->join($foreign_table, $defaults);
@@ -274,15 +262,10 @@ class Join
     /**
      * Another leftJoin will be attached to a current join.
      *
-     * @param array $defaults
-     *
      * @return self
      */
-    public function leftJoin(string $foreign_table, $defaults = [])
+    public function leftJoin(string $foreign_table, array $defaults = [])
     {
-        if (!is_array($defaults)) {
-            $defaults = ['master_field' => $defaults];
-        }
         $defaults['joinName'] = $this->short_name;
 
         return $this->getOwner()->leftJoin($foreign_table, $defaults);
@@ -292,8 +275,6 @@ class Join
      * weakJoin will be attached to a current join.
      *
      * @todo NOT IMPLEMENTED! weakJoin method does not exist!
-     *
-     * @param array $defaults
      *
      * @return
      */
@@ -309,16 +290,10 @@ class Join
     /**
      * Creates reference based on a field from the join.
      *
-     * @param array $defaults
-     *
      * @return Reference\HasOne
      */
-    public function hasOne(string $link, $defaults = [])
+    public function hasOne(string $link, array $defaults = [])
     {
-        if (!is_array($defaults)) {
-            $defaults = ['model' => $defaults];
-        }
-
         $defaults['joinName'] = $this->short_name;
 
         return $this->getOwner()->hasOne($link, $defaults);
@@ -327,16 +302,10 @@ class Join
     /**
      * Creates reference based on the field from the join.
      *
-     * @param array $defaults
-     *
      * @return Reference\HasMany
      */
-    public function hasMany(string $link, $defaults = [])
+    public function hasMany(string $link, array $defaults = [])
     {
-        if (!is_array($defaults)) {
-            $defaults = ['model' => $defaults];
-        }
-
         $defaults = array_merge([
             'our_field' => $this->id_field,
             'their_field' => $this->getOwner()->table . '_' . $this->id_field,
@@ -351,18 +320,11 @@ class Join
      *
      * @todo NOT IMPLEMENTED !
      *
-     * @param Model $model
-     * @param array $defaults
-     *
      * @return ???
      */
     /*
-    public function containsOne($model, $defaults = [])
+    public function containsOne(Model $model, array $defaults = [])
     {
-        if (!is_array($defaults)) {
-            $defaults = [$defaults];
-        }
-
         if (is_string($defaults[0])) {
             $defaults[0] = $this->addField($defaults[0], ['system' => true]);
         }
@@ -377,18 +339,11 @@ class Join
      *
      * @todo NOT IMPLEMENTED !
      *
-     * @param Model $model
-     * @param array $defaults
-     *
      * @return ???
      */
     /*
-    public function containsMany($model, $defaults = [])
+    public function containsMany(Model $model, array $defaults = [])
     {
-        if (!is_array($defaults)) {
-            $defaults = [$defaults];
-        }
-
         if (is_string($defaults[0])) {
             $defaults[0] = $this->addField($defaults[0], ['system' => true]);
         }
@@ -408,12 +363,9 @@ class Join
      * to all the fields. Conditions will be automatically mapped.
      *
      * @todo NOT IMPLEMENTED !
-     *
-     * @param Model $model
-     * @param array $defaults
      */
     /*
-    public function importModel($model, $defaults = [])
+    public function importModel(Model $model, array $defaults = [])
     {
         // not implemented yet !!!
     }
@@ -424,12 +376,9 @@ class Join
      * then import all of the data into our model.
      *
      * @todo NOT IMPLEMENTED!
-     *
-     * @param Model $model
-     * @param array $fields
      */
     /*
-    public function weakJoinModel($model, $fields = [])
+    public function weakJoinModel(Model $model, array $fields = [])
     {
         if (!is_object($model)) {
             $model = $this->getOwner()->connection->add($model);

--- a/src/Model/JoinsTrait.php
+++ b/src/Model/JoinsTrait.php
@@ -23,7 +23,7 @@ trait JoinsTrait
      * join will also query $foreignTable in order to find additional fields. When inserting
      * the record will be also added inside $foreignTable and relationship will be maintained.
      *
-     * @param array<string, string> $defaults
+     * @param array<string, mixed> $defaults
      */
     public function join(string $foreignTable, array $defaults = []): Join
     {
@@ -37,7 +37,7 @@ trait JoinsTrait
      *
      * @see join()
      *
-     * @param array<string, string> $defaults
+     * @param array<string, mixed> $defaults
      */
     public function leftJoin(string $foreignTable, array $defaults = []): Join
     {

--- a/src/Model/JoinsTrait.php
+++ b/src/Model/JoinsTrait.php
@@ -23,17 +23,10 @@ trait JoinsTrait
      * join will also query $foreignTable in order to find additional fields. When inserting
      * the record will be also added inside $foreignTable and relationship will be maintained.
      *
-     * @param array|string $defaults
+     * @param array<string, string> $defaults
      */
-    public function join(string $foreignTable, $defaults = []): Join
+    public function join(string $foreignTable, array $defaults = []): Join
     {
-        if (!is_array($defaults)) {
-            $defaults = ['master_field' => $defaults];
-        } elseif (isset($defaults[0])) {
-            $defaults['master_field'] = $defaults[0];
-            unset($defaults[0]);
-        }
-
         $defaults[0] = $foreignTable;
 
         return $this->add(Join::fromSeed($this->_default_seed_join, $defaults));
@@ -44,13 +37,10 @@ trait JoinsTrait
      *
      * @see join()
      *
-     * @param array|string $defaults
+     * @param array<string, string> $defaults
      */
-    public function leftJoin(string $foreignTable, $defaults = []): Join
+    public function leftJoin(string $foreignTable, array $defaults = []): Join
     {
-        if (!is_array($defaults)) {
-            $defaults = ['master_field' => $defaults];
-        }
         $defaults['weak'] = true;
 
         return $this->join($foreignTable, $defaults);

--- a/src/Model/ReferencesTrait.php
+++ b/src/Model/ReferencesTrait.php
@@ -48,17 +48,10 @@ trait ReferencesTrait
     public $_default_seed_containsMany = [Reference\ContainsMany::class];
 
     /**
-     * @param array|\Closure $defaults Properties which we will pass to Reference object constructor
+     * @param array<string, mixed> $defaults Properties which we will pass to Reference object constructor
      */
-    protected function _hasReference(array $seed, string $link, $defaults = []): Reference
+    protected function _hasReference(array $seed, string $link, array $defaults = []): Reference
     {
-        if (!is_array($defaults)) {
-            $defaults = ['model' => $defaults];
-        } elseif (isset($defaults[0])) {
-            $defaults['model'] = $defaults[0];
-            unset($defaults[0]);
-        }
-
         $defaults[0] = $link;
 
         $reference = Reference::fromSeed($seed, $defaults);
@@ -76,22 +69,18 @@ trait ReferencesTrait
 
     /**
      * Add generic relation. Provide your own call-back that will return the model.
-     *
-     * @param array|\Closure $fx Callback
      */
-    public function addRef(string $link, $fx): Reference
+    public function addRef(string $link, array $defaults): Reference
     {
-        return $this->_hasReference($this->_default_seed_addRef, $link, $fx);
+        return $this->_hasReference($this->_default_seed_addRef, $link, $defaults);
     }
 
     /**
      * Add hasOne reference.
      *
-     * @param array $defaults
-     *
      * @return Reference\HasOne
      */
-    public function hasOne(string $link, $defaults = []): Reference
+    public function hasOne(string $link, array $defaults = []): Reference
     {
         return $this->_hasReference($this->_default_seed_hasOne, $link, $defaults); // @phpstan-ignore-line
     }
@@ -99,11 +88,9 @@ trait ReferencesTrait
     /**
      * Add hasMany reference.
      *
-     * @param array $defaults
-     *
      * @return Reference\HasMany
      */
-    public function hasMany(string $link, $defaults = []): Reference
+    public function hasMany(string $link, array $defaults = []): Reference
     {
         return $this->_hasReference($this->_default_seed_hasMany, $link, $defaults); // @phpstan-ignore-line
     }
@@ -111,11 +98,9 @@ trait ReferencesTrait
     /**
      * Add containsOne reference.
      *
-     * @param array $defaults
-     *
      * @return Reference\ContainsOne
      */
-    public function containsOne(string $link, $defaults = []): Reference
+    public function containsOne(string $link, array $defaults = []): Reference
     {
         return $this->_hasReference($this->_default_seed_containsOne, $link, $defaults); // @phpstan-ignore-line
     }
@@ -123,11 +108,9 @@ trait ReferencesTrait
     /**
      * Add containsMany reference.
      *
-     * @param array $defaults
-     *
      * @return Reference\ContainsMany
      */
-    public function containsMany(string $link, $defaults = []): Reference
+    public function containsMany(string $link, array $defaults = []): Reference
     {
         return $this->_hasReference($this->_default_seed_containsMany, $link, $defaults); // @phpstan-ignore-line
     }
@@ -135,11 +118,9 @@ trait ReferencesTrait
     /**
      * Traverse to related model.
      *
-     * @param array $defaults
-     *
      * @return \Atk4\Data\Model
      */
-    public function ref(string $link, $defaults = []): self
+    public function ref(string $link, array $defaults = []): self
     {
         return $this->getRef($link)->ref($defaults);
     }
@@ -147,11 +128,9 @@ trait ReferencesTrait
     /**
      * Return related model.
      *
-     * @param array $defaults
-     *
      * @return \Atk4\Data\Model
      */
-    public function refModel(string $link, $defaults = []): self
+    public function refModel(string $link, array $defaults = []): self
     {
         return $this->getRef($link)->refModel($defaults);
     }
@@ -159,11 +138,9 @@ trait ReferencesTrait
     /**
      * Returns model that can be used for generating sub-query actions.
      *
-     * @param array $defaults
-     *
      * @return \Atk4\Data\Model
      */
-    public function refLink(string $link, $defaults = []): self
+    public function refLink(string $link, array $defaults = []): self
     {
         return $this->getRef($link)->refLink($defaults);
     }

--- a/tests/ConditionTest.php
+++ b/tests/ConditionTest.php
@@ -58,7 +58,7 @@ class ConditionTest extends AtkPhpunit\TestCase
 
         $m = new Model();
         $m->addField('name');
-        $m->hasOne('gender_id', $gender);
+        $m->hasOne('gender_id', ['model' => $gender]);
 
         $this->assertFalse($m->getField('gender_id')->system);
         $this->assertTrue($m->getField('gender_id')->isEditable());

--- a/tests/DeepCopyTest.php
+++ b/tests/DeepCopyTest.php
@@ -19,9 +19,9 @@ class DcClient extends Model
 
         $this->addField('name');
 
-        $this->hasMany('Invoices', new DcInvoice());
-        $this->hasMany('Quotes', new DcQuote());
-        $this->hasMany('Payments', new DcPayment());
+        $this->hasMany('Invoices', ['model' => [DcInvoice::class]]);
+        $this->hasMany('Quotes', ['model' => [DcQuote::class]]);
+        $this->hasMany('Payments', ['model' => [DcPayment::class]]);
     }
 }
 
@@ -33,12 +33,12 @@ class DcInvoice extends Model
     {
         parent::init();
 
-        $this->hasOne('client_id', new DcClient());
+        $this->hasOne('client_id', ['model' => [DcClient::class]]);
 
-        $this->hasMany('Lines', [new DcInvoiceLine(), 'their_field' => 'parent_id'])
+        $this->hasMany('Lines', ['model' => [DcInvoiceLine::class], 'their_field' => 'parent_id'])
             ->addField('total', ['aggregate' => 'sum', 'field' => 'total']);
 
-        $this->hasMany('Payments', new DcPayment())
+        $this->hasMany('Payments', ['model' => [DcPayment::class]])
             ->addField('paid', ['aggregate' => 'sum', 'field' => 'amount']);
 
         $this->addExpression('due', '[total]-[paid]');
@@ -62,9 +62,9 @@ class DcQuote extends Model
     protected function init(): void
     {
         parent::init();
-        $this->hasOne('client_id', new DcClient());
+        $this->hasOne('client_id', ['model' => [DcClient::class]]);
 
-        $this->hasMany('Lines', [new DcQuoteLine(), 'their_field' => 'parent_id'])
+        $this->hasMany('Lines', ['model' => [DcQuoteLine::class], 'their_field' => 'parent_id'])
             ->addField('total', ['aggregate' => 'sum', 'field' => 'total']);
 
         $this->addField('ref');
@@ -80,7 +80,7 @@ class DcInvoiceLine extends Model
     protected function init(): void
     {
         parent::init();
-        $this->hasOne('parent_id', new DcInvoice());
+        $this->hasOne('parent_id', ['model' => [DcInvoice::class]]);
 
         $this->addField('name');
 
@@ -104,7 +104,7 @@ class DcQuoteLine extends Model
     {
         parent::init();
 
-        $this->hasOne('parent_id', new DcQuote());
+        $this->hasOne('parent_id', ['model' => [DcQuote::class]]);
 
         $this->addField('name');
 
@@ -126,9 +126,9 @@ class DcPayment extends Model
     protected function init(): void
     {
         parent::init();
-        $this->hasOne('client_id', new DcClient());
+        $this->hasOne('client_id', ['model' => [DcClient::class]]);
 
-        $this->hasOne('invoice_id', new DcInvoice());
+        $this->hasOne('invoice_id', ['model' => [DcInvoice::class]]);
 
         $this->addField('amount', ['type' => 'money']);
     }
@@ -269,7 +269,7 @@ class DeepCopyTest extends \Atk4\Schema\PhpunitTestCase
         $client_id = $client->insert(['name' => 'John']);
 
         $quote = new DcQuote($this->db);
-        $quote->hasMany('Lines2', [new DcQuoteLine(), 'their_field' => 'parent_id']);
+        $quote->hasMany('Lines2', ['model' => [DcQuoteLine::class], 'their_field' => 'parent_id']);
 
         $quote->insert(['ref' => 'q1', 'client_id' => $client_id, 'Lines' => [
             ['name' => 'tools', 'qty' => 5, 'price' => 10],

--- a/tests/FieldTest.php
+++ b/tests/FieldTest.php
@@ -360,7 +360,7 @@ class FieldTest extends \Atk4\Schema\PhpunitTestCase
 
         $m = new Model($db, ['table' => 'user']);
         $m->addField('name');
-        $m->hasOne('category_id', $c)
+        $m->hasOne('category_id', ['model' => $c])
             ->addTitle();
 
         $m->load(1);

--- a/tests/FolderTest.php
+++ b/tests/FolderTest.php
@@ -16,10 +16,10 @@ class Folder extends Model
         parent::init();
         $this->addField('name');
 
-        $this->hasMany('SubFolder', [new self(), 'their_field' => 'parent_id'])
+        $this->hasMany('SubFolder', ['model' => [self::class], 'their_field' => 'parent_id'])
             ->addField('count', ['aggregate' => 'count', 'field' => $this->persistence->expr($this, '*')]);
 
-        $this->hasOne('parent_id', new self())
+        $this->hasOne('parent_id', ['model' => [self::class]])
             ->addTitle();
 
         $this->addField('is_deleted', ['type' => 'boolean']);

--- a/tests/JoinArrayTest.php
+++ b/tests/JoinArrayTest.php
@@ -34,18 +34,13 @@ class JoinArrayTest extends AtkPhpunit\TestCase
         $this->assertSame('id', $this->getProtected($j, 'master_field'));
         $this->assertSame('test_id', $this->getProtected($j, 'foreign_field'));
 
-        $j = $m->join('contact3', 'test_id');
-        $this->assertFalse($this->getProtected($j, 'reverse'));
-        $this->assertSame('test_id', $this->getProtected($j, 'master_field'));
-        $this->assertSame('id', $this->getProtected($j, 'foreign_field'));
-
-        $j = $m->join('contact3', ['test_id']);
+        $j = $m->join('contact3', ['master_field' => 'test_id']);
         $this->assertFalse($this->getProtected($j, 'reverse'));
         $this->assertSame('test_id', $this->getProtected($j, 'master_field'));
         $this->assertSame('id', $this->getProtected($j, 'foreign_field'));
 
         $this->expectException(Exception::class); // TODO not implemented yet, see https://github.com/atk4/data/issues/803
-        $j = $m->join('contact4.foo_id', ['test_id', 'reverse' => true]);
+        $j = $m->join('contact4.foo_id', ['master_field' => 'test_id', 'reverse' => true]);
         $this->assertTrue($this->getProtected($j, 'reverse'));
         $this->assertSame('test_id', $this->getProtected($j, 'master_field'));
         $this->assertSame('foo_id', $this->getProtected($j, 'foreign_field'));
@@ -57,7 +52,7 @@ class JoinArrayTest extends AtkPhpunit\TestCase
         $m = new Model($db, ['table' => 'user']);
 
         $this->expectException(Exception::class);
-        $j = $m->join('contact.foo_id', 'test_id');
+        $j = $m->join('contact.foo_id', ['master_field' => 'test_id']);
     }
 
     public function testJoinSaving1()
@@ -170,7 +165,7 @@ class JoinArrayTest extends AtkPhpunit\TestCase
         $db = new Persistence\Array_(['user' => [], 'contact' => []]);
         $m_u = new Model($db, ['table' => 'user']);
         $m_u->addField('name');
-        $j = $m_u->join('contact', 'test_id');
+        $j = $m_u->join('contact', ['master_field' => 'test_id']);
         $j->addField('contact_phone');
 
         $m_u->set('name', 'John');
@@ -190,7 +185,7 @@ class JoinArrayTest extends AtkPhpunit\TestCase
         $m_u = new Model($db, 'user');
         $m_u->addField('name');
         $m_u->addField('code');
-        $j = $m_u->join('contact.code', 'code');
+        $j = $m_u->join('contact.code', ['master_field' => 'code']);
         $j->addField('contact_phone');
 
         $m_u->get('name') = 'John';
@@ -383,7 +378,7 @@ class JoinArrayTest extends AtkPhpunit\TestCase
 
         // tricky cases to testt
         //
-        //$m->join('foo.bar', ['master_field'=>'baz']);
+        //$m->join('foo.bar', ['master_field' => 'baz']);
         // foreign_table = 'foo.bar'
     }
     */

--- a/tests/JoinSqlTest.php
+++ b/tests/JoinSqlTest.php
@@ -31,18 +31,13 @@ class JoinSqlTest extends \Atk4\Schema\PhpunitTestCase
         $this->assertSame('id', $this->getProtected($j, 'master_field'));
         $this->assertSame('test_id', $this->getProtected($j, 'foreign_field'));
 
-        $j = $m->join('contact3', 'test_id');
-        $this->assertFalse($this->getProtected($j, 'reverse'));
-        $this->assertSame('test_id', $this->getProtected($j, 'master_field'));
-        $this->assertSame('id', $this->getProtected($j, 'foreign_field'));
-
-        $j = $m->join('contact3', ['test_id']);
+        $j = $m->join('contact3', ['master_field' => 'test_id']);
         $this->assertFalse($this->getProtected($j, 'reverse'));
         $this->assertSame('test_id', $this->getProtected($j, 'master_field'));
         $this->assertSame('id', $this->getProtected($j, 'foreign_field'));
 
         $this->expectException(Exception::class); // TODO not implemented yet, see https://github.com/atk4/data/issues/803
-        $j = $m->join('contact4.foo_id', ['test_id', 'reverse' => true]);
+        $j = $m->join('contact4.foo_id', ['master_field' => 'test_id', 'reverse' => true]);
         $this->assertTrue($this->getProtected($j, 'reverse'));
         $this->assertSame('test_id', $this->getProtected($j, 'master_field'));
         $this->assertSame('foo_id', $this->getProtected($j, 'foreign_field'));
@@ -54,7 +49,7 @@ class JoinSqlTest extends \Atk4\Schema\PhpunitTestCase
         $m = new Model($db, ['table' => 'user']);
 
         $this->expectException(Exception::class);
-        $j = $m->join('contact.foo_id', 'test_id');
+        $j = $m->join('contact.foo_id', ['master_field' => 'test_id']);
     }
 
     public function testJoinSaving1()
@@ -184,7 +179,7 @@ class JoinSqlTest extends \Atk4\Schema\PhpunitTestCase
         ]);
 
         $m_u->addField('name');
-        $j = $m_u->join('contact', 'test_id');
+        $j = $m_u->join('contact', ['master_field' => 'test_id']);
         $j->addField('contact_phone');
 
         $m_u->set('name', 'John');

--- a/tests/JoinSqlTest.php
+++ b/tests/JoinSqlTest.php
@@ -563,7 +563,7 @@ class JoinSqlTest extends \Atk4\Schema\PhpunitTestCase
         // hasOne phone model
         $m_p = new Model($db, ['table' => 'phone']);
         $m_p->addField('number');
-        $ref = $j->hasOne('phone_id', $m_p); // hasOne on JOIN
+        $ref = $j->hasOne('phone_id', ['model' => $m_p]); // hasOne on JOIN
         $ref->addField('number');
 
         $m_u->load(1);
@@ -575,7 +575,7 @@ class JoinSqlTest extends \Atk4\Schema\PhpunitTestCase
         $m_t = new Model($db, ['table' => 'token']);
         $m_t->addField('user_id');
         $m_t->addField('token');
-        $ref = $j->hasMany('Token', $m_t); // hasMany on JOIN (use default our_field, their_field)
+        $ref = $j->hasMany('Token', ['model' => $m_t]); // hasMany on JOIN (use default our_field, their_field)
 
         $m_u->load(1);
         $this->assertEquals([
@@ -587,7 +587,7 @@ class JoinSqlTest extends \Atk4\Schema\PhpunitTestCase
         $m_e = new Model($db, ['table' => 'email']);
         $m_e->addField('contact_id');
         $m_e->addField('address');
-        $ref = $j->hasMany('Email', [$m_e, 'our_field' => 'contact_id', 'their_field' => 'contact_id']); // hasMany on JOIN (use custom our_field, their_field)
+        $ref = $j->hasMany('Email', ['model' => $m_e, 'our_field' => 'contact_id', 'their_field' => 'contact_id']); // hasMany on JOIN (use custom our_field, their_field)
 
         $m_u->load(1);
         $this->assertEquals([

--- a/tests/LookupSqlTest.php
+++ b/tests/LookupSqlTest.php
@@ -32,7 +32,7 @@ class LCountry extends Model
 
         $this->addField('is_eu', ['type' => 'boolean', 'default' => false]);
 
-        $this->hasMany('Users', new LUser())
+        $this->hasMany('Users', ['model' => [LUser::class]])
             ->addField('user_names', ['field' => 'name', 'concat' => ',']);
     }
 }
@@ -66,11 +66,11 @@ class LUser extends Model
         $this->addField('name');
         $this->addField('is_vip', ['type' => 'boolean', 'default' => false]);
 
-        $this->hasOne('country_id', new LCountry())
+        $this->hasOne('country_id', ['model' => [LCountry::class]])
             ->withTitle()
             ->addFields(['country_code' => 'code', 'is_eu']);
 
-        $this->hasMany('Friends', new LFriend())
+        $this->hasMany('Friends', ['model' => [LFriend::class]])
             ->addField('friend_names', ['field' => 'friend_name', 'concat' => ',']);
     }
 }
@@ -97,9 +97,9 @@ class LFriend extends Model
     {
         parent::init();
 
-        $this->hasOne('user_id', new LUser())
+        $this->hasOne('user_id', ['model' => [LUser::class]])
             ->addField('my_name', 'name');
-        $this->hasOne('friend_id', new LUser())
+        $this->hasOne('friend_id', ['model' => [LUser::class]])
             ->addField('friend_name', 'name');
 
         // add or remove reverse friendships

--- a/tests/Model/Smbo/Account.php
+++ b/tests/Model/Smbo/Account.php
@@ -16,7 +16,7 @@ class Account extends Model
 
         $this->addField('name');
 
-        $this->hasMany('Payment', new Payment())
+        $this->hasMany('Payment', ['model' => [Payment::class]])
             ->addField('balance', ['aggregate' => 'sum', 'field' => 'amount']);
     }
 

--- a/tests/Model/Smbo/Document.php
+++ b/tests/Model/Smbo/Document.php
@@ -15,8 +15,8 @@ class Document extends Model
         parent::init();
 
         // Documest is sent from one Contact to Another
-        $this->hasOne('contact_from_id', new Contact());
-        $this->hasOne('contact_to_id', new Contact());
+        $this->hasOne('contact_from_id', ['model' => [Contact::class]]);
+        $this->hasOne('contact_to_id', ['model' => [Contact::class]]);
 
         $this->addField('doc_type', ['enum' => ['invoice', 'payment']]);
 

--- a/tests/Model/Smbo/Payment.php
+++ b/tests/Model/Smbo/Payment.php
@@ -20,7 +20,7 @@ class Payment extends Document
         $this->j_payment = $this->join('payment.document_id');
 
         $this->j_payment->addField('cheque_no');
-        $this->j_payment->hasOne('account_id', new Account());
+        $this->j_payment->hasOne('account_id', ['model' => [Account::class]]);
 
         $this->j_payment->addField('misc_payment', ['type' => 'bool']);
     }

--- a/tests/Model/Smbo/Transfer.php
+++ b/tests/Model/Smbo/Transfer.php
@@ -14,7 +14,7 @@ class Transfer extends Payment
     {
         parent::init();
 
-        $this->j_payment->hasOne('transfer_document_id', new self());
+        $this->j_payment->hasOne('transfer_document_id', ['model' => [self::class]]);
 
         // only used to create / destroy trasfer legs
         if (!$this->detached) {

--- a/tests/PersistentArrayTest.php
+++ b/tests/PersistentArrayTest.php
@@ -879,7 +879,7 @@ class PersistentArrayTest extends AtkPhpunit\TestCase
         $country->table = 'country';
         $country->addField('name');
 
-        $user->hasOne('country_id', $country);
+        $user->hasOne('country_id', ['model' => $country]);
 
         $uu = (clone $user)->load(1);
         $this->assertSame('Latvia', $uu->ref('country_id')->get('name'));
@@ -913,8 +913,8 @@ class PersistentArrayTest extends AtkPhpunit\TestCase
         $user->addField('name');
         $user->addField('surname');
 
-        $country->hasMany('Users', $user);
-        $user->hasOne('country_id', $country);
+        $country->hasMany('Users', ['model' => $user]);
+        $user->hasOne('country_id', ['model' => $country]);
 
         $cc = (clone $country)->load(1);
         $this->assertSame(2, $cc->ref('Users')->action('count')->getOne());

--- a/tests/RandomTest.php
+++ b/tests/RandomTest.php
@@ -41,7 +41,7 @@ class Model_Item2 extends Model
         parent::init();
         $this->addField('name');
         $i2 = $this->join('item2.item_id');
-        $i2->hasOne('parent_item_id', new self())
+        $i2->hasOne('parent_item_id', ['model' => [self::class]])
             ->addTitle();
     }
 }
@@ -58,10 +58,10 @@ class Model_Item3 extends Model
         $this->addField('name');
         $this->addField('age');
         $i2 = $this->join('item2.item_id');
-        $i2->hasOne('parent_item_id', [$m, 'table_alias' => 'parent'])
+        $i2->hasOne('parent_item_id', ['model' => $m, 'table_alias' => 'parent'])
             ->withTitle();
 
-        $this->hasMany('Child', [$m, 'their_field' => 'parent_item_id', 'table_alias' => 'child'])
+        $this->hasMany('Child', ['model' => $m, 'their_field' => 'parent_item_id', 'table_alias' => 'child'])
             ->addField('child_age', ['aggregate' => 'sum', 'field' => 'age']);
     }
 }
@@ -533,8 +533,8 @@ class RandomTest extends \Atk4\Schema\PhpunitTestCase
         $m = new Model($this->db, ['table' => 'db1.user']);
         $m->addField('name');
 
-        $d->hasOne('user_id', $m)->addTitle();
-        $m->hasMany('Documents', $d);
+        $d->hasOne('user_id', ['model' => $m])->addTitle();
+        $m->hasMany('Documents', ['model' => $d]);
 
         $d->addCondition('user', 'Sarah');
 

--- a/tests/ReferenceSqlTest.php
+++ b/tests/ReferenceSqlTest.php
@@ -36,7 +36,7 @@ class ReferenceSqlTest extends \Atk4\Schema\PhpunitTestCase
         $u = (new Model($this->db, ['table' => 'user']))->addFields(['name']);
         $o = (new Model($this->db, ['table' => 'order']))->addFields(['amount', 'user_id']);
 
-        $u->hasMany('Orders', $o);
+        $u->hasMany('Orders', ['model' => $o]);
 
         $oo = (clone $u)->load(1)->ref('Orders');
         $ooo = (clone $oo)->tryLoad(1);
@@ -70,7 +70,7 @@ class ReferenceSqlTest extends \Atk4\Schema\PhpunitTestCase
         $u = (new Model($this->db, ['table' => 'user']))->addFields(['name']);
         $o = (new Model($this->db, ['table' => 'order']))->addFields(['amount', 'user_id']);
 
-        $u->hasMany('Orders', $o);
+        $u->hasMany('Orders', ['model' => $o]);
 
         $this->assertSameSql(
             'select "id","amount","user_id" from "order" where "user_id" = "user"."id"',
@@ -95,7 +95,7 @@ class ReferenceSqlTest extends \Atk4\Schema\PhpunitTestCase
         $u = (new Model($this->db, ['table' => 'user']))->addFields(['name', 'currency']);
         $c = (new Model($this->db, ['table' => 'currency']))->addFields(['currency', 'name']);
 
-        $u->hasMany('cur', [$c, 'our_field' => 'currency', 'their_field' => 'currency']);
+        $u->hasMany('cur', ['model' => $c, 'our_field' => 'currency', 'their_field' => 'currency']);
 
         $cc = (clone $u)->load(1)->ref('cur');
         $cc->tryLoadAny();
@@ -111,7 +111,7 @@ class ReferenceSqlTest extends \Atk4\Schema\PhpunitTestCase
         $u = (new Model($this->db, ['table' => 'user']))->addFields(['name', 'currency_code']);
         $c = (new Model($this->db, ['table' => 'currency']))->addFields(['code', 'name']);
 
-        $u->hasMany('cur', [$c, 'our_field' => 'currency_code', 'their_field' => 'code']);
+        $u->hasMany('cur', ['model' => $c, 'our_field' => 'currency_code', 'their_field' => 'code']);
 
         $this->assertSameSql(
             'select "id","code","name" from "currency" where "code" = "user"."currency_code"',
@@ -142,7 +142,7 @@ class ReferenceSqlTest extends \Atk4\Schema\PhpunitTestCase
         $u = (new Model($this->db, ['table' => 'user']))->addFields(['name']);
         $o = (new Model($this->db, ['table' => 'order']))->addFields(['amount']);
 
-        $o->hasOne('user_id', $u);
+        $o->hasOne('user_id', ['model' => $u]);
 
         $this->assertSame('John', (clone $o)->load(1)->ref('user_id')->get('name'));
         $this->assertSame('Peter', (clone $o)->load(2)->ref('user_id')->get('name'));
@@ -181,7 +181,7 @@ class ReferenceSqlTest extends \Atk4\Schema\PhpunitTestCase
         $u = (new Model($this->db, ['table' => 'user']))->addFields(['name', ['date', 'type' => 'date']]);
 
         $o = (new Model($this->db, ['table' => 'order']))->addFields(['amount']);
-        $o->hasOne('user_id', $u)->addFields(['username' => 'name', ['date', 'type' => 'date']]);
+        $o->hasOne('user_id', ['model' => $u])->addFields(['username' => 'name', ['date', 'type' => 'date']]);
 
         $this->assertSame('John', (clone $o)->load(1)->get('username'));
         $this->assertEquals(new \DateTime('2001-01-02'), (clone $o)->load(1)->get('date'));
@@ -192,12 +192,12 @@ class ReferenceSqlTest extends \Atk4\Schema\PhpunitTestCase
 
         // few more tests
         $o = (new Model($this->db, ['table' => 'order']))->addFields(['amount']);
-        $o->hasOne('user_id', $u)->addFields(['username' => 'name', 'thedate' => ['date', 'type' => 'date']]);
+        $o->hasOne('user_id', ['model' => $u])->addFields(['username' => 'name', 'thedate' => ['date', 'type' => 'date']]);
         $this->assertSame('John', (clone $o)->load(1)->get('username'));
         $this->assertEquals(new \DateTime('2001-01-02'), $o->load(1)->get('thedate'));
 
         $o = (new Model($this->db, ['table' => 'order']))->addFields(['amount']);
-        $o->hasOne('user_id', $u)->addFields(['date'], ['type' => 'date']);
+        $o->hasOne('user_id', ['model' => $u])->addFields(['date'], ['type' => 'date']);
         $this->assertEquals(new \DateTime('2001-01-02'), (clone $o)->load(1)->get('date'));
     }
 
@@ -221,7 +221,7 @@ class ReferenceSqlTest extends \Atk4\Schema\PhpunitTestCase
 
         $i = (new Model($this->db, ['table' => 'invoice']))->addFields(['ref_no']);
         $l = (new Model($this->db, ['table' => 'invoice_line']))->addFields(['invoice_id', 'total_net', 'total_vat', 'total_gross']);
-        $i->hasMany('line', $l);
+        $i->hasMany('line', ['model' => $l]);
 
         $i->addExpression('total_net', $i->refLink('line')->action('fx', ['sum', 'total_net']));
 
@@ -256,7 +256,7 @@ class ReferenceSqlTest extends \Atk4\Schema\PhpunitTestCase
             ['total_vat', 'type' => 'money'],
             ['total_gross', 'type' => 'money'],
         ]);
-        $i->hasMany('line', $l)
+        $i->hasMany('line', ['model' => $l])
             ->addFields([
                 ['total_vat', 'aggregate' => 'sum', 'type' => 'money'],
                 ['total_net', 'aggregate' => 'sum'],
@@ -320,7 +320,7 @@ class ReferenceSqlTest extends \Atk4\Schema\PhpunitTestCase
 
         $l = (new Model($this->db, ['table' => 'list']))->addFields(['name']);
         $i = (new Model($this->db, ['table' => 'item']))->addFields(['list_id', 'name', 'code']);
-        $l->hasMany('Items', $i)
+        $l->hasMany('Items', ['model' => $i])
             ->addFields([
                 ['items_name', 'aggregate' => 'count', 'field' => 'name'],
                 ['items_code', 'aggregate' => 'count', 'field' => 'code'], // counts only not-null values
@@ -375,14 +375,14 @@ class ReferenceSqlTest extends \Atk4\Schema\PhpunitTestCase
 
         $company = (new Model($this->db, ['table' => 'company']))->addFields(['name']);
 
-        $user->hasOne('Company', [$company, 'our_field' => 'company_id', 'their_field' => 'id']);
+        $user->hasOne('Company', ['model' => $company, 'our_field' => 'company_id', 'their_field' => 'id']);
 
         $order = new Model($this->db, ['table' => 'order']);
         $order->addField('company_id');
         $order->addField('description');
         $order->addField('amount', ['default' => 20, 'type' => 'float']);
 
-        $company->hasMany('Orders', [$order]);
+        $company->hasMany('Orders', ['model' => $order]);
 
         $user->load(1);
 
@@ -425,7 +425,7 @@ class ReferenceSqlTest extends \Atk4\Schema\PhpunitTestCase
         $u = (new Model($this->db, ['table' => 'user']))->addFields(['name']);
         $c = (new Model($this->db, ['table' => 'contact']))->addFields(['address']);
 
-        $u->hasOne('contact_id', $c)
+        $u->hasOne('contact_id', ['model' => $c])
             ->addField('address');
 
         $uu = (clone $u)->load(1);
@@ -473,9 +473,9 @@ class ReferenceSqlTest extends \Atk4\Schema\PhpunitTestCase
 
         $s = (new Model($this->db, ['table' => 'stadium']));
         $s->addFields(['name']);
-        $s->hasOne('player_id', $p);
+        $s->hasOne('player_id', ['model' => $p]);
 
-        $p->hasOne('Stadium', [$s, 'our_field' => 'id', 'their_field' => 'player_id']);
+        $p->hasOne('Stadium', ['model' => $s, 'our_field' => 'id', 'their_field' => 'player_id']);
 
         $p->load(2);
         $p->ref('Stadium')->import([['name' => 'Nou camp nou']]);
@@ -509,7 +509,7 @@ class ReferenceSqlTest extends \Atk4\Schema\PhpunitTestCase
         $o = (new Model($this->db, ['table' => 'order']))->addFields(['amount']);
 
         // by default not set
-        $o->hasOne('user_id', $u);
+        $o->hasOne('user_id', ['model' => $u]);
         $this->assertSame($o->getField('user_id')->isVisible(), true);
 
         $o->getRef('user_id')->addTitle();
@@ -519,7 +519,7 @@ class ReferenceSqlTest extends \Atk4\Schema\PhpunitTestCase
 
         // if it is set manually then it will not be changed
         $o = (new Model($this->db, ['table' => 'order']))->addFields(['amount']);
-        $o->hasOne('user_id', $u);
+        $o->hasOne('user_id', ['model' => $u]);
         $o->getField('user_id')->ui['visible'] = true;
         $o->getRef('user_id')->addTitle();
 
@@ -550,7 +550,7 @@ class ReferenceSqlTest extends \Atk4\Schema\PhpunitTestCase
         // with default title_field='name'
         $u = (new Model($this->db, ['table' => 'user']))->addFields(['name', 'last_name']);
         $o = (new Model($this->db, ['table' => 'order']));
-        $o->hasOne('user_id', $u)->addTitle();
+        $o->hasOne('user_id', ['model' => $u])->addTitle();
 
         // change order user by changing title_field value
         $o->load(1);
@@ -567,7 +567,7 @@ class ReferenceSqlTest extends \Atk4\Schema\PhpunitTestCase
         // with custom title_field='last_name'
         $u = (new Model($this->db, ['table' => 'user', 'title_field' => 'last_name']))->addFields(['name', 'last_name']);
         $o = (new Model($this->db, ['table' => 'order']));
-        $o->hasOne('user_id', $u)->addTitle();
+        $o->hasOne('user_id', ['model' => $u])->addTitle();
 
         // change order user by changing title_field value
         $o->load(1);
@@ -584,7 +584,7 @@ class ReferenceSqlTest extends \Atk4\Schema\PhpunitTestCase
         // with custom title_field='last_name' and custom link name
         $u = (new Model($this->db, ['table' => 'user', 'title_field' => 'last_name']))->addFields(['name', 'last_name']);
         $o = (new Model($this->db, ['table' => 'order']));
-        $o->hasOne('my_user', [$u, 'our_field' => 'user_id'])->addTitle();
+        $o->hasOne('my_user', ['model' => $u, 'our_field' => 'user_id'])->addTitle();
 
         // change order user by changing ref field value
         $o->load(1);
@@ -601,7 +601,7 @@ class ReferenceSqlTest extends \Atk4\Schema\PhpunitTestCase
         // with custom title_field='last_name' and custom link name
         $u = (new Model($this->db, ['table' => 'user', 'title_field' => 'last_name']))->addFields(['name', 'last_name']);
         $o = (new Model($this->db, ['table' => 'order']));
-        $o->hasOne('my_user', [$u, 'our_field' => 'user_id'])->addTitle();
+        $o->hasOne('my_user', ['model' => $u, 'our_field' => 'user_id'])->addTitle();
 
         // change order user by changing ref field value
         $o->load(1);
@@ -644,7 +644,7 @@ class ReferenceSqlTest extends \Atk4\Schema\PhpunitTestCase
         $this->assertSame('Surname', $u->getField('last_name')->getCaption());
 
         $o = (new Model($this->db, ['table' => 'order']));
-        $order_user_ref = $o->hasOne('my_user', [$u, 'our_field' => 'user_id']);
+        $order_user_ref = $o->hasOne('my_user', ['model' => $u, 'our_field' => 'user_id']);
         $order_user_ref->addField('user_last_name', 'last_name');
 
         $referenced_caption = $o->getField('user_last_name')->getCaption();

--- a/tests/ReferenceTest.php
+++ b/tests/ReferenceTest.php
@@ -26,19 +26,19 @@ class ReferenceTest extends AtkPhpunit\TestCase
         $order->addField('amount', ['default' => 20]);
         $order->addField('user_id');
 
-        $user->hasMany('Orders', [$order, 'caption' => 'My Orders']);
+        $user->hasMany('Orders', ['model' => $order, 'caption' => 'My Orders']);
         $o = $user->ref('Orders');
 
         $this->assertSame(20, $o->get('amount'));
         $this->assertSame(1, $o->get('user_id'));
 
-        $user->hasMany('BigOrders', function () {
+        $user->hasMany('BigOrders', ['model' => function () {
             $m = new Model();
             $m->addField('amount', ['default' => 100]);
             $m->addField('user_id');
 
             return $m;
-        });
+        }]);
 
         $this->assertSame(100, $user->ref('BigOrders')->get('amount'));
     }
@@ -58,7 +58,7 @@ class ReferenceTest extends AtkPhpunit\TestCase
         $order->addField('amount', ['default' => 20]);
         $order->addField('user_id');
 
-        $user->hasMany('Orders', [$order, 'caption' => 'My Orders']);
+        $user->hasMany('Orders', ['model' => $order, 'caption' => 'My Orders']);
 
         // test caption of containsOne reference
         $this->assertSame('My Orders', $user->refModel('Orders')->getModelCaption());
@@ -81,9 +81,9 @@ class ReferenceTest extends AtkPhpunit\TestCase
         $order = new Model();
         $order->addField('user_id');
 
-        $user->hasMany('Orders', $order);
+        $user->hasMany('Orders', ['model' => $order]);
         $this->expectException(Exception::class);
-        $user->hasMany('Orders', $order);
+        $user->hasMany('Orders', ['model' => $order]);
     }
 
     public function testRefName2()
@@ -91,22 +91,22 @@ class ReferenceTest extends AtkPhpunit\TestCase
         $order = new Model(null, ['table' => 'order']);
         $user = new Model(null, ['table' => 'user']);
 
-        $user->hasOne('user_id', $user);
+        $user->hasOne('user_id', ['model' => $user]);
         $this->expectException(Exception::class);
-        $user->hasOne('user_id', $user);
+        $user->hasOne('user_id', ['model' => $user]);
     }
 
     public function testRefName3()
     {
         $db = new Persistence();
         $order = new Model($db, ['table' => 'order']);
-        $order->addRef('archive', function ($m) {
+        $order->addRef('archive', ['model' => function ($m) {
             return $m->newInstance(null, ['table' => $m->table . '_archive']);
-        });
+        }]);
         $this->expectException(Exception::class);
-        $order->addRef('archive', function ($m) {
+        $order->addRef('archive', ['model' => function ($m) {
             return $m->newInstance(null, ['table' => $m->table . '_archive']);
-        });
+        }]);
     }
 
     public function testCustomRef()
@@ -114,9 +114,9 @@ class ReferenceTest extends AtkPhpunit\TestCase
         $p = new Persistence\Array_();
 
         $m = new Model($p, ['table' => 'user']);
-        $m->addRef('archive', function ($m) {
+        $m->addRef('archive', ['model' => function ($m) {
             return $m->newInstance(null, ['table' => $m->table . '_archive']);
-        });
+        }]);
 
         $this->assertSame('user_archive', $m->ref('archive')->table);
     }

--- a/tests/ScopeTest.php
+++ b/tests/ScopeTest.php
@@ -26,7 +26,7 @@ class SCountry extends Model
 
         $this->addField('is_eu', ['type' => 'boolean', 'default' => false]);
 
-        $this->hasMany('Users', new SUser())
+        $this->hasMany('Users', ['model' => [SUser::class]])
             ->addField('user_names', ['field' => 'name', 'concat' => ',']);
     }
 }
@@ -45,11 +45,11 @@ class SUser extends Model
         $this->addField('surname');
         $this->addField('is_vip', ['type' => 'boolean', 'default' => false]);
 
-        $this->hasOne('country_id', new SCountry())
+        $this->hasOne('country_id', ['model' => [SCountry::class]])
             ->withTitle()
             ->addFields(['country_code' => 'code', 'is_eu']);
 
-        $this->hasMany('Tickets', [new STicket(), 'their_field' => 'user']);
+        $this->hasMany('Tickets', ['model' => [STicket::class], 'their_field' => 'user']);
     }
 }
 
@@ -67,7 +67,7 @@ class STicket extends Model
         $this->addField('venue');
         $this->addField('is_vip', ['type' => 'boolean', 'default' => false]);
 
-        $this->hasOne('user', new SUser());
+        $this->hasOne('user', ['model' => [SUser::class]]);
     }
 }
 

--- a/tests/SubTypesTest.php
+++ b/tests/SubTypesTest.php
@@ -16,16 +16,16 @@ class StAccount extends Model
 
         $this->addField('name');
 
-        $this->hasMany('Transactions', new StGenericTransaction())
+        $this->hasMany('Transactions', ['model' => [StGenericTransaction::class]])
             ->addField('balance', ['aggregate' => 'sum', 'field' => 'amount']);
 
-        $this->hasMany('Transactions:Deposit', new StTransaction_Deposit());
-        $this->hasMany('Transactions:Withdrawal', new StTransaction_Withdrawal());
-        $this->hasMany('Transactions:Ob', new StTransaction_Ob())
+        $this->hasMany('Transactions:Deposit', ['model' => [StTransaction_Deposit::class]]);
+        $this->hasMany('Transactions:Withdrawal', ['model' => [StTransaction_Withdrawal::class]]);
+        $this->hasMany('Transactions:Ob', ['model' => [StTransaction_Ob::class]])
             ->addField('opening_balance', ['aggregate' => 'sum', 'field' => 'amount']);
 
-        $this->hasMany('Transactions:TransferOut', new StTransaction_TransferOut());
-        $this->hasMany('Transactions:TransferIn', new StTransaction_TransferIn());
+        $this->hasMany('Transactions:TransferOut', ['model' => [StTransaction_TransferOut::class]]);
+        $this->hasMany('Transactions:TransferIn', ['model' => [StTransaction_TransferIn::class]]);
     }
 
     public static function open($persistence, $name, $amount = 0)
@@ -68,7 +68,7 @@ class StGenericTransaction extends Model
     {
         parent::init();
 
-        $this->hasOne('account_id', new StAccount());
+        $this->hasOne('account_id', ['model' => [StAccount::class]]);
         $this->addField('type', ['enum' => ['Ob', 'Deposit', 'Withdrawal', 'TransferOut', 'TransferIn']]);
 
         if ($this->type) {
@@ -115,7 +115,7 @@ class StTransaction_TransferOut extends StGenericTransaction
     protected function init(): void
     {
         parent::init();
-        $this->hasOne('link_id', new StTransaction_TransferIn());
+        $this->hasOne('link_id', ['model' => [StTransaction_TransferIn::class]]);
 
         //$this->join('transaction','linked_transaction');
     }
@@ -128,7 +128,7 @@ class StTransaction_TransferIn extends StGenericTransaction
     protected function init(): void
     {
         parent::init();
-        $this->hasOne('link_id', new StTransaction_TransferOut());
+        $this->hasOne('link_id', ['model' => [StTransaction_TransferOut::class]]);
     }
 }
 

--- a/tests/WithTest.php
+++ b/tests/WithTest.php
@@ -39,7 +39,7 @@ class WithTest extends \Atk4\Schema\PhpunitTestCase
 
         $m_invoice = new Model($db, ['table' => 'invoice']);
         $m_invoice->addField('net', ['type' => 'money']);
-        $m_invoice->hasOne('user_id', $m_user);
+        $m_invoice->hasOne('user_id', ['model' => $m_user]);
         $m_invoice->addCondition('net', '>', 100);
 
         // setup test model


### PR DESCRIPTION
hasOne/hasMany was nice with string/object, but allowing string violates seed definition

if we however allow a seed for Model directly (without `['model' => ...]`) then it can not be distinguished from type only (array vs. array)

thus this impl. is strict, but the only one simple and reliable