### PR TITLE
Fix composer autoload/PSR4 warning

### DIFF
--- a/tests/ValidationTest.php
+++ b/tests/ValidationTest.php
@@ -9,6 +9,11 @@ use Atk4\Data\Model;
 use Atk4\Data\Persistence;
 use Atk4\Data\ValidationException;
 
+class ValidationTest
+{
+    // TODO ignore CS fixer error
+}
+
 class MyValidationModel extends Model
 {
     protected function init(): void


### PR DESCRIPTION
fixes:
```
Class Atk4\Data\Tests\MyValidationModel located in ./vendor/atk4/data/tests/ValidationTest.php does not comply with psr-4 autoloading standard. Skipping.
Class Atk4\Data\Tests\BadValidationModel located in ./vendor/atk4/data/tests/ValidationTest.php does not comply with psr-4 autoloading standard. Skipping.
Class Atk4\Data\Tests\ValidationTests located in ./vendor/atk4/data/tests/ValidationTest.php does not comply with psr-4 autoloading standard. Skipping.
```