### PR TITLE
Fix too long trigger name for Oracle autoincrement

### DIFF
--- a/src-schema/Migration.php
+++ b/src-schema/Migration.php
@@ -100,7 +100,7 @@ class Migration
                             EOT,
                         [
                             'table' => $this->table->getName(),
-                            'table_ai_trigger_before' => $this->table->getName() . '_ai_trigger_before',
+                            'table_ai_trigger_before' => $this->table->getName() . '__aitb',
                         ]
                     )->render(),
                 ]
@@ -130,7 +130,7 @@ class Migration
                     $this->connection->expr(
                         'drop trigger {table_ai_trigger_before}',
                         [
-                            'table_ai_trigger_before' => $this->table->getName() . '_ai_trigger_before',
+                            'table_ai_trigger_before' => $this->table->getName() . '__aitb',
                         ]
                     )->render(),
                 ]


### PR DESCRIPTION
no bc break, Oracle users can still use the old deployed name

max. trigger name length is 30 chars