### PR TITLE
Fix title field name guessing

### DIFF
--- a/src/Reference.php
+++ b/src/Reference.php
@@ -195,7 +195,7 @@ class Reference
             $ourModel = $this->getOurModel();
 
             $this->table_alias = $this->link;
-            $this->table_alias = preg_replace('~_(' . $ourModel->id_field . '|id)~', '', $this->table_alias);
+            $this->table_alias = preg_replace('~_(' . preg_quote($ourModel->id_field, '~') . '|id)$~', '', $this->table_alias);
             $this->table_alias = preg_replace('~([a-z])[a-z]*[^a-z]*~i', '$1', $this->table_alias);
             if (isset($ourModel->table_alias)) {
                 $this->table_alias = $ourModel->table_alias . '_' . $this->table_alias;

--- a/src/Reference.php
+++ b/src/Reference.php
@@ -195,8 +195,8 @@ class Reference
             $ourModel = $this->getOurModel();
 
             $this->table_alias = $this->link;
-            $this->table_alias = preg_replace('/_' . ($ourModel->id_field ?: 'id') . '/', '', $this->table_alias);
-            $this->table_alias = preg_replace('/([a-zA-Z])[a-zA-Z]*[^a-zA-Z]*/', '\1', $this->table_alias);
+            $this->table_alias = preg_replace('~_(' . $ourModel->id_field . '|id)~', '', $this->table_alias);
+            $this->table_alias = preg_replace('~([a-z])[a-z]*[^a-z]*~i', '$1', $this->table_alias);
             if (isset($ourModel->table_alias)) {
                 $this->table_alias = $ourModel->table_alias . '_' . $this->table_alias;
             }

--- a/src/Reference/HasOneSql.php
+++ b/src/Reference/HasOneSql.php
@@ -177,7 +177,7 @@ class HasOneSql extends HasOne
     {
         $ourModel = $this->getOurModel();
 
-        $fieldName = $defaults['field'] ?? preg_replace('/_' . $ourModel->id_field . '$/i', '', $this->link) . '_title';
+        $fieldName = $defaults['field'] ?? preg_replace('~_(' . $ourModel->id_field . '|id)$~i', '', $this->link);
 
         if ($ourModel->hasField($fieldName)) {
             throw (new Exception('Field with this name already exists. Please set title field name manually addTitle([\'field\'=>\'field_name\'])'))

--- a/src/Reference/HasOneSql.php
+++ b/src/Reference/HasOneSql.php
@@ -177,7 +177,7 @@ class HasOneSql extends HasOne
     {
         $ourModel = $this->getOurModel();
 
-        $fieldName = $defaults['field'] ?? preg_replace('~_(' . $ourModel->id_field . '|id)$~i', '', $this->link);
+        $fieldName = $defaults['field'] ?? preg_replace('~_(' . $ourModel->id_field . '|id)$~', '', $this->link);
 
         if ($ourModel->hasField($fieldName)) {
             throw (new Exception('Field with this name already exists. Please set title field name manually addTitle([\'field\'=>\'field_name\'])'))

--- a/src/Reference/HasOneSql.php
+++ b/src/Reference/HasOneSql.php
@@ -177,7 +177,7 @@ class HasOneSql extends HasOne
     {
         $ourModel = $this->getOurModel();
 
-        $fieldName = $defaults['field'] ?? preg_replace('/_' . $ourModel->id_field . '$/i', '', $this->link);
+        $fieldName = $defaults['field'] ?? preg_replace('/_' . $ourModel->id_field . '$/i', '', $this->link) . '_title';
 
         if ($ourModel->hasField($fieldName)) {
             throw (new Exception('Field with this name already exists. Please set title field name manually addTitle([\'field\'=>\'field_name\'])'))

--- a/src/Reference/HasOneSql.php
+++ b/src/Reference/HasOneSql.php
@@ -177,7 +177,7 @@ class HasOneSql extends HasOne
     {
         $ourModel = $this->getOurModel();
 
-        $fieldName = $defaults['field'] ?? preg_replace('~_(' . $ourModel->id_field . '|id)$~', '', $this->link);
+        $fieldName = $defaults['field'] ?? preg_replace('~_(' . preg_quote($ourModel->id_field, '~') . '|id)$~', '', $this->link);
 
         if ($ourModel->hasField($fieldName)) {
             throw (new Exception('Field with this name already exists. Please set title field name manually addTitle([\'field\'=>\'field_name\'])'))


### PR DESCRIPTION
for https://github.com/atk4/ui/pull/1595

guessing is always a compromise, but if `id_field` is prefixed, removing `'id'` should be ok as a fallback