### PR TITLE
Use strict tryLoadOne in ContainsOne

### DIFF
--- a/docs/advanced.rst
+++ b/docs/advanced.rst
@@ -806,14 +806,14 @@ field only to offer payments made by the same client. Inside Model_Invoice add::
     $m = new Model_Invoice($db);
     $m->set('client_id', 123);
 
-    $m->set('payment_invoice_id', $m->ref('payment_invoice_id')->tryLoadAny()->getId());
+    $m->set('payment_invoice_id', $m->ref('payment_invoice_id')->tryLoadOne()->getId());
 
 In this case the payment_invoice_id will be set to ID of any payment by client
 123. There also may be some better uses::
 
     $cl->ref('Invoice')->each(function($m) {
 
-        $m->set('payment_invoice_id', $m->ref('payment_invoice_id')->tryLoadAny()->getId());
+        $m->set('payment_invoice_id', $m->ref('payment_invoice_id')->tryLoadOne()->getId());
         $m->save();
 
     });

--- a/docs/expressions.rst
+++ b/docs/expressions.rst
@@ -84,7 +84,7 @@ database at once::
     $m->addExpression('total_payments', (new Model_Payment($db))->action('count'));
     $m->addExpression('total_received', (new Model_Payment($db))->action('fx0', ['sum', 'amount']));
 
-    $data = $m->loadAny()->get();
+    $data = $m->loadOne()->get();
 
 Of course you can also use a DSQL for this::
 

--- a/docs/persistence.rst
+++ b/docs/persistence.rst
@@ -73,19 +73,6 @@ There are several ways to link your model up with the persistence::
 
         $m->save();     // will either create new record or update existing
 
-.. php:method:: loadAny
-
-    Attempt to load any matching record. You can use this in conjunction with
-    setOrder()::
-
-        $m->loadAny();
-        echo $m->get('name');
-
-.. php:method:: tryLoadAny
-
-    Attempt to load any record, but silently fail if there are no records in
-    the DataSet.
-
 .. php:method:: unload
 
     Remove active record and restore model to default state::

--- a/src/Reference/ContainsOne.php
+++ b/src/Reference/ContainsOne.php
@@ -100,8 +100,7 @@ class ContainsOne extends Reference
             });
         }
 
-        // try to load any (actually only one possible) record
-        $theirModel->tryLoadAny();
+        $theirModel->tryLoadOne();
 
         return $theirModel;
     }

--- a/tests/ConditionSqlTest.php
+++ b/tests/ConditionSqlTest.php
@@ -338,7 +338,7 @@ class ConditionSqlTest extends \Atk4\Schema\PhpunitTestCase
         $m->addField('date', ['type' => 'date']);
 
         $m->addCondition('date', new \DateTime('08-12-1982'));
-        $m->loadAny();
+        $m->loadOne();
         $this->assertSame('Sue', $m->get('name'));
     }
 

--- a/tests/DeepCopyTest.php
+++ b/tests/DeepCopyTest.php
@@ -162,7 +162,7 @@ class DeepCopyTest extends \Atk4\Schema\PhpunitTestCase
             ['name' => 'tools', 'qty' => 5, 'price' => 10],
             ['name' => 'work', 'qty' => 1, 'price' => 40],
         ]]);
-        $quote->loadAny();
+        $quote->loadOne();
 
         // total price should match
         $this->assertEquals(90.00, $quote->get('total'));
@@ -275,7 +275,7 @@ class DeepCopyTest extends \Atk4\Schema\PhpunitTestCase
             ['name' => 'tools', 'qty' => 5, 'price' => 10],
             ['name' => 'work', 'qty' => 1, 'price' => 40],
         ]]);
-        $quote->loadAny();
+        $quote->loadOne();
 
         $invoice = new DcInvoice();
         $invoice->onHook(DeepCopy::HOOK_AFTER_COPY, static function ($m) {
@@ -316,7 +316,7 @@ class DeepCopyTest extends \Atk4\Schema\PhpunitTestCase
             ['name' => 'tools', 'qty' => 5, 'price' => 10],
             ['name' => 'work', 'qty' => 1, 'price' => 40],
         ]]);
-        $quote->loadAny();
+        $quote->loadOne();
 
         $invoice = new DcInvoice();
         $invoice->onHook(DeepCopy::HOOK_AFTER_COPY, static function ($m) {

--- a/tests/ExpressionSqlTest.php
+++ b/tests/ExpressionSqlTest.php
@@ -17,7 +17,7 @@ class ExpressionSqlTest extends \Atk4\Schema\PhpunitTestCase
         $db = new Persistence\Sql($this->db->connection);
         $m = new Model($db, ['table' => false]);
         $m->addExpression('x', '2+3');
-        $m->tryLoadAny();
+        $m->loadOne();
         $this->assertEquals(5, $m->get('x'));
     }
 
@@ -254,7 +254,7 @@ class ExpressionSqlTest extends \Atk4\Schema\PhpunitTestCase
         $i->addExpression('one_basic', [$i->expr('1'), 'type' => 'integer', 'system' => true]);
         $i->addExpression('one_never_save', [$i->expr('1'), 'type' => 'integer', 'system' => true, 'never_save' => true]);
         $i->addExpression('one_never_persist', [$i->expr('1'), 'type' => 'integer', 'system' => true, 'never_persist' => true]);
-        $i->loadAny();
+        $i->loadOne();
 
         // normal fields
         $this->assertSame(0, $i->get('zero_basic'));

--- a/tests/ReferenceSqlTest.php
+++ b/tests/ReferenceSqlTest.php
@@ -96,11 +96,11 @@ class ReferenceSqlTest extends \Atk4\Schema\PhpunitTestCase
         $u->hasMany('cur', ['model' => $c, 'our_field' => 'currency', 'their_field' => 'currency']);
 
         $cc = (clone $u)->load(1)->ref('cur');
-        $cc->tryLoadAny();
+        $cc->tryLoadOne();
         $this->assertSame('Euro', $cc->get('name'));
 
         $cc = (clone $u)->load(2)->ref('cur');
-        $cc->tryLoadAny();
+        $cc->tryLoadOne();
         $this->assertSame('Pound', $cc->get('name'));
     }
 

--- a/tests/ScopeTest.php
+++ b/tests/ScopeTest.php
@@ -129,7 +129,7 @@ class ScopeTest extends \Atk4\Schema\PhpunitTestCase
 
         $user->scope()->add($condition);
 
-        $user->loadAny();
+        $user->loadOne();
 
         $this->assertEquals('Smith', $user->get('surname'));
     }

--- a/tests/TypecastingTest.php
+++ b/tests/TypecastingTest.php
@@ -377,7 +377,7 @@ class TypecastingTest extends \Atk4\Schema\PhpunitTestCase
         $m = new Model($db, ['table' => 'types']);
         $m->addField('date', ['type' => 'date', 'dateTimeClass' => MyDate::class]);
 
-        $m->loadAny();
+        $m->loadOne();
         $this->assertTrue($m->loaded());
         $d = $m->get('date');
         $m->unload();
@@ -386,7 +386,7 @@ class TypecastingTest extends \Atk4\Schema\PhpunitTestCase
         $this->assertTrue($m->loaded());
         $m->unload();
 
-        $m->addCondition('date', $d)->loadAny();
+        $m->addCondition('date', $d)->loadOne();
         $this->assertTrue($m->loaded());
     }
 
@@ -453,7 +453,7 @@ class TypecastingTest extends \Atk4\Schema\PhpunitTestCase
 
         $m = new Model($db, ['table' => 'types']);
         $m->addField('ts', ['actual' => 'date', 'type' => 'datetime']);
-        $m->loadAny();
+        $m->loadOne();
 
         // must respect 'actual'
         $this->assertNotNull($m->get('ts'));
@@ -475,7 +475,7 @@ class TypecastingTest extends \Atk4\Schema\PhpunitTestCase
         $m = new Model($db, ['table' => 'types']);
         $m->addField('ts', ['actual' => 'date', 'type' => 'datetime']);
         $this->expectException(Exception::class);
-        $m->loadAny();
+        $m->loadOne();
     }
 
     public function testDirtyTimestamp()
@@ -493,7 +493,7 @@ class TypecastingTest extends \Atk4\Schema\PhpunitTestCase
 
         $m = new Model($db, ['table' => 'types']);
         $m->addField('ts', ['actual' => 'date', 'type' => 'datetime']);
-        $m->loadAny();
+        $m->loadOne();
         $m->set('ts', clone $m->get('ts'));
 
         $this->assertFalse($m->isDirty('ts'));
@@ -512,7 +512,7 @@ class TypecastingTest extends \Atk4\Schema\PhpunitTestCase
 
         $m = new Model($db, ['table' => 'types']);
         $m->addField('ts', ['actual' => 'date', 'type' => 'date']);
-        $m->loadAny();
+        $m->loadOne();
         $m->set('ts', new \DateTime('2012-02-30'));
         $m->save();
 
@@ -575,7 +575,7 @@ class TypecastingTest extends \Atk4\Schema\PhpunitTestCase
 
         $m = new Model($db, ['table' => 'types']);
         $m->addField('ts', ['actual' => 'date', 'type' => 'time']);
-        $m->loadAny();
+        $m->loadOne();
 
         $m->set('ts', $sql_time_new);
         $this->assertTrue($m->isDirty('ts'));
@@ -603,7 +603,7 @@ class TypecastingTest extends \Atk4\Schema\PhpunitTestCase
 
         $m = new Model($db, ['table' => 'types']);
         $m->addField('ts', ['actual' => 'date', 'type' => 'time']);
-        $m->loadAny();
+        $m->loadOne();
 
         $m->set('ts', $sql_time);
         $this->assertTrue($m->isDirty('ts'));


### PR DESCRIPTION
to enforce stronger checks from https://github.com/atk4/data/pull/846

regex to find possible places to fix: `(try)?loadAny`