### PR TITLE
No iterate over entity

### DIFF
--- a/src/Model.php
+++ b/src/Model.php
@@ -1640,6 +1640,11 @@ class Model implements \IteratorAggregate
      */
     public function export(array $fields = null, $key_field = null, $typecast_data = true): array
     {
+        if ($this->entityId !== null) {
+            throw (new Exception('Model is loaded as an entity, it can not be iterated'))
+                ->addMoreInfo('entityId', $this->entityId);;
+        }
+
         $this->checkPersistence('export');
 
         // no key field - then just do export
@@ -1762,6 +1767,11 @@ class Model implements \IteratorAggregate
      */
     public function rawIterator(): \Traversable
     {
+        if ($this->entityId !== null) {
+            throw (new Exception('Model is loaded as an entity, it can not be iterated'))
+                ->addMoreInfo('entityId', $this->entityId);
+        }
+
         return $this->persistence->prepareIterator($this);
     }
 

--- a/src/Model.php
+++ b/src/Model.php
@@ -228,7 +228,7 @@ class Model implements \IteratorAggregate
      * you would want to use a different one or maybe don't create field
      * at all.
      *
-     * @var string
+     * @var string|null
      */
     public $id_field = 'id';
 
@@ -1642,7 +1642,7 @@ class Model implements \IteratorAggregate
     {
         if ($this->entityId !== null) {
             throw (new Exception('Model is loaded as an entity, it can not be iterated'))
-                ->addMoreInfo('entityId', $this->entityId);;
+                ->addMoreInfo('entityId', $this->entityId);
         }
 
         $this->checkPersistence('export');

--- a/tests/ConditionSqlTest.php
+++ b/tests/ConditionSqlTest.php
@@ -66,7 +66,7 @@ class ConditionSqlTest extends \Atk4\Schema\PhpunitTestCase
         $mm->tryLoad(1);
         $this->assertSame('John', $mm->get('name'));
         $this->expectException(\Atk4\Data\Exception::class);
-        $this->expectExceptionMessageMatches('~different~');
+        $this->expectExceptionMessageMatches('~entity.+different~');
         $mm->tryLoad(2);
     }
 

--- a/tests/ContainsManyTest.php
+++ b/tests/ContainsManyTest.php
@@ -257,7 +257,7 @@ class ContainsManyTest extends \Atk4\Schema\PhpunitTestCase
         $this->assertSame(24.2 * 15 / 100 + 86.25 * 20 / 100, $i->discounts_total_sum); // =20.88
 
         // let's test how it all looks in persistence without typecasting
-        $exp_lines = $i->setOrder($i->fieldName()->id)->export(null, null, false)[0][$i->fieldName()->lines];
+        $exp_lines = $i->duplicate()->setOrder($i->fieldName()->id)->export(null, null, false)[0][$i->fieldName()->lines];
         $formatDtForCompareFunc = function (\DateTimeInterface $dt): string {
             $dt = (clone $dt)->setTimeZone(new \DateTimeZone('UTC')); // @phpstan-ignore-line
 

--- a/tests/ContainsOneTest.php
+++ b/tests/ContainsOneTest.php
@@ -127,7 +127,7 @@ class ContainsOneTest extends \Atk4\Schema\PhpunitTestCase
         $this->assertSame('United Kingdom', $c->name);
 
         // let's test how it all looks in persistence without typecasting
-        $exp_addr = $i->setOrder('id')->export(null, null, false)[0][$i->fieldName()->addr];
+        $exp_addr = $i->duplicate()->setOrder('id')->export(null, null, false)[0][$i->fieldName()->addr];
         $formatDtForCompareFunc = function (\DateTimeInterface $dt): string {
             $dt = (clone $dt)->setTimeZone(new \DateTimeZone('UTC')); // @phpstan-ignore-line
 

--- a/tests/FieldTest.php
+++ b/tests/FieldTest.php
@@ -404,8 +404,10 @@ class FieldTest extends \Atk4\Schema\PhpunitTestCase
         $m->addField('first_name', ['actual' => 'name']);
         $m->addField('surname');
         $m->insert(['first_name' => 'Peter', 'surname' => 'qq']);
-        $m->loadBy('first_name', 'John');
-        $this->assertSame('John', $m->get('first_name'));
+
+        $mm = clone $m;
+        $mm->loadBy('first_name', 'John');
+        $this->assertSame('John', $mm->get('first_name'));
 
         $d = $m->export();
         $this->assertSame('John', $d[0]['first_name']);
@@ -417,8 +419,8 @@ class FieldTest extends \Atk4\Schema\PhpunitTestCase
             ],
         ], $this->getDb());
 
-        $m->set('first_name', 'Scott');
-        $m->save();
+        $mm->set('first_name', 'Scott');
+        $mm->save();
 
         $this->assertEquals([
             'user' => [

--- a/tests/LimitOrderTest.php
+++ b/tests/LimitOrderTest.php
@@ -22,7 +22,7 @@ class LimitOrderTest extends \Atk4\Schema\PhpunitTestCase
         $i = (new Model($this->db, ['table' => 'invoice']))->addFields(['total_net', 'total_vat']);
         $i->addExpression('total_gross', '[total_net]+[total_vat]');
         $i->getField($i->id_field)->system = false;
-        $i->id_field = false;
+        $i->id_field = null;
 
         $i->setOrder('total_net');
         $i->onlyFields(['total_net']);
@@ -46,7 +46,7 @@ class LimitOrderTest extends \Atk4\Schema\PhpunitTestCase
         $ii = (new Model($this->db, ['table' => 'invoice']))->addFields(['total_net', 'total_vat']);
         $ii->addExpression('total_gross', '[total_net]+[total_vat]');
         $ii->getField($ii->id_field)->system = false;
-        $ii->id_field = false;
+        $ii->id_field = null;
 
         $i = clone $ii;
         $i->setOrder(['total_net' => 'desc', 'total_gross' => 'desc']);
@@ -97,7 +97,7 @@ class LimitOrderTest extends \Atk4\Schema\PhpunitTestCase
 
         $ii = (new Model($this->db, ['table' => 'invoice']))->addFields(['net', 'vat']);
         $ii->getField($ii->id_field)->system = false;
-        $ii->id_field = false;
+        $ii->id_field = null;
 
         // pass parameters as array elements [field,order]
         $i = clone $ii;
@@ -144,7 +144,7 @@ class LimitOrderTest extends \Atk4\Schema\PhpunitTestCase
         $i = (new Model($this->db, ['table' => 'invoice']))->addFields(['code', 'net', 'vat']);
         $i->addExpression('gross', '[net]+[vat]');
         $i->getField($i->id_field)->system = false;
-        $i->id_field = false;
+        $i->id_field = null;
 
         $i->setOrder('gross');
         $i->onlyFields(['gross']);
@@ -225,7 +225,7 @@ class LimitOrderTest extends \Atk4\Schema\PhpunitTestCase
         $i = (new Model($this->db, ['table' => 'invoice']))->addFields(['total_net', 'total_vat']);
         $i->addExpression('total_gross', '[total_net]+[total_vat]');
         $i->getField($i->id_field)->system = false;
-        $i->id_field = false;
+        $i->id_field = null;
 
         $i->setOrder('total_net');
         $i->onlyFields(['total_net']);

--- a/tests/LimitOrderTest.php
+++ b/tests/LimitOrderTest.php
@@ -22,6 +22,7 @@ class LimitOrderTest extends \Atk4\Schema\PhpunitTestCase
         $i = (new Model($this->db, ['table' => 'invoice']))->addFields(['total_net', 'total_vat']);
         $i->addExpression('total_gross', '[total_net]+[total_vat]');
         $i->getField($i->id_field)->system = false;
+        $i->id_field = false;
 
         $i->setOrder('total_net');
         $i->onlyFields(['total_net']);
@@ -45,6 +46,7 @@ class LimitOrderTest extends \Atk4\Schema\PhpunitTestCase
         $ii = (new Model($this->db, ['table' => 'invoice']))->addFields(['total_net', 'total_vat']);
         $ii->addExpression('total_gross', '[total_net]+[total_vat]');
         $ii->getField($ii->id_field)->system = false;
+        $ii->id_field = false;
 
         $i = clone $ii;
         $i->setOrder(['total_net' => 'desc', 'total_gross' => 'desc']);
@@ -95,6 +97,7 @@ class LimitOrderTest extends \Atk4\Schema\PhpunitTestCase
 
         $ii = (new Model($this->db, ['table' => 'invoice']))->addFields(['net', 'vat']);
         $ii->getField($ii->id_field)->system = false;
+        $ii->id_field = false;
 
         // pass parameters as array elements [field,order]
         $i = clone $ii;
@@ -141,6 +144,7 @@ class LimitOrderTest extends \Atk4\Schema\PhpunitTestCase
         $i = (new Model($this->db, ['table' => 'invoice']))->addFields(['code', 'net', 'vat']);
         $i->addExpression('gross', '[net]+[vat]');
         $i->getField($i->id_field)->system = false;
+        $i->id_field = false;
 
         $i->setOrder('gross');
         $i->onlyFields(['gross']);
@@ -221,6 +225,7 @@ class LimitOrderTest extends \Atk4\Schema\PhpunitTestCase
         $i = (new Model($this->db, ['table' => 'invoice']))->addFields(['total_net', 'total_vat']);
         $i->addExpression('total_gross', '[total_net]+[total_vat]');
         $i->getField($i->id_field)->system = false;
+        $i->id_field = false;
 
         $i->setOrder('total_net');
         $i->onlyFields(['total_net']);

--- a/tests/Model/Smbo/Transfer.php
+++ b/tests/Model/Smbo/Transfer.php
@@ -18,7 +18,7 @@ class Transfer extends Payment
 
         // only used to create / destroy trasfer legs
         if (!$this->detached) {
-            $this->addCondition('transfer_document_id', 'not', null);
+            $this->addCondition('transfer_document_id', '!=', null);
         }
 
         $this->addField('destination_account_id', ['never_persist' => true]);

--- a/tests/PersistentArrayOfStringsTest.php
+++ b/tests/PersistentArrayOfStringsTest.php
@@ -46,7 +46,7 @@ class PersistentArrayOfStringsTest extends AtkPhpunit\TestCase
             'array' => ['foo' => 'bar', 'int' => 123, 'rows' => ['a', 'b']],
             'object' => (object) ['foo' => 'bar', 'int' => 123, 'rows' => ['a', 'b']],
         ]);
-        $m->saveAndUnload();
+        (clone $m)->saveAndUnload();
 
         // no typecasting option set in export()
         $data = $m->export(null, null, false);

--- a/tests/RandomTest.php
+++ b/tests/RandomTest.php
@@ -494,7 +494,7 @@ class RandomTest extends \Atk4\Schema\PhpunitTestCase
         $db = new Persistence\Sql($this->db->connection);
         $m = new Model_Rate($db);
 
-        $m->load(1)->duplicate()->save();
+        (clone $m)->load(1)->duplicate()->save();
 
         $this->assertSame([
             ['id' => 1, 'dat' => '18/12/12', 'bid' => 3.4, 'ask' => 9.4],

--- a/tests/RandomTest.php
+++ b/tests/RandomTest.php
@@ -380,7 +380,6 @@ class RandomTest extends \Atk4\Schema\PhpunitTestCase
 
         $m->load(2);
         $this->assertSame('Sue', $m->getTitle()); // loaded returns title_field value
-        $this->assertSame([1 => 'John', 2 => 'Sue'], $m->getTitles()); // all titles
 
         // set custom title_field
         $m->title_field = 'parent_item_id';
@@ -399,7 +398,10 @@ class RandomTest extends \Atk4\Schema\PhpunitTestCase
         $m->title_field = 'my_name';
         $m->load(2);
         $this->assertEquals(2, $m->getTitle()); // loaded returns id value
-        $this->assertEquals([1 => 1, 2 => 2], $m->getTitles()); // all titles (my_name)
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessageMatches('~entity.+iterate~');
+        $m->getTitles();
     }
 
     /**

--- a/tests/SmboTransferTest.php
+++ b/tests/SmboTransferTest.php
@@ -53,12 +53,12 @@ class SmboTransferTest extends \Atk4\Schema\PhpunitTestCase
         $boi = (new Account($this->db))->save(['name' => 'BOI']);
 
         $t = $aib->transfer($boi, 100); // create transfer between accounts
-
         $t->save();
 
         $this->assertEquals(-100, $aib->reload()->get('balance'));
         $this->assertEquals(100, $boi->reload()->get('balance'));
 
+        $t = new Transfer($this->db);
         $data = $t->export(['id', 'transfer_document_id']);
         usort($data, function ($e1, $e2) {
             return $e1['id'] < $e2['id'] ? -1 : 1;

--- a/tests/TypecastingTest.php
+++ b/tests/TypecastingTest.php
@@ -80,7 +80,7 @@ class TypecastingTest extends \Atk4\Schema\PhpunitTestCase
         $this->assertSame([1, 2, 3], $mm->get('array'));
         $this->assertSame(8.202343, $mm->get('float'));
 
-        $m->setMulti(array_diff_key($mm->get(), ['id' => true]))->save();
+        (clone $m)->setMulti(array_diff_key($mm->get(), ['id' => true]))->save();
 
         $dbData = [
             'types' => [


### PR DESCRIPTION
If you want to iterate over entity (loaded model), use `Model::duplicate` before `Model::export` or other iterating functions (like iterator in `foreach`).