### PR TITLE
Fix traversal when parent model is loaded

### DIFF
--- a/.github/workflows/test-unit.yml
+++ b/.github/workflows/test-unit.yml
@@ -61,6 +61,12 @@ jobs:
         if: matrix.type == 'Phpunit'
         run: "vendor/bin/phpunit \"$(if [ -n \"$LOG_COVERAGE\" ]; then echo '--coverage-text'; else echo '--no-coverage'; fi)\" -v"
 
+      - name: "Run tests: SQLite Hintable (only for Phpunit)"
+        if: matrix.type == 'Phpunit'
+        run: |
+          sed -i 's~"psr-4": {~"psr-4": { "Mvorisek\\\\Atk4\\\\Hintable\\\\Tests\\\\": "vendor/mahalux/atk4-hintable/tests/",~' composer.json && composer dump
+          vendor/bin/phpunit --configuration vendor/mahalux/atk4-hintable/phpunit.xml.dist --bootstrap vendor/autoload.php --no-coverage -v
+
       - name: Check Coding Style (only for CodingStyle)
         if: matrix.type == 'CodingStyle'
         run: vendor/bin/php-cs-fixer fix --dry-run --using-cache=no --diff --diff-format=udiff --verbose --show-progress=dots

--- a/src/Persistence/Array_.php
+++ b/src/Persistence/Array_.php
@@ -385,7 +385,15 @@ class Array_ extends Persistence
      */
     protected function applyScope(Model $model, Action $action): void
     {
-        $action->filter($model->scope());
+        $scope = $model->scope();
+
+        // add entity ID to scope to allow easy traversal
+        if ($model->id_field && $model->getId() !== null) {
+            $scope = new Model\Scope([$scope]);
+            $scope->addCondition($model->getField($model->id_field), $model->getId());
+        }
+
+        $action->filter($scope);
     }
 
     /**

--- a/tests/ExpressionSqlTest.php
+++ b/tests/ExpressionSqlTest.php
@@ -113,9 +113,9 @@ class ExpressionSqlTest extends \Atk4\Schema\PhpunitTestCase
             );
         }
 
-        $i->tryLoad(1);
-        $this->assertEquals(10, $i->get('total_net'));
-        $this->assertEquals(30, $i->get('sum_net'));
+        $ii = (clone $i)->tryLoad(1);
+        $this->assertEquals(10, $ii->get('total_net'));
+        $this->assertEquals(30, $ii->get('sum_net'));
 
         $q = $db->dsql();
         $q->field($i->action('count'), 'total_orders');


### PR DESCRIPTION
finish after #855, #860, #861

discussion here: https://github.com/atk4/data/commit/c8cbce3e0ceceab616d990763a6b7f28abadded3#r49718142

fixes https://github.com/mvorisek/atk4-hintable-mirror/blob/1.2.1/tests/Data/HintableModelTest.php#L120

```
$model = new Model\Standard($db);
$model->load(2)->simpleMany->loadAny()->id;
```

must traverse from model with ID = 2 only (before this PR, ID = 2 condition was not applied and it was required to be added manually, now with entity concept we can assume locked ID)

note: this works also with `$model->load{One, Any}()->simpleMany` and also with `Model::duplicate()` which will unset the ID correctly.