### PR TITLE
Fix PHPStan 4267 issue until fixed officially

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -54,6 +54,7 @@ jobs:
           if [ "${{ matrix.type }}" != "CodingStyle" ]; then composer remove --no-interaction --no-update friendsofphp/php-cs-fixer --dev && composer --no-interaction --no-update require jdorn/sql-formatter ; fi
           if [ "${{ matrix.type }}" != "StaticAnalysis" ]; then composer remove --no-interaction --no-update phpstan/phpstan --dev ; fi
           composer install --no-suggest --ansi --prefer-dist --no-interaction --no-progress --optimize-autoloader
+          if [ "${{ matrix.type }}" = "StaticAnalysis" ]; then git clone --depth 1 --branch 1.1.5 https://github.com/mvorisek/atk4-hintable-mirror.git && php -d phar.readonly=0 atk4-hintable-mirror/patch-phpstan-static-type-issue-4267.php vendor/phpstan/phpstan/phpstan.phar && rm -R atk4-hintable-mirror ; fi
 
       - name: Init
         run: |

--- a/tests/ContainsManyTest.php
+++ b/tests/ContainsManyTest.php
@@ -51,7 +51,7 @@ class Invoice2 extends Model
         $this->addCalculatedField('discounts_total_sum', function (self $m) {
             $total = 0;
             foreach ($m->lines as $line) {
-                $total += $line->total_gross * $line->get('discounts_percent') / 100; // @phpstan-ignore-line
+                $total += $line->total_gross * $line->get('discounts_percent') / 100;
             }
 
             return $total;


### PR DESCRIPTION
related with https://github.com/phpstan/phpstan/issues/4267

otherwise `foreach ($model as $itemModel)` `$itemModel` is assumed as `Model` instead of `static`