### PR TITLE
Load methods return a new instance (distinguish strictly between model and entity)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -37,13 +37,13 @@
         "php": ">=7.3.0",
         "ext-intl": "*",
         "atk4/dsql": "dev-develop",
-        "mahalux/atk4-hintable": "~1.2.1"
+        "mahalux/atk4-hintable": "~1.3.1"
     },
     "require-release": {
         "php": ">=7.3.0",
         "ext-intl": "*",
         "atk4/dsql": "~2.5.0",
-        "mahalux/atk4-hintable": "~1.2.1"
+        "mahalux/atk4-hintable": "~1.3.1"
     },
     "conflict": {
         "atk4/schema": "*"

--- a/docs/advanced.rst
+++ b/docs/advanced.rst
@@ -81,7 +81,7 @@ hook. Place the following inside Transaction::init()::
         if (get_class($this) != $this->getClassName()) {
             $cl = '\\'.$this->getClassName();
             $cl = new $cl($this->persistence);
-            $cl->load($this->getId());
+            $cl = $cl->load($this->getId());
 
             $this->breakHook($cl);
         }
@@ -284,7 +284,7 @@ When active, a new field will be defined 'is_deleted' and a new dynamic method
 will be added into a model, allowing you to do this::
 
     $m = new Model_Invoice($db);
-    $m->load(10);
+    $m = $m->load(10);
     $m->softDelete();
 
 The method body is actually defined in our controller. Notice that we have
@@ -310,7 +310,7 @@ It's also possible for you to easily look at deleted records and even restore
 them::
 
     $m = new Model_Invoice($db, ['deleted_only'=>true]);
-    $m->load(10);
+    $m = $m->load(10);
     $m->restore();
 
 Note that you can call $m->delete() still on any record to permanently delete it.
@@ -392,7 +392,7 @@ the record is marked as deleted and unloaded.
 You can still access the deleted records::
 
     $m = new Model_Invoice($db, ['deleted_only'=>true]);
-    $m->load(10);
+    $m = $m->load(10);
     $m->restore();
 
 Calling delete() on the model with 'deleted_only' property will delete it
@@ -434,7 +434,7 @@ inside your model are unique::
                 if ($m->getDirtyRef()[$field]) {
                     $mm = clone $m;
                     $mm->addCondition($mm->id_field != $this->id);
-                    $mm->tryLoadBy($field, $m->get($field));
+                    $mm = $mm->tryLoadBy($field, $m->get($field));
 
                     if ($mm->loaded()) {
                         throw (new \Atk4\Core\Exception('Duplicate record exists'))
@@ -568,12 +568,12 @@ payment towards a most suitable invoice::
         while($this->get('amount_due') > 0) {
 
             // See if any invoices match by 'reference';
-            $invoices->tryLoadBy('reference', $this->get('reference'));
+            $invoices = $invoices->tryLoadBy('reference', $this->get('reference'));
 
             if (!$invoices->loaded()) {
 
                 // otherwise load any unpaid invoice
-                $invoices->tryLoadAny();
+                $invoices = $invoices->tryLoadAny();
 
                 if(!$invoices->loaded()) {
 

--- a/docs/conditions.rst
+++ b/docs/conditions.rst
@@ -14,7 +14,7 @@ When model is associated with the database, you can specify a default table
 either explicitly or through a $table property inside a model::
 
     $m = new Model_User($db, 'user');
-    $m->load(1);
+    $m = $m->load(1);
     echo $m->get('gender');   // "M"
 
 
@@ -23,7 +23,7 @@ narrow down set of "loadable" records by introducing a condition::
 
     $m = new Model_User($db, 'user');
     $m->addCondition('gender','F');
-    $m->load(1);    // exception, user with ID=1 is M
+    $m = $m->load(1);    // exception, user with ID=1 is M
 
 Conditions serve important role and must be used to intelligently restrict
 logically accessible data for a model before you attempt the loading.
@@ -45,8 +45,8 @@ to preserve the state of your model, you need to use clone::
     $m = new Model_User($db, 'user');
     $girls = (clone $m)->addCondition('gender','F');
 
-    $m->load(1);        // success
-    $girls->load(1);    // exception
+    $m = $m->load(1);        // success
+    $girls = $girls->load(1);    // exception
 
 Operations
 ----------

--- a/docs/design.rst
+++ b/docs/design.rst
@@ -272,7 +272,7 @@ ID Field
 Each object is stored with some unique identifier, so you can load and store
 object if you know it's ID::
 
-    $order->load(20);
+    $order = $order->load(20);
     $order->set('amount', 1200.20);
     $order->save();
 
@@ -360,7 +360,7 @@ DataSet is an object that represents collection of Domain model records that
 are persisted::
 
     $order = $db->add('Model_Order');
-    $order->load(10);
+    $order = $order->load(10);
 
 In scenario above we loaded a specific record. Agile Data does not create a
 separate object when loading, instead the same object is re-used. This is done
@@ -372,13 +372,13 @@ Orders::
 
     $sum = 0;
     $order = $db->add('Model_Order');
-    $order->load(10);
+    $order = $order->load(10);
     $sum += $order->get('amount');
 
-    $order->load(11);
+    $order = $order->load(11);
     $sum += $order->get('amount');
 
-    $order->load(13);
+    $order = $order->load(13);
     $sum += $order->get('amount');
 
 You can iterate over the DataSet::

--- a/docs/expressions.rst
+++ b/docs/expressions.rst
@@ -23,7 +23,7 @@ Example will calculate "total_gross" by adding up values for "net" and "vat"::
     $m->addFields(['total_net', 'total_vat']);
 
     $m->addExpression('total_gross', '[total_net]+[total_vat]');
-    $m->load(1);
+    $m = $m->load(1);
 
     echo $m->get('total_gross');
 
@@ -65,7 +65,7 @@ example::
 
     $m = new Model($db, ['table' => false]);
     $m->addExpression('now', 'now()');
-    $m->loadAny();
+    $m = $m->loadAny();
     echo $m->get('now');
 
 In this example the query will look like this:

--- a/docs/fields.rst
+++ b/docs/fields.rst
@@ -289,7 +289,7 @@ will always get `NULL`.
 
 There is another way to verify passwords using :php:meth:`Model::compare`::
 
-    $user->loadBy('email', $email);
+    $user = $user->loadBy('email', $email);
     return $user->compare('password', $password);
 
 This should return `true` if your supplied password matches the one that is

--- a/docs/model.rst
+++ b/docs/model.rst
@@ -21,12 +21,12 @@ object you can load/unload individual records (See Single record Operations belo
 
    $m = new User($db);
 
-   $m->load(3);
+   $m = $m->load(3);
    $m->set('note', 'just updating');
    $m->save();
    $m->unload();
 
-   $m->load(8);
+   $m = $m->load(8);
    ....
 
 and even perform operations on multiple records (See `Persistence Actions` below)::
@@ -363,7 +363,7 @@ a user invokable actions::
 
 With a method alone, you can generate and send passwords::
 
-   $user->load(3);
+   $user = $user->load(3);
    $user->send_new_password();
 
 but using `$this->addUserAction()` exposes that method to the ATK UI wigets,
@@ -457,7 +457,7 @@ of static persistence::
 
    $m = new Model(new Persistence\Static_(['john', 'peter', 'steve']);
 
-   $m->load(1);
+   $m = $m->load(1);
    echo $m->get('name');  // peter
 
 See :php:class:`Persistence\\Static_`
@@ -642,7 +642,7 @@ Full example::
     echo $m->get('salary');          // 1000
 
     // Next we load record from $db
-    $m->load(1);
+    $m = $m->load(1);
 
     echo $m->get('salary');          // 2000 (from db)
     echo $m->_isset('salary');  // false, was not changed

--- a/docs/overview.rst
+++ b/docs/overview.rst
@@ -133,7 +133,7 @@ using::
 
     $user = new User($db);
 
-    $user->load(20);            // load specific user record into PHP
+    $user = $user->load(20);            // load specific user record into PHP
     echo $user->get('name').': ';    // access field values
 
     $gross = $user->ref('Invoice')

--- a/docs/persistence.rst
+++ b/docs/persistence.rst
@@ -45,7 +45,7 @@ There are several ways to link your model up with the persistence::
 
     Load active record from the DataSet::
 
-        $m->load(10);
+        $m = $m->load(10);
         echo $m->get('name');
 
     If record not found, will throw exception.
@@ -55,7 +55,7 @@ There are several ways to link your model up with the persistence::
     Store active record back into DataSet. If record wasn't loaded, store it as
     a new record::
 
-        $m->load(10);
+        $m = $m->load(10);
         $m->set('name', 'John');
         $m->save();
 
@@ -68,7 +68,7 @@ There are several ways to link your model up with the persistence::
 
     Same as load() but will silently fail if record is not found::
 
-        $m->tryLoad(10);
+        $m = $m->tryLoad(10);
         $m->setMulti($data);
 
         $m->save();     // will either create new record or update existing
@@ -77,7 +77,7 @@ There are several ways to link your model up with the persistence::
 
     Remove active record and restore model to default state::
 
-        $m->load(10);
+        $m = $m->load(10);
         $m->unload();
 
         $m->set('name', 'New User');
@@ -103,7 +103,7 @@ explicitly::
 However if you change the ID for record that was loaded, then your database
 record will also have its ID changed. Here is example::
 
-    $m->load(123);
+    $m = $m->load(123);
     $m->setId(321);
     $m->save();
 
@@ -125,7 +125,7 @@ correctly for saving and restored as they were when loading::
 
     // SQL database will actually store `0`
 
-    $m->load();
+    $m = $m->load();
 
     $m->get('is_admin');  // converted back to `false`
 
@@ -190,7 +190,7 @@ Final field flag that is worth mentioning is called :php:attr:`Field::read_only`
 and if set, then value of a field may not be modified directly::
 
     $m->addField('ref_no', ['read_only' => true]);
-    $m->load(123);
+    $m = $m->load(123);
 
     $m->get('ref_no'); // perfect for reading field that is populated by trigger.
 
@@ -507,7 +507,7 @@ option to archive your orders. The method `archive()` is supposed to mark order
 as archived and return that order back. Here is the usage pattern::
 
     $o->addCondition('is_archived', false); // to restrict loading of archived orders
-    $o->load(123);
+    $o = $o->load(123);
     $archive = $o->archive();
     $archive->set('note', $archive->get('note') . "\nArchived on $date.");
     $archive->save();
@@ -538,7 +538,7 @@ The other, more appropriate option is to re-use a vanilla Order record::
         $this->save(); // just to be sure, no dirty stuff is left over
 
         $archive = (new static());
-        $archive->load($this->getId());
+        $archive = $archive->load($this->getId());
         $archive->set('is_archived', true);
 
         $this->unload(); // active record is no longer accessible
@@ -720,7 +720,7 @@ you can implement it like this::
 
     $sess = new \Atk4\Data\Persistence\Array_($_SESSION['ad']);
     $logged_user = new User($sess);
-    $logged_user->load('active_user');
+    $logged_user = $logged_user->load('active_user');
 
 This would load the user data from Array located inside a local session. There
 is no point storing multiple users, so I'm using id='active_user' for the only
@@ -729,7 +729,7 @@ user record that I'm going to store there.
 How to add record inside session, e.g. log the user in? Here is the code::
 
     $u = new User($db);
-    $u->load(123);
+    $u = $u->load(123);
 
     $u->withPersistence($sess, 'active_user')->save();
 

--- a/docs/persistence/csv.rst
+++ b/docs/persistence/csv.rst
@@ -28,7 +28,7 @@ actually opened unless you perform load/save operation::
     $p = new Persistence\Csv('myfile.csv');
 
     $u = new Model_User($p);
-    $u->tryLoadAny();   // actually opens file and finds first record
+    $u = $u->tryLoadAny();   // actually opens file and finds first record
 
 Exporting and Importing data from CSV
 =====================================

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -136,7 +136,7 @@ inside console::
     $m = new \Atk4\Data\Model($db, 'contact_info');
     $m->addFields(['address_1','address_2']);
     $m->addCondition('address_1', 'not', null);
-    $m->loadAny();
+    $m = $m->loadAny();
     $m->get();
     $m->action('count')->getOne();
 
@@ -158,7 +158,7 @@ Next, exit and create file `src/Model_ContactInfo.php`::
 Save, exit and run console again. You can now type this::
 
     $m = new Model_ContactInfo($db);
-    $m->loadAny();
+    $m = $m->loadAny();
     $m->get();
 
 .. note:: Should the "addCondition" be located inside model definition or
@@ -220,7 +220,7 @@ Active Record is a third essential piece of information that your model stores.
 You can load / unload records like this::
 
     $m = new Model_User($db);
-    $m->loadAny();
+    $m = $m->loadAny();
 
     $m->get();     // inside console, this will show you what's inside your model
 
@@ -353,7 +353,7 @@ Lets once again load up the console for some exercises::
 
     $m = new Model_User($db);
 
-    $m->loadBy('username','john');
+    $m = $m->loadBy('username','john');
     $m->get();
 
 At this point you'll see that address has also been loaded for the user.
@@ -393,7 +393,7 @@ For some persistence classes, you should use constructor directly::
     $db = new \Atk4\Data\Persistence\Array_($array);
     $m = new \Atk4\Data\Model($db);
     $m->addField('name');
-    $m->load(2);
+    $m = $m->load(2);
     echo $m->get('name');  // Peter
 
 There are several Persistence classes that deal with different data sources.
@@ -441,7 +441,7 @@ As per our database design - one user can have multiple 'system' records::
 
 Next you can load a specific user and traverse into System model::
 
-    $m->loadBy('username', 'john');
+    $m = $m->loadBy('username', 'john');
     $s = $m->ref('System');
 
 Unlike most ORM and ActiveRecord implementations today - instead of returning
@@ -573,7 +573,7 @@ This is useful with hasMany references::
 
     $m = new Model_User($db);
     $m->getRef('country_id')->addField('country', 'name');
-    $m->loadAny();
+    $m = $m->loadAny();
     $m->get();  // look for 'country' field
 
 hasMany::addField() again is a short-cut for creating expression, which you can
@@ -590,7 +590,7 @@ to change Client/Supplier status to 'suspended' for a specific user. Fire up a
 console once away::
 
     $m = new Model_User($db);
-    $m->loadBy('username','john');
+    $m = $m->loadBy('username','john');
     $m->hasMany('System');
     $c = $m->ref('System')->ref('Client');
     $s = $m->ref('System')->ref('Supplier');

--- a/docs/references.rst
+++ b/docs/references.rst
@@ -19,7 +19,7 @@ use::
 
     $m = new Model_User($db, 'user');
     $m->hasMany('Orders', ['model' => [Model_Order::class]]);
-    $m->load(13);
+    $m = $m->load(13);
 
     $orders_for_user_13 = $m->ref('Orders');
 
@@ -32,7 +32,7 @@ also possible::
     $m->addCondition('is_vip', true);
 
     $orders_for_vips = $m->ref('Orders');
-    $orders_for_vips->loadAny();
+    $orders_for_vips = $orders_for_vips->loadAny();
 
 Condition on the base model will be carried over to the orders and you will
 only be able to access orders that belong to VIP users. The query for loading
@@ -89,7 +89,7 @@ If you are worried about performance you can keep 2 models in memory::
     $client = $order->refModel('client_id');
 
     foreach($order as $o) {
-        $client->load($o->get('client_id'));
+        $client = $client->load($o->get('client_id'));
     }
 
 .. warning:: This code is seriously flawed and is called "N+1 Problem".
@@ -326,7 +326,7 @@ DataSet of the user model::
     $u = $o->ref('user_id');
 
 
-    $u->loadAny();  // will load some user who has at least one failed order
+    $u = $u->loadAny();  // will load some user who has at least one failed order
 
 The important point here is that no additional queries are generated in the
 process and the loadAny() will look like this:
@@ -403,7 +403,7 @@ easier way how to define currency title::
 
 This would create 'currency' field containing name of the currency::
 
-    $i->load(20);
+    $i = $i->load(20);
 
     echo "Currency for invoice 20 is ".$i->get('currency');   // EUR
 

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -49,3 +49,5 @@ parameters:
         # for tests/ReferenceSqlTest.php
         - '~^Call to an undefined method Atk4\\Data\\Reference\\HasOne::addFields\(\)\.$~'
         - '~^Call to an undefined method Atk4\\Data\\Reference::addTitle\(\)\.$~'
+        # for tests/ScopeTest.php
+        - '~^Call to an undefined method Atk4\\Data\\Tests\\SUser::expr\(\)\.$~'

--- a/src/Model.php
+++ b/src/Model.php
@@ -1168,6 +1168,8 @@ class Model implements \IteratorAggregate
      */
     public function setLimit(int $count = null, int $offset = 0)
     {
+        $this->assertIsModel();
+
         $this->limit = [$count, $offset];
 
         return $this;

--- a/src/Model.php
+++ b/src/Model.php
@@ -89,16 +89,12 @@ class Model implements \IteratorAggregate
     /**
      * The class used by addField() method.
      *
-     * @todo use Field::class here and refactor addField() method to not use namespace prefixes.
-     *       but because that's backward incompatible change, then we can do that only in next
-     *       major version.
-     *
      * @var string|array
      */
     public $_default_seed_addField = [Field::class];
 
     /**
-     * The class used by addField() method.
+     * The class used by addExpression() method.
      *
      * @var string|array
      */
@@ -452,7 +448,7 @@ class Model implements \IteratorAggregate
     public function assertIsModel(): void
     {
         if ($this->isEntity()) {
-//            throw new \Error('Expected model, but instance is an entity'); // TODO Exception, but Error for debug
+            throw new \Error('Expected model, but instance is an entity'); // TODO Exception, but Error for debug
         }
     }
 
@@ -463,19 +459,19 @@ class Model implements \IteratorAggregate
         }
     }
 
-//    /**
-//     * @return static
-//     */
-//    public function getModel(): self
-//    {
-//        $this->assertIsEntity();
-//
-//        $model = clone $this; // TODO
-//        $model->unload();
-//        $model->entityId = null;
-//
-//        return $model;
-//    }
+    /**
+     * @return static
+     */
+    public function getModel(): self
+    {
+        $this->assertIsEntity();
+
+        $model = clone $this; // TODO
+        $model->unload();
+        $model->entityId = null;
+
+        return $model;
+    }
 
     /**
      * @return static
@@ -484,13 +480,8 @@ class Model implements \IteratorAggregate
     {
         $this->assertIsModel();
 
-        // TODO remove, $this->assertIsModel() above is enough once enabled
-        if ($this->isEntity()) {
-            throw new \Error('Expected model, but instance is an entity');
-        }
-
         $model = clone $this;
-        if ($model->entityId === null) { // TODO
+        if ($model->entityId === null) {
             $model->entityId = true;
         }
 
@@ -562,7 +553,7 @@ class Model implements \IteratorAggregate
      */
     public function addField(string $name, $seed = []): Field
     {
-        $this->assertIsModel();
+//        $this->assertIsModel();
 
         if (is_object($seed)) {
             $field = $seed;
@@ -647,7 +638,7 @@ class Model implements \IteratorAggregate
 
     public function getField(string $name): Field
     {
-        $this->assertIsModel();
+//        $this->assertIsModel();
 
         try {
             return $this->_getFromCollection($name, 'fields');
@@ -1066,7 +1057,7 @@ class Model implements \IteratorAggregate
      */
     public function addCondition($field, $operator = null, $value = null)
     {
-        $this->assertIsModel();
+//        $this->assertIsModel();
 
         $this->scope()->addCondition(...func_get_args());
 

--- a/src/Model.php
+++ b/src/Model.php
@@ -87,6 +87,14 @@ class Model implements \IteratorAggregate
     // {{{ Properties of the class
 
     /**
+     * Once set, Model behaves like an entity and loading a different ID
+     * will result in an error.
+     *
+     * @var mixed
+     */
+    private $entityId;
+
+    /**
      * The class used by addField() method.
      *
      * @var string|array
@@ -212,14 +220,6 @@ class Model implements \IteratorAggregate
     public $read_only = false;
 
     /**
-     * Once set, Model behaves like an entity and loading a different ID
-     * will result in an error.
-     *
-     * @var mixed
-     */
-    private $entityId;
-
-    /**
      * While in most cases your id field will be called 'id', sometimes
      * you would want to use a different one or maybe don't create field
      * at all.
@@ -339,6 +339,54 @@ class Model implements \IteratorAggregate
         }
     }
 
+    public function isEntity(): bool
+    {
+        return $this->entityId !== null;
+    }
+
+    public function assertIsModel(): void
+    {
+        if ($this->isEntity()) {
+            throw new \Error('Expected model, but instance is an entity'); // TODO Exception, but Error for debug
+        }
+    }
+
+    public function assertIsEntity(): void
+    {
+        if (!$this->isEntity()) {
+            throw new \Error('Expected entity, but instance is a model'); // TODO Exception, but Error for debug
+        }
+    }
+
+    /**
+     * @return static
+     */
+    public function getModel(): self
+    {
+        $this->assertIsEntity();
+
+        $model = clone $this; // TODO
+        $model->unload();
+        $model->entityId = null;
+
+        return $model;
+    }
+
+    /**
+     * @return static
+     */
+    public function createEntity(): self
+    {
+        $this->assertIsModel();
+
+        $model = clone $this;
+        if ($model->entityId === null) {
+            $model->entityId = true;
+        }
+
+        return $model;
+    }
+
     /**
      * Clones model object.
      */
@@ -441,54 +489,6 @@ class Model implements \IteratorAggregate
         $this->onHookShort(self::HOOK_AFTER_DELETE, $checkFx, [], -10);
         $this->onHookShort(self::HOOK_BEFORE_SAVE, $checkFx, [], 10);
         $this->onHookShort(self::HOOK_AFTER_SAVE, $checkFx, [], -10);
-    }
-
-    public function isEntity(): bool
-    {
-        return $this->entityId !== null;
-    }
-
-    public function assertIsModel(): void
-    {
-        if ($this->isEntity()) {
-            throw new \Error('Expected model, but instance is an entity'); // TODO Exception, but Error for debug
-        }
-    }
-
-    public function assertIsEntity(): void
-    {
-        if (!$this->isEntity()) {
-            throw new \Error('Expected entity, but instance is a model'); // TODO Exception, but Error for debug
-        }
-    }
-
-    /**
-     * @return static
-     */
-    public function getModel(): self
-    {
-        $this->assertIsEntity();
-
-        $model = clone $this; // TODO
-        $model->unload();
-        $model->entityId = null;
-
-        return $model;
-    }
-
-    /**
-     * @return static
-     */
-    public function createEntity(): self
-    {
-        $this->assertIsModel();
-
-        $model = clone $this;
-        if ($model->entityId === null) {
-            $model->entityId = true;
-        }
-
-        return $model;
     }
 
     /**

--- a/src/Model.php
+++ b/src/Model.php
@@ -1182,10 +1182,6 @@ class Model implements \IteratorAggregate
      */
     public function loaded(): bool
     {
-        if (!$this->isEntity()) { // TODO for debug only
-            return false;
-        }
-
         return $this->id_field && $this->getId() !== null && ($this->entityId !== null && $this->entityId !== true);
     }
 

--- a/src/Model.php
+++ b/src/Model.php
@@ -2015,8 +2015,17 @@ class Model implements \IteratorAggregate
      */
     public function __debugInfo(): array
     {
+        if ($this->isEntity()) {
+            return [
+                'entityId' => $this->id_field && $this->hasField('id')
+                    ? (($this->_entityId !== null ? $this->_entityId . ($this->getId() !== null ? '' : ' (unloaded)') : 'null'))
+                    : 'no id field',
+                'model' => $this->getModel()->__debugInfo(),
+            ];
+        }
+
         return [
-            'id' => $this->id_field && $this->hasField('id') ? $this->getId() : 'no id field',
+            'table' => $this->table,
             'scope' => $this->scope()->toWords(),
         ];
     }

--- a/src/Model.php
+++ b/src/Model.php
@@ -906,10 +906,6 @@ class Model implements \IteratorAggregate
      */
     public function getId()
     {
-        if (!$this->isEntity()) { // TODO for debug only
-            return null;
-        }
-
         $this->assertHasIdField();
 
         return $this->get($this->id_field);

--- a/src/Model.php
+++ b/src/Model.php
@@ -1698,12 +1698,8 @@ class Model implements \IteratorAggregate
      */
     public function insert(array $row)
     {
-        if (!$this->isEntity()) {
-            return $this->createEntity()->insert($row);
-        }
-
-        $model = clone $this;
-        $model->_entityId = null; // TODO we want to use probably getModel here
+        $model = ($this->isEntity() ? $this->getModel() : $this)
+            ->createEntity();
         $model->_rawInsert($row);
 
         return $this->id_field ? $model->getId() : null;

--- a/src/Model.php
+++ b/src/Model.php
@@ -1056,7 +1056,7 @@ class Model implements \IteratorAggregate
      */
     public function addCondition($field, $operator = null, $value = null)
     {
-//        $this->assertIsModel();
+        $this->assertIsModel();
 
         $this->scope()->addCondition(...func_get_args());
 

--- a/src/Model.php
+++ b/src/Model.php
@@ -502,7 +502,7 @@ class Model implements \IteratorAggregate
      */
     public function &getDataRef(): array
     {
-        // $this->assertIsEntity();
+        $this->assertIsEntity();
 
         return $this->data;
     }
@@ -512,7 +512,7 @@ class Model implements \IteratorAggregate
      */
     public function &getDirtyRef(): array
     {
-        // $this->assertIsEntity();
+        $this->assertIsEntity();
 
         return $this->dirty;
     }
@@ -1455,13 +1455,17 @@ class Model implements \IteratorAggregate
      * @param mixed                $id
      * @param class-string<static> $class
      *
-     * @return static
+     * @return self
      */
     public function withPersistence(Persistence $persistence, $id = null, string $class = null)
     {
         $class = $class ?? static::class;
 
+        /** @var self $model */
         $model = new $class($persistence, ['table' => $this->table]);
+        if ($this->isEntity()) { // TODO should this method work with entity at all?
+            $model = $model->createEntity();
+        }
 
         if ($this->id_field && $id !== null) {
             $model->setId($id === true ? $this->getId() : $id);
@@ -1474,10 +1478,12 @@ class Model implements \IteratorAggregate
             }
         }
 
-        $modelDataRef = &$model->getDataRef();
-        $modelDirtyRef = &$model->getDirtyRef();
-        $modelDataRef = &$this->getDataRef();
-        $modelDirtyRef = &$this->getDirtyRef();
+        if ($this->isEntity()) {
+            $modelDataRef = &$model->getDataRef();
+            $modelDirtyRef = &$model->getDirtyRef();
+            $modelDataRef = &$this->getDataRef();
+            $modelDirtyRef = &$this->getDirtyRef();
+        }
         $model->limit = $this->limit;
         $model->order = $this->order;
         $model->scope = (clone $this->scope)->setModel($model);

--- a/src/Model.php
+++ b/src/Model.php
@@ -495,7 +495,7 @@ class Model implements \IteratorAggregate
     }
 
     /**
-     * @internal should be removed or made non-public after #862 is merged
+     * @internal should be not used outside atk4/data
      */
     public function &getDataRef(): array
     {
@@ -505,7 +505,7 @@ class Model implements \IteratorAggregate
     }
 
     /**
-     * @internal should be removed or made non-public after #862 is merged
+     * @internal should be not used outside atk4/data
      */
     public function &getDirtyRef(): array
     {

--- a/src/Model.php
+++ b/src/Model.php
@@ -329,7 +329,8 @@ class Model implements \IteratorAggregate
     {
         $this->scope = \Closure::bind(function () {
             return new Model\Scope\RootScope();
-        }, null, Model\Scope\RootScope::class)();
+        }, null, Model\Scope\RootScope::class)()
+            ->setModel($this);
 
         $this->setDefaults($defaults);
 
@@ -343,7 +344,9 @@ class Model implements \IteratorAggregate
      */
     public function __clone()
     {
-        $this->scope = (clone $this->scope)->setModel($this);
+        if (!$this->isEntity()) {
+            $this->scope = (clone $this->scope)->setModel($this);
+        }
         $this->_cloneCollection('elements');
         $this->_cloneCollection('fields');
         $this->_cloneCollection('userActions');
@@ -1069,7 +1072,11 @@ class Model implements \IteratorAggregate
      */
     public function scope(): Model\Scope\RootScope
     {
-        return $this->scope->setModel($this);
+        if ($this->scope->getModel() === null) {
+            $this->scope->setModel($this);
+        }
+
+        return $this->scope;
     }
 
     /**
@@ -1477,7 +1484,9 @@ class Model implements \IteratorAggregate
         }
         $model->limit = $this->limit;
         $model->order = $this->order;
-        $model->scope = (clone $this->scope)->setModel($model);
+        if (!$this->isEntity()) {
+            $model->scope = (clone $this->scope)->setModel($model);
+        }
 
         return $model;
     }

--- a/src/Model.php
+++ b/src/Model.php
@@ -377,8 +377,12 @@ class Model implements \IteratorAggregate
     {
         $this->assertIsModel();
 
-        $model = clone $this;
-        $model->_model = $this;
+        $this->_model = $this;
+        try {
+            $model = clone $this;
+        } finally {
+            $this->_model = null;
+        }
         $model->_entityId = null;
 
         return $model;

--- a/src/Model.php
+++ b/src/Model.php
@@ -349,14 +349,14 @@ class Model implements \IteratorAggregate
     public function assertIsModel(): void
     {
         if ($this->isEntity()) {
-            throw new \Error('Expected model, but instance is an entity'); // TODO Exception, but Error for debug
+            throw new Exception('Expected model, but instance is an entity');
         }
     }
 
     public function assertIsEntity(): void
     {
         if (!$this->isEntity()) {
-            throw new \Error('Expected entity, but instance is a model'); // TODO Exception, but Error for debug
+            throw new Exception('Expected entity, but instance is a model');
         }
     }
 

--- a/src/Model.php
+++ b/src/Model.php
@@ -1392,7 +1392,7 @@ class Model implements \IteratorAggregate
      */
     public function duplicate()
     {
-        // TODO remove in v2.6
+        // deprecated, TODO remove in v3.1
         if (func_num_args() > 0) {
             throw new Exception('Duplicating using existing ID is no longer supported');
         }
@@ -1557,7 +1557,7 @@ class Model implements \IteratorAggregate
      */
     public function save(array $data = [])
     {
-        // deprecated, remove on 2021-03
+        // deprecated, TODO remove in v3.1
         if (func_num_args() > 1) {
             throw new Exception('Model::save() with 2nd param $to_persistence is no longer supported');
         }
@@ -1959,7 +1959,7 @@ class Model implements \IteratorAggregate
      */
     public function atomic(\Closure $fx)
     {
-        // deprecated, remove on 2021-03
+        // deprecated, TODO remove in v3.1
         if (func_num_args() > 1) {
             throw new Exception('Model::atomic() with 2nd param $persistence is no longer supported');
         }

--- a/src/Model.php
+++ b/src/Model.php
@@ -1235,12 +1235,12 @@ class Model implements \IteratorAggregate
         if (!$this->isEntity()) {
             return $this->createEntity()->tryLoad($id);
         }
+        $callerFrame = debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS, 2)[1];
+        if (($callerFrame['class'] ?? null) !== self::class || ($callerFrame['function'] ?? null) !== 'tryLoad') {
+            $this->assertIsModel();
+        }
 
         $this->checkPersistence();
-
-        if ($this->loaded()) {
-            $this->unload();
-        }
 
         $noId = $id === self::ID_LOAD_ONE || $id === self::ID_LOAD_ANY;
         $dataRef = &$this->getDataRef();
@@ -1286,15 +1286,15 @@ class Model implements \IteratorAggregate
         if (!$this->isEntity()) {
             return $this->createEntity()->load($id);
         }
+        $callerFrame = debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS, 2)[1];
+        if (($callerFrame['class'] ?? null) !== self::class || !in_array($callerFrame['function'] ?? null, ['load', 'reload'], true) || $this->loaded()) {
+            $this->assertIsModel();
+        }
 
         $this->checkPersistence();
 
-        if ($this->loaded()) {
-            $this->unload();
-        }
-
-        $dataRef = &$this->getDataRef();
         $noId = $id === self::ID_LOAD_ONE || $id === self::ID_LOAD_ANY;
+        $dataRef = &$this->getDataRef();
         if ($noId) {
             $dataRef = $this->persistence->load($this, $this->remapIdLoadToPersistence($id));
         } else {

--- a/src/Model/Scope/Condition.php
+++ b/src/Model/Scope/Condition.php
@@ -153,7 +153,10 @@ class Condition extends AbstractScope
                     $field = $model->getField($field);
                 }
 
-                if ($field instanceof Field) {
+                // TODO Model/field should not be mutated, see:
+                // https://github.com/atk4/data/issues/662
+                // for now, do not set default at least for PK/ID
+                if ($field instanceof Field && $field->short_name !== $field->getOwner()->id_field) {
                     $field->system = true;
                     $field->default = $this->value;
                 }

--- a/src/Model/Scope/Condition.php
+++ b/src/Model/Scope/Condition.php
@@ -370,7 +370,7 @@ class Condition extends AbstractScope
         $title = null;
         if (is_object($field) && $field->getReference() !== null) {
             // make sure we set the value in the Model
-            $model = clone $model;
+            $model = $model->isEntity() ? clone $model : $model->createEntity();
             $model->set($field->short_name, $value);
 
             // then take the title

--- a/src/Model/Scope/RootScope.php
+++ b/src/Model/Scope/RootScope.php
@@ -22,8 +22,13 @@ class RootScope extends Model\Scope
         parent::__construct($nestedConditions, self::AND);
     }
 
+    /**
+     * @return $this
+     */
     public function setModel(Model $model)
     {
+        $model->assertIsModel();
+
         if ($this->model !== $model) {
             $this->model = $model;
 

--- a/src/Model/UserAction.php
+++ b/src/Model/UserAction.php
@@ -17,7 +17,7 @@ use Atk4\Data\Model;
  *
  * UserAction must NOT rely on any specific UI implementation.
  *
- * @method Exception getOwner() use getEntity() method instead
+ * @method Exception getOwner() use getModel() or getEntity() method instead
  */
 class UserAction
 {
@@ -113,7 +113,7 @@ class UserAction
             };
 
             if ($this->atomic) {
-                return $this->getEntity()->atomic($run);
+                return $this->getModel()->atomic($run);
             }
 
             return $run();
@@ -220,15 +220,19 @@ class UserAction
      */
     public function getModel(): Model
     {
-        return $this->getOwner()->getModel(true);
+        return $this->getOwner()->getModel(true); // @phpstan-ignore-line
     }
-    
+
     public function getEntity(): Model
     {
-        if (!$this->entity) {
-            $this->setEntity($this->getModel()->createEntity());
+        if ($this->getOwner()->isEntity()) { // @phpstan-ignore-line
+            return $this->getOwner(); // @phpstan-ignore-line
         }
-        
+
+        if ($this->entity === null) {
+            $this->setEntity($this->getOwner()->createEntity()); // @phpstan-ignore-line
+        }
+
         return $this->entity;
     }
 

--- a/src/Model/UserAction.php
+++ b/src/Model/UserAction.php
@@ -187,7 +187,7 @@ class UserAction
     public function getDescription(): string
     {
         if ($this->description instanceof \Closure) {
-            return call_user_func($this->description, $this);
+            return ($this->description)($this);
         }
 
         return $this->description ?? $this->getCaption() . ' ' . $this->getOwner()->getModelCaption();
@@ -199,7 +199,7 @@ class UserAction
     public function getConfirmation()
     {
         if ($this->confirmation instanceof \Closure) {
-            return call_user_func($this->confirmation, $this);
+            return ($this->confirmation)($this);
         } elseif ($this->confirmation === true) {
             $confirmation = 'Are you sure you wish to execute ';
             $confirmation .= $this->getCaption();

--- a/src/Persistence.php
+++ b/src/Persistence.php
@@ -147,7 +147,7 @@ abstract class Persistence
             throw (new Exception($noId ? 'No record was found' : 'Record with specified ID was not found', 404))
                 ->addMoreInfo('model', $model)
                 ->addMoreInfo('id', $noId ? null : $id)
-                ->addMoreInfo('scope', $model->scope()->toWords());
+                ->addMoreInfo('scope', $model->getModel(true)->scope()->toWords());
         }
 
         return $data;

--- a/src/Persistence/Array_.php
+++ b/src/Persistence/Array_.php
@@ -215,7 +215,6 @@ class Array_ extends Persistence
             $id = $selectRow[$model->id_field];
 
             $row = $this->tryLoad($model, $id);
-            $model->setId($id); // @TODO is it needed?
 
             return $row;
         }
@@ -385,7 +384,7 @@ class Array_ extends Persistence
      */
     protected function applyScope(Model $model, Action $action): void
     {
-        $scope = $model->scope();
+        $scope = $model->getModel(true)->scope();
 
         // add entity ID to scope to allow easy traversal
         if ($model->isEntity() && $model->id_field && $model->getId() !== null) {

--- a/src/Persistence/Array_.php
+++ b/src/Persistence/Array_.php
@@ -388,7 +388,7 @@ class Array_ extends Persistence
         $scope = $model->scope();
 
         // add entity ID to scope to allow easy traversal
-        if ($model->id_field && $model->getId() !== null) {
+        if ($model->isEntity() && $model->id_field && $model->getId() !== null) {
             $scope = new Model\Scope([$scope]);
             $scope->addCondition($model->getField($model->id_field), $model->getId());
         }

--- a/src/Persistence/Array_/Action.php
+++ b/src/Persistence/Array_/Action.php
@@ -298,7 +298,7 @@ class Action
     }
 
     /**
-     * @deprecated use "getRows" method instead - will be removed in v2.5
+     * @deprecated use "getRows" method instead - TODO remove in v3.1
      */
     public function get(): array
     {

--- a/src/Persistence/Sql.php
+++ b/src/Persistence/Sql.php
@@ -633,7 +633,7 @@ class Sql extends Persistence
                 $this->initQueryConditions($model, $query);
                 $this->setLimitOrder($model, $query);
 
-                if ($model->loaded()) {
+                if ($model->isEntity() && $model->loaded()) {
                     $query->where($model->getField($model->id_field), $model->getId());
                 }
 

--- a/src/Persistence/Sql.php
+++ b/src/Persistence/Sql.php
@@ -370,7 +370,7 @@ class Sql extends Persistence
      */
     public function initQueryConditions(Model $model, Query $query): void
     {
-        $this->_initQueryConditions($query, $model->scope());
+        $this->_initQueryConditions($query, $model->getModel(true)->scope());
 
         // add entity ID to scope to allow easy traversal
         if ($model->isEntity() && $model->id_field && $model->getId() !== null) {
@@ -749,7 +749,7 @@ class Sql extends Persistence
                 ->addMoreInfo('query', $insert->getDebugQuery())
                 ->addMoreInfo('message', $e->getMessage())
                 ->addMoreInfo('model', $model)
-                ->addMoreInfo('scope', $model->scope()->toWords());
+                ->addMoreInfo('scope', $model->getModel(true)->scope()->toWords());
         }
 
         if ($model->id_field && isset($data[$model->id_field])) {
@@ -827,7 +827,7 @@ class Sql extends Persistence
                 ->addMoreInfo('query', $update->getDebugQuery())
                 ->addMoreInfo('message', $e->getMessage())
                 ->addMoreInfo('model', $model)
-                ->addMoreInfo('scope', $model->scope()->toWords());
+                ->addMoreInfo('scope', $model->getModel(true)->scope()->toWords());
         }
 
         if ($model->id_field && isset($data[$model->id_field]) && $model->getDirtyRef()[$model->id_field]) {
@@ -870,7 +870,7 @@ class Sql extends Persistence
                 ->addMoreInfo('query', $delete->getDebugQuery())
                 ->addMoreInfo('message', $e->getMessage())
                 ->addMoreInfo('model', $model)
-                ->addMoreInfo('scope', $model->scope()->toWords());
+                ->addMoreInfo('scope', $model->getModel(true)->scope()->toWords());
         }
     }
 

--- a/src/Persistence/Sql.php
+++ b/src/Persistence/Sql.php
@@ -373,7 +373,7 @@ class Sql extends Persistence
         $this->_initQueryConditions($query, $model->scope());
 
         // add entity ID to scope to allow easy traversal
-        if ($model->id_field && $model->getId() !== null) {
+        if ($model->isEntity() && $model->id_field && $model->getId() !== null) {
             $query->group($model->getField($model->id_field));
             if ($this->getDatabasePlatform() instanceof SQLServer2012Platform
                 || $this->getDatabasePlatform() instanceof OraclePlatform) {

--- a/src/Reference.php
+++ b/src/Reference.php
@@ -188,11 +188,6 @@ class Reference
 
     protected function getOurFieldValue()
     {
-        // @TODO PR Distinguish strictly between model and entity #862
-        if (!$this->getOurModel()->isEntity()) {
-            return null;
-        }
-
         return $this->getOurField()->get();
     }
 

--- a/src/Reference.php
+++ b/src/Reference.php
@@ -171,7 +171,9 @@ class Reference
             $theirModel = Factory::factory($theirModelSeed, $defaults);
         }
 
-        return $this->addToPersistence($theirModel, $defaults);
+        $this->addToPersistence($theirModel, $defaults);
+
+        return $theirModel;
     }
 
     protected function getOurField(): Field
@@ -186,6 +188,11 @@ class Reference
 
     protected function getOurFieldValue()
     {
+        // @TODO PR Distinguish strictly between model and entity #862
+        if (!$this->getOurModel()->isEntity()) {
+            return null;
+        }
+
         return $this->getOurField()->get();
     }
 
@@ -205,10 +212,7 @@ class Reference
         }
     }
 
-    /**
-     * Adds model to persistence.
-     */
-    protected function addToPersistence(Model $theirModel, array $defaults = []): Model
+    protected function addToPersistence(Model $theirModel, array $defaults = []): void
     {
         if (!$theirModel->persistence && $persistence = $this->getDefaultPersistence($theirModel)) {
             $persistence->add($theirModel, $defaults);
@@ -218,8 +222,6 @@ class Reference
         if ($this->caption !== null) {
             $theirModel->caption = $this->caption;
         }
-
-        return $theirModel;
     }
 
     /**

--- a/src/Reference/ContainsMany.php
+++ b/src/Reference/ContainsMany.php
@@ -15,7 +15,8 @@ class ContainsMany extends ContainsOne
     protected function getDefaultPersistence(Model $theirModel)
     {
         return new Persistence\ArrayOfStrings([
-            $this->table_alias => $this->getOurFieldValue() ?: [],
+            // @TODO PR Distinguish strictly between model and entity #862
+            $this->table_alias => $this->getOurModel()->isEntity() ? ($this->getOurFieldValue() ?: []) : [],
         ]);
     }
 

--- a/src/Reference/ContainsMany.php
+++ b/src/Reference/ContainsMany.php
@@ -15,8 +15,7 @@ class ContainsMany extends ContainsOne
     protected function getDefaultPersistence(Model $theirModel)
     {
         return new Persistence\ArrayOfStrings([
-            // @TODO PR Distinguish strictly between model and entity #862
-            $this->table_alias => $this->getOurModel()->isEntity() ? ($this->getOurFieldValue() ?: []) : [],
+            $this->table_alias => $this->getOurModel()->isEntity() && $this->getOurFieldValue() !== null ? $this->getOurFieldValue() : [],
         ]);
     }
 

--- a/src/Reference/ContainsOne.php
+++ b/src/Reference/ContainsOne.php
@@ -76,7 +76,7 @@ class ContainsOne extends Reference
     protected function getDefaultPersistence(Model $theirModel)
     {
         return new Persistence\ArrayOfStrings([
-            $this->table_alias => $this->getOurFieldValue() ? [1 => $this->getOurFieldValue()] : [],
+            $this->table_alias => $this->getOurModel()->isEntity() && $this->getOurFieldValue() !== null ? [1 => $this->getOurFieldValue()] : [],
         ]);
     }
 

--- a/src/Reference/ContainsOne.php
+++ b/src/Reference/ContainsOne.php
@@ -100,7 +100,7 @@ class ContainsOne extends Reference
             });
         }
 
-        $theirModel->tryLoadOne();
+        $theirModel = $theirModel->tryLoadOne();
 
         return $theirModel;
     }

--- a/src/Reference/HasMany.php
+++ b/src/Reference/HasMany.php
@@ -41,7 +41,7 @@ class HasMany extends Reference
     {
         $ourModel = $this->getOurModel();
 
-        if ($ourModel->loaded()) {
+        if ($ourModel->isEntity() && $ourModel->loaded()) {
             return $this->our_field
                 ? $ourModel->get($this->our_field)
                 : $ourModel->getId();

--- a/src/Reference/HasOne.php
+++ b/src/Reference/HasOne.php
@@ -210,9 +210,9 @@ class HasOne extends Reference
         if ($ourValue = $this->getOurFieldValue()) {
             // if our model is loaded, then try to load referenced model
             if ($this->their_field) {
-                $theirModel->tryLoadBy($this->their_field, $ourValue);
+                $theirModel = $theirModel->tryLoadBy($this->their_field, $ourValue);
             } else {
-                $theirModel->tryLoad($ourValue);
+                $theirModel = $theirModel->tryLoad($ourValue);
             }
         }
 

--- a/src/Reference/HasOne.php
+++ b/src/Reference/HasOne.php
@@ -207,12 +207,16 @@ class HasOne extends Reference
             $this->getOurField()->setNull();
         });
 
-        if ($ourValue = $this->getOurFieldValue()) {
-            // if our model is loaded, then try to load referenced model
-            if ($this->their_field) {
-                $theirModel = $theirModel->tryLoadBy($this->their_field, $ourValue);
+        if ($this->getOurModel()->isEntity()) {
+            if ($ourValue = $this->getOurFieldValue()) {
+                // if our model is loaded, then try to load referenced model
+                if ($this->their_field) {
+                    $theirModel = $theirModel->tryLoadBy($this->their_field, $ourValue);
+                } else {
+                    $theirModel = $theirModel->tryLoad($ourValue);
+                }
             } else {
-                $theirModel = $theirModel->tryLoad($ourValue);
+                $theirModel = $theirModel->createEntity();
             }
         }
 

--- a/src/Reference/HasOne.php
+++ b/src/Reference/HasOne.php
@@ -203,7 +203,7 @@ class HasOne extends Reference
         $theirModel = $this->createTheirModel($defaults);
 
         // add hook to set our_field = null when record of referenced model is deleted
-        $this->onHookToTheirModel($theirModel, Model::HOOK_AFTER_DELETE, function ($theirModel) {
+        $this->onHookToTheirModel($theirModel, Model::HOOK_AFTER_DELETE, function (Model $theirModel) {
             $this->getOurField()->setNull();
         });
 
@@ -219,7 +219,7 @@ class HasOne extends Reference
         // their model will be reloaded after saving our model to reflect changes in referenced fields
         $theirModel->reload_after_save = false;
 
-        $this->onHookToTheirModel($theirModel, Model::HOOK_AFTER_SAVE, function ($theirModel) {
+        $this->onHookToTheirModel($theirModel, Model::HOOK_AFTER_SAVE, function (Model $theirModel) {
             $theirValue = $this->their_field ? $theirModel->get($this->their_field) : $theirModel->getId();
 
             if ($this->getOurFieldValue() !== $theirValue) {

--- a/src/Reference/HasOneSql.php
+++ b/src/Reference/HasOneSql.php
@@ -162,7 +162,7 @@ class HasOneSql extends HasOne
         // handles the deep traversal using an expression
         $ourFieldExpression = $ourModel->action('field', [$ourField]);
 
-        ($theirModel->isEntity() ? $theirModel->getModel() : $theirModel)
+        $theirModel->getModel(true)
             ->addCondition($theirField, $ourFieldExpression);
 
         return $theirModel;

--- a/src/Reference/HasOneSql.php
+++ b/src/Reference/HasOneSql.php
@@ -152,7 +152,7 @@ class HasOneSql extends HasOne
         // if our_field is the id_field and is being used in the reference
         // we should persist the relation in condtition
         // example - $model->load(1)->ref('refLink')->import($rows);
-        if ($ourModel->loaded() && !$theirModel->loaded()) {
+        if ($ourModel->isEntity() && $ourModel->loaded() && !$theirModel->loaded()) {
             if ($ourModel->id_field === $this->getOurFieldName()) {
                 return $theirModel->addCondition($theirField, $this->getOurFieldValue());
             }

--- a/src/Reference/HasOneSql.php
+++ b/src/Reference/HasOneSql.php
@@ -154,14 +154,18 @@ class HasOneSql extends HasOne
         // example - $model->load(1)->ref('refLink')->import($rows);
         if ($ourModel->isEntity() && $ourModel->loaded() && !$theirModel->loaded()) {
             if ($ourModel->id_field === $this->getOurFieldName()) {
-                return $theirModel->addCondition($theirField, $this->getOurFieldValue());
+                return $theirModel->getModel()
+                    ->addCondition($theirField, $this->getOurFieldValue());
             }
         }
 
         // handles the deep traversal using an expression
         $ourFieldExpression = $ourModel->action('field', [$ourField]);
 
-        return $theirModel->addCondition($theirField, $ourFieldExpression);
+        ($theirModel->isEntity() ? $theirModel->getModel() : $theirModel)
+            ->addCondition($theirField, $ourFieldExpression);
+
+        return $theirModel;
     }
 
     /**

--- a/src/Util/DeepCopy.php
+++ b/src/Util/DeepCopy.php
@@ -182,6 +182,10 @@ class DeepCopy
      */
     protected function _copy(Model $source, Model $destination, array $references, array $exclusions, array $transforms): Model
     {
+        if (!$destination->isEntity()) { // @TODO PR Distinguish strictly between model and entity #862
+            $destination = $destination->createEntity();
+        }
+
         try {
             // Perhaps source was already copied, then simply load destination model and return
             if (isset($this->mapping[$source->table]) && isset($this->mapping[$source->table][$source->getId()])) {

--- a/src/Util/DeepCopy.php
+++ b/src/Util/DeepCopy.php
@@ -187,7 +187,7 @@ class DeepCopy
             if (isset($this->mapping[$source->table]) && isset($this->mapping[$source->table][$source->getId()])) {
                 $this->debug('Skipping ' . get_class($source));
 
-                $destination->load($this->mapping[$source->table][$source->getId()]);
+                $destination = $destination->load($this->mapping[$source->table][$source->getId()]);
             } else {
                 $this->debug('Copying ' . get_class($source));
 

--- a/src/Util/DeepCopy.php
+++ b/src/Util/DeepCopy.php
@@ -182,10 +182,6 @@ class DeepCopy
      */
     protected function _copy(Model $source, Model $destination, array $references, array $exclusions, array $transforms): Model
     {
-        if (!$destination->isEntity()) { // @TODO PR Distinguish strictly between model and entity #862
-            $destination = $destination->createEntity();
-        }
-
         try {
             // Perhaps source was already copied, then simply load destination model and return
             if (isset($this->mapping[$source->table]) && isset($this->mapping[$source->table][$source->getId()])) {
@@ -216,6 +212,7 @@ class DeepCopy
                 unset($data[$source->id_field]);
 
                 // Copy fields as they are
+                $destination = $destination->createEntity();
                 foreach ($data as $key => $val) {
                     if ($destination->hasField($key) && $destination->getField($key)->isEditable()) {
                         $destination->set($key, $val);

--- a/tests-schema/ModelTest.php
+++ b/tests-schema/ModelTest.php
@@ -23,7 +23,7 @@ class ModelTest extends PhpunitTestCase
         $this->getMigrator($user)->create();
 
         // now we can use user
-        $user->save(['name' => 'john', 'is_admin' => true, 'notes' => 'some long notes']);
+        $user->createEntity()->save(['name' => 'john', 'is_admin' => true, 'notes' => 'some long notes']);
     }
 
     public function testImportTable()

--- a/tests/BusinessModelTest.php
+++ b/tests/BusinessModelTest.php
@@ -35,6 +35,7 @@ class BusinessModelTest extends AtkPhpunit\TestCase
         $m = new Model();
         $m->addField('name');
         $m->addField('surname');
+        $m = $m->createEntity();
 
         $m->set('name', 5);
         $this->assertSame(5, $m->get('name'));
@@ -49,6 +50,7 @@ class BusinessModelTest extends AtkPhpunit\TestCase
     public function testNoFieldException()
     {
         $m = new Model();
+        $m = $m->createEntity();
         $this->expectException(Exception::class);
         $m->set('name', 5);
     }
@@ -57,6 +59,7 @@ class BusinessModelTest extends AtkPhpunit\TestCase
     {
         $m = new Model();
         $m->addField('name');
+        $m = $m->createEntity();
         $dataRef = &$m->getDataRef();
         $dirtyRef = &$m->getDirtyRef();
         $dataRef = ['name' => 5];
@@ -109,6 +112,7 @@ class BusinessModelTest extends AtkPhpunit\TestCase
         // now with defaults
         $m = new Model();
         $f = $m->addField('name', ['default' => 'John']);
+        $m = $m->createEntity();
         $this->assertSame('John', $f->default);
 
         $this->assertSame('John', $m->get('name'));
@@ -122,26 +126,17 @@ class BusinessModelTest extends AtkPhpunit\TestCase
         $this->assertSame('John', $m->get('name'));
     }
 
-    /*
-     * This is no longer the case after PR #69
-     *
-     * Now changing $m->get('id') will actually update the value
-     * of original records. In a way $m->get('id') is not a direct
-     * alias to ID, but has a deeper meaning and behaves more
-     * like a regular field.
-     *
-     *
     public function testDefaultInit()
     {
-        $d = new Persistence();
-        $m = new Model($d);
+        $p = new Persistence\Array_();
+        $m = new Model($p);
+        $m = $m->createEntity();
 
         $this->assertNotNull($m->getField('id'));
 
         $m->set('id', 20);
         $this->assertEquals(20, $m->getId());
     }
-     */
 
     public function testException1()
     {
@@ -149,17 +144,19 @@ class BusinessModelTest extends AtkPhpunit\TestCase
         $m->addField('name');
         $m->addField('surname');
         $m->onlyFields(['surname']);
+        $m = $m->createEntity();
 
         $this->expectException(Exception::class);
         $m->set('name', 5);
     }
 
-    public function testException1fixed()
+    public function testException1Fixed()
     {
         $m = new Model();
         $m->addField('name');
         $m->addField('surname');
         $m->onlyFields(['surname']);
+        $m = $m->createEntity();
 
         $m->allFields();
 
@@ -174,6 +171,7 @@ class BusinessModelTest extends AtkPhpunit\TestCase
     {
         $m = new Model();
         $m->addField('name');
+        $m = $m->createEntity();
         $m->set('name', 'foo');
         $this->assertSame('foo', $m->get('name'));
 
@@ -187,6 +185,7 @@ class BusinessModelTest extends AtkPhpunit\TestCase
     public function testException2()
     {
         $m = new Model();
+        $m = $m->createEntity();
         $this->expectException(\Error::class);
         $m->set(0, 'foo'); // @phpstan-ignore-line
     }
@@ -194,6 +193,7 @@ class BusinessModelTest extends AtkPhpunit\TestCase
     public function testException2a()
     {
         $m = new Model();
+        $m = $m->createEntity();
         $this->expectException(Exception::class);
         $m->set('3', 'foo');
     }
@@ -201,6 +201,7 @@ class BusinessModelTest extends AtkPhpunit\TestCase
     public function testException2b()
     {
         $m = new Model();
+        $m = $m->createEntity();
         $this->expectException(Exception::class);
         $m->set('3b', 'foo');
     }
@@ -208,6 +209,7 @@ class BusinessModelTest extends AtkPhpunit\TestCase
     public function testException2c()
     {
         $m = new Model();
+        $m = $m->createEntity();
         $this->expectException(Exception::class);
         $m->set('', 'foo');
     }
@@ -216,6 +218,7 @@ class BusinessModelTest extends AtkPhpunit\TestCase
     {
         $p = new Persistence\Array_();
         $c = new Client($p);
+        $c = $c->createEntity();
         $this->assertEquals(10, $c->get('order'));
     }
 
@@ -225,6 +228,7 @@ class BusinessModelTest extends AtkPhpunit\TestCase
         $m->addField('name', ['type' => 'string']);
         $m->addField('age', ['type' => 'int']);
         $m->addField('data');
+        $m = $m->createEntity();
 
         $m->set('name', '');
         $this->assertSame('', $m->get('name'));
@@ -241,6 +245,8 @@ class BusinessModelTest extends AtkPhpunit\TestCase
         $m = new User();
 
         $m->addField('salary', ['default' => 1000]);
+        $m = $m->createEntity();
+
         $this->assertSame(1000, $m->get('salary'));
         $this->assertFalse($m->_isset('salary'));
 

--- a/tests/ConditionSqlTest.php
+++ b/tests/ConditionSqlTest.php
@@ -29,10 +29,10 @@ class ConditionSqlTest extends \Atk4\Schema\PhpunitTestCase
 
         $mm = clone $m;
         $mm->addCondition('gender', 'M');
-        $mm = $mm->tryLoad(1);
-        $this->assertSame('John', $mm->get('name'));
-        $mm = $mm->tryLoad(2);
-        $this->assertNull($mm->get('name'));
+        $mm2 = $mm->tryLoad(1);
+        $this->assertSame('John', $mm2->get('name'));
+        $mm2 = $mm->tryLoad(2);
+        $this->assertNull($mm2->get('name'));
 
         if ($this->getDatabasePlatform() instanceof SqlitePlatform) {
             $this->assertSame(
@@ -43,10 +43,10 @@ class ConditionSqlTest extends \Atk4\Schema\PhpunitTestCase
 
         $mm = clone $m;
         $mm->withId(2); // = addCondition(id, 2)
-        $mm = $mm->tryLoad(1);
-        $this->assertNull($mm->get('name'));
-        $mm = $mm->tryLoad(2);
-        $this->assertSame('Sue', $mm->get('name'));
+        $mm2 = $mm->tryLoad(1);
+        $this->assertNull($mm2->get('name'));
+        $mm2 = $mm->tryLoad(2);
+        $this->assertSame('Sue', $mm2->get('name'));
     }
 
     public function testEntityReloadWithDifferentIdException()
@@ -63,9 +63,10 @@ class ConditionSqlTest extends \Atk4\Schema\PhpunitTestCase
 
         $m = $m->tryLoad(1);
         $this->assertSame('John', $m->get('name'));
+        $m->setId(2);
         $this->expectException(\Atk4\Data\Exception::class);
         $this->expectExceptionMessageMatches('~entity.+different~');
-        $m = $m->tryLoad(2);
+        $m->reload();
     }
 
     public function testNull()
@@ -114,31 +115,31 @@ class ConditionSqlTest extends \Atk4\Schema\PhpunitTestCase
 
         $mm = clone $m;
         $mm->addCondition('gender', 'M');
-        $mm = $mm->tryLoad(1);
-        $this->assertSame('John', $mm->get('name'));
-        $mm = $mm->tryLoad(2);
-        $this->assertNull($mm->get('name'));
+        $mm2 = $mm->tryLoad(1);
+        $this->assertSame('John', $mm2->get('name'));
+        $mm2 = $mm->tryLoad(2);
+        $this->assertNull($mm2->get('name'));
 
         $mm = clone $m;
         $mm->addCondition('gender', '!=', 'M');
-        $mm = $mm->tryLoad(1);
-        $this->assertNull($mm->get('name'));
-        $mm = $mm->tryLoad(2);
-        $this->assertSame('Sue', $mm->get('name'));
+        $mm2 = $mm->tryLoad(1);
+        $this->assertNull($mm2->get('name'));
+        $mm2 = $mm->tryLoad(2);
+        $this->assertSame('Sue', $mm2->get('name'));
 
         $mm = clone $m;
         $mm->addCondition('id', '>', 1);
-        $mm = $mm->tryLoad(1);
-        $this->assertNull($mm->get('name'));
-        $mm = $mm->tryLoad(2);
-        $this->assertSame('Sue', $mm->get('name'));
+        $mm2 = $mm->tryLoad(1);
+        $this->assertNull($mm2->get('name'));
+        $mm2 = $mm->tryLoad(2);
+        $this->assertSame('Sue', $mm2->get('name'));
 
         $mm = clone $m;
         $mm->addCondition('id', 'in', [1, 3]);
-        $mm = $mm->tryLoad(1);
-        $this->assertSame('John', $mm->get('name'));
-        $mm = $mm->tryLoad(2);
-        $this->assertNull($mm->get('name'));
+        $mm2 = $mm->tryLoad(1);
+        $this->assertSame('John', $mm2->get('name'));
+        $mm2 = $mm->tryLoad(2);
+        $this->assertNull($mm2->get('name'));
     }
 
     public function testExpressions1()
@@ -160,17 +161,17 @@ class ConditionSqlTest extends \Atk4\Schema\PhpunitTestCase
 
         $mm = clone $m;
         $mm->addCondition($mm->expr('[] > 1', [$mm->getField('id')]));
-        $mm = $mm->tryLoad(1);
-        $this->assertNull($mm->get('name'));
-        $mm = $mm->tryLoad(2);
-        $this->assertSame('Sue', $mm->get('name'));
+        $mm2 = $mm->tryLoad(1);
+        $this->assertNull($mm2->get('name'));
+        $mm2 = $mm->tryLoad(2);
+        $this->assertSame('Sue', $mm2->get('name'));
 
         $mm = clone $m;
         $mm->addCondition($mm->expr('[id] > 1'));
-        $mm = $mm->tryLoad(1);
-        $this->assertNull($mm->get('name'));
-        $mm = $mm->tryLoad(2);
-        $this->assertSame('Sue', $mm->get('name'));
+        $mm2 = $mm->tryLoad(1);
+        $this->assertNull($mm2->get('name'));
+        $mm2 = $mm->tryLoad(2);
+        $this->assertSame('Sue', $mm2->get('name'));
     }
 
     public function testExpressions2()
@@ -192,31 +193,31 @@ class ConditionSqlTest extends \Atk4\Schema\PhpunitTestCase
 
         $mm = clone $m;
         $mm->addCondition($mm->expr('[name] = [surname]'));
-        $mm = $mm->tryLoad(1);
-        $this->assertNull($mm->get('name'));
-        $mm = $mm->tryLoad(2);
-        $this->assertSame('Sue', $mm->get('name'));
+        $mm2 = $mm->tryLoad(1);
+        $this->assertNull($mm2->get('name'));
+        $mm2 = $mm->tryLoad(2);
+        $this->assertSame('Sue', $mm2->get('name'));
 
         $mm = clone $m;
         $mm->addCondition($m->getField('name'), $m->getField('surname'));
-        $mm = $mm->tryLoad(1);
-        $this->assertNull($mm->get('name'));
-        $mm = $mm->tryLoad(2);
-        $this->assertSame('Sue', $mm->get('name'));
+        $mm2 = $mm->tryLoad(1);
+        $this->assertNull($mm2->get('name'));
+        $mm2 = $mm->tryLoad(2);
+        $this->assertSame('Sue', $mm2->get('name'));
 
         $mm = clone $m;
         $mm->addCondition($mm->expr('[name] != [surname]'));
-        $mm = $mm->tryLoad(1);
-        $this->assertSame('John', $mm->get('name'));
-        $mm = $mm->tryLoad(2);
-        $this->assertNull($mm->get('name'));
+        $mm2 = $mm->tryLoad(1);
+        $this->assertSame('John', $mm2->get('name'));
+        $mm2 = $mm->tryLoad(2);
+        $this->assertNull($mm2->get('name'));
 
         $mm = clone $m;
         $mm->addCondition($m->getField('name'), '!=', $m->getField('surname'));
-        $mm = $mm->tryLoad(1);
-        $this->assertSame('John', $mm->get('name'));
-        $mm = $mm->tryLoad(2);
-        $this->assertNull($mm->get('name'));
+        $mm2 = $mm->tryLoad(1);
+        $this->assertSame('John', $mm2->get('name'));
+        $mm2 = $mm->tryLoad(2);
+        $this->assertNull($mm2->get('name'));
     }
 
     public function testExpressionJoin()
@@ -237,37 +238,37 @@ class ConditionSqlTest extends \Atk4\Schema\PhpunitTestCase
 
         $m->join('contact')->addField('contact_phone');
 
-        $mm = $m->tryLoad(1);
-        $this->assertSame('John', $mm->get('name'));
-        $this->assertSame('+123 smiths', $mm->get('contact_phone'));
-        $mm = $m->tryLoad(2);
-        $this->assertSame('Sue', $mm->get('name'));
-        $this->assertSame('+321 sues', $mm->get('contact_phone'));
-        $mm = $m->tryLoad(3);
-        $this->assertSame('Peter', $mm->get('name'));
-        $this->assertSame('+123 smiths', $mm->get('contact_phone'));
+        $mm2 = $m->tryLoad(1);
+        $this->assertSame('John', $mm2->get('name'));
+        $this->assertSame('+123 smiths', $mm2->get('contact_phone'));
+        $mm2 = $m->tryLoad(2);
+        $this->assertSame('Sue', $mm2->get('name'));
+        $this->assertSame('+321 sues', $mm2->get('contact_phone'));
+        $mm2 = $m->tryLoad(3);
+        $this->assertSame('Peter', $mm2->get('name'));
+        $this->assertSame('+123 smiths', $mm2->get('contact_phone'));
 
         $mm = clone $m;
         $mm->addCondition($mm->expr('[name] = [surname]'));
-        $mm = $mm->tryLoad(1);
-        $this->assertFalse($mm->loaded());
-        $mm = $mm->tryLoad(2);
-        $this->assertSame('Sue', $mm->get('name'));
-        $this->assertSame('+321 sues', $mm->get('contact_phone'));
-        $mm = $mm->tryLoad(3);
-        $this->assertFalse($mm->loaded());
+        $mm2 = $mm->tryLoad(1);
+        $this->assertFalse($mm2->loaded());
+        $mm2 = $mm->tryLoad(2);
+        $this->assertSame('Sue', $mm2->get('name'));
+        $this->assertSame('+321 sues', $mm2->get('contact_phone'));
+        $mm2 = $mm->tryLoad(3);
+        $this->assertFalse($mm2->loaded());
 
         $mm = clone $m;
         $mm->addCondition($mm->expr('\'+123 smiths\' = [contact_phone]'));
-        $mmm = $mm->tryLoad(1);
-        $this->assertSame('John', $mmm->get('name'));
-        $this->assertSame('+123 smiths', $mmm->get('contact_phone'));
-        $mmm = $mm->tryLoad(2);
-        $this->assertNull($mmm->get('name'));
-        $this->assertNull($mmm->get('contact_phone'));
-        $mmm = $mm->tryLoad(3);
-        $this->assertSame('Peter', $mmm->get('name'));
-        $this->assertSame('+123 smiths', $mmm->get('contact_phone'));
+        $mm2 = $mm->tryLoad(1);
+        $this->assertSame('John', $mm2->get('name'));
+        $this->assertSame('+123 smiths', $mm2->get('contact_phone'));
+        $mm2 = $mm->tryLoad(2);
+        $this->assertNull($mm2->get('name'));
+        $this->assertNull($mm2->get('contact_phone'));
+        $mm2 = $mm->tryLoad(3);
+        $this->assertSame('Peter', $mm2->get('name'));
+        $this->assertSame('+123 smiths', $mm2->get('contact_phone'));
     }
 
     public function testArrayCondition()

--- a/tests/ConditionSqlTest.php
+++ b/tests/ConditionSqlTest.php
@@ -30,9 +30,9 @@ class ConditionSqlTest extends \Atk4\Schema\PhpunitTestCase
 
         $mm = clone $m;
         $mm->addCondition('gender', 'M');
-        $mm->tryLoad(1);
+        $mm = $mm->tryLoad(1);
         $this->assertSame('John', $mm->get('name'));
-        $mm->tryLoad(2);
+        $mm = $mm->tryLoad(2);
         $this->assertNull($mm->get('name'));
 
         if ($this->getDatabasePlatform() instanceof SqlitePlatform) {
@@ -44,9 +44,9 @@ class ConditionSqlTest extends \Atk4\Schema\PhpunitTestCase
 
         $mm = clone $m;
         $mm->withId(2); // = addCondition(id, 2)
-        $mm->tryLoad(1);
+        $mm = $mm->tryLoad(1);
         $this->assertNull($mm->get('name'));
-        $mm->tryLoad(2);
+        $mm = $mm->tryLoad(2);
         $this->assertSame('Sue', $mm->get('name'));
     }
 
@@ -63,11 +63,11 @@ class ConditionSqlTest extends \Atk4\Schema\PhpunitTestCase
         $m->addFields(['name', 'gender']);
 
         $mm = clone $m;
-        $mm->tryLoad(1);
+        $mm = $mm->tryLoad(1);
         $this->assertSame('John', $mm->get('name'));
         $this->expectException(\Atk4\Data\Exception::class);
         $this->expectExceptionMessageMatches('~entity.+different~');
-        $mm->tryLoad(2);
+        $mm = $mm->tryLoad(2);
     }
 
     public function testNull()
@@ -117,30 +117,30 @@ class ConditionSqlTest extends \Atk4\Schema\PhpunitTestCase
 
         $mm = clone $m;
         $mm->addCondition('gender', 'M');
-        $mm->tryLoad(1);
+        $mm = $mm->tryLoad(1);
         $this->assertSame('John', $mm->get('name'));
-        $mm->tryLoad(2);
+        $mm = $mm->tryLoad(2);
         $this->assertNull($mm->get('name'));
 
         $mm = clone $m;
         $mm->addCondition('gender', '!=', 'M');
-        $mm->tryLoad(1);
+        $mm = $mm->tryLoad(1);
         $this->assertNull($mm->get('name'));
-        $mm->tryLoad(2);
+        $mm = $mm->tryLoad(2);
         $this->assertSame('Sue', $mm->get('name'));
 
         $mm = clone $m;
         $mm->addCondition('id', '>', 1);
-        $mm->tryLoad(1);
+        $mm = $mm->tryLoad(1);
         $this->assertNull($mm->get('name'));
-        $mm->tryLoad(2);
+        $mm = $mm->tryLoad(2);
         $this->assertSame('Sue', $mm->get('name'));
 
         $mm = clone $m;
         $mm->addCondition('id', 'in', [1, 3]);
-        $mm->tryLoad(1);
+        $mm = $mm->tryLoad(1);
         $this->assertSame('John', $mm->get('name'));
-        $mm->tryLoad(2);
+        $mm = $mm->tryLoad(2);
         $this->assertNull($mm->get('name'));
     }
 
@@ -164,16 +164,16 @@ class ConditionSqlTest extends \Atk4\Schema\PhpunitTestCase
 
         $mm = clone $m;
         $mm->addCondition($mm->expr('[] > 1', [$mm->getField('id')]));
-        $mm->tryLoad(1);
+        $mm = $mm->tryLoad(1);
         $this->assertNull($mm->get('name'));
-        $mm->tryLoad(2);
+        $mm = $mm->tryLoad(2);
         $this->assertSame('Sue', $mm->get('name'));
 
         $mm = clone $m;
         $mm->addCondition($mm->expr('[id] > 1'));
-        $mm->tryLoad(1);
+        $mm = $mm->tryLoad(1);
         $this->assertNull($mm->get('name'));
-        $mm->tryLoad(2);
+        $mm = $mm->tryLoad(2);
         $this->assertSame('Sue', $mm->get('name'));
     }
 
@@ -197,30 +197,30 @@ class ConditionSqlTest extends \Atk4\Schema\PhpunitTestCase
 
         $mm = clone $m;
         $mm->addCondition($mm->expr('[name] = [surname]'));
-        $mm->tryLoad(1);
+        $mm = $mm->tryLoad(1);
         $this->assertNull($mm->get('name'));
-        $mm->tryLoad(2);
+        $mm = $mm->tryLoad(2);
         $this->assertSame('Sue', $mm->get('name'));
 
         $mm = clone $m;
         $mm->addCondition($m->getField('name'), $m->getField('surname'));
-        $mm->tryLoad(1);
+        $mm = $mm->tryLoad(1);
         $this->assertNull($mm->get('name'));
-        $mm->tryLoad(2);
+        $mm = $mm->tryLoad(2);
         $this->assertSame('Sue', $mm->get('name'));
 
         $mm = clone $m;
         $mm->addCondition($mm->expr('[name] != [surname]'));
-        $mm->tryLoad(1);
+        $mm = $mm->tryLoad(1);
         $this->assertSame('John', $mm->get('name'));
-        $mm->tryLoad(2);
+        $mm = $mm->tryLoad(2);
         $this->assertNull($mm->get('name'));
 
         $mm = clone $m;
         $mm->addCondition($m->getField('name'), '!=', $m->getField('surname'));
-        $mm->tryLoad(1);
+        $mm = $mm->tryLoad(1);
         $this->assertSame('John', $mm->get('name'));
-        $mm->tryLoad(2);
+        $mm = $mm->tryLoad(2);
         $this->assertNull($mm->get('name'));
     }
 
@@ -255,12 +255,12 @@ class ConditionSqlTest extends \Atk4\Schema\PhpunitTestCase
 
         $mm = clone $m;
         $mm->addCondition($mm->expr('[name] = [surname]'));
-        $mm->tryLoad(1);
+        $mm = $mm->tryLoad(1);
         $this->assertFalse($mm->loaded());
-        $mm->tryLoad(2);
+        $mm = $mm->tryLoad(2);
         $this->assertSame('Sue', $mm->get('name'));
         $this->assertSame('+321 sues', $mm->get('contact_phone'));
-        $mm->tryLoad(3);
+        $mm = $mm->tryLoad(3);
         $this->assertFalse($mm->loaded());
 
         $mm = clone $m;
@@ -320,7 +320,7 @@ class ConditionSqlTest extends \Atk4\Schema\PhpunitTestCase
         $m->addField('name');
         $m->addField('date', ['type' => 'date']);
 
-        $m->tryLoadBy('date', new \DateTime('08-12-1982'));
+        $m = $m->tryLoadBy('date', new \DateTime('08-12-1982'));
         $this->assertSame('Sue', $m->get('name'));
     }
 
@@ -338,7 +338,7 @@ class ConditionSqlTest extends \Atk4\Schema\PhpunitTestCase
         $m->addField('date', ['type' => 'date']);
 
         $m->addCondition('date', new \DateTime('08-12-1982'));
-        $m->loadOne();
+        $m = $m->loadOne();
         $this->assertSame('Sue', $m->get('name'));
     }
 
@@ -356,7 +356,7 @@ class ConditionSqlTest extends \Atk4\Schema\PhpunitTestCase
         $m->addField('date', ['type' => 'date']);
 
         $this->expectException(\Atk4\Dsql\Exception::class);
-        $m->tryLoadBy('name', new \DateTime('08-12-1982'));
+        $m = $m->tryLoadBy('name', new \DateTime('08-12-1982'));
     }
 
     public function testOrConditions()
@@ -401,12 +401,12 @@ class ConditionSqlTest extends \Atk4\Schema\PhpunitTestCase
 
         $u = (new Model($this->db, ['table' => 'user']))->addFields(['name']);
 
-        $u->loadBy('name', 'John');
+        $u = $u->loadBy('name', 'John');
         $this->assertTrue($u->scope()->isEmpty());
         $this->assertFalse($u->getField('name')->system); // should not set field as system
         $this->assertNull($u->getField('name')->default); // should not set field default value
 
-        $u->tryLoadBy('name', 'John');
+        $u = $u->tryLoadBy('name', 'John');
         $this->assertTrue($u->scope()->isEmpty());
         $this->assertFalse($u->getField('name')->system); // should not set field as system
         $this->assertNull($u->getField('name')->default); // should not set field default value

--- a/tests/ConditionSqlTest.php
+++ b/tests/ConditionSqlTest.php
@@ -22,11 +22,10 @@ class ConditionSqlTest extends \Atk4\Schema\PhpunitTestCase
         $m = new Model($this->db, ['table' => 'user']);
         $m->addFields(['name', 'gender']);
 
-        $mm = clone $m;
-        $mmm = $mm->tryLoad(1);
-        $this->assertSame('John', $mmm->get('name'));
-        $mmm = $mm->tryLoad(2);
-        $this->assertSame('Sue', $mmm->get('name'));
+        $mm = $m->tryLoad(1);
+        $this->assertSame('John', $mm->get('name'));
+        $mm = $m->tryLoad(2);
+        $this->assertSame('Sue', $mm->get('name'));
 
         $mm = clone $m;
         $mm->addCondition('gender', 'M');
@@ -62,12 +61,11 @@ class ConditionSqlTest extends \Atk4\Schema\PhpunitTestCase
         $m = new Model($this->db, ['table' => 'user']);
         $m->addFields(['name', 'gender']);
 
-        $mm = clone $m;
-        $mm = $mm->tryLoad(1);
-        $this->assertSame('John', $mm->get('name'));
+        $m = $m->tryLoad(1);
+        $this->assertSame('John', $m->get('name'));
         $this->expectException(\Atk4\Data\Exception::class);
         $this->expectExceptionMessageMatches('~entity.+different~');
-        $mm = $mm->tryLoad(2);
+        $m = $m->tryLoad(2);
     }
 
     public function testNull()
@@ -109,11 +107,10 @@ class ConditionSqlTest extends \Atk4\Schema\PhpunitTestCase
         $m = new Model($this->db, ['table' => 'user']);
         $m->addFields(['name', 'gender']);
 
-        $mm = clone $m;
-        $mmm = $mm->tryLoad(1);
-        $this->assertSame('John', $mmm->get('name'));
-        $mmm = $mm->tryLoad(2);
-        $this->assertSame('Sue', $mmm->get('name'));
+        $mm = $m->tryLoad(1);
+        $this->assertSame('John', $mm->get('name'));
+        $mm = $m->tryLoad(2);
+        $this->assertSame('Sue', $mm->get('name'));
 
         $mm = clone $m;
         $mm->addCondition('gender', 'M');
@@ -156,11 +153,10 @@ class ConditionSqlTest extends \Atk4\Schema\PhpunitTestCase
         $m = new Model($this->db, ['table' => 'user']);
         $m->addFields(['name', 'gender']);
 
-        $mm = clone $m;
-        $mmm = $mm->tryLoad(1);
-        $this->assertSame('John', $mmm->get('name'));
-        $mmm = $mm->tryLoad(2);
-        $this->assertSame('Sue', $mmm->get('name'));
+        $mm = $m->tryLoad(1);
+        $this->assertSame('John', $mm->get('name'));
+        $mm = $m->tryLoad(2);
+        $this->assertSame('Sue', $mm->get('name'));
 
         $mm = clone $m;
         $mm->addCondition($mm->expr('[] > 1', [$mm->getField('id')]));
@@ -189,11 +185,10 @@ class ConditionSqlTest extends \Atk4\Schema\PhpunitTestCase
         $m = new Model($this->db, ['table' => 'user']);
         $m->addFields(['name', 'gender', 'surname']);
 
-        $mm = clone $m;
-        $mmm = $mm->tryLoad(1);
-        $this->assertSame('John', $mmm->get('name'));
-        $mmm = $mm->tryLoad(2);
-        $this->assertSame('Sue', $mmm->get('name'));
+        $mm = $m->tryLoad(1);
+        $this->assertSame('John', $mm->get('name'));
+        $mm = $m->tryLoad(2);
+        $this->assertSame('Sue', $mm->get('name'));
 
         $mm = clone $m;
         $mm->addCondition($mm->expr('[name] = [surname]'));
@@ -242,16 +237,15 @@ class ConditionSqlTest extends \Atk4\Schema\PhpunitTestCase
 
         $m->join('contact')->addField('contact_phone');
 
-        $mm = clone $m;
-        $mmm = $mm->tryLoad(1);
-        $this->assertSame('John', $mmm->get('name'));
-        $this->assertSame('+123 smiths', $mmm->get('contact_phone'));
-        $mmm = $mm->tryLoad(2);
-        $this->assertSame('Sue', $mmm->get('name'));
-        $this->assertSame('+321 sues', $mmm->get('contact_phone'));
-        $mmm = $mm->tryLoad(3);
-        $this->assertSame('Peter', $mmm->get('name'));
-        $this->assertSame('+123 smiths', $mmm->get('contact_phone'));
+        $mm = $m->tryLoad(1);
+        $this->assertSame('John', $mm->get('name'));
+        $this->assertSame('+123 smiths', $mm->get('contact_phone'));
+        $mm = $m->tryLoad(2);
+        $this->assertSame('Sue', $mm->get('name'));
+        $this->assertSame('+321 sues', $mm->get('contact_phone'));
+        $mm = $m->tryLoad(3);
+        $this->assertSame('Peter', $mm->get('name'));
+        $this->assertSame('+123 smiths', $mm->get('contact_phone'));
 
         $mm = clone $m;
         $mm->addCondition($mm->expr('[name] = [surname]'));

--- a/tests/ConditionSqlTest.php
+++ b/tests/ConditionSqlTest.php
@@ -395,12 +395,14 @@ class ConditionSqlTest extends \Atk4\Schema\PhpunitTestCase
 
         $u = (new Model($this->db, ['table' => 'user']))->addFields(['name']);
 
-        $u = $u->loadBy('name', 'John');
+        $u2 = $u->loadBy('name', 'John');
+        $this->assertSame(['id' => 1, 'name' => 'John'], $u2->get());
         $this->assertTrue($u->scope()->isEmpty());
         $this->assertFalse($u->getField('name')->system); // should not set field as system
         $this->assertNull($u->getField('name')->default); // should not set field default value
 
-        $u = $u->tryLoadBy('name', 'John');
+        $u2 = $u->tryLoadBy('name', 'Joe');
+        $this->assertSame(['id' => 3, 'name' => 'Joe'], $u2->get());
         $this->assertTrue($u->scope()->isEmpty());
         $this->assertFalse($u->getField('name')->system); // should not set field as system
         $this->assertNull($u->getField('name')->default); // should not set field default value

--- a/tests/ConditionSqlTest.php
+++ b/tests/ConditionSqlTest.php
@@ -53,7 +53,9 @@ class ConditionSqlTest extends \Atk4\Schema\PhpunitTestCase
     {
         $m = new Model($this->db, ['table' => 'user']);
         $scope = $m->scope();
-        $this->assertSame($scope, $m->createEntity()->scope());
+        $this->assertSame($scope, $m->createEntity()->getModel()->scope());
+//        $this->expectException(\Atk4\Data\Exception::class);
+//        $m->createEntity()->scope();
     }
 
     public function testEntityReloadWithDifferentIdException()

--- a/tests/ConditionSqlTest.php
+++ b/tests/ConditionSqlTest.php
@@ -54,8 +54,8 @@ class ConditionSqlTest extends \Atk4\Schema\PhpunitTestCase
         $m = new Model($this->db, ['table' => 'user']);
         $scope = $m->scope();
         $this->assertSame($scope, $m->createEntity()->getModel()->scope());
-//        $this->expectException(\Atk4\Data\Exception::class);
-//        $m->createEntity()->scope();
+        $this->expectException(\Atk4\Data\Exception::class);
+        $m->createEntity()->scope();
     }
 
     public function testEntityReloadWithDifferentIdException()

--- a/tests/ConditionSqlTest.php
+++ b/tests/ConditionSqlTest.php
@@ -63,7 +63,9 @@ class ConditionSqlTest extends \Atk4\Schema\PhpunitTestCase
 
         $m = $m->tryLoad(1);
         $this->assertSame('John', $m->get('name'));
-        $m->setId(2);
+        \Closure::bind(function () use ($m) {
+            $m->_entityId = 2;
+        }, null, Model::class)();
         $this->expectException(\Atk4\Data\Exception::class);
         $this->expectExceptionMessageMatches('~entity.+different~');
         $m->reload();

--- a/tests/ConditionSqlTest.php
+++ b/tests/ConditionSqlTest.php
@@ -49,6 +49,13 @@ class ConditionSqlTest extends \Atk4\Schema\PhpunitTestCase
         $this->assertSame('Sue', $mm2->get('name'));
     }
 
+    public function testEntityNoScopeCloning()
+    {
+        $m = new Model($this->db, ['table' => 'user']);
+        $scope = $m->scope();
+        $this->assertSame($scope, $m->createEntity()->scope());
+    }
+
     public function testEntityReloadWithDifferentIdException()
     {
         $this->setDb([

--- a/tests/ConditionSqlTest.php
+++ b/tests/ConditionSqlTest.php
@@ -23,9 +23,9 @@ class ConditionSqlTest extends \Atk4\Schema\PhpunitTestCase
         $m->addFields(['name', 'gender']);
 
         $mm = clone $m;
-        $mmm = (clone $mm)->tryLoad(1);
+        $mmm = $mm->tryLoad(1);
         $this->assertSame('John', $mmm->get('name'));
-        $mmm = (clone $mm)->tryLoad(2);
+        $mmm = $mm->tryLoad(2);
         $this->assertSame('Sue', $mmm->get('name'));
 
         $mm = clone $m;
@@ -110,9 +110,9 @@ class ConditionSqlTest extends \Atk4\Schema\PhpunitTestCase
         $m->addFields(['name', 'gender']);
 
         $mm = clone $m;
-        $mmm = (clone $mm)->tryLoad(1);
+        $mmm = $mm->tryLoad(1);
         $this->assertSame('John', $mmm->get('name'));
-        $mmm = (clone $mm)->tryLoad(2);
+        $mmm = $mm->tryLoad(2);
         $this->assertSame('Sue', $mmm->get('name'));
 
         $mm = clone $m;
@@ -157,9 +157,9 @@ class ConditionSqlTest extends \Atk4\Schema\PhpunitTestCase
         $m->addFields(['name', 'gender']);
 
         $mm = clone $m;
-        $mmm = (clone $mm)->tryLoad(1);
+        $mmm = $mm->tryLoad(1);
         $this->assertSame('John', $mmm->get('name'));
-        $mmm = (clone $mm)->tryLoad(2);
+        $mmm = $mm->tryLoad(2);
         $this->assertSame('Sue', $mmm->get('name'));
 
         $mm = clone $m;
@@ -190,9 +190,9 @@ class ConditionSqlTest extends \Atk4\Schema\PhpunitTestCase
         $m->addFields(['name', 'gender', 'surname']);
 
         $mm = clone $m;
-        $mmm = (clone $mm)->tryLoad(1);
+        $mmm = $mm->tryLoad(1);
         $this->assertSame('John', $mmm->get('name'));
-        $mmm = (clone $mm)->tryLoad(2);
+        $mmm = $mm->tryLoad(2);
         $this->assertSame('Sue', $mmm->get('name'));
 
         $mm = clone $m;
@@ -243,13 +243,13 @@ class ConditionSqlTest extends \Atk4\Schema\PhpunitTestCase
         $m->join('contact')->addField('contact_phone');
 
         $mm = clone $m;
-        $mmm = (clone $mm)->tryLoad(1);
+        $mmm = $mm->tryLoad(1);
         $this->assertSame('John', $mmm->get('name'));
         $this->assertSame('+123 smiths', $mmm->get('contact_phone'));
-        $mmm = (clone $mm)->tryLoad(2);
+        $mmm = $mm->tryLoad(2);
         $this->assertSame('Sue', $mmm->get('name'));
         $this->assertSame('+321 sues', $mmm->get('contact_phone'));
-        $mmm = (clone $mm)->tryLoad(3);
+        $mmm = $mm->tryLoad(3);
         $this->assertSame('Peter', $mmm->get('name'));
         $this->assertSame('+123 smiths', $mmm->get('contact_phone'));
 
@@ -265,13 +265,13 @@ class ConditionSqlTest extends \Atk4\Schema\PhpunitTestCase
 
         $mm = clone $m;
         $mm->addCondition($mm->expr('\'+123 smiths\' = [contact_phone]'));
-        $mmm = (clone $mm)->tryLoad(1);
+        $mmm = $mm->tryLoad(1);
         $this->assertSame('John', $mmm->get('name'));
         $this->assertSame('+123 smiths', $mmm->get('contact_phone'));
-        $mmm = (clone $mm)->tryLoad(2);
+        $mmm = $mm->tryLoad(2);
         $this->assertNull($mmm->get('name'));
         $this->assertNull($mmm->get('contact_phone'));
-        $mmm = (clone $mm)->tryLoad(3);
+        $mmm = $mm->tryLoad(3);
         $this->assertSame('Peter', $mmm->get('name'));
         $this->assertSame('+123 smiths', $mmm->get('contact_phone'));
     }

--- a/tests/ContainsManyTest.php
+++ b/tests/ContainsManyTest.php
@@ -217,17 +217,17 @@ class ContainsManyTest extends \Atk4\Schema\PhpunitTestCase
         }
 
         // add some discounts
-        (clone $l)->load(1)->discounts->insert([
+        $l->load(1)->discounts->insert([
             $l->discounts->fieldName()->id => 1,
             $l->discounts->fieldName()->percent => 5,
             $l->discounts->fieldName()->valid_till => new \DateTime('2019-07-15'),
         ]);
-        (clone $l)->load(1)->discounts->insert([
+        $l->load(1)->discounts->insert([
             $l->discounts->fieldName()->id => 2,
             $l->discounts->fieldName()->percent => 10,
             $l->discounts->fieldName()->valid_till => new \DateTime('2019-07-30'),
         ]);
-        (clone $l)->load(2)->discounts->insert([
+        $l->load(2)->discounts->insert([
             $l->discounts->fieldName()->id => 1,
             $l->discounts->fieldName()->percent => 20,
             $l->discounts->fieldName()->valid_till => new \DateTime('2019-12-31'),

--- a/tests/ContainsManyTest.php
+++ b/tests/ContainsManyTest.php
@@ -80,7 +80,7 @@ class ContainsManyTest extends \Atk4\Schema\PhpunitTestCase
     public function testContainsMany()
     {
         $i = new Invoice($this->db);
-        $i->loadBy($i->fieldName()->ref_no, 'A1');
+        $i = $i->loadBy($i->fieldName()->ref_no, 'A1');
 
         // now let's add some lines
         $l = $i->lines;
@@ -191,7 +191,7 @@ class ContainsManyTest extends \Atk4\Schema\PhpunitTestCase
     public function testNestedContainsMany()
     {
         $i = new Invoice($this->db);
-        $i->loadBy($i->fieldName()->ref_no, 'A1');
+        $i = $i->loadBy($i->fieldName()->ref_no, 'A1');
 
         // now let's add some lines
         $l = $i->lines;

--- a/tests/ContainsManyTest.php
+++ b/tests/ContainsManyTest.php
@@ -257,7 +257,7 @@ class ContainsManyTest extends \Atk4\Schema\PhpunitTestCase
         $this->assertSame(24.2 * 15 / 100 + 86.25 * 20 / 100, $i->discounts_total_sum); // =20.88
 
         // let's test how it all looks in persistence without typecasting
-        $exp_lines = $i->duplicate()->setOrder($i->fieldName()->id)->export(null, null, false)[0][$i->fieldName()->lines];
+        $exp_lines = $i->getModel()->setOrder($i->fieldName()->id)->export(null, null, false)[0][$i->fieldName()->lines];
         $formatDtForCompareFunc = function (\DateTimeInterface $dt): string {
             $dt = (clone $dt)->setTimeZone(new \DateTimeZone('UTC')); // @phpstan-ignore-line
 

--- a/tests/ContainsOneTest.php
+++ b/tests/ContainsOneTest.php
@@ -127,7 +127,7 @@ class ContainsOneTest extends \Atk4\Schema\PhpunitTestCase
         $this->assertSame('United Kingdom', $c->name);
 
         // let's test how it all looks in persistence without typecasting
-        $exp_addr = $i->duplicate()->setOrder('id')->export(null, null, false)[0][$i->fieldName()->addr];
+        $exp_addr = $i->getModel()->setOrder('id')->export(null, null, false)[0][$i->fieldName()->addr];
         $formatDtForCompareFunc = function (\DateTimeInterface $dt): string {
             $dt = (clone $dt)->setTimeZone(new \DateTimeZone('UTC')); // @phpstan-ignore-line
 

--- a/tests/ContainsOneTest.php
+++ b/tests/ContainsOneTest.php
@@ -78,7 +78,7 @@ class ContainsOneTest extends \Atk4\Schema\PhpunitTestCase
     public function testContainsOne()
     {
         $i = new Invoice($this->db);
-        $i->loadBy($i->fieldName()->ref_no, 'A1');
+        $i = $i->loadBy($i->fieldName()->ref_no, 'A1');
 
         // check do we have address set
         $a = $i->addr;
@@ -168,7 +168,7 @@ class ContainsOneTest extends \Atk4\Schema\PhpunitTestCase
     public function testContainsOneWhenChangeModelFields()
     {
         $i = new Invoice($this->db);
-        $i->loadBy($i->fieldName()->ref_no, 'A1');
+        $i = $i->loadBy($i->fieldName()->ref_no, 'A1');
 
         // with address
         $a = $i->addr;

--- a/tests/DeepCopyTest.php
+++ b/tests/DeepCopyTest.php
@@ -162,7 +162,7 @@ class DeepCopyTest extends \Atk4\Schema\PhpunitTestCase
             ['name' => 'tools', 'qty' => 5, 'price' => 10],
             ['name' => 'work', 'qty' => 1, 'price' => 40],
         ]]);
-        $quote->loadOne();
+        $quote = $quote->loadOne();
 
         // total price should match
         $this->assertEquals(90.00, $quote->get('total'));
@@ -275,7 +275,7 @@ class DeepCopyTest extends \Atk4\Schema\PhpunitTestCase
             ['name' => 'tools', 'qty' => 5, 'price' => 10],
             ['name' => 'work', 'qty' => 1, 'price' => 40],
         ]]);
-        $quote->loadOne();
+        $quote = $quote->loadOne();
 
         $invoice = new DcInvoice();
         $invoice->onHook(DeepCopy::HOOK_AFTER_COPY, static function ($m) {
@@ -316,7 +316,7 @@ class DeepCopyTest extends \Atk4\Schema\PhpunitTestCase
             ['name' => 'tools', 'qty' => 5, 'price' => 10],
             ['name' => 'work', 'qty' => 1, 'price' => 40],
         ]]);
-        $quote->loadOne();
+        $quote = $quote->loadOne();
 
         $invoice = new DcInvoice();
         $invoice->onHook(DeepCopy::HOOK_AFTER_COPY, static function ($m) {

--- a/tests/DefaultTest.php
+++ b/tests/DefaultTest.php
@@ -13,6 +13,7 @@ class DefaultTest extends \Atk4\Schema\PhpunitTestCase
         $m = new Model();
         $m->addField('nodefault');
         $m->addField('withdefault', ['default' => 'abc']);
+        $m = $m->createEntity();
 
         $this->assertNull($m->get('nodefault'));
         $this->assertSame('abc', $m->get('withdefault'));

--- a/tests/ExpressionSqlTest.php
+++ b/tests/ExpressionSqlTest.php
@@ -41,11 +41,11 @@ class ExpressionSqlTest extends \Atk4\Schema\PhpunitTestCase
             );
         }
 
-        $ii = (clone $i)->tryLoad(1);
+        $ii = $i->tryLoad(1);
         $this->assertEquals(10, $ii->get('total_net'));
         $this->assertEquals($ii->get('total_net') + $ii->get('total_vat'), $ii->get('total_gross'));
 
-        $ii = (clone $i)->tryLoad(2);
+        $ii = $i->tryLoad(2);
         $this->assertEquals(20, $ii->get('total_net'));
         $this->assertEquals($ii->get('total_net') + $ii->get('total_vat'), $ii->get('total_gross'));
 
@@ -84,11 +84,11 @@ class ExpressionSqlTest extends \Atk4\Schema\PhpunitTestCase
             );
         }
 
-        $ii = (clone $i)->tryLoad(1);
+        $ii = $i->tryLoad(1);
         $this->assertEquals(10, $ii->get('total_net'));
         $this->assertEquals($ii->get('total_net') + $ii->get('total_vat'), $ii->get('total_gross'));
 
-        $ii = (clone $i)->tryLoad(2);
+        $ii = $i->tryLoad(2);
         $this->assertEquals(20, $ii->get('total_net'));
         $this->assertEquals($ii->get('total_net') + $ii->get('total_vat'), $ii->get('total_gross'));
     }
@@ -113,7 +113,7 @@ class ExpressionSqlTest extends \Atk4\Schema\PhpunitTestCase
             );
         }
 
-        $ii = (clone $i)->tryLoad(1);
+        $ii = $i->tryLoad(1);
         $this->assertEquals(10, $ii->get('total_net'));
         $this->assertEquals(30, $ii->get('sum_net'));
 
@@ -186,7 +186,7 @@ class ExpressionSqlTest extends \Atk4\Schema\PhpunitTestCase
 
         $m->addExpression('sum', '[a] + [b]');
 
-        $mm = (clone $m)->load(1);
+        $mm = $m->load(1);
         $this->assertEquals(4, $mm->get('sum'));
 
         $mm->save(['a' => 3]);
@@ -200,7 +200,7 @@ class ExpressionSqlTest extends \Atk4\Schema\PhpunitTestCase
 
         $m->addExpression('sum', '[a] + [b]');
 
-        $mm = (clone $m)->load(1);
+        $mm = $m->load(1);
         $this->assertEquals(4, $mm->get('sum'));
 
         $mm->save(['a' => 3]);

--- a/tests/ExpressionSqlTest.php
+++ b/tests/ExpressionSqlTest.php
@@ -192,7 +192,7 @@ class ExpressionSqlTest extends \Atk4\Schema\PhpunitTestCase
         $mm->save(['a' => 3]);
         $this->assertEquals(5, $mm->get('sum'));
 
-        $this->assertEquals(9, $m->unload()->save(['a' => 4, 'b' => 5])->get('sum'));
+        $this->assertEquals(9, $m->createEntity()->save(['a' => 4, 'b' => 5])->get('sum'));
 
         $this->setDb($dbData);
         $m = new Model($db, ['table' => 'math', 'reload_after_save' => false]);
@@ -206,7 +206,7 @@ class ExpressionSqlTest extends \Atk4\Schema\PhpunitTestCase
         $mm->save(['a' => 3]);
         $this->assertEquals(4, $mm->get('sum'));
 
-        $this->assertNull($m->unload()->save(['a' => 4, 'b' => 5])->get('sum'));
+        $this->assertNull($m->createEntity()->save(['a' => 4, 'b' => 5])->get('sum'));
     }
 
     public function testExpressionActionAlias()

--- a/tests/ExpressionSqlTest.php
+++ b/tests/ExpressionSqlTest.php
@@ -166,10 +166,10 @@ class ExpressionSqlTest extends \Atk4\Schema\PhpunitTestCase
             );
         }
 
-        $m = $m->tryLoad(1);
-        $this->assertNull($m->get('name'));
-        $m = $m->tryLoad(2);
-        $this->assertSame('Sue', $m->get('name'));
+        $mm = $m->tryLoad(1);
+        $this->assertNull($mm->get('name'));
+        $mm = $m->tryLoad(2);
+        $this->assertSame('Sue', $mm->get('name'));
     }
 
     public function testReloading()

--- a/tests/ExpressionSqlTest.php
+++ b/tests/ExpressionSqlTest.php
@@ -17,7 +17,7 @@ class ExpressionSqlTest extends \Atk4\Schema\PhpunitTestCase
         $db = new Persistence\Sql($this->db->connection);
         $m = new Model($db, ['table' => false]);
         $m->addExpression('x', '2+3');
-        $m->loadOne();
+        $m = $m->loadOne();
         $this->assertEquals(5, $m->get('x'));
     }
 
@@ -58,7 +58,7 @@ class ExpressionSqlTest extends \Atk4\Schema\PhpunitTestCase
             );
         }
 
-        $i->tryLoad(1);
+        $i = $i->tryLoad(1);
         $this->assertEquals(($i->get('total_net') + $i->get('total_vat')) * 2, $i->get('double_total_gross'));
     }
 
@@ -166,9 +166,9 @@ class ExpressionSqlTest extends \Atk4\Schema\PhpunitTestCase
             );
         }
 
-        $m->tryLoad(1);
+        $m = $m->tryLoad(1);
         $this->assertNull($m->get('name'));
-        $m->tryLoad(2);
+        $m = $m->tryLoad(2);
         $this->assertSame('Sue', $m->get('name'));
     }
 
@@ -254,7 +254,7 @@ class ExpressionSqlTest extends \Atk4\Schema\PhpunitTestCase
         $i->addExpression('one_basic', [$i->expr('1'), 'type' => 'integer', 'system' => true]);
         $i->addExpression('one_never_save', [$i->expr('1'), 'type' => 'integer', 'system' => true, 'never_save' => true]);
         $i->addExpression('one_never_persist', [$i->expr('1'), 'type' => 'integer', 'system' => true, 'never_persist' => true]);
-        $i->loadOne();
+        $i = $i->loadOne();
 
         // normal fields
         $this->assertSame(0, $i->get('zero_basic'));

--- a/tests/FieldHereditaryTest.php
+++ b/tests/FieldHereditaryTest.php
@@ -19,7 +19,7 @@ class FieldHereditaryTest extends \Atk4\Schema\PhpunitTestCase
             return strtoupper($m->get('name'));
         });
 
-        $m->load(1);
+        $m = $m->load(1);
         $this->assertSame('world', $m->get('name'));
         $this->assertSame('WORLD', $m->get('caps'));
     }

--- a/tests/FieldTest.php
+++ b/tests/FieldTest.php
@@ -130,7 +130,7 @@ class FieldTest extends \Atk4\Schema\PhpunitTestCase
         $m = new Model($db, ['table' => 'user']);
         $m->addField('name', ['mandatory' => true]);
         $m->addField('surname');
-        $m->load(1);
+        $m = $m->load(1);
         $this->expectException(Exception::class);
         $m->save(['name' => null]);
     }
@@ -296,7 +296,7 @@ class FieldTest extends \Atk4\Schema\PhpunitTestCase
         $m = new Model($db, ['table' => 'item']);
         $m->addField('name', ['never_persist' => true]);
         $m->addField('surname', ['never_save' => true]);
-        $m->load(1);
+        $m = $m->load(1);
 
         $this->assertNull($m->get('name'));
         $this->assertSame('Smith', $m->get('surname'));
@@ -363,7 +363,7 @@ class FieldTest extends \Atk4\Schema\PhpunitTestCase
         $m->hasOne('category_id', ['model' => $c])
             ->addTitle();
 
-        $m->load(1);
+        $m = $m->load(1);
 
         $this->assertSame('John', $m->get('name'));
         $this->assertSame('Programmer', $m->get('category'));
@@ -406,7 +406,7 @@ class FieldTest extends \Atk4\Schema\PhpunitTestCase
         $m->insert(['first_name' => 'Peter', 'surname' => 'qq']);
 
         $mm = clone $m;
-        $mm->loadBy('first_name', 'John');
+        $mm = $mm->loadBy('first_name', 'John');
         $this->assertSame('John', $mm->get('first_name'));
 
         $d = $m->export();

--- a/tests/FieldTest.php
+++ b/tests/FieldTest.php
@@ -536,7 +536,8 @@ class FieldTest extends \Atk4\Schema\PhpunitTestCase
         $this->assertNotNull($dbData['user'][1]['secret']);
         $this->assertNotSame('i am a woman', $dbData['user'][1]['secret']);
 
-        $m->unload()->load(1);
+        $m->set('secret', 'unload');
+        $m->reload();
         $this->assertSame('i am a woman', $m->get('secret'));
     }
 

--- a/tests/FieldTest.php
+++ b/tests/FieldTest.php
@@ -447,9 +447,9 @@ class FieldTest extends \Atk4\Schema\PhpunitTestCase
         });
         $m->insert(['net' => 30, 'vat' => 8]);
 
-        $mm = (clone $m)->load(1);
+        $mm = $m->load(1);
         $this->assertEquals(121, $mm->get('total'));
-        $mm = (clone $m)->load(2);
+        $mm = $m->load(2);
         $this->assertEquals(38, $mm->get('total'));
 
         $d = $m->export(); // in export calculated fields are not included

--- a/tests/FieldTest.php
+++ b/tests/FieldTest.php
@@ -16,6 +16,7 @@ class FieldTest extends \Atk4\Schema\PhpunitTestCase
     {
         $m = new Model();
         $m->addField('foo', ['default' => 'abc']);
+        $m = $m->createEntity();
 
         $this->assertFalse($m->isDirty('foo'));
 
@@ -46,6 +47,7 @@ class FieldTest extends \Atk4\Schema\PhpunitTestCase
     {
         $m = new Model();
         $m->addField('foo', ['default' => 'abc']);
+        $m = $m->createEntity();
 
         $this->assertTrue($m->compare('foo', 'abc'));
         $m->set('foo', 'zzz');
@@ -58,6 +60,7 @@ class FieldTest extends \Atk4\Schema\PhpunitTestCase
     {
         $m = new Model();
         $m->addField('foo', ['mandatory' => true]);
+        $m = $m->createEntity();
         $m->set('foo', 'abc');
         $m->set('foo', '');
 
@@ -72,6 +75,7 @@ class FieldTest extends \Atk4\Schema\PhpunitTestCase
     {
         $m = new Model();
         $m->addField('foo', ['required' => true]);
+        $m = $m->createEntity();
 
         $this->expectException(ValidationException::class);
         $m->set('foo', '');
@@ -81,6 +85,7 @@ class FieldTest extends \Atk4\Schema\PhpunitTestCase
     {
         $m = new Model();
         $m->addField('foo', ['required' => true]);
+        $m = $m->createEntity();
 
         $this->expectException(ValidationException::class);
         $m->set('foo', null);
@@ -185,6 +190,7 @@ class FieldTest extends \Atk4\Schema\PhpunitTestCase
     {
         $m = new Model();
         $m->addField('foo', ['read_only' => true]);
+        $m = $m->createEntity();
         $this->expectException(Exception::class);
         $m->set('foo', 'bar');
     }
@@ -193,6 +199,7 @@ class FieldTest extends \Atk4\Schema\PhpunitTestCase
     {
         $m = new Model();
         $m->addField('foo', ['read_only' => true, 'default' => 'abc']);
+        $m = $m->createEntity();
         $m->set('foo', 'abc');
         $this->assertSame('abc', $m->get('foo'));
     }
@@ -201,6 +208,7 @@ class FieldTest extends \Atk4\Schema\PhpunitTestCase
     {
         $m = new Model();
         $m->addField('foo', ['enum' => ['foo', 'bar']]);
+        $m = $m->createEntity();
         $this->expectException(Exception::class);
         $m->set('foo', 'xx');
     }
@@ -209,6 +217,7 @@ class FieldTest extends \Atk4\Schema\PhpunitTestCase
     {
         $m = new Model();
         $m->addField('foo', ['enum' => [1, 'bar']]);
+        $m = $m->createEntity();
         $m->set('foo', 1);
 
         $this->assertSame(1, $m->get('foo'));
@@ -221,6 +230,7 @@ class FieldTest extends \Atk4\Schema\PhpunitTestCase
     {
         $m = new Model();
         $m->addField('foo', ['enum' => [1, 'bar']]);
+        $m = $m->createEntity();
         $this->expectException(Exception::class);
         $m->set('foo', true);
     }
@@ -232,6 +242,7 @@ class FieldTest extends \Atk4\Schema\PhpunitTestCase
         // to a weird behaviours of PHP
         $m = new Model();
         $m->addField('foo', ['enum' => [1, 'bar'], 'default' => 1]);
+        $m = $m->createEntity();
         $m->set('foo', null);
 
         $this->assertNull($m->get('foo'));
@@ -241,6 +252,7 @@ class FieldTest extends \Atk4\Schema\PhpunitTestCase
     {
         $m = new Model();
         $m->addField('foo', ['values' => ['foo', 'bar']]);
+        $m = $m->createEntity();
         $this->expectException(Exception::class);
         $m->set('foo', 4);
     }
@@ -249,6 +261,7 @@ class FieldTest extends \Atk4\Schema\PhpunitTestCase
     {
         $m = new Model();
         $m->addField('foo', ['values' => [3 => 'bar']]);
+        $m = $m->createEntity();
         $m->set('foo', 3);
 
         $this->assertSame(3, $m->get('foo'));
@@ -261,6 +274,7 @@ class FieldTest extends \Atk4\Schema\PhpunitTestCase
     {
         $m = new Model();
         $m->addField('foo', ['values' => [1 => 'bar']]);
+        $m = $m->createEntity();
         $this->expectException(Exception::class);
         $m->set('foo', true);
     }
@@ -269,6 +283,7 @@ class FieldTest extends \Atk4\Schema\PhpunitTestCase
     {
         $m = new Model();
         $m->addField('foo', ['values' => [1 => 'bar']]);
+        $m = $m->createEntity();
         $this->expectException(Exception::class);
         $m->set('foo', 'bar');
     }
@@ -280,6 +295,7 @@ class FieldTest extends \Atk4\Schema\PhpunitTestCase
         // to a weird behaviours of PHP
         $m = new Model();
         $m->addField('foo', ['values' => ['1a' => 'bar']]);
+        $m = $m->createEntity();
         $m->set('foo', '1a');
         $this->assertSame('1a', $m->get('foo'));
     }
@@ -387,6 +403,7 @@ class FieldTest extends \Atk4\Schema\PhpunitTestCase
     {
         $m = new Model();
         $m->addField('foo');
+        $m = $m->createEntity();
         $this->expectException(Exception::class);
         $m->set('baz', 'bar');
     }
@@ -405,8 +422,7 @@ class FieldTest extends \Atk4\Schema\PhpunitTestCase
         $m->addField('surname');
         $m->insert(['first_name' => 'Peter', 'surname' => 'qq']);
 
-        $mm = clone $m;
-        $mm = $mm->loadBy('first_name', 'John');
+        $mm = $m->loadBy('first_name', 'John');
         $this->assertSame('John', $mm->get('first_name'));
 
         $d = $m->export();
@@ -513,6 +529,7 @@ class FieldTest extends \Atk4\Schema\PhpunitTestCase
             //'password'  => 'bonkers',
             'typecast' => [$encrypt, $decrypt],
         ]);
+        $m = $m->createEntity();
         $m->save(['name' => 'John', 'secret' => 'i am a woman']);
 
         $dbData = $this->getDb();
@@ -541,6 +558,7 @@ class FieldTest extends \Atk4\Schema\PhpunitTestCase
         $m->addField('time', ['type' => 'time']);
         $m->addField('array', ['type' => 'array']);
         $m->addField('object', ['type' => 'object']);
+        $m = $m->createEntity();
 
         // string
         $m->set('string', "Two\r\nLines  ");
@@ -608,6 +626,7 @@ class FieldTest extends \Atk4\Schema\PhpunitTestCase
     {
         $m = new Model(null, ['strict_types' => true]);
         $m->addField('foo', ['type' => 'string']);
+        $m = $m->createEntity();
         $this->expectException(ValidationException::class);
         $m->set('foo', []);
     }
@@ -616,6 +635,7 @@ class FieldTest extends \Atk4\Schema\PhpunitTestCase
     {
         $m = new Model(null, ['strict_types' => true]);
         $m->addField('foo', ['type' => 'text']);
+        $m = $m->createEntity();
         $this->expectException(ValidationException::class);
         $m->set('foo', []);
     }
@@ -624,6 +644,7 @@ class FieldTest extends \Atk4\Schema\PhpunitTestCase
     {
         $m = new Model(null, ['strict_types' => true]);
         $m->addField('foo', ['type' => 'integer']);
+        $m = $m->createEntity();
         $this->expectException(ValidationException::class);
         $m->set('foo', []);
     }
@@ -632,6 +653,7 @@ class FieldTest extends \Atk4\Schema\PhpunitTestCase
     {
         $m = new Model(null, ['strict_types' => true]);
         $m->addField('foo', ['type' => 'money']);
+        $m = $m->createEntity();
         $this->expectException(ValidationException::class);
         $m->set('foo', []);
     }
@@ -640,6 +662,7 @@ class FieldTest extends \Atk4\Schema\PhpunitTestCase
     {
         $m = new Model(null, ['strict_types' => true]);
         $m->addField('foo', ['type' => 'float']);
+        $m = $m->createEntity();
         $this->expectException(ValidationException::class);
         $m->set('foo', []);
     }
@@ -648,6 +671,7 @@ class FieldTest extends \Atk4\Schema\PhpunitTestCase
     {
         $m = new Model(null, ['strict_types' => true]);
         $m->addField('foo', ['type' => 'date']);
+        $m = $m->createEntity();
         $this->expectException(ValidationException::class);
         $m->set('foo', []);
     }
@@ -656,6 +680,7 @@ class FieldTest extends \Atk4\Schema\PhpunitTestCase
     {
         $m = new Model(null, ['strict_types' => true]);
         $m->addField('foo', ['type' => 'datetime']);
+        $m = $m->createEntity();
         $this->expectException(ValidationException::class);
         $m->set('foo', []);
     }
@@ -664,6 +689,7 @@ class FieldTest extends \Atk4\Schema\PhpunitTestCase
     {
         $m = new Model(null, ['strict_types' => true]);
         $m->addField('foo', ['type' => 'time']);
+        $m = $m->createEntity();
         $this->expectException(ValidationException::class);
         $m->set('foo', []);
     }
@@ -672,6 +698,7 @@ class FieldTest extends \Atk4\Schema\PhpunitTestCase
     {
         $m = new Model(null, ['strict_types' => true]);
         $m->addField('foo', ['type' => 'integer']);
+        $m = $m->createEntity();
         $this->expectException(ValidationException::class);
         $m->set('foo', '123---456');
     }
@@ -680,6 +707,7 @@ class FieldTest extends \Atk4\Schema\PhpunitTestCase
     {
         $m = new Model(null, ['strict_types' => true]);
         $m->addField('foo', ['type' => 'money']);
+        $m = $m->createEntity();
         $this->expectException(ValidationException::class);
         $m->set('foo', '123---456');
     }
@@ -688,6 +716,7 @@ class FieldTest extends \Atk4\Schema\PhpunitTestCase
     {
         $m = new Model(null, ['strict_types' => true]);
         $m->addField('foo', ['type' => 'float']);
+        $m = $m->createEntity();
         $this->expectException(ValidationException::class);
         $m->set('foo', '123---456');
     }
@@ -696,6 +725,7 @@ class FieldTest extends \Atk4\Schema\PhpunitTestCase
     {
         $m = new Model(null, ['strict_types' => true]);
         $m->addField('foo', ['type' => 'array']);
+        $m = $m->createEntity();
         $this->expectException(ValidationException::class);
         $m->set('foo', 'ABC');
     }
@@ -704,6 +734,7 @@ class FieldTest extends \Atk4\Schema\PhpunitTestCase
     {
         $m = new Model(null, ['strict_types' => true]);
         $m->addField('foo', ['type' => 'object']);
+        $m = $m->createEntity();
         $this->expectException(ValidationException::class);
         $m->set('foo', 'ABC');
     }
@@ -712,6 +743,7 @@ class FieldTest extends \Atk4\Schema\PhpunitTestCase
     {
         $m = new Model(null, ['strict_types' => true]);
         $m->addField('foo', ['type' => 'boolean']);
+        $m = $m->createEntity();
         $this->expectException(ValidationException::class);
         $m->set('foo', 'ABC');
     }
@@ -734,6 +766,7 @@ class FieldTest extends \Atk4\Schema\PhpunitTestCase
         $m->addField('time', ['type' => 'time']);
         $m->addField('array', ['type' => 'array']);
         $m->addField('object', ['type' => 'object']);
+        $m = $m->createEntity();
 
         $this->assertSame('TwoLines', $m->getField('string')->toString("Two\r\nLines  "));
         $this->assertSame("Two\nLines", $m->getField('text')->toString("Two\r\nLines  "));
@@ -767,6 +800,7 @@ class FieldTest extends \Atk4\Schema\PhpunitTestCase
         $model->addField('visible', ['ui' => ['visible' => true]]);
         $model->addField('visible_system', ['ui' => ['visible' => true], 'system' => true]);
         $model->addField('not_editable', ['ui' => ['editable' => false]]);
+        $model = $model->createEntity();
 
         $this->assertSame(['system', 'editable', 'editable_system', 'visible', 'visible_system', 'not_editable'], array_keys($model->getFields()));
         $this->assertSame(['system', 'editable_system', 'visible_system'], array_keys($model->getFields('system')));
@@ -793,6 +827,7 @@ class FieldTest extends \Atk4\Schema\PhpunitTestCase
         $model->addField('date', ['type' => 'date']);
         $model->addField('time', ['type' => 'time']);
         $model->addField('datetime', ['type' => 'datetime']);
+        $model = $model->createEntity();
 
         $this->assertSame('', $model->getField('date')->toString());
         $this->assertSame('', $model->getField('time')->toString());
@@ -825,6 +860,7 @@ class FieldTest extends \Atk4\Schema\PhpunitTestCase
         $m->addField('a');
         $m->addField('b', ['mandatory' => true]);
         $m->addField('c', ['required' => true]);
+        $m = $m->createEntity();
 
         // valid value for set()
         $m->set('a', 'x');
@@ -859,6 +895,7 @@ class FieldTest extends \Atk4\Schema\PhpunitTestCase
         $m->addField('is_vip_1', ['type' => 'boolean', 'enum' => ['No', 'Yes']]);
         $m->addField('is_vip_2', ['type' => 'boolean', 'valueTrue' => 1, 'valueFalse' => 0]);
         $m->addField('is_vip_3', ['type' => 'boolean', 'valueTrue' => 'Y', 'valueFalse' => 'N']);
+        $m = $m->createEntity();
 
         $m->set('is_vip_1', 'No');
         $this->assertFalse($m->get('is_vip_1'));

--- a/tests/FieldTypesTest.php
+++ b/tests/FieldTypesTest.php
@@ -14,6 +14,7 @@ use Atk4\Data\ValidationException;
  */
 class FieldTypesTest extends \Atk4\Schema\PhpunitTestCase
 {
+    /** @var Persistence_Static */
     public $pers;
 
     protected function setUp(): void
@@ -30,6 +31,7 @@ class FieldTypesTest extends \Atk4\Schema\PhpunitTestCase
     {
         $m = new Model($this->pers);
         $m->addField('email', [Field\Email::class]);
+        $m = $m->createEntity();
 
         // null value
         $m->set('email', null);
@@ -57,6 +59,7 @@ class FieldTypesTest extends \Atk4\Schema\PhpunitTestCase
         $m = new Model($this->pers);
         $m->addField('email', [Field\Email::class]);
         $m->addField('emails', [Field\Email::class, 'allow_multiple' => true]);
+        $m = $m->createEntity();
 
         $m->set('emails', 'bar@exampe.com, foo@example.com');
         $this->assertSame('bar@exampe.com, foo@example.com', $m->get('emails'));
@@ -70,6 +73,7 @@ class FieldTypesTest extends \Atk4\Schema\PhpunitTestCase
     {
         $m = new Model($this->pers);
         $m->addField('email', [Field\Email::class, 'dns_check' => true]);
+        $m = $m->createEntity();
 
         $m->set('email', ' foo@gmail.com');
 
@@ -85,6 +89,7 @@ class FieldTypesTest extends \Atk4\Schema\PhpunitTestCase
         $m->addField('email_names', [Field\Email::class, 'include_names' => true, 'allow_multiple' => true, 'dns_check' => true, 'separator' => [',', ';']]);
         $m->addField('email_idn', [Field\Email::class, 'dns_check' => true]);
         $m->addField('email', [Field\Email::class]);
+        $m = $m->createEntity();
 
         $m->set('email_name', 'Romans <me@gmail.com>');
         $m->set('email_names', 'Romans1 <me1@gmail.com>, Romans2 <me2@gmail.com>; Romans Žlutý Kůň <me3@gmail.com>');

--- a/tests/FolderTest.php
+++ b/tests/FolderTest.php
@@ -46,7 +46,7 @@ class FolderTest extends \Atk4\Schema\PhpunitTestCase
 
         $db = new Persistence\Sql($this->db->connection);
         $f = new Folder($db);
-        $f->load(4);
+        $f = $f->load(4);
 
         $this->assertEquals([
             'id' => 4,

--- a/tests/IteratorTest.php
+++ b/tests/IteratorTest.php
@@ -188,12 +188,12 @@ class IteratorTest extends \Atk4\Schema\PhpunitTestCase
 
         $data = [];
         foreach ($i as $id => $item) {
-            $data[$id] = clone $item;
+            $data[$id] = $item;
         }
 
         $this->assertEquals(10, $data[1]->get('total_net'));
         $this->assertEquals(20, $data[2]->get('total_net'));
         $this->assertEquals(15, $data[3]->get('total_net'));
-        $this->assertNull($i->get('total_net'));
+        $this->assertNull($i->createEntity()->get('total_net'));
     }
 }

--- a/tests/IteratorTest.php
+++ b/tests/IteratorTest.php
@@ -28,7 +28,7 @@ class IteratorTest extends \Atk4\Schema\PhpunitTestCase
     {
         $m = new Model();
         $this->expectException(Exception::class);
-        $m->tryLoad(1);
+        $m = $m->tryLoad(1);
     }
 
     /**
@@ -38,7 +38,7 @@ class IteratorTest extends \Atk4\Schema\PhpunitTestCase
     {
         $m = new Model();
         $this->expectException(Exception::class);
-        $m->tryLoadAny();
+        $m = $m->tryLoadAny();
     }
 
     /**
@@ -48,7 +48,7 @@ class IteratorTest extends \Atk4\Schema\PhpunitTestCase
     {
         $m = new Model();
         $this->expectException(Exception::class);
-        $m->load(1);
+        $m = $m->load(1);
     }
 
     /**
@@ -58,7 +58,7 @@ class IteratorTest extends \Atk4\Schema\PhpunitTestCase
     {
         $m = new Model();
         $this->expectException(Exception::class);
-        $m->loadAny();
+        $m = $m->loadAny();
     }
 
     /**

--- a/tests/JoinArrayTest.php
+++ b/tests/JoinArrayTest.php
@@ -72,7 +72,7 @@ class JoinArrayTest extends AtkPhpunit\TestCase
         $j = $m_u->join('contact');
         $j->addField('contact_phone');
 
-        $m_u2 = clone $m_u;
+        $m_u2 = $m_u->createEntity();
         $m_u2->set('name', 'John');
         $m_u2->set('contact_phone', '+123');
         $m_u2->save();
@@ -83,7 +83,7 @@ class JoinArrayTest extends AtkPhpunit\TestCase
         ], $this->getInternalPersistenceData($db));
 
         $m_u2->unload();
-        $m_u2 = clone $m_u;
+        $m_u2 = $m_u->createEntity();
         $m_u2->set('name', 'Peter');
         $m_u2->set('contact_id', 1);
         $m_u2->save();
@@ -98,7 +98,7 @@ class JoinArrayTest extends AtkPhpunit\TestCase
         ], $this->getInternalPersistenceData($db));
 
         $m_u2->unload();
-        $m_u2 = clone $m_u;
+        $m_u2 = $m_u->createEntity();
         $m_u2->set('name', 'Joe');
         $m_u2->set('contact_phone', '+321');
         $m_u2->save();
@@ -123,7 +123,7 @@ class JoinArrayTest extends AtkPhpunit\TestCase
         $j = $m_u->join('contact.test_id');
         $j->addField('contact_phone');
 
-        $m_u2 = clone $m_u;
+        $m_u2 = $m_u->createEntity();
         $m_u2->set('name', 'John');
         $m_u2->set('contact_phone', '+123');
         $m_u2->save();
@@ -134,7 +134,7 @@ class JoinArrayTest extends AtkPhpunit\TestCase
         ], $this->getInternalPersistenceData($db));
 
         $m_u2->unload();
-        $m_u2 = clone $m_u;
+        $m_u2 = $m_u->createEntity();
         $m_u2->set('name', 'Peter');
         $m_u2->save();
         $this->assertEquals([
@@ -152,7 +152,7 @@ class JoinArrayTest extends AtkPhpunit\TestCase
         $m_c->delete();
 
         $m_u2->unload();
-        $m_u2 = clone $m_u;
+        $m_u2 = $m_u->createEntity();
         $m_u2->set('name', 'Sue');
         $m_u2->set('contact_phone', '+444');
         $m_u2->save();
@@ -175,6 +175,7 @@ class JoinArrayTest extends AtkPhpunit\TestCase
         $m_u->addField('name');
         $j = $m_u->join('contact', ['master_field' => 'test_id']);
         $j->addField('contact_phone');
+        $m_u = $m_u->createEntity();
 
         $m_u->set('name', 'John');
         $m_u->set('contact_phone', '+123');
@@ -195,6 +196,7 @@ class JoinArrayTest extends AtkPhpunit\TestCase
         $m_u->addField('code');
         $j = $m_u->join('contact.code', ['master_field' => 'code']);
         $j->addField('contact_phone');
+        $m_u = $m_u->createEntity();
 
         $m_u->get('name') = 'John';
         $m_u->get('code') = 'C28';

--- a/tests/JoinArrayTest.php
+++ b/tests/JoinArrayTest.php
@@ -226,17 +226,17 @@ class JoinArrayTest extends AtkPhpunit\TestCase
         $j = $m_u->join('contact');
         $j->addField('contact_phone');
 
-        $m_u2 = (clone $m_u)->load(1);
+        $m_u2 = $m_u->load(1);
         $this->assertEquals([
             'name' => 'John', 'contact_id' => 1, 'contact_phone' => '+123', 'id' => 1,
         ], $m_u2->get());
 
-        $m_u2 = (clone $m_u)->load(3);
+        $m_u2 = $m_u->load(3);
         $this->assertEquals([
             'name' => 'Joe', 'contact_id' => 2, 'contact_phone' => '+321', 'id' => 3,
         ], $m_u2->get());
 
-        $m_u2 = (clone $m_u)->tryLoad(4);
+        $m_u2 = $m_u->tryLoad(4);
         $this->assertEquals([
             'name' => null, 'contact_id' => null, 'contact_phone' => null, 'id' => null,
         ], $m_u2->get());
@@ -260,7 +260,7 @@ class JoinArrayTest extends AtkPhpunit\TestCase
         $j = $m_u->join('contact');
         $j->addField('contact_phone');
 
-        $m_u2 = (clone $m_u)->load(1);
+        $m_u2 = $m_u->load(1);
         $m_u2->set('name', 'John 2');
         $m_u2->set('contact_phone', '+555');
         $m_u2->save();
@@ -276,7 +276,7 @@ class JoinArrayTest extends AtkPhpunit\TestCase
             ],
         ], $this->getInternalPersistenceData($db));
 
-        $m_u2 = (clone $m_u)->load(3);
+        $m_u2 = $m_u->load(3);
         $m_u2->set('name', 'XX');
         $m_u2->set('contact_phone', '+999');
         $m_u2->save();
@@ -292,7 +292,7 @@ class JoinArrayTest extends AtkPhpunit\TestCase
             ],
         ], $this->getInternalPersistenceData($db));
 
-        $m_u2 = (clone $m_u)->tryLoad(4);
+        $m_u2 = $m_u->tryLoad(4);
         $m_u2->set('name', 'YYY');
         $m_u2->set('contact_phone', '+777');
         $m_u2->save();

--- a/tests/JoinArrayTest.php
+++ b/tests/JoinArrayTest.php
@@ -148,7 +148,7 @@ class JoinArrayTest extends AtkPhpunit\TestCase
         ], $this->getInternalPersistenceData($db));
 
         $m_c = new Model($db, ['table' => 'contact']);
-        $m_c->load(2);
+        $m_c = $m_c->load(2);
         $m_c->delete();
 
         $m_u2->unload();
@@ -331,7 +331,7 @@ class JoinArrayTest extends AtkPhpunit\TestCase
         $j = $m_u->join('contact');
         $j->addField('contact_phone');
 
-        $m_u->load(1);
+        $m_u = $m_u->load(1);
         $m_u->delete();
 
         $this->assertSame([
@@ -364,7 +364,7 @@ class JoinArrayTest extends AtkPhpunit\TestCase
         $j = $m_u->join('contact');
         $j->addField('contact_phone');
         $this->expectException(Exception::class);
-        $m_u->load(2);
+        $m_u = $m_u->load(2);
     }
 
     /*

--- a/tests/JoinSqlTest.php
+++ b/tests/JoinSqlTest.php
@@ -350,7 +350,7 @@ class JoinSqlTest extends \Atk4\Schema\PhpunitTestCase
         $j = $m_u->join('contact');
         $j->addField('contact_phone');
 
-        $m_u->load(1);
+        $m_u = $m_u->load(1);
         $m_u->delete();
 
         $this->assertEquals(
@@ -498,7 +498,7 @@ class JoinSqlTest extends \Atk4\Schema\PhpunitTestCase
         $m_u2 = (clone $m_u)->load(10);
         $m_u2->delete();
 
-        $m_u->loadBy('country_name', 'US');
+        $m_u = $m_u->loadBy('country_name', 'US');
         $this->assertEquals(30, $m_u->getId());
 
         $this->assertEquals(
@@ -552,7 +552,7 @@ class JoinSqlTest extends \Atk4\Schema\PhpunitTestCase
         $m_u->addField('name');
         $j = $m_u->join('contact');
 
-        $m_u->load(1);
+        $m_u = $m_u->load(1);
         $this->assertEquals([
             'id' => 1, 'name' => 'John', 'contact_id' => 10,
         ], $m_u->get());
@@ -563,7 +563,7 @@ class JoinSqlTest extends \Atk4\Schema\PhpunitTestCase
         $ref = $j->hasOne('phone_id', ['model' => $m_p]); // hasOne on JOIN
         $ref->addField('number');
 
-        $m_u->load(1);
+        $m_u = $m_u->load(1);
         $this->assertEquals([
             'id' => 1, 'name' => 'John', 'contact_id' => 10, 'phone_id' => 20, 'number' => '+123',
         ], $m_u->get());
@@ -574,7 +574,7 @@ class JoinSqlTest extends \Atk4\Schema\PhpunitTestCase
         $m_t->addField('token');
         $ref = $j->hasMany('Token', ['model' => $m_t]); // hasMany on JOIN (use default our_field, their_field)
 
-        $m_u->load(1);
+        $m_u = $m_u->load(1);
         $this->assertEquals([
             ['id' => 30, 'user_id' => 1, 'token' => 'ABC'],
             ['id' => 31, 'user_id' => 1, 'token' => 'DEF'],
@@ -586,7 +586,7 @@ class JoinSqlTest extends \Atk4\Schema\PhpunitTestCase
         $m_e->addField('address');
         $ref = $j->hasMany('Email', ['model' => $m_e, 'our_field' => 'contact_id', 'their_field' => 'contact_id']); // hasMany on JOIN (use custom our_field, their_field)
 
-        $m_u->load(1);
+        $m_u = $m_u->load(1);
         $this->assertEquals([
             ['id' => 40, 'contact_id' => 10, 'address' => 'john@foo.net'],
             ['id' => 41, 'contact_id' => 10, 'address' => 'johnny@foo.net'],

--- a/tests/JoinSqlTest.php
+++ b/tests/JoinSqlTest.php
@@ -553,45 +553,45 @@ class JoinSqlTest extends \Atk4\Schema\PhpunitTestCase
         $m_u->addField('name');
         $j = $m_u->join('contact');
 
-        $m_u = $m_u->load(1);
+        $m_u2 = $m_u->load(1);
         $this->assertEquals([
             'id' => 1, 'name' => 'John', 'contact_id' => 10,
-        ], $m_u->get());
+        ], $m_u2->get());
 
         // hasOne phone model
         $m_p = new Model($db, ['table' => 'phone']);
         $m_p->addField('number');
-        $ref = $j->hasOne('phone_id', ['model' => $m_p]); // hasOne on JOIN
-        $ref->addField('number');
+        $ref_one = $j->hasOne('phone_id', ['model' => $m_p]); // hasOne on JOIN
+        $ref_one->addField('number');
 
-        $m_u = $m_u->load(1);
+        $m_u2 = $m_u->load(1);
         $this->assertEquals([
             'id' => 1, 'name' => 'John', 'contact_id' => 10, 'phone_id' => 20, 'number' => '+123',
-        ], $m_u->get());
+        ], $m_u2->get());
 
         // hasMany token model (uses default our_field, their_field)
         $m_t = new Model($db, ['table' => 'token']);
         $m_t->addField('user_id');
         $m_t->addField('token');
-        $ref = $j->hasMany('Token', ['model' => $m_t]); // hasMany on JOIN (use default our_field, their_field)
+        $ref_many = $j->hasMany('Token', ['model' => $m_t]); // hasMany on JOIN (use default our_field, their_field)
 
-        $m_u = $m_u->load(1);
+        $m_u2 = $m_u->load(1);
         $this->assertEquals([
             ['id' => 30, 'user_id' => 1, 'token' => 'ABC'],
             ['id' => 31, 'user_id' => 1, 'token' => 'DEF'],
-        ], $m_u->ref('Token')->export());
+        ], $m_u2->ref('Token')->export());
 
         // hasMany email model (uses custom our_field, their_field)
         $m_e = new Model($db, ['table' => 'email']);
         $m_e->addField('contact_id');
         $m_e->addField('address');
-        $ref = $j->hasMany('Email', ['model' => $m_e, 'our_field' => 'contact_id', 'their_field' => 'contact_id']); // hasMany on JOIN (use custom our_field, their_field)
+        $ref_many = $j->hasMany('Email', ['model' => $m_e, 'our_field' => 'contact_id', 'their_field' => 'contact_id']); // hasMany on JOIN (use custom our_field, their_field)
 
-        $m_u = $m_u->load(1);
+        $m_u2 = $m_u->load(1);
         $this->assertEquals([
             ['id' => 40, 'contact_id' => 10, 'address' => 'john@foo.net'],
             ['id' => 41, 'contact_id' => 10, 'address' => 'johnny@foo.net'],
-        ], $m_u->ref('Email')->export());
+        ], $m_u2->ref('Email')->export());
     }
 
     public function testJoinReverseOneOnOne()

--- a/tests/JoinSqlTest.php
+++ b/tests/JoinSqlTest.php
@@ -209,17 +209,17 @@ class JoinSqlTest extends \Atk4\Schema\PhpunitTestCase
         $j = $m_u->join('contact');
         $j->addField('contact_phone');
 
-        $m_u2 = (clone $m_u)->load(1);
+        $m_u2 = $m_u->load(1);
         $this->assertEquals([
             'name' => 'John', 'contact_id' => 1, 'contact_phone' => '+123', 'id' => 1,
         ], $m_u2->get());
 
-        $m_u2 = (clone $m_u)->load(3);
+        $m_u2 = $m_u->load(3);
         $this->assertEquals([
             'name' => 'Joe', 'contact_id' => 2, 'contact_phone' => '+321', 'id' => 3,
         ], $m_u2->get());
 
-        $m_u2 = (clone $m_u)->tryLoad(4);
+        $m_u2 = $m_u->tryLoad(4);
         $this->assertEquals([
             'name' => null, 'contact_id' => null, 'contact_phone' => null, 'id' => null,
         ], $m_u2->get());
@@ -249,7 +249,7 @@ class JoinSqlTest extends \Atk4\Schema\PhpunitTestCase
         $j = $m_u->join('contact');
         $j->addField('contact_phone');
 
-        $m_u2 = (clone $m_u)->load(1);
+        $m_u2 = $m_u->load(1);
         $m_u2->set('name', 'John 2');
         $m_u2->set('contact_phone', '+555');
         $m_u2->save();
@@ -268,10 +268,10 @@ class JoinSqlTest extends \Atk4\Schema\PhpunitTestCase
             $this->getDb()
         );
 
-        $m_u2 = (clone $m_u)->load(1);
+        $m_u2 = $m_u->load(1);
         $m_u2->set('name', 'XX');
         $m_u2->set('contact_phone', '+999');
-        $m_u2 = (clone $m_u)->load(3);
+        $m_u2 = $m_u->load(3);
         $m_u2->set('name', 'XX');
         $m_u2->save();
 
@@ -306,7 +306,7 @@ class JoinSqlTest extends \Atk4\Schema\PhpunitTestCase
             $this->getDb()
         );
 
-        $m_u2 = (clone $m_u)->tryLoad(4);
+        $m_u2 = $m_u->tryLoad(4);
         $m_u2->set('name', 'YYY');
         $m_u2->set('contact_phone', '+777');
         $m_u2->save();
@@ -431,15 +431,15 @@ class JoinSqlTest extends \Atk4\Schema\PhpunitTestCase
         $j_country = $j_contact->join('country');
         $j_country->addField('country_name', ['actual' => 'name']);
 
-        $m_u2 = (clone $m_u)->load(10);
+        $m_u2 = $m_u->load(10);
         $m_u2->delete();
 
-        $m_u2 = (clone $m_u)->loadBy('country_name', 'US');
+        $m_u2 = $m_u->loadBy('country_name', 'US');
         $this->assertEquals(30, $m_u2->getId());
         $m_u2->set('country_name', 'USA');
         $m_u2->save();
 
-        $m_u2 = (clone $m_u)->tryLoad(40);
+        $m_u2 = $m_u->tryLoad(40);
         $this->assertFalse($m_u2->loaded());
 
         $this->assertSame($m_u2->getField('country_id')->getJoin(), $m_u2->getField('contact_phone')->getJoin());
@@ -495,7 +495,7 @@ class JoinSqlTest extends \Atk4\Schema\PhpunitTestCase
         $c = $j->join('country');
         $c->addFields([['country_name', ['actual' => 'name']]]);
 
-        $m_u2 = (clone $m_u)->load(10);
+        $m_u2 = $m_u->load(10);
         $m_u2->delete();
 
         $m_u = $m_u->loadBy('country_name', 'US');
@@ -617,19 +617,19 @@ class JoinSqlTest extends \Atk4\Schema\PhpunitTestCase
         $j->addField('notes');
 
         // try load one record
-        $m = (clone $m_user)->tryLoad(20);
+        $m = $m_user->tryLoad(20);
         $this->assertTrue($m->loaded());
         $this->assertEquals(['id' => 20, 'name' => 'Peter', 'notes' => 'second note'], $m->get());
 
         // try to update loaded record
         $m->save(['name' => 'Mark', 'notes' => '2nd note']);
-        $m = (clone $m_user)->tryLoad(20);
+        $m = $m_user->tryLoad(20);
         $this->assertTrue($m->loaded());
         $this->assertEquals(['id' => 20, 'name' => 'Mark', 'notes' => '2nd note'], $m->get());
 
         // insert new record
         $m = (clone $m_user)->save(['name' => 'Emily', 'notes' => '3rd note']);
-        $m = (clone $m_user)->tryLoad(21);
+        $m = $m_user->tryLoad(21);
         $this->assertTrue($m->loaded());
         $this->assertEquals(['id' => 21, 'name' => 'Emily', 'notes' => '3rd note'], $m->get());
 
@@ -644,7 +644,7 @@ class JoinSqlTest extends \Atk4\Schema\PhpunitTestCase
 
         // insert new record
         $m = (clone $m_user)->save(['name' => 'Olaf', 'notes' => '4th note']);
-        $m = (clone $m_user)->tryLoad(22);
+        $m = $m_user->tryLoad(22);
         $this->assertTrue($m->loaded());
         $this->assertEquals(['id' => 22, 'name' => 'Olaf', 'notes' => '4th note'], $m->get());
 
@@ -660,7 +660,7 @@ class JoinSqlTest extends \Atk4\Schema\PhpunitTestCase
 
         // insert new record
         $m = (clone $m_user)->save(['name' => 'Chris', 'notes' => '5th note']);
-        $m = (clone $m_user)->tryLoad(23);
+        $m = $m_user->tryLoad(23);
         $this->assertTrue($m->loaded());
         $this->assertEquals(['id' => 23, 'name' => 'Chris', 'notes' => '5th note'], $m->get());
     }
@@ -697,7 +697,7 @@ class JoinSqlTest extends \Atk4\Schema\PhpunitTestCase
         $j2->addField('salary', ['actual' => 'amount']);
 
         // update
-        $m_u2 = (clone $m_u)->load(1);
+        $m_u2 = $m_u->load(1);
         $m_u2->set('name', 'John 2');
         $m_u2->set('j1_phone', '+555');
         $m_u2->set('j2_salary', 111);

--- a/tests/JoinSqlTest.php
+++ b/tests/JoinSqlTest.php
@@ -70,7 +70,7 @@ class JoinSqlTest extends \Atk4\Schema\PhpunitTestCase
         $j = $m_u->join('contact');
         $j->addField('contact_phone');
 
-        $m_u2 = clone $m_u;
+        $m_u2 = $m_u->createEntity();
         $m_u2->set('name', 'John');
         $m_u2->set('contact_phone', '+123');
 
@@ -81,7 +81,7 @@ class JoinSqlTest extends \Atk4\Schema\PhpunitTestCase
             'contact' => [1 => ['id' => 1, 'contact_phone' => '+123']],
         ], $this->getDb(['user', 'contact']));
 
-        $m_u2 = clone $m_u;
+        $m_u2 = $m_u->createEntity();
         $m_u2->set('name', 'Joe');
         $m_u2->set('contact_phone', '+321');
         $m_u2->save();
@@ -112,7 +112,7 @@ class JoinSqlTest extends \Atk4\Schema\PhpunitTestCase
         $j = $m_u->join('contact.test_id');
         $j->addFields(['contact_phone']);
 
-        $m_u2 = clone $m_u;
+        $m_u2 = $m_u->createEntity();
         $m_u2->set('name', 'John');
         $m_u2->set('contact_phone', '+123');
         $m_u2->save();
@@ -123,7 +123,7 @@ class JoinSqlTest extends \Atk4\Schema\PhpunitTestCase
         ], $this->getDb(['user', 'contact']));
 
         $m_u2->unload();
-        $m_u2 = clone $m_u;
+        $m_u2 = $m_u->createEntity();
         $m_u2->set('name', 'Peter');
         $m_u2->save();
         $this->assertEquals([
@@ -143,7 +143,7 @@ class JoinSqlTest extends \Atk4\Schema\PhpunitTestCase
         }
 
         $m_u2->unload();
-        $m_u2 = clone $m_u;
+        $m_u2 = $m_u->createEntity();
         $m_u2->set('name', 'Sue');
         $m_u2->set('contact_phone', '+444');
         $m_u2->save();
@@ -178,6 +178,7 @@ class JoinSqlTest extends \Atk4\Schema\PhpunitTestCase
         $m_u->addField('name');
         $j = $m_u->join('contact', ['master_field' => 'test_id']);
         $j->addField('contact_phone');
+        $m_u = $m_u->createEntity();
 
         $m_u->set('name', 'John');
         $m_u->set('contact_phone', '+123');
@@ -389,7 +390,7 @@ class JoinSqlTest extends \Atk4\Schema\PhpunitTestCase
                 $m->save();
             }
         });
-
+        $m_u = $m_u->createEntity();
         $m_u->set('name', 'John');
         $m_u->save();
 
@@ -444,7 +445,7 @@ class JoinSqlTest extends \Atk4\Schema\PhpunitTestCase
 
         $this->assertSame($m_u2->getField('country_id')->getJoin(), $m_u2->getField('contact_phone')->getJoin());
 
-        (clone $m_u)->save(['name' => 'new', 'contact_phone' => '+000', 'country_name' => 'LV']);
+        $m_u->createEntity()->save(['name' => 'new', 'contact_phone' => '+000', 'country_name' => 'LV']);
 
         $this->assertEquals(
             [
@@ -628,7 +629,7 @@ class JoinSqlTest extends \Atk4\Schema\PhpunitTestCase
         $this->assertEquals(['id' => 20, 'name' => 'Mark', 'notes' => '2nd note'], $m->get());
 
         // insert new record
-        $m = (clone $m_user)->save(['name' => 'Emily', 'notes' => '3rd note']);
+        $m = $m_user->createEntity()->save(['name' => 'Emily', 'notes' => '3rd note']);
         $m = $m_user->tryLoad(21);
         $this->assertTrue($m->loaded());
         $this->assertEquals(['id' => 21, 'name' => 'Emily', 'notes' => '3rd note'], $m->get());
@@ -643,7 +644,7 @@ class JoinSqlTest extends \Atk4\Schema\PhpunitTestCase
         $j->addField('notes');
 
         // insert new record
-        $m = (clone $m_user)->save(['name' => 'Olaf', 'notes' => '4th note']);
+        $m = $m_user->createEntity()->save(['name' => 'Olaf', 'notes' => '4th note']);
         $m = $m_user->tryLoad(22);
         $this->assertTrue($m->loaded());
         $this->assertEquals(['id' => 22, 'name' => 'Olaf', 'notes' => '4th note'], $m->get());
@@ -659,7 +660,7 @@ class JoinSqlTest extends \Atk4\Schema\PhpunitTestCase
         $j->addField('notes');
 
         // insert new record
-        $m = (clone $m_user)->save(['name' => 'Chris', 'notes' => '5th note']);
+        $m = $m_user->createEntity()->save(['name' => 'Chris', 'notes' => '5th note']);
         $m = $m_user->tryLoad(23);
         $this->assertTrue($m->loaded());
         $this->assertEquals(['id' => 23, 'name' => 'Chris', 'notes' => '5th note'], $m->get());
@@ -721,7 +722,7 @@ class JoinSqlTest extends \Atk4\Schema\PhpunitTestCase
         );
 
         // insert
-        $m_u3 = (clone $m_u)->unload();
+        $m_u3 = $m_u->createEntity()->unload();
         $m_u3->set('name', 'Marvin');
         $m_u3->set('j1_phone', '+999');
         $m_u3->set('j2_salary', 222);

--- a/tests/LocaleTest.php
+++ b/tests/LocaleTest.php
@@ -41,7 +41,7 @@ class LocaleTest extends AtkPhpunit\TestCase
             $m = new Model($p, ['table' => 'user']);
             $m->addField('name');
             $m->addField('surname');
-            $m->load(4);
+            $m = $m->load(4);
         } catch (Exception $e) {
             $this->assertStringContainsString('Запись', json_decode($e->getJson(), true)['message']);
 

--- a/tests/LookupSqlTest.php
+++ b/tests/LookupSqlTest.php
@@ -125,7 +125,7 @@ class LFriend extends Model
             $c = clone $this;
             $c->skip_reverse = true;
 
-            $c->loadBy([
+            $c = $c->loadBy([
                 'user_id' => $this->get('friend_id'),
                 'friend_id' => $this->get('user_id'),
             ])->delete();

--- a/tests/LookupSqlTest.php
+++ b/tests/LookupSqlTest.php
@@ -89,9 +89,11 @@ class LUser extends Model
  */
 class LFriend extends Model
 {
-    public $skip_reverse = false;
     public $table = 'friend';
     public $title_field = 'friend_name';
+
+    /** @var bool */
+    public $skip_reverse = false;
 
     protected function init(): void
     {
@@ -159,14 +161,15 @@ class LookupSqlTest extends \Atk4\Schema\PhpunitTestCase
         $results = [];
 
         // should be OK, will set country name, rest of fields will be null
-        (clone $c)->saveAndUnload(['name' => 'Canada']);
+        $c->createEntity()->saveAndUnload(['name' => 'Canada']);
 
         // adds another country, but with more fields
-        (clone $c)->saveAndUnload(['name' => 'Latvia', 'code' => 'LV', 'is_eu' => true]);
+        $c->createEntity()->saveAndUnload(['name' => 'Latvia', 'code' => 'LV', 'is_eu' => true]);
 
         // setting field prior will affect save()
-        $c->set('is_eu', true);
-        $c->save(['name' => 'Estonia', 'code' => 'ES']);
+        $cc = $c->createEntity();
+        $cc->set('is_eu', true);
+        $cc->save(['name' => 'Estonia', 'code' => 'ES']);
 
         // is_eu will NOT BLEED into this record, because insert() does not make use of current model values.
         $c->insert(['name' => 'Korea', 'code' => 'KR']);

--- a/tests/Model/Smbo/Account.php
+++ b/tests/Model/Smbo/Account.php
@@ -26,6 +26,7 @@ class Account extends Model
     public function transfer(self $a, $amount)
     {
         $t = new Transfer($this->persistence, ['detached' => true]);
+        $t = $t->createEntity();
         $t->set('account_id', $this->getId());
 
         $t->set('destination_account_id', $a->getId());

--- a/tests/Model/Smbo/Transfer.php
+++ b/tests/Model/Smbo/Transfer.php
@@ -6,8 +6,9 @@ namespace Atk4\Data\Tests\Model\Smbo;
 
 class Transfer extends Payment
 {
+    /** @var bool */
     public $detached = false;
-
+    /** @var static|null */
     public $other_leg_creation;
 
     protected function init(): void
@@ -33,18 +34,6 @@ class Transfer extends Payment
                 $m2->set('amount', -$m2->get('amount'));
 
                 $m2->_unset('destination_account_id');
-
-                /*/
-
-                // If clone is not working, then this is a current work-around
-
-                $this->other_leg_creation = $m2 = new Transfer($this->persistence);
-                $m2->set($this->get());
-                $m2->unset('destination_account_id');
-                $m2->set('account_id', $this->get('destination_account_id'));
-                $m2->set('amount', -$m2->get('amount')); // neagtive amount
-
-                // */
 
                 $m2->reload_after_save = false; // avoid check
 

--- a/tests/ModelWithoutIdTest.php
+++ b/tests/ModelWithoutIdTest.php
@@ -136,7 +136,7 @@ class ModelWithoutIdTest extends \Atk4\Schema\PhpunitTestCase
 
     public function testFailDelete1()
     {
-        $this->expectException(\TypeError::class);
+        $this->expectException(Exception::class);
         $this->m->delete(4);
     }
 }

--- a/tests/ModelWithoutIdTest.php
+++ b/tests/ModelWithoutIdTest.php
@@ -14,6 +14,7 @@ use Doctrine\DBAL\Platforms\PostgreSQL94Platform;
  */
 class ModelWithoutIdTest extends \Atk4\Schema\PhpunitTestCase
 {
+    /** @var Model */
     public $m;
 
     protected function setUp(): void
@@ -38,12 +39,12 @@ class ModelWithoutIdTest extends \Atk4\Schema\PhpunitTestCase
      */
     public function testBasic()
     {
-        $this->m->tryLoadAny();
-        $this->assertSame('John', $this->m->get('name'));
+        $m = $this->m->tryLoadAny();
+        $this->assertSame('John', $m->get('name'));
 
         $this->m->setOrder('name', 'desc');
-        $this->m->tryLoadAny();
-        $this->assertSame('Sue', $this->m->get('name'));
+        $m = $this->m->tryLoadAny();
+        $this->assertSame('Sue', $m->get('name'));
 
         $n = [];
         foreach ($this->m as $row) {
@@ -54,17 +55,18 @@ class ModelWithoutIdTest extends \Atk4\Schema\PhpunitTestCase
 
     public function testGetIdException()
     {
-        $this->m->loadAny();
+        $m = $this->m->loadAny();
         $this->expectException(Exception::class);
         $this->expectErrorMessage('ID field is not defined');
-        $this->m->dummy = $this->m->getId();
+        $m->getId();
     }
 
     public function testSetIdException()
     {
+        $m = $this->m->createEntity();
         $this->expectException(Exception::class);
         $this->expectErrorMessage('ID field is not defined');
-        $this->m->setId(1);
+        $m->setId(1);
     }
 
     public function testFail1()
@@ -95,8 +97,8 @@ class ModelWithoutIdTest extends \Atk4\Schema\PhpunitTestCase
             $this->markTestIncomplete('PostgreSQL requires PK specified in SQL to use autoincrement');
         }
 
-        $this->m->tryLoadAny();
-        $this->m->saveAndUnload();
+        $m = $this->m->tryLoadAny();
+        $m->saveAndUnload();
 
         $this->assertEquals(3, $this->m->action('count')->getOne());
     }
@@ -110,8 +112,8 @@ class ModelWithoutIdTest extends \Atk4\Schema\PhpunitTestCase
             $this->markTestIncomplete('PostgreSQL requires PK specified in SQL to use autoincrement');
         }
 
-        $this->m->tryLoadAny();
-        $this->m->save();
+        $m = $this->m->tryLoadAny();
+        $m->save();
 
         $this->assertEquals(3, $this->m->action('count')->getOne());
     }
@@ -121,15 +123,15 @@ class ModelWithoutIdTest extends \Atk4\Schema\PhpunitTestCase
      */
     public function testLoadBy()
     {
-        $this->m->loadBy('name', 'Sue');
-        $this->assertSame('Sue', $this->m->get('name'));
+        $m = $this->m->loadBy('name', 'Sue');
+        $this->assertSame('Sue', $m->get('name'));
     }
 
     public function testLoadCondition()
     {
         $this->m->addCondition('name', 'Sue');
-        $this->m->loadAny();
-        $this->assertSame('Sue', $this->m->get('name'));
+        $m = $this->m->loadAny();
+        $this->assertSame('Sue', $m->get('name'));
     }
 
     public function testFailDelete1()

--- a/tests/PersistenceCsvTest.php
+++ b/tests/PersistenceCsvTest.php
@@ -172,7 +172,10 @@ class PersistenceCsvTest extends AtkPhpunit\TestCase
         $m = new Person($p);
 
         $m2 = $m->withPersistence($p2);
-        $m2->reload_after_save = false; // TODO should be not needed after https://github.com/atk4/data/pull/690 is merged
+
+        // TODO should be not needed after https://github.com/atk4/data/pull/690 is merged
+        // Exception: CSV Persistence does not support other than LOAD ANY mode
+        $m2->reload_after_save = false;
 
         foreach ($m as $row) {
             $m2->createEntity()->save($row->get());

--- a/tests/PersistenceCsvTest.php
+++ b/tests/PersistenceCsvTest.php
@@ -109,7 +109,7 @@ class PersistenceCsvTest extends AtkPhpunit\TestCase
         $m = new Model($p);
         $m->addField('name');
         $m->addField('surname');
-        $m->loadAny();
+        $m = $m->loadAny();
 
         $this->assertSame('John', $m->get('name'));
         $this->assertSame('Smith', $m->get('surname'));
@@ -130,15 +130,15 @@ class PersistenceCsvTest extends AtkPhpunit\TestCase
         $m->addField('surname');
 
         $mm = clone $m;
-        $mm->loadAny();
+        $mm = $mm->loadAny();
         $mm = clone $m;
-        $mm->loadAny();
+        $mm = $mm->loadAny();
 
         $this->assertSame('Sarah', $mm->get('name'));
         $this->assertSame('Jones', $mm->get('surname'));
 
         $mm = clone $m;
-        $mm->tryLoadAny();
+        $mm = $mm->tryLoadAny();
         $this->assertFalse($mm->loaded());
     }
 
@@ -154,7 +154,7 @@ class PersistenceCsvTest extends AtkPhpunit\TestCase
         $p = $this->makeCsvPersistence($this->file);
         $m = new Model($p);
         $this->expectException(Exception::class);
-        $m->tryLoad(1);
+        $m = $m->tryLoad(1);
     }
 
     public function testPersistenceCopy()

--- a/tests/PersistenceCsvTest.php
+++ b/tests/PersistenceCsvTest.php
@@ -12,7 +12,9 @@ use Atk4\Data\Tests\Model\Person;
 
 class PersistenceCsvTest extends AtkPhpunit\TestCase
 {
+    /** @var resource */
     protected $file;
+    /** @var resource */
     protected $file2;
 
     protected function setUp(): void
@@ -34,6 +36,7 @@ class PersistenceCsvTest extends AtkPhpunit\TestCase
     protected function makeCsvPersistence($fileHandle, array $defaults = []): Persistence\Csv
     {
         return new class($fileHandle, $defaults) extends Persistence\Csv {
+            /** @var resource */
             private $handleUnloaded;
 
             public function __construct($fileHandle, $defaults)
@@ -129,16 +132,13 @@ class PersistenceCsvTest extends AtkPhpunit\TestCase
         $m->addField('name');
         $m->addField('surname');
 
-        $mm = clone $m;
-        $mm = $mm->loadAny();
-        $mm = clone $m;
-        $mm = $mm->loadAny();
+        $mm = $m->loadAny();
+        $mm = $m->loadAny();
 
         $this->assertSame('Sarah', $mm->get('name'));
         $this->assertSame('Jones', $mm->get('surname'));
 
-        $mm = clone $m;
-        $mm = $mm->tryLoadAny();
+        $mm = $m->tryLoadAny();
         $this->assertFalse($mm->loaded());
     }
 
@@ -175,7 +175,7 @@ class PersistenceCsvTest extends AtkPhpunit\TestCase
         $m2->reload_after_save = false; // TODO should be not needed after https://github.com/atk4/data/pull/690 is merged
 
         foreach ($m as $row) {
-            (clone $m2)->save($row->get());
+            $m2->createEntity()->save($row->get());
         }
 
         fseek($this->file, 0);

--- a/tests/PersistentArrayOfStringsTest.php
+++ b/tests/PersistentArrayOfStringsTest.php
@@ -32,7 +32,8 @@ class PersistentArrayOfStringsTest extends AtkPhpunit\TestCase
         $m->addField('array', ['type' => 'array']);
         $m->addField('object', ['type' => 'object']);
 
-        $m->setMulti([
+        $mm = $m->createEntity();
+        $mm->setMulti([
             'string' => "Two\r\nLines  ",
             'text' => "Two\r\nLines  ",
             'integer' => 123,
@@ -46,7 +47,7 @@ class PersistentArrayOfStringsTest extends AtkPhpunit\TestCase
             'array' => ['foo' => 'bar', 'int' => 123, 'rows' => ['a', 'b']],
             'object' => (object) ['foo' => 'bar', 'int' => 123, 'rows' => ['a', 'b']],
         ]);
-        (clone $m)->saveAndUnload();
+        $mm->saveAndUnload();
 
         // no typecasting option set in export()
         $data = $m->export(null, null, false);

--- a/tests/PersistentArrayTest.php
+++ b/tests/PersistentArrayTest.php
@@ -50,7 +50,7 @@ class PersistentArrayTest extends AtkPhpunit\TestCase
         $mm->unload();
         $this->assertFalse($mm->loaded());
 
-        $mm = $mm->tryLoadAny();
+        $mm = $m->tryLoadAny();
         $this->assertTrue($mm->loaded());
 
         $mm = $m->load(2);

--- a/tests/PersistentArrayTest.php
+++ b/tests/PersistentArrayTest.php
@@ -50,7 +50,7 @@ class PersistentArrayTest extends AtkPhpunit\TestCase
         $mm->unload();
         $this->assertFalse($mm->loaded());
 
-        $mm->tryLoadAny();
+        $mm = $mm->tryLoadAny();
         $this->assertTrue($mm->loaded());
 
         $mm = (clone $m)->load(2);
@@ -75,14 +75,14 @@ class PersistentArrayTest extends AtkPhpunit\TestCase
         ]);
         $m = new Male($p, ['table' => 'user']);
 
-        $m->load(1);
+        $m = $m->load(1);
         $this->assertTrue($m->loaded());
         $m->set('gender', 'F');
         $m->saveAndUnload();
         $this->assertFalse($m->loaded());
 
         $m = new Female($p, ['table' => 'user']);
-        $m->load(1);
+        $m = $m->load(1);
         $this->assertTrue($m->loaded());
 
         $this->assertSame([
@@ -882,7 +882,7 @@ class PersistentArrayTest extends AtkPhpunit\TestCase
         $m = new Model($p);
         $m->addField('name');
         $this->expectExceptionCode(404);
-        $m->loadAny();
+        $m = $m->loadAny();
     }
 
     public function testTryLoadAnyNotThrowsExceptionOnRecordNotFound()
@@ -891,7 +891,7 @@ class PersistentArrayTest extends AtkPhpunit\TestCase
         $m = new Model($p);
         $m->addField('name');
         $m->addField('surname');
-        $m->tryLoadAny();
+        $m = $m->tryLoadAny();
         $this->assertFalse($m->loaded());
     }
 
@@ -906,7 +906,7 @@ class PersistentArrayTest extends AtkPhpunit\TestCase
         $m = new Model($p);
         $m->addField('name');
         $m->addField('surname');
-        $m->tryLoadAny();
+        $m = $m->tryLoadAny();
         $this->assertSame(2, $m->getId());
     }
 }

--- a/tests/PersistentArrayTest.php
+++ b/tests/PersistentArrayTest.php
@@ -122,7 +122,7 @@ class PersistentArrayTest extends AtkPhpunit\TestCase
             ],
         ], $this->getInternalPersistenceData($p));
 
-        $m->unload();
+        $m = $m->createEntity();
         $m->setMulti(['name' => 'Foo', 'surname' => 'Bar']);
         $m->save();
 
@@ -316,7 +316,6 @@ class PersistentArrayTest extends AtkPhpunit\TestCase
         $this->assertSame($dbDataCountries[7], $result[7]);
         $this->assertSame($dbDataCountries[9], $result[9]);
         unset($result);
-        $m->unload();
 
         // case : str% NOT LIKE
         $m->scope()->clear();
@@ -341,7 +340,6 @@ class PersistentArrayTest extends AtkPhpunit\TestCase
         $this->assertSame($dbDataCountries[8], $result[8]);
         $this->assertSame($dbDataCountries[9], $result[9]);
         unset($result);
-        $m->unload();
 
         // case : %str%
         $m->scope()->clear();
@@ -356,7 +354,6 @@ class PersistentArrayTest extends AtkPhpunit\TestCase
         $this->assertSame($dbDataCountries[8], $result[8]);
         $this->assertSame($dbDataCountries[9], $result[9]);
         unset($result);
-        $m->unload();
 
         // case : boolean field
         $m->scope()->clear();
@@ -431,7 +428,6 @@ class PersistentArrayTest extends AtkPhpunit\TestCase
         $this->assertSame($dbDataCountries[5], $result[5]);
         $this->assertSame($dbDataCountries[6], $result[6]);
         unset($result);
-        $m->unload();
 
         $m->scope()->clear();
         $m->addCondition('country', 'NOT REGEXP', 'Ireland|UK|Latvia');
@@ -439,7 +435,6 @@ class PersistentArrayTest extends AtkPhpunit\TestCase
         $this->assertCount(1, $result);
         $this->assertSame($dbDataCountries[8], $result[8]);
         unset($result);
-        $m->unload();
 
         $m->scope()->clear();
         $m->addCondition('code', '>', 18);
@@ -447,7 +442,6 @@ class PersistentArrayTest extends AtkPhpunit\TestCase
         $this->assertCount(1, $result);
         $this->assertSame($dbDataCountries[9], $result[9]);
         unset($result);
-        $m->unload();
 
         $m->scope()->clear();
         $m->addCondition('code', '>=', 18);
@@ -456,7 +450,6 @@ class PersistentArrayTest extends AtkPhpunit\TestCase
         $this->assertSame($dbDataCountries[8], $result[8]);
         $this->assertSame($dbDataCountries[9], $result[9]);
         unset($result);
-        $m->unload();
 
         $m->scope()->clear();
         $m->addCondition('code', '<', 12);
@@ -464,7 +457,6 @@ class PersistentArrayTest extends AtkPhpunit\TestCase
         $this->assertCount(1, $result);
         $this->assertSame($dbDataCountries[1], $result[1]);
         unset($result);
-        $m->unload();
 
         $m->scope()->clear();
         $m->addCondition('code', '<=', 12);
@@ -473,7 +465,6 @@ class PersistentArrayTest extends AtkPhpunit\TestCase
         $this->assertSame($dbDataCountries[1], $result[1]);
         $this->assertSame($dbDataCountries[2], $result[2]);
         unset($result);
-        $m->unload();
 
         $m->scope()->clear();
         $m->addCondition('code', [11, 12]);
@@ -482,14 +473,12 @@ class PersistentArrayTest extends AtkPhpunit\TestCase
         $this->assertSame($dbDataCountries[1], $result[1]);
         $this->assertSame($dbDataCountries[2], $result[2]);
         unset($result);
-        $m->unload();
 
         $m->scope()->clear();
         $m->addCondition('code', 'IN', []);
         $result = $m->action('select')->getRows();
         $this->assertCount(0, $result);
         unset($result);
-        $m->unload();
 
         $m->scope()->clear();
         $m->addCondition('code', 'NOT IN', [11, 12, 13, 14, 15, 16, 17]);
@@ -498,7 +487,6 @@ class PersistentArrayTest extends AtkPhpunit\TestCase
         $this->assertSame($dbDataCountries[8], $result[8]);
         $this->assertSame($dbDataCountries[9], $result[9]);
         unset($result);
-        $m->unload();
 
         $m->scope()->clear();
         $m->addCondition('code', '!=', [11, 12, 13, 14, 15, 16, 17]);
@@ -507,7 +495,6 @@ class PersistentArrayTest extends AtkPhpunit\TestCase
         $this->assertSame($dbDataCountries[8], $result[8]);
         $this->assertSame($dbDataCountries[9], $result[9]);
         unset($result);
-        $m->unload();
     }
 
     public function testAggregates()

--- a/tests/PersistentArrayTest.php
+++ b/tests/PersistentArrayTest.php
@@ -44,7 +44,7 @@ class PersistentArrayTest extends AtkPhpunit\TestCase
         $m->addField('name');
         $m->addField('surname');
 
-        $mm = (clone $m)->load(1);
+        $mm = $m->load(1);
         $this->assertSame('John', $mm->get('name'));
 
         $mm->unload();
@@ -53,15 +53,15 @@ class PersistentArrayTest extends AtkPhpunit\TestCase
         $mm = $mm->tryLoadAny();
         $this->assertTrue($mm->loaded());
 
-        $mm = (clone $m)->load(2);
+        $mm = $m->load(2);
         $this->assertSame('Jones', $mm->get('surname'));
         $mm->set('surname', 'Smith');
         $mm->save();
 
-        $mm = (clone $m)->load(1);
+        $mm = $m->load(1);
         $this->assertSame('John', $mm->get('name'));
 
-        $mm = (clone $m)->load(2);
+        $mm = $m->load(2);
         $this->assertSame('Smith', $mm->get('surname'));
     }
 
@@ -105,11 +105,11 @@ class PersistentArrayTest extends AtkPhpunit\TestCase
         $m->addField('name');
         $m->addField('surname');
 
-        $mm = (clone $m)->load(1);
+        $mm = $m->load(1);
         $mm->set('name', 'Peter');
         $mm->save();
 
-        $mm = (clone $m)->load(2);
+        $mm = $m->load(2);
         $mm->set('surname', 'Smith');
         $mm->save();
         $mm->set('surname', 'QQ');
@@ -194,18 +194,18 @@ class PersistentArrayTest extends AtkPhpunit\TestCase
         $m->addField('name');
         $m->addField('surname');
 
-        $mm = (clone $m)->load(1);
+        $mm = $m->load(1);
         $this->assertSame('John', $mm->get('name'));
 
-        $mm = (clone $m)->load(2);
+        $mm = $m->load(2);
         $this->assertSame('Jones', $mm->get('surname'));
         $mm->set('surname', 'Smith');
         $mm->save();
 
-        $mm = (clone $m)->load(1);
+        $mm = $m->load(1);
         $this->assertSame('John', $mm->get('name'));
 
-        $mm = (clone $m)->load(2);
+        $mm = $m->load(2);
         $this->assertSame('Smith', $mm->get('surname'));
     }
 
@@ -834,10 +834,10 @@ class PersistentArrayTest extends AtkPhpunit\TestCase
 
         $user->hasOne('country_id', ['model' => $country]);
 
-        $uu = (clone $user)->load(1);
+        $uu = $user->load(1);
         $this->assertSame('Latvia', $uu->ref('country_id')->get('name'));
 
-        $uu = (clone $user)->load(2);
+        $uu = $user->load(2);
         $this->assertSame('UK', $uu->ref('country_id')->get('name'));
     }
 
@@ -869,10 +869,10 @@ class PersistentArrayTest extends AtkPhpunit\TestCase
         $country->hasMany('Users', ['model' => $user]);
         $user->hasOne('country_id', ['model' => $country]);
 
-        $cc = (clone $country)->load(1);
+        $cc = $country->load(1);
         $this->assertSame(2, $cc->ref('Users')->action('count')->getOne());
 
-        $cc = (clone $country)->load(2);
+        $cc = $country->load(2);
         $this->assertSame(1, $cc->ref('Users')->action('count')->getOne());
     }
 

--- a/tests/PersistentSqlTest.php
+++ b/tests/PersistentSqlTest.php
@@ -150,6 +150,7 @@ class PersistentSqlTest extends \Atk4\Schema\PhpunitTestCase
 
         // insert new record, model id field
         $m->reload_after_save = false;
+        $m = $m->createEntity();
         $m->save(['name' => 'Jane', 'surname' => 'Doe']);
         $this->assertSame('Jane', $m->get('name'));
         $this->assertSame('Doe', $m->get('surname'));

--- a/tests/PersistentSqlTest.php
+++ b/tests/PersistentSqlTest.php
@@ -25,18 +25,18 @@ class PersistentSqlTest extends \Atk4\Schema\PhpunitTestCase
         $m->addField('name');
         $m->addField('surname');
 
-        $mm = (clone $m)->load(1);
+        $mm = $m->load(1);
         $this->assertSame('John', $mm->get('name'));
 
-        $mm = (clone $m)->load(2);
+        $mm = $m->load(2);
         $this->assertSame('Jones', $mm->get('surname'));
         $mm->set('surname', 'Smith');
         $mm->save();
 
-        $mm = (clone $m)->load(1);
+        $mm = $m->load(1);
         $this->assertSame('John', $mm->get('name'));
 
-        $mm = (clone $m)->load(2);
+        $mm = $m->load(2);
         $this->assertSame('Smith', $mm->get('surname'));
     }
 
@@ -54,26 +54,26 @@ class PersistentSqlTest extends \Atk4\Schema\PhpunitTestCase
         $m->addField('surname');
 
         $mm = (clone $m)->addCondition($m->id_field, 1);
-        $this->assertSame('John', (clone $mm)->load(1)->get('name'));
-        $this->assertNull((clone $mm)->tryload(2)->get('name'));
-        $this->assertSame('John', (clone $mm)->tryloadOne()->get('name'));
-        $this->assertSame('John', (clone $mm)->loadOne()->get('name'));
-        $this->assertSame('John', (clone $mm)->tryLoadAny()->get('name'));
-        $this->assertSame('John', (clone $mm)->loadAny()->get('name'));
+        $this->assertSame('John', $mm->load(1)->get('name'));
+        $this->assertNull($mm->tryload(2)->get('name'));
+        $this->assertSame('John', $mm->tryloadOne()->get('name'));
+        $this->assertSame('John', $mm->loadOne()->get('name'));
+        $this->assertSame('John', $mm->tryLoadAny()->get('name'));
+        $this->assertSame('John', $mm->loadAny()->get('name'));
 
         $mm = (clone $m)->addCondition('surname', 'Jones');
-        $this->assertSame('Sarah', (clone $mm)->load(2)->get('name'));
-        $this->assertNull((clone $mm)->tryload(1)->get('name'));
-        $this->assertSame('Sarah', (clone $mm)->tryloadOne()->get('name'));
-        $this->assertSame('Sarah', (clone $mm)->loadOne()->get('name'));
-        $this->assertSame('Sarah', (clone $mm)->tryLoadAny()->get('name'));
-        $this->assertSame('Sarah', (clone $mm)->loadAny()->get('name'));
+        $this->assertSame('Sarah', $mm->load(2)->get('name'));
+        $this->assertNull($mm->tryload(1)->get('name'));
+        $this->assertSame('Sarah', $mm->tryloadOne()->get('name'));
+        $this->assertSame('Sarah', $mm->loadOne()->get('name'));
+        $this->assertSame('Sarah', $mm->tryLoadAny()->get('name'));
+        $this->assertSame('Sarah', $mm->loadAny()->get('name'));
 
-        (clone $m)->loadAny();
-        (clone $m)->tryLoadAny();
+        $m->loadAny();
+        $m->tryLoadAny();
         $this->expectException(Exception::class);
         $this->expectExceptionMessage('Ambiguous conditions, more than one record can be loaded.');
-        (clone $m)->tryLoadOne();
+        $m->tryLoadOne();
     }
 
     public function testPersistenceInsert()
@@ -96,18 +96,18 @@ class PersistentSqlTest extends \Atk4\Schema\PhpunitTestCase
             $ids[] = $this->db->insert($m, $row);
         }
 
-        $mm = (clone $m)->load($ids[0]);
+        $mm = $m->load($ids[0]);
         $this->assertSame('John', $mm->get('name'));
 
-        $mm = (clone $m)->load($ids[1]);
+        $mm = $m->load($ids[1]);
         $this->assertSame('Jones', $mm->get('surname'));
         $mm->set('surname', 'Smith');
         $mm->save();
 
-        $mm = (clone $m)->load($ids[0]);
+        $mm = $m->load($ids[0]);
         $this->assertSame('John', $mm->get('name'));
 
-        $mm = (clone $m)->load($ids[1]);
+        $mm = $m->load($ids[1]);
         $this->assertSame('Smith', $mm->get('surname'));
     }
 
@@ -130,9 +130,9 @@ class PersistentSqlTest extends \Atk4\Schema\PhpunitTestCase
             $ms[] = $m->insert($row);
         }
 
-        $this->assertSame('John', (clone $m)->load($ms[0])->get('name'));
+        $this->assertSame('John', $m->load($ms[0])->get('name'));
 
-        $this->assertSame('Jones', (clone $m)->load($ms[1])->get('surname'));
+        $this->assertSame('Jones', $m->load($ms[1])->get('surname'));
     }
 
     public function testModelSaveNoReload()

--- a/tests/PersistentSqlTest.php
+++ b/tests/PersistentSqlTest.php
@@ -200,10 +200,8 @@ class PersistentSqlTest extends \Atk4\Schema\PhpunitTestCase
         foreach ($dbData['user'] as $id => $row) {
             $ids[] = $this->db->insert($m, $row);
         }
-        $this->assertFalse($m->loaded());
 
         $m->delete($ids[0]);
-        $this->assertFalse($m->loaded());
 
         $m = $m->load($ids[1]);
         $this->assertSame('Jones', $m->get('surname'));

--- a/tests/PersistentSqlTest.php
+++ b/tests/PersistentSqlTest.php
@@ -203,16 +203,16 @@ class PersistentSqlTest extends \Atk4\Schema\PhpunitTestCase
 
         $m->delete($ids[0]);
 
-        $m = $m->load($ids[1]);
-        $this->assertSame('Jones', $m->get('surname'));
-        $m->set('surname', 'Smith');
-        $m->save();
+        $m2 = $m->load($ids[1]);
+        $this->assertSame('Jones', $m2->get('surname'));
+        $m2->set('surname', 'Smith');
+        $m2->save();
 
-        $m = $m->tryLoad($ids[0]);
-        $this->assertFalse($m->loaded());
+        $m2 = $m->tryLoad($ids[0]);
+        $this->assertFalse($m2->loaded());
 
-        $m = $m->load($ids[1]);
-        $this->assertSame('Smith', $m->get('surname'));
+        $m2 = $m->load($ids[1]);
+        $this->assertSame('Smith', $m2->get('surname'));
     }
 
     /**

--- a/tests/PersistentSqlTest.php
+++ b/tests/PersistentSqlTest.php
@@ -204,15 +204,15 @@ class PersistentSqlTest extends \Atk4\Schema\PhpunitTestCase
         $m->delete($ids[0]);
         $this->assertFalse($m->loaded());
 
-        $m->load($ids[1]);
+        $m = $m->load($ids[1]);
         $this->assertSame('Jones', $m->get('surname'));
         $m->set('surname', 'Smith');
         $m->save();
 
-        $m->tryLoad($ids[0]);
+        $m = $m->tryLoad($ids[0]);
         $this->assertFalse($m->loaded());
 
-        $m->load($ids[1]);
+        $m = $m->load($ids[1]);
         $this->assertSame('Smith', $m->get('surname'));
     }
 

--- a/tests/RandomTest.php
+++ b/tests/RandomTest.php
@@ -159,7 +159,7 @@ class RandomTest extends \Atk4\Schema\PhpunitTestCase
             ['id' => 2, 'name' => 'anonymous', 'last_name' => null, 'login' => 'unknown', 'salary' => 100, 'tax' => 20, 'vat' => 15],
         ], $m->export());
 
-        $m->load(2);
+        $m = $m->load(2);
         $this->assertTrue(is_float($m->get('salary')));
         $this->assertTrue(is_float($m->get('tax')));
         $this->assertTrue(is_float($m->get('vat')));
@@ -248,7 +248,7 @@ class RandomTest extends \Atk4\Schema\PhpunitTestCase
 
         $m = new Model($db, ['table' => 'item']);
         $m->addField('name');
-        $m->load(2);
+        $m = $m->load(2);
 
         $m->onHook(Persistence\Sql::HOOK_AFTER_UPDATE_QUERY, static function ($m, $update, $st) {
             // we can use afterUpdate to make sure that record was updated
@@ -343,7 +343,7 @@ class RandomTest extends \Atk4\Schema\PhpunitTestCase
         $m = new Model_Rate($db);
         $m->addField('x1', new \Atk4\Data\FieldSql());
         $m->addField('x2', new \Atk4\Data\Field());
-        $m->load(1);
+        $m = $m->load(1);
 
         $this->assertEquals(3.4, $m->get('bid'));
         $this->assertSame('y1', $m->get('x1'));
@@ -379,7 +379,7 @@ class RandomTest extends \Atk4\Schema\PhpunitTestCase
         $this->assertNull($m->getTitle()); // not loaded model returns null
         $this->assertSame([1 => 'John', 2 => 'Sue'], $m->getTitles()); // all titles
 
-        $m->load(2);
+        $m = $m->load(2);
         $this->assertSame('Sue', $m->getTitle()); // loaded returns title_field value
 
         // set custom title_field
@@ -397,7 +397,7 @@ class RandomTest extends \Atk4\Schema\PhpunitTestCase
         // expression as title field
         $m->addExpression('my_name', '[id]');
         $m->title_field = 'my_name';
-        $m->load(2);
+        $m = $m->load(2);
         $this->assertEquals(2, $m->getTitle()); // loaded returns id value
 
         $this->expectException(Exception::class);

--- a/tests/RandomTest.php
+++ b/tests/RandomTest.php
@@ -296,6 +296,7 @@ class RandomTest extends \Atk4\Schema\PhpunitTestCase
 
         $m = new Model($db, ['table' => 'user']);
         $m->addField('name');
+        $m = $m->createEntity();
 
         $m->onHook(Model::HOOK_BEFORE_SAVE, static function ($m) {
             $m->breakHook(false);
@@ -374,6 +375,7 @@ class RandomTest extends \Atk4\Schema\PhpunitTestCase
         ]);
 
         $m = new Model_Item($db, ['table' => 'item']);
+        $m = $m->createEntity();
 
         // default title_field = name
         $this->assertNull($m->getTitle()); // not loaded model returns null
@@ -400,9 +402,9 @@ class RandomTest extends \Atk4\Schema\PhpunitTestCase
         $m = $m->load(2);
         $this->assertEquals(2, $m->getTitle()); // loaded returns id value
 
-        $this->expectException(Exception::class);
-        $this->expectExceptionMessageMatches('~entity.+iterate~');
-        $m->getTitles();
+//        $this->expectException(Exception::class);
+//        $this->expectExceptionMessageMatches('~entity.+iterate~');
+//        $m->getTitles();
     }
 
     /**

--- a/tests/RandomTest.php
+++ b/tests/RandomTest.php
@@ -375,11 +375,13 @@ class RandomTest extends \Atk4\Schema\PhpunitTestCase
         ]);
 
         $m = new Model_Item($db, ['table' => 'item']);
+
+        $this->assertSame([1 => 'John', 2 => 'Sue'], $m->getTitles()); // all titles
+
         $m = $m->createEntity();
 
         // default title_field = name
         $this->assertNull($m->getTitle()); // not loaded model returns null
-        $this->assertSame([1 => 'John', 2 => 'Sue'], $m->getTitles()); // all titles
 
         $m = $m->load(2);
         $this->assertSame('Sue', $m->getTitle()); // loaded returns title_field value
@@ -403,7 +405,6 @@ class RandomTest extends \Atk4\Schema\PhpunitTestCase
         $this->assertEquals(2, $m->getTitle()); // loaded returns id value
 
 //        $this->expectException(Exception::class);
-//        $this->expectExceptionMessageMatches('~entity.+iterate~');
 //        $m->getTitles();
     }
 

--- a/tests/RandomTest.php
+++ b/tests/RandomTest.php
@@ -317,9 +317,9 @@ class RandomTest extends \Atk4\Schema\PhpunitTestCase
         $m->set('name', 'john');
         $m->save();
 
-        $this->assertSame('rec #3', $m->load(3)->get('name'));
+        $this->assertSame('rec #3', $m->getModel()->load(3)->get('name'));
 
-        $m->delete();
+//        $m->delete();
     }
 
     public function testIssue220()
@@ -378,34 +378,34 @@ class RandomTest extends \Atk4\Schema\PhpunitTestCase
 
         $this->assertSame([1 => 'John', 2 => 'Sue'], $m->getTitles()); // all titles
 
-        $m = $m->createEntity();
+        $mm = $m->createEntity();
 
         // default title_field = name
-        $this->assertNull($m->getTitle()); // not loaded model returns null
+        $this->assertNull($mm->getTitle()); // not loaded model returns null
 
-        $m = $m->load(2);
-        $this->assertSame('Sue', $m->getTitle()); // loaded returns title_field value
+        $mm = $m->load(2);
+        $this->assertSame('Sue', $mm->getTitle()); // loaded returns title_field value
 
         // set custom title_field
-        $m->title_field = 'parent_item_id';
-        $this->assertEquals(1, $m->getTitle()); // returns parent_item_id value
+        $mm->title_field = 'parent_item_id';
+        $this->assertEquals(1, $mm->getTitle()); // returns parent_item_id value
 
         // set custom title_field as title_field from linked model
-        $m->title_field = 'parent_item';
-        $this->assertSame('John', $m->getTitle()); // returns parent record title_field
+        $mm->title_field = 'parent_item';
+        $this->assertSame('John', $mm->getTitle()); // returns parent record title_field
 
         // no title_field set - return id value
-        $m->title_field = null; // @phpstan-ignore-line
-        $this->assertEquals(2, $m->getTitle()); // loaded returns id value
+        $mm->title_field = null; // @phpstan-ignore-line
+        $this->assertEquals(2, $mm->getTitle()); // loaded returns id value
 
         // expression as title field
         $m->addExpression('my_name', '[id]');
         $m->title_field = 'my_name';
-        $m = $m->load(2);
-        $this->assertEquals(2, $m->getTitle()); // loaded returns id value
+        $mm = $m->load(2);
+        $this->assertEquals(2, $mm->getTitle()); // loaded returns id value
 
 //        $this->expectException(Exception::class);
-//        $m->getTitles();
+//        $mm->getTitles();
     }
 
     /**

--- a/tests/RandomTest.php
+++ b/tests/RandomTest.php
@@ -495,7 +495,7 @@ class RandomTest extends \Atk4\Schema\PhpunitTestCase
         $db = new Persistence\Sql($this->db->connection);
         $m = new Model_Rate($db);
 
-        (clone $m)->load(1)->duplicate()->save();
+        $m->load(1)->duplicate()->save();
 
         $this->assertSame([
             ['id' => 1, 'dat' => '18/12/12', 'bid' => 3.4, 'ask' => 9.4],

--- a/tests/RandomTest.php
+++ b/tests/RandomTest.php
@@ -294,32 +294,32 @@ class RandomTest extends \Atk4\Schema\PhpunitTestCase
             ],
         ]);
 
-        $m = new Model($db, ['table' => 'user']);
+        $m = new Model($db, ['table' => 'never_used']);
         $m->addField('name');
-        $m = $m->createEntity();
 
-        $m->onHook(Model::HOOK_BEFORE_SAVE, static function ($m) {
+        $m->onHook(Model::HOOK_BEFORE_SAVE, static function (Model $m) {
             $m->breakHook(false);
         });
 
-        $m->onHook(Model::HOOK_BEFORE_LOAD, static function ($m, $id) {
-            $dataRef = &$m->getDataRef();
-            $dataRef = ['name' => 'rec #' . $id];
+        $m->onHook(Model::HOOK_BEFORE_LOAD, static function (Model $m, int $id) {
             $m->setId($id);
+            $m->set('name', 'rec #' . $id);
             $m->breakHook(false);
         });
 
-        $m->onHook(Model::HOOK_BEFORE_DELETE, static function ($m, $id) {
+        $m->onHook(Model::HOOK_BEFORE_DELETE, static function (Model $m, int $id) {
             $m->unload();
             $m->breakHook(false);
         });
 
+        $m = $m->createEntity();
         $m->set('name', 'john');
         $m->save();
 
-        $this->assertSame('rec #3', $m->getModel()->load(3)->get('name'));
+        $m = $m->getModel()->load(3);
+        $this->assertSame('rec #3', $m->get('name'));
 
-//        $m->delete();
+        $m->delete();
     }
 
     public function testIssue220()

--- a/tests/RandomTest.php
+++ b/tests/RandomTest.php
@@ -404,8 +404,8 @@ class RandomTest extends \Atk4\Schema\PhpunitTestCase
         $mm = $m->load(2);
         $this->assertEquals(2, $mm->getTitle()); // loaded returns id value
 
-//        $this->expectException(Exception::class);
-//        $mm->getTitles();
+        $this->expectException(Exception::class);
+        $mm->getTitles();
     }
 
     /**

--- a/tests/ReadOnlyModeTest.php
+++ b/tests/ReadOnlyModeTest.php
@@ -13,6 +13,7 @@ use Atk4\Data\Persistence;
  */
 class ReadOnlyModeTest extends \Atk4\Schema\PhpunitTestCase
 {
+    /** @var Model */
     public $m;
 
     protected function setUp(): void
@@ -37,12 +38,12 @@ class ReadOnlyModeTest extends \Atk4\Schema\PhpunitTestCase
      */
     public function testBasic()
     {
-        $mm = (clone $this->m)->tryLoadAny();
-        $this->assertSame('John', $mm->get('name'));
+        $m = $this->m->tryLoadAny();
+        $this->assertSame('John', $m->get('name'));
 
         $this->m->setOrder('name', 'desc');
-        $mm = (clone $this->m)->tryLoadAny();
-        $this->assertSame('Sue', $mm->get('name'));
+        $m = $this->m->tryLoadAny();
+        $this->assertSame('Sue', $m->get('name'));
 
         $this->assertEquals([1 => 'John', 2 => 'Sue'], $this->m->getTitles());
     }
@@ -52,8 +53,8 @@ class ReadOnlyModeTest extends \Atk4\Schema\PhpunitTestCase
      */
     public function testLoad()
     {
-        $this->m->load(1);
-        $this->assertTrue($this->m->loaded());
+        $m = $this->m->load(1);
+        $this->assertTrue($m->loaded());
     }
 
     /**
@@ -61,10 +62,10 @@ class ReadOnlyModeTest extends \Atk4\Schema\PhpunitTestCase
      */
     public function testLoadSave()
     {
-        $this->m->load(1);
-        $this->m->set('name', 'X');
+        $m = $this->m->load(1);
+        $m->set('name', 'X');
         $this->expectException(Exception::class);
-        $this->m->save();
+        $m->save();
     }
 
     /**
@@ -81,9 +82,9 @@ class ReadOnlyModeTest extends \Atk4\Schema\PhpunitTestCase
      */
     public function testSave1()
     {
-        $this->m->tryLoadAny();
+        $m = $this->m->tryLoadAny();
         $this->expectException(Exception::class);
-        $this->m->saveAndUnload();
+        $m->saveAndUnload();
     }
 
     /**
@@ -91,15 +92,15 @@ class ReadOnlyModeTest extends \Atk4\Schema\PhpunitTestCase
      */
     public function testLoadBy()
     {
-        $this->m->loadBy('name', 'Sue');
-        $this->assertSame('Sue', $this->m->get('name'));
+        $m = $this->m->loadBy('name', 'Sue');
+        $this->assertSame('Sue', $m->get('name'));
     }
 
     public function testLoadCondition()
     {
         $this->m->addCondition('name', 'Sue');
-        $this->m->loadAny();
-        $this->assertSame('Sue', $this->m->get('name'));
+        $m = $this->m->loadAny();
+        $this->assertSame('Sue', $m->get('name'));
     }
 
     public function testFailDelete1()

--- a/tests/ReferenceSqlTest.php
+++ b/tests/ReferenceSqlTest.php
@@ -52,7 +52,7 @@ class ReferenceSqlTest extends \Atk4\Schema\PhpunitTestCase
         $ooo = $oo->tryLoad(3);
         $this->assertNull($ooo->get('amount'));
 
-        $oo = $u->unload()->addCondition('id', '>', '1')->ref('Orders');
+        $oo = $u->addCondition('id', '>', '1')->ref('Orders');
 
         $this->assertSameSql(
             'select "id","amount","user_id" from "order" where "user_id" in (select "id" from "user" where "id" > :a)',
@@ -147,7 +147,6 @@ class ReferenceSqlTest extends \Atk4\Schema\PhpunitTestCase
         $this->assertSame('John', $o->load(3)->ref('user_id')->get('name'));
         $this->assertSame('Joe', $o->load(5)->ref('user_id')->get('name'));
 
-        $o->unload();
         $o->addCondition('amount', '>', 6);
         $o->addCondition('amount', '<', 9);
 

--- a/tests/ReferenceSqlTest.php
+++ b/tests/ReferenceSqlTest.php
@@ -36,20 +36,20 @@ class ReferenceSqlTest extends \Atk4\Schema\PhpunitTestCase
 
         $u->hasMany('Orders', ['model' => $o]);
 
-        $oo = (clone $u)->load(1)->ref('Orders');
-        $ooo = (clone $oo)->tryLoad(1);
+        $oo = $u->load(1)->ref('Orders');
+        $ooo = $oo->tryLoad(1);
         $this->assertEquals(20, $ooo->get('amount'));
-        $ooo = (clone $oo)->tryLoad(2);
+        $ooo = $oo->tryLoad(2);
         $this->assertNull($ooo->get('amount'));
-        $ooo = (clone $oo)->tryLoad(3);
+        $ooo = $oo->tryLoad(3);
         $this->assertEquals(5, $ooo->get('amount'));
 
-        $oo = (clone $u)->load(2)->ref('Orders');
-        $ooo = (clone $oo)->tryLoad(1);
+        $oo = $u->load(2)->ref('Orders');
+        $ooo = $oo->tryLoad(1);
         $this->assertNull($ooo->get('amount'));
-        $ooo = (clone $oo)->tryLoad(2);
+        $ooo = $oo->tryLoad(2);
         $this->assertEquals(15, $ooo->get('amount'));
-        $ooo = (clone $oo)->tryLoad(3);
+        $ooo = $oo->tryLoad(3);
         $this->assertNull($ooo->get('amount'));
 
         $oo = $u->unload()->addCondition('id', '>', '1')->ref('Orders');
@@ -95,11 +95,11 @@ class ReferenceSqlTest extends \Atk4\Schema\PhpunitTestCase
 
         $u->hasMany('cur', ['model' => $c, 'our_field' => 'currency', 'their_field' => 'currency']);
 
-        $cc = (clone $u)->load(1)->ref('cur');
+        $cc = $u->load(1)->ref('cur');
         $cc = $cc->tryLoadOne();
         $this->assertSame('Euro', $cc->get('name'));
 
-        $cc = (clone $u)->load(2)->ref('cur');
+        $cc = $u->load(2)->ref('cur');
         $cc = $cc->tryLoadOne();
         $this->assertSame('Pound', $cc->get('name'));
     }
@@ -142,10 +142,10 @@ class ReferenceSqlTest extends \Atk4\Schema\PhpunitTestCase
 
         $o->hasOne('user_id', ['model' => $u]);
 
-        $this->assertSame('John', (clone $o)->load(1)->ref('user_id')->get('name'));
-        $this->assertSame('Peter', (clone $o)->load(2)->ref('user_id')->get('name'));
-        $this->assertSame('John', (clone $o)->load(3)->ref('user_id')->get('name'));
-        $this->assertSame('Joe', (clone $o)->load(5)->ref('user_id')->get('name'));
+        $this->assertSame('John', $o->load(1)->ref('user_id')->get('name'));
+        $this->assertSame('Peter', $o->load(2)->ref('user_id')->get('name'));
+        $this->assertSame('John', $o->load(3)->ref('user_id')->get('name'));
+        $this->assertSame('Joe', $o->load(5)->ref('user_id')->get('name'));
 
         $o->unload();
         $o->addCondition('amount', '>', 6);
@@ -181,22 +181,22 @@ class ReferenceSqlTest extends \Atk4\Schema\PhpunitTestCase
         $o = (new Model($this->db, ['table' => 'order']))->addFields(['amount']);
         $o->hasOne('user_id', ['model' => $u])->addFields(['username' => 'name', ['date', 'type' => 'date']]);
 
-        $this->assertSame('John', (clone $o)->load(1)->get('username'));
-        $this->assertEquals(new \DateTime('2001-01-02'), (clone $o)->load(1)->get('date'));
+        $this->assertSame('John', $o->load(1)->get('username'));
+        $this->assertEquals(new \DateTime('2001-01-02'), $o->load(1)->get('date'));
 
-        $this->assertSame('Peter', (clone $o)->load(2)->get('username'));
-        $this->assertSame('John', (clone $o)->load(3)->get('username'));
-        $this->assertSame('Joe', (clone $o)->load(5)->get('username'));
+        $this->assertSame('Peter', $o->load(2)->get('username'));
+        $this->assertSame('John', $o->load(3)->get('username'));
+        $this->assertSame('Joe', $o->load(5)->get('username'));
 
         // few more tests
         $o = (new Model($this->db, ['table' => 'order']))->addFields(['amount']);
         $o->hasOne('user_id', ['model' => $u])->addFields(['username' => 'name', 'thedate' => ['date', 'type' => 'date']]);
-        $this->assertSame('John', (clone $o)->load(1)->get('username'));
+        $this->assertSame('John', $o->load(1)->get('username'));
         $this->assertEquals(new \DateTime('2001-01-02'), $o->load(1)->get('thedate'));
 
         $o = (new Model($this->db, ['table' => 'order']))->addFields(['amount']);
         $o->hasOne('user_id', ['model' => $u])->addFields(['date'], ['type' => 'date']);
-        $this->assertEquals(new \DateTime('2001-01-02'), (clone $o)->load(1)->get('date'));
+        $this->assertEquals(new \DateTime('2001-01-02'), $o->load(1)->get('date'));
     }
 
     public function testRelatedExpression()
@@ -330,7 +330,7 @@ class ReferenceSqlTest extends \Atk4\Schema\PhpunitTestCase
                 ['chicken5',  'expr' => 'sum([])', 'args' => ['5']],
             ]);
 
-        $ll = (clone $l)->load(1);
+        $ll = $l->load(1);
         $this->assertEquals(2, $ll->get('items_name')); // 2 not-null values
         $this->assertEquals(1, $ll->get('items_code')); // only 1 not-null value
         $this->assertEquals(2, $ll->get('items_star')); // 2 rows in total
@@ -340,7 +340,7 @@ class ReferenceSqlTest extends \Atk4\Schema\PhpunitTestCase
         $this->assertEquals(strlen('Chicken') + strlen('Pork'), $ll->get('len2'));
         $this->assertEquals(10, $ll->get('chicken5'));
 
-        $ll = (clone $l)->load(2);
+        $ll = $l->load(2);
         $this->assertEquals(0, $ll->get('items_name'));
         $this->assertEquals(0, $ll->get('items_code'));
         $this->assertEquals(0, $ll->get('items_star'));
@@ -426,20 +426,20 @@ class ReferenceSqlTest extends \Atk4\Schema\PhpunitTestCase
         $u->hasOne('contact_id', ['model' => $c])
             ->addField('address');
 
-        $uu = (clone $u)->load(1);
+        $uu = $u->load(1);
         $this->assertSame('John contact', $uu->get('address'));
         $this->assertSame('John contact', $uu->ref('contact_id')->get('address'));
 
-        $uu = (clone $u)->load(2);
+        $uu = $u->load(2);
         $this->assertNull($uu->get('address'));
         $this->assertNull($uu->get('contact_id'));
         $this->assertNull($uu->ref('contact_id')->get('address'));
 
-        $uu = (clone $u)->load(3);
+        $uu = $u->load(3);
         $this->assertSame('Joe contact', $uu->get('address'));
         $this->assertSame('Joe contact', $uu->ref('contact_id')->get('address'));
 
-        $uu = (clone $u)->load(2);
+        $uu = $u->load(2);
         $uu->ref('contact_id')->save(['address' => 'Peters new contact']);
 
         $this->assertNotNull($uu->get('contact_id'));

--- a/tests/ReferenceSqlTest.php
+++ b/tests/ReferenceSqlTest.php
@@ -96,11 +96,11 @@ class ReferenceSqlTest extends \Atk4\Schema\PhpunitTestCase
         $u->hasMany('cur', ['model' => $c, 'our_field' => 'currency', 'their_field' => 'currency']);
 
         $cc = (clone $u)->load(1)->ref('cur');
-        $cc->tryLoadOne();
+        $cc = $cc->tryLoadOne();
         $this->assertSame('Euro', $cc->get('name'));
 
         $cc = (clone $u)->load(2)->ref('cur');
-        $cc->tryLoadOne();
+        $cc = $cc->tryLoadOne();
         $this->assertSame('Pound', $cc->get('name'));
     }
 
@@ -260,7 +260,7 @@ class ReferenceSqlTest extends \Atk4\Schema\PhpunitTestCase
                 ['total_net', 'aggregate' => 'sum'],
                 ['total_gross', 'aggregate' => 'sum'],
             ]);
-        $i->load('1');
+        $i = $i->load('1');
 
         // type was set explicitly
         $this->assertSame('money', $i->getField('total_vat')->type);
@@ -382,7 +382,7 @@ class ReferenceSqlTest extends \Atk4\Schema\PhpunitTestCase
 
         $company->hasMany('Orders', ['model' => $order]);
 
-        $user->load(1);
+        $user = $user->load(1);
 
         $firstUserOrders = $user->ref('Company')->ref('Orders');
         $firstUserOrders->setOrder('id');
@@ -475,7 +475,7 @@ class ReferenceSqlTest extends \Atk4\Schema\PhpunitTestCase
 
         $p->hasOne('Stadium', ['model' => $s, 'our_field' => 'id', 'their_field' => 'player_id']);
 
-        $p->load(2);
+        $p = $p->load(2);
         $p->ref('Stadium')->import([['name' => 'Nou camp nou']]);
         $this->assertSame('Nou camp nou', $p->ref('Stadium')->get('name'));
         $this->assertSame(2, $p->ref('Stadium')->get('player_id'));
@@ -551,7 +551,7 @@ class ReferenceSqlTest extends \Atk4\Schema\PhpunitTestCase
         $o->hasOne('user_id', ['model' => $u])->addTitle();
 
         // change order user by changing title_field value
-        $o->load(1);
+        $o = $o->load(1);
         $o->set('user', 'Peter');
         $this->assertEquals(1, $o->get('user_id'));
         $o->save();
@@ -568,7 +568,7 @@ class ReferenceSqlTest extends \Atk4\Schema\PhpunitTestCase
         $o->hasOne('user_id', ['model' => $u])->addTitle();
 
         // change order user by changing title_field value
-        $o->load(1);
+        $o = $o->load(1);
         $o->set('user', 'Foo');
         $this->assertEquals(1, $o->get('user_id'));
         $o->save();
@@ -585,7 +585,7 @@ class ReferenceSqlTest extends \Atk4\Schema\PhpunitTestCase
         $o->hasOne('my_user', ['model' => $u, 'our_field' => 'user_id'])->addTitle();
 
         // change order user by changing ref field value
-        $o->load(1);
+        $o = $o->load(1);
         $o->set('my_user', 'Foo');
         $this->assertEquals(1, $o->get('user_id'));
         $o->save();
@@ -602,7 +602,7 @@ class ReferenceSqlTest extends \Atk4\Schema\PhpunitTestCase
         $o->hasOne('my_user', ['model' => $u, 'our_field' => 'user_id'])->addTitle();
 
         // change order user by changing ref field value
-        $o->load(1);
+        $o = $o->load(1);
         $o->set('my_user', 'Foo'); // user_id=2
         $o->set('user_id', 3);     // user_id=3 (this will take precedence)
         $this->assertEquals(3, $o->get('user_id'));

--- a/tests/ReferenceTest.php
+++ b/tests/ReferenceTest.php
@@ -16,6 +16,7 @@ class ReferenceTest extends AtkPhpunit\TestCase
         $user = new Model(null, ['table' => 'user']);
         $user->addField('id');
         $user->addField('name');
+        $user = $user->createEntity();
         $user->setId(1);
 
         $order = new Model();
@@ -24,7 +25,7 @@ class ReferenceTest extends AtkPhpunit\TestCase
         $order->addField('user_id');
 
         $user->hasMany('Orders', ['model' => $order, 'caption' => 'My Orders']);
-        $o = $user->ref('Orders');
+        $o = $user->ref('Orders')->createEntity();
 
         $this->assertSame(20, $o->get('amount'));
         $this->assertSame(1, $o->get('user_id'));
@@ -37,7 +38,7 @@ class ReferenceTest extends AtkPhpunit\TestCase
             return $m;
         }]);
 
-        $this->assertSame(100, $user->ref('BigOrders')->get('amount'));
+        $this->assertSame(100, $user->ref('BigOrders')->createEntity()->get('amount'));
     }
 
     /**
@@ -48,6 +49,7 @@ class ReferenceTest extends AtkPhpunit\TestCase
         $user = new Model(null, ['table' => 'user']);
         $user->addField('id');
         $user->addField('name');
+        $user = $user->createEntity();
         $user->setId(1);
 
         $order = new Model();
@@ -66,6 +68,7 @@ class ReferenceTest extends AtkPhpunit\TestCase
     {
         $db = new Persistence\Array_();
         $user = new Model($db, ['table' => 'user']);
+        $user = $user->createEntity();
         $user->setId(1);
         $user->hasOne('order_id', ['model' => [Model::class, 'table' => 'order']]);
         $o = $user->ref('order_id');

--- a/tests/ScopeTest.php
+++ b/tests/ScopeTest.php
@@ -14,7 +14,6 @@ use Doctrine\DBAL\Platforms\SqlitePlatform;
 class SCountry extends Model
 {
     public $table = 'country';
-
     public $caption = 'Country';
 
     protected function init(): void
@@ -34,7 +33,6 @@ class SCountry extends Model
 class SUser extends Model
 {
     public $table = 'user';
-
     public $caption = 'User';
 
     protected function init(): void
@@ -56,7 +54,6 @@ class SUser extends Model
 class STicket extends Model
 {
     public $table = 'ticket';
-
     public $caption = 'Ticket';
 
     protected function init(): void
@@ -73,20 +70,13 @@ class STicket extends Model
 
 class ScopeTest extends \Atk4\Schema\PhpunitTestCase
 {
-    protected $user;
-    protected $country;
-    protected $ticket;
-
     protected function setUp(): void
     {
         parent::setUp();
 
-        $this->country = new SCountry($this->db);
-
-        $this->getMigrator($this->country)->dropIfExists()->create();
-
-        // Specifying hasMany here will perform input
-        $this->country->import([
+        $country = new SCountry($this->db);
+        $this->getMigrator($country)->dropIfExists()->create();
+        $country->import([
             ['name' => 'Canada', 'code' => 'CA'],
             ['name' => 'Latvia', 'code' => 'LV'],
             ['name' => 'Japan', 'code' => 'JP'],
@@ -96,11 +86,9 @@ class ScopeTest extends \Atk4\Schema\PhpunitTestCase
             ['name' => 'Brazil', 'code' => 'BR'],
         ]);
 
-        $this->user = new SUser($this->db);
-
-        $this->getMigrator($this->user)->dropIfExists()->create();
-
-        $this->user->import([
+        $user = new SUser($this->db);
+        $this->getMigrator($user)->dropIfExists()->create();
+        $user->import([
             ['name' => 'John', 'surname' => 'Smith', 'country_code' => 'CA'],
             ['name' => 'Jane', 'surname' => 'Doe', 'country_code' => 'LV'],
             ['name' => 'Alain', 'surname' => 'Prost', 'country_code' => 'FR'],
@@ -108,11 +96,9 @@ class ScopeTest extends \Atk4\Schema\PhpunitTestCase
             ['name' => 'Rubens', 'surname' => 'Barichello', 'country_code' => 'BR'],
         ]);
 
-        $this->ticket = new STicket($this->db);
-
-        $this->getMigrator($this->ticket)->dropIfExists()->create();
-
-        $this->ticket->import([
+        $ticket = new STicket($this->db);
+        $this->getMigrator($ticket)->dropIfExists()->create();
+        $ticket->import([
             ['number' => '001', 'venue' => 'Best Stadium', 'user' => 1],
             ['number' => '002', 'venue' => 'Best Stadium', 'user' => 2],
             ['number' => '003', 'venue' => 'Best Stadium', 'user' => 2],
@@ -123,7 +109,7 @@ class ScopeTest extends \Atk4\Schema\PhpunitTestCase
 
     public function testCondition()
     {
-        $user = clone $this->user;
+        $user = new SUser($this->db);
 
         $condition = new Condition('name', 'John');
 
@@ -136,7 +122,7 @@ class ScopeTest extends \Atk4\Schema\PhpunitTestCase
 
     public function testConditionToWords()
     {
-        $user = clone $this->user;
+        $user = new SUser($this->db);
 
         $condition = new Condition(new Expression('false'));
 
@@ -172,7 +158,7 @@ class ScopeTest extends \Atk4\Schema\PhpunitTestCase
 
         $this->assertEquals('Surname is equal to User Name', $condition->toWords($user));
 
-        $country = clone $this->country;
+        $country = new SCountry($this->db);
 
         $country->addCondition('Users/#', '>', 0);
 
@@ -189,7 +175,7 @@ class ScopeTest extends \Atk4\Schema\PhpunitTestCase
 
     public function testConditionUnsupportedOperator()
     {
-        $country = clone $this->country;
+        $country = new SCountry($this->db);
 
         $this->expectException(Exception::class);
         $country->addCondition('name', '==', 'abc');
@@ -205,7 +191,7 @@ class ScopeTest extends \Atk4\Schema\PhpunitTestCase
 
     public function testRootScopeUnsupportedNegate()
     {
-        $country = clone $this->country;
+        $country = new SCountry($this->db);
 
         $this->expectException(Exception::class);
         $country->scope()->negate();
@@ -213,7 +199,7 @@ class ScopeTest extends \Atk4\Schema\PhpunitTestCase
 
     public function testConditionOnReferencedRecords()
     {
-        $user = clone $this->user;
+        $user = new SUser($this->db);
 
         $user->addCondition('country_id/code', 'LV');
 
@@ -223,7 +209,7 @@ class ScopeTest extends \Atk4\Schema\PhpunitTestCase
             $this->assertEquals('LV', $u->get('country_code'));
         }
 
-        $user = clone $this->user;
+        $user = new SUser($this->db);
 
         // users that have no ticket
         $user->addCondition('Tickets/#', 0);
@@ -234,7 +220,7 @@ class ScopeTest extends \Atk4\Schema\PhpunitTestCase
             $this->assertTrue(in_array($u->get('name'), ['Alain', 'Aerton', 'Rubens'], true));
         }
 
-        $country = clone $this->country;
+        $country = new SCountry($this->db);
 
         // countries with more than one user
         $country->addCondition('Users/#', '>', 1);
@@ -243,7 +229,7 @@ class ScopeTest extends \Atk4\Schema\PhpunitTestCase
             $this->assertEquals('BR', $c->get('code'));
         }
 
-        $country = clone $this->country;
+        $country = new SCountry($this->db);
 
         // countries with users that have ticket number 001
         $country->addCondition('Users/Tickets/number', '001');
@@ -252,7 +238,7 @@ class ScopeTest extends \Atk4\Schema\PhpunitTestCase
             $this->assertEquals('CA', $c->get('code'));
         }
 
-        $country = clone $this->country;
+        $country = new SCountry($this->db);
 
         // countries with users that have more than one ticket
         $country->addCondition('Users/Tickets/#', '>', 1);
@@ -261,7 +247,7 @@ class ScopeTest extends \Atk4\Schema\PhpunitTestCase
             $this->assertEquals('LV', $c->get('code'));
         }
 
-        $country = clone $this->country;
+        $country = new SCountry($this->db);
 
         // countries with users that have any tickets
         $country->addCondition('Users/Tickets/#', '>', 0);
@@ -272,7 +258,7 @@ class ScopeTest extends \Atk4\Schema\PhpunitTestCase
             $this->assertTrue(in_array($c->get('code'), ['LV', 'CA', 'BR'], true));
         }
 
-        $country = clone $this->country;
+        $country = new SCountry($this->db);
 
         // countries with users that have no tickets
         $country->addCondition('Users/Tickets/#', 0);
@@ -283,7 +269,7 @@ class ScopeTest extends \Atk4\Schema\PhpunitTestCase
             $this->assertTrue(in_array($c->get('code'), ['FR'], true));
         }
 
-        $user = clone $this->user;
+        $user = new SUser($this->db);
 
         // users with tickets that have more than two users per country
         // test if a model can be referenced multiple times
@@ -307,7 +293,7 @@ class ScopeTest extends \Atk4\Schema\PhpunitTestCase
 
     public function testScope()
     {
-        $user = clone $this->user;
+        $user = new SUser($this->db);
 
         $condition1 = ['name', 'John'];
         $condition2 = new Condition('country_code', 'CA');
@@ -345,7 +331,7 @@ class ScopeTest extends \Atk4\Schema\PhpunitTestCase
 
         $this->assertEquals('(Name is equal to \'John\' and Code is equal to \'CA\') or (Surname is equal to \'Doe\' and Code is equal to \'LV\') or Code is equal to \'BR\'', $scope->toWords($user));
 
-        $user = clone $this->user;
+        $user = new SUser($this->db);
 
         $user->scope()->add($scope);
 
@@ -354,7 +340,7 @@ class ScopeTest extends \Atk4\Schema\PhpunitTestCase
 
     public function testScopeToWords()
     {
-        $user = clone $this->user;
+        $user = new SUser($this->db);
 
         $condition1 = new Condition('name', 'Alain');
         $condition2 = new Condition('country_code', 'CA');
@@ -369,7 +355,7 @@ class ScopeTest extends \Atk4\Schema\PhpunitTestCase
 
     public function testNegate()
     {
-        $user = clone $this->user;
+        $user = new SUser($this->db);
 
         $condition1 = new Condition('name', '!=', 'Alain');
         $condition2 = new Condition('country_code', '!=', 'FR');
@@ -385,7 +371,7 @@ class ScopeTest extends \Atk4\Schema\PhpunitTestCase
 
     public function testAnd()
     {
-        $user = clone $this->user;
+        $user = new SUser($this->db);
 
         $condition1 = new Condition('name', 'Alain');
         $condition2 = new Condition('country_code', 'FR');
@@ -399,7 +385,7 @@ class ScopeTest extends \Atk4\Schema\PhpunitTestCase
 
     public function testOr()
     {
-        $user = clone $this->user;
+        $user = new SUser($this->db);
 
         $condition1 = new Condition('name', 'Alain');
         $condition2 = new Condition('country_code', 'FR');
@@ -413,7 +399,7 @@ class ScopeTest extends \Atk4\Schema\PhpunitTestCase
 
     public function testMerge()
     {
-        $user = clone $this->user;
+        $user = new SUser($this->db);
 
         $condition1 = new Condition('name', 'Alain');
         $condition2 = new Condition('country_code', 'FR');
@@ -425,7 +411,7 @@ class ScopeTest extends \Atk4\Schema\PhpunitTestCase
 
     public function testDestroyEmpty()
     {
-        $user = clone $this->user;
+        $user = new SUser($this->db);
 
         $condition1 = new Condition('name', 'Alain');
         $condition2 = new Condition('country_code', 'FR');

--- a/tests/ScopeTest.php
+++ b/tests/ScopeTest.php
@@ -129,7 +129,7 @@ class ScopeTest extends \Atk4\Schema\PhpunitTestCase
 
         $user->scope()->add($condition);
 
-        $user->loadOne();
+        $user = $user->loadOne();
 
         $this->assertEquals('Smith', $user->get('surname'));
     }

--- a/tests/SmboTransferTest.php
+++ b/tests/SmboTransferTest.php
@@ -49,8 +49,8 @@ class SmboTransferTest extends \Atk4\Schema\PhpunitTestCase
      */
     public function testTransfer()
     {
-        $aib = (new Account($this->db))->save(['name' => 'AIB']);
-        $boi = (new Account($this->db))->save(['name' => 'BOI']);
+        $aib = (new Account($this->db))->createEntity()->save(['name' => 'AIB']);
+        $boi = (new Account($this->db))->createEntity()->save(['name' => 'BOI']);
 
         $t = $aib->transfer($boi, 100); // create transfer between accounts
         $t->save();
@@ -74,20 +74,20 @@ class SmboTransferTest extends \Atk4\Schema\PhpunitTestCase
         // create accounts and payments
         $a = new Account($this->db);
 
-        $aa = clone $a;
+        $aa = $a->createEntity();
         $aa->save(['name' => 'AIB']);
-        $aa->ref('Payment')->save(['amount' => 10]);
-        $aa->ref('Payment')->save(['amount' => 20]);
+        $aa->ref('Payment')->createEntity()->save(['amount' => 10]);
+        $aa->ref('Payment')->createEntity()->save(['amount' => 20]);
         $aa->unload();
 
-        $aa = clone $a;
+        $aa = $a->createEntity();
         $aa->save(['name' => 'BOI']);
-        $aa->ref('Payment')->save(['amount' => 30]);
-        $a->unload();
+        $aa->ref('Payment')->createEntity()->save(['amount' => 30]);
+        $aa->unload();
 
         // create payment without link to account
         $p = new Payment($this->db);
-        $p->saveAndUnload(['amount' => 40]);
+        $p->createEntity()->saveAndUnload(['amount' => 40]);
 
         // Account is not loaded, will dump all Payments related to ANY Account
         $data = $a->ref('Payment')->export(['amount']);

--- a/tests/SmboTransferTest.php
+++ b/tests/SmboTransferTest.php
@@ -99,7 +99,7 @@ class SmboTransferTest extends \Atk4\Schema\PhpunitTestCase
         ], $data);
 
         // Account is loaded, will dump all Payments related to that particular Account
-        $a->load(1);
+        $a = $a->load(1);
         $data = $a->ref('Payment')->export(['amount']);
         $this->assertEquals([
             ['amount' => 10],

--- a/tests/StaticPersistenceTest.php
+++ b/tests/StaticPersistenceTest.php
@@ -19,12 +19,12 @@ class StaticPersistenceTest extends AtkPhpunit\TestCase
 
         // default title field
         $m = new Model($p);
-        $m->load(1);
+        $m = $m->load(1);
         $this->assertSame('world', $m->get('name'));
 
         // custom title field and try loading from same static twice
         $m = new Model($p); //, ['title_field' => 'foo']);
-        $m->load(1);
+        $m = $m->load(1);
         $this->assertSame('world', $m->get('name')); // still 'name' here not 'foo'
     }
 
@@ -33,7 +33,7 @@ class StaticPersistenceTest extends AtkPhpunit\TestCase
         $p = new Persistence\Static_([['hello', 'xx', true], ['world', 'xy', false]]);
         $m = new Model($p);
 
-        $m->load(1);
+        $m = $m->load(1);
 
         $this->assertSame('world', $m->get('name'));
         $this->assertSame('xy', $m->get('field1'));
@@ -45,7 +45,7 @@ class StaticPersistenceTest extends AtkPhpunit\TestCase
         $p = new Persistence\Static_([['foo' => 'hello'], ['foo' => 'world']]);
         $m = new Model($p);
 
-        $m->load(1);
+        $m = $m->load(1);
 
         $this->assertSame('world', $m->get('foo'));
     }
@@ -55,7 +55,7 @@ class StaticPersistenceTest extends AtkPhpunit\TestCase
         $p = new Persistence\Static_([['id' => 20, 'foo' => 'hello'], ['id' => 21, 'foo' => 'world']]);
         $m = new Model($p);
 
-        $m->load(21);
+        $m = $m->load(21);
 
         $this->assertSame('world', $m->get('foo'));
     }
@@ -65,7 +65,7 @@ class StaticPersistenceTest extends AtkPhpunit\TestCase
         $p = new Persistence\Static_([20 => ['foo' => 'hello'], 21 => ['foo' => 'world']]);
         $m = new Model($p);
 
-        $m->load(21);
+        $m = $m->load(21);
 
         $this->assertSame('world', $m->get('foo'));
     }
@@ -75,7 +75,7 @@ class StaticPersistenceTest extends AtkPhpunit\TestCase
         $p = new Persistence\Static_([]);
         $m = new Model($p);
 
-        $m->tryLoadAny();
+        $m = $m->tryLoadAny();
 
         $this->assertFalse($m->loaded());
     }

--- a/tests/SubTypesTest.php
+++ b/tests/SubTypesTest.php
@@ -30,11 +30,12 @@ class StAccount extends Model
 
     public static function open($persistence, $name, $amount = 0)
     {
-        $m = new self($persistence);
+        $m = new static($persistence);
+        $m = $m->createEntity();
         $m->save(['name' => $name]);
 
         if ($amount) {
-            $m->ref('Transactions:Ob')->save(['amount' => $amount]);
+            $m->ref('Transactions:Ob')->createEntity()->save(['amount' => $amount]);
         }
 
         return $m;
@@ -42,18 +43,18 @@ class StAccount extends Model
 
     public function deposit($amount)
     {
-        return $this->ref('Transactions:Deposit')->save(['amount' => $amount]);
+        return $this->ref('Transactions:Deposit')->createEntity()->save(['amount' => $amount]);
     }
 
     public function withdraw($amount)
     {
-        return $this->ref('Transactions:Withdrawal')->save(['amount' => $amount]);
+        return $this->ref('Transactions:Withdrawal')->createEntity()->save(['amount' => $amount]);
     }
 
     public function transferTo(self $account, $amount)
     {
-        $out = $this->ref('Transactions:TransferOut')->save(['amount' => $amount]);
-        $in = $account->ref('Transactions:TransferIn')->save(['amount' => $amount, 'link_id' => $out->getId()]);
+        $out = $this->ref('Transactions:TransferOut')->createEntity()->save(['amount' => $amount]);
+        $in = $account->ref('Transactions:TransferIn')->createEntity()->save(['amount' => $amount, 'link_id' => $out->getId()]);
         $out->set('link_id', $in->getId());
         $out->save();
     }
@@ -62,6 +63,7 @@ class StAccount extends Model
 class StGenericTransaction extends Model
 {
     public $table = 'transaction';
+    /** @var string */
     public $type;
 
     protected function init(): void

--- a/tests/SubTypesTest.php
+++ b/tests/SubTypesTest.php
@@ -80,7 +80,7 @@ class StGenericTransaction extends Model
             if (static::class !== $this->getClassName()) {
                 $cl = $this->getClassName();
                 $cl = new $cl($this->persistence);
-                $cl->load($this->getId());
+                $cl = $cl->load($this->getId());
 
                 $this->breakHook($cl);
             }

--- a/tests/TransactionTest.php
+++ b/tests/TransactionTest.php
@@ -63,16 +63,17 @@ class TransactionTest extends \Atk4\Schema\PhpunitTestCase
         // test insert
         $m = new Model($db, ['table' => 'item']);
         $m->addField('name');
-        $m->onHook(Model::HOOK_BEFORE_SAVE, function ($model, $is_update) {
-            $this->assertFalse($is_update);
+        $testCase = $this;
+        $m->onHookShort(Model::HOOK_BEFORE_SAVE, static function (bool $isUpdate) use ($testCase) {
+            $testCase->assertFalse($isUpdate);
         });
-        $m->save(['name' => 'Foo']);
+        $m->createEntity()->save(['name' => 'Foo']);
 
         // test update
         $m = new Model($db, ['table' => 'item']);
         $m->addField('name');
-        $m->onHook(Model::HOOK_AFTER_SAVE, function ($model, $is_update) {
-            $this->assertTrue($is_update);
+        $m->onHookShort(Model::HOOK_AFTER_SAVE, static function (bool $isUpdate) use ($testCase) {
+            $testCase->assertTrue($isUpdate);
         });
         $m = $m->loadBy('name', 'John')->save(['name' => 'Foo']);
     }
@@ -89,16 +90,17 @@ class TransactionTest extends \Atk4\Schema\PhpunitTestCase
         // test insert
         $m = new Model($db, ['table' => 'item']);
         $m->addField('name');
-        $m->onHook(Model::HOOK_AFTER_SAVE, function ($model, $is_update) {
-            $this->assertFalse($is_update);
+        $testCase = $this;
+        $m->onHookShort(Model::HOOK_AFTER_SAVE, static function (bool $isUpdate) use ($testCase) {
+            $testCase->assertFalse($isUpdate);
         });
-        $m->save(['name' => 'Foo']);
+        $m->createEntity()->save(['name' => 'Foo']);
 
         // test update
         $m = new Model($db, ['table' => 'item']);
         $m->addField('name');
-        $m->onHook(Model::HOOK_AFTER_SAVE, function ($model, $is_update) {
-            $this->assertTrue($is_update);
+        $m->onHookShort(Model::HOOK_AFTER_SAVE, static function (bool $isUpdate) use ($testCase) {
+            $testCase->assertTrue($isUpdate);
         });
         $m = $m->loadBy('name', 'John')->save(['name' => 'Foo']);
     }
@@ -119,13 +121,14 @@ class TransactionTest extends \Atk4\Schema\PhpunitTestCase
 
         $hook_called = false;
         $values = [];
-        $m->onHook(Model::HOOK_ROLLBACK, function ($mm, $e) use (&$hook_called, &$values) {
+        $m->onHook(Model::HOOK_ROLLBACK, static function (Model $model, \Exception $e) use (&$hook_called, &$values) {
             $hook_called = true;
-            $values = $mm->get(); // model field values are still the same no matter we rolled back
-            $mm->breakHook(false); // if we break hook and return false then exception is not thrown, but rollback still happens
+            $values = $model->get(); // model field values are still the same no matter we rolled back
+            $model->breakHook(false); // if we break hook and return false then exception is not thrown, but rollback still happens
         });
 
         // this will fail because field foo is not in DB and call onRollback hook
+        $m = $m->createEntity();
         $m->setMulti(['name' => 'Jane', 'foo' => 'bar']);
         $m->save();
 

--- a/tests/TransactionTest.php
+++ b/tests/TransactionTest.php
@@ -25,7 +25,7 @@ class TransactionTest extends \Atk4\Schema\PhpunitTestCase
 
         $m = new Model($db, ['table' => 'item']);
         $m->addField('name');
-        $m->load(2);
+        $m = $m->load(2);
 
         $m->onHook(Model::HOOK_AFTER_SAVE, static function ($m) {
             throw new \Exception('Awful thing happened');
@@ -74,7 +74,7 @@ class TransactionTest extends \Atk4\Schema\PhpunitTestCase
         $m->onHook(Model::HOOK_AFTER_SAVE, function ($model, $is_update) {
             $this->assertTrue($is_update);
         });
-        $m->loadBy('name', 'John')->save(['name' => 'Foo']);
+        $m = $m->loadBy('name', 'John')->save(['name' => 'Foo']);
     }
 
     public function testAfterSaveHook()
@@ -100,7 +100,7 @@ class TransactionTest extends \Atk4\Schema\PhpunitTestCase
         $m->onHook(Model::HOOK_AFTER_SAVE, function ($model, $is_update) {
             $this->assertTrue($is_update);
         });
-        $m->loadBy('name', 'John')->save(['name' => 'Foo']);
+        $m = $m->loadBy('name', 'John')->save(['name' => 'Foo']);
     }
 
     public function testOnRollbackHook()

--- a/tests/TypecastingTest.php
+++ b/tests/TypecastingTest.php
@@ -68,7 +68,7 @@ class TypecastingTest extends \Atk4\Schema\PhpunitTestCase
         $m->addField('float', ['type' => 'float']);
         $m->addField('integer', ['type' => 'integer']);
         $m->addField('array', ['type' => 'array']);
-        $mm = (clone $m)->load(1);
+        $mm = $m->load(1);
 
         $this->assertSame('foo', $mm->get('string'));
         $this->assertTrue($mm->get('boolean'));
@@ -162,7 +162,7 @@ class TypecastingTest extends \Atk4\Schema\PhpunitTestCase
         $m->addField('float', ['type' => 'float']);
         $m->addField('array', ['type' => 'array']);
         $m->addField('object', ['type' => 'object']);
-        $mm = (clone $m)->load(1);
+        $mm = $m->load(1);
 
         // Only
         $this->assertSame($emptyStringValue, $mm->get('string'));
@@ -281,7 +281,7 @@ class TypecastingTest extends \Atk4\Schema\PhpunitTestCase
 
         $m->addField('rot13', ['typecast' => [$rot, $rot]]);
 
-        $mm = (clone $m)->load(1);
+        $mm = $m->load(1);
 
         $this->assertSame('hello world', $mm->get('rot13'));
         $this->assertSame(1, (int) $mm->getId());

--- a/tests/TypecastingTest.php
+++ b/tests/TypecastingTest.php
@@ -35,6 +35,23 @@ class MyDateTime extends \DateTime
 
 class TypecastingTest extends \Atk4\Schema\PhpunitTestCase
 {
+    /** @var string */
+    private $defaultTzBackup;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->defaultTzBackup = date_default_timezone_get();
+    }
+
+    protected function tearDown(): void
+    {
+        date_default_timezone_set($this->defaultTzBackup);
+
+        parent::tearDown();
+    }
+
     public function testType()
     {
         $dbData = [
@@ -80,7 +97,7 @@ class TypecastingTest extends \Atk4\Schema\PhpunitTestCase
         $this->assertSame([1, 2, 3], $mm->get('array'));
         $this->assertSame(8.202343, $mm->get('float'));
 
-        (clone $m)->setMulti(array_diff_key($mm->get(), ['id' => true]))->save();
+        $m->createEntity()->setMulti(array_diff_key($mm->get(), ['id' => true]))->save();
 
         $dbData = [
             'types' => [
@@ -198,7 +215,7 @@ class TypecastingTest extends \Atk4\Schema\PhpunitTestCase
         $mm->save();
         $this->assertEquals($dbData, $this->getDb());
 
-        $m->setMulti(array_diff_key($mm->get(), ['id' => true]))->save();
+        $m->createEntity()->setMulti(array_diff_key($mm->get(), ['id' => true]))->save();
 
         $dbData['types'][2] = [
             'id' => 2,
@@ -232,6 +249,7 @@ class TypecastingTest extends \Atk4\Schema\PhpunitTestCase
         $m->addField('a');
         $m->addField('b');
         $m->addField('c');
+        $m = $m->createEntity();
 
         unset($row['id']);
         $m->setMulti($row);
@@ -293,7 +311,7 @@ class TypecastingTest extends \Atk4\Schema\PhpunitTestCase
         $this->assertTrue($mm->get('b1'));
         $this->assertFalse($mm->get('b2'));
 
-        (clone $m)->setMulti(array_diff_key($mm->get(), ['id' => true]))->save();
+        $m->createEntity()->setMulti(array_diff_key($mm->get(), ['id' => true]))->save();
         $m->delete(1);
 
         unset($dbData['types'][0]);
@@ -526,6 +544,7 @@ class TypecastingTest extends \Atk4\Schema\PhpunitTestCase
 
         $m = new Model($db, ['table' => 'types']);
         $m->addField('i', ['type' => 'integer']);
+        $m = $m->createEntity();
 
         $m->getDataRef()['i'] = 1;
         $this->assertSame([], $m->getDirtyRef());
@@ -542,6 +561,7 @@ class TypecastingTest extends \Atk4\Schema\PhpunitTestCase
         // same test without type integer
         $m = new Model($db, ['table' => 'types']);
         $m->addField('i');
+        $m = $m->createEntity();
 
         $m->getDataRef()['i'] = 1;
         $this->assertSame([], $m->getDirtyRef());

--- a/tests/TypecastingTest.php
+++ b/tests/TypecastingTest.php
@@ -318,7 +318,7 @@ class TypecastingTest extends \Atk4\Schema\PhpunitTestCase
 
         $m->addField('date', ['type' => 'date', 'dateTimeClass' => MyDate::class]);
 
-        $m->tryLoad(1);
+        $m = $m->tryLoad(1);
 
         $this->assertTrue($m->get('date') instanceof MyDate);
     }
@@ -338,7 +338,7 @@ class TypecastingTest extends \Atk4\Schema\PhpunitTestCase
 
         $m->addField('date', ['type' => 'date', 'dateTimeClass' => MyDate::class]);
 
-        $m->tryLoadAny();
+        $m = $m->tryLoadAny();
 
         $this->assertTrue($m->get('date') instanceof MyDate);
     }
@@ -358,7 +358,7 @@ class TypecastingTest extends \Atk4\Schema\PhpunitTestCase
 
         $m->addField('date', ['type' => 'date', 'dateTimeClass' => MyDate::class]);
 
-        $m->loadBy('id', 1);
+        $m = $m->loadBy('id', 1);
 
         $this->assertTrue($m->get('date') instanceof MyDate);
     }
@@ -377,12 +377,12 @@ class TypecastingTest extends \Atk4\Schema\PhpunitTestCase
         $m = new Model($db, ['table' => 'types']);
         $m->addField('date', ['type' => 'date', 'dateTimeClass' => MyDate::class]);
 
-        $m->loadOne();
+        $m = $m->loadOne();
         $this->assertTrue($m->loaded());
         $d = $m->get('date');
         $m->unload();
 
-        $m->loadBy('date', $d);
+        $m = $m->loadBy('date', $d);
         $this->assertTrue($m->loaded());
         $m->unload();
 
@@ -453,7 +453,7 @@ class TypecastingTest extends \Atk4\Schema\PhpunitTestCase
 
         $m = new Model($db, ['table' => 'types']);
         $m->addField('ts', ['actual' => 'date', 'type' => 'datetime']);
-        $m->loadOne();
+        $m = $m->loadOne();
 
         // must respect 'actual'
         $this->assertNotNull($m->get('ts'));
@@ -475,7 +475,7 @@ class TypecastingTest extends \Atk4\Schema\PhpunitTestCase
         $m = new Model($db, ['table' => 'types']);
         $m->addField('ts', ['actual' => 'date', 'type' => 'datetime']);
         $this->expectException(Exception::class);
-        $m->loadOne();
+        $m = $m->loadOne();
     }
 
     public function testDirtyTimestamp()
@@ -493,7 +493,7 @@ class TypecastingTest extends \Atk4\Schema\PhpunitTestCase
 
         $m = new Model($db, ['table' => 'types']);
         $m->addField('ts', ['actual' => 'date', 'type' => 'datetime']);
-        $m->loadOne();
+        $m = $m->loadOne();
         $m->set('ts', clone $m->get('ts'));
 
         $this->assertFalse($m->isDirty('ts'));
@@ -512,7 +512,7 @@ class TypecastingTest extends \Atk4\Schema\PhpunitTestCase
 
         $m = new Model($db, ['table' => 'types']);
         $m->addField('ts', ['actual' => 'date', 'type' => 'date']);
-        $m->loadOne();
+        $m = $m->loadOne();
         $m->set('ts', new \DateTime('2012-02-30'));
         $m->save();
 
@@ -575,7 +575,7 @@ class TypecastingTest extends \Atk4\Schema\PhpunitTestCase
 
         $m = new Model($db, ['table' => 'types']);
         $m->addField('ts', ['actual' => 'date', 'type' => 'time']);
-        $m->loadOne();
+        $m = $m->loadOne();
 
         $m->set('ts', $sql_time_new);
         $this->assertTrue($m->isDirty('ts'));
@@ -603,7 +603,7 @@ class TypecastingTest extends \Atk4\Schema\PhpunitTestCase
 
         $m = new Model($db, ['table' => 'types']);
         $m->addField('ts', ['actual' => 'date', 'type' => 'time']);
-        $m->loadOne();
+        $m = $m->loadOne();
 
         $m->set('ts', $sql_time);
         $this->assertTrue($m->isDirty('ts'));

--- a/tests/TypecastingTest.php
+++ b/tests/TypecastingTest.php
@@ -395,17 +395,17 @@ class TypecastingTest extends \Atk4\Schema\PhpunitTestCase
         $m = new Model($db, ['table' => 'types']);
         $m->addField('date', ['type' => 'date', 'dateTimeClass' => MyDate::class]);
 
-        $m = $m->loadOne();
-        $this->assertTrue($m->loaded());
-        $d = $m->get('date');
-        $m->unload();
+        $m2 = $m->loadOne();
+        $this->assertTrue($m2->loaded());
+        $d = $m2->get('date');
+        $m2->unload();
 
-        $m = $m->loadBy('date', $d);
-        $this->assertTrue($m->loaded());
-        $m->unload();
+        $m2 = $m->loadBy('date', $d);
+        $this->assertTrue($m2->loaded());
+        $m2->unload();
 
-        $m->addCondition('date', $d)->loadOne();
-        $this->assertTrue($m->loaded());
+        $m2 = $m->addCondition('date', $d)->loadOne();
+        $this->assertTrue($m2->loaded());
     }
 
     public function testTypecastBoolean()

--- a/tests/UserActionTest.php
+++ b/tests/UserActionTest.php
@@ -81,7 +81,7 @@ class UserActionTest extends \Atk4\Schema\PhpunitTestCase
         $this->assertSame(Model\UserAction::APPLIES_TO_SINGLE_RECORD, $act1->appliesTo);
 
         // load record, before executing, because scope is single record
-        $client->load(1);
+        $client = $client->load(1);
 
         $this->assertNotTrue($client->get('reminder_sent'));
         $res = $act1->execute();
@@ -111,7 +111,7 @@ class UserActionTest extends \Atk4\Schema\PhpunitTestCase
             return $m->get('name');
         });
 
-        $client->load(1);
+        $client = $client->load(1);
         $this->assertSame('John', $client->getUserAction('say_name')->execute());
 
         $client->getUserAction('say_name')->preview = function ($m, $arg) {
@@ -146,7 +146,7 @@ class UserActionTest extends \Atk4\Schema\PhpunitTestCase
     {
         $client = new UaClient($this->pers);
         $client->addUserAction('new_client', ['appliesTo' => Model\UserAction::APPLIES_TO_NO_RECORDS]);
-        $client->load(1);
+        $client = $client->load(1);
 
         $this->expectExceptionMessage('can be executed on non-existing record');
         $client->executeUserAction('new_client');
@@ -171,7 +171,7 @@ class UserActionTest extends \Atk4\Schema\PhpunitTestCase
     public function testDisabled1()
     {
         $client = new UaClient($this->pers);
-        $client->load(1);
+        $client = $client->load(1);
 
         $client->getUserAction('send_reminder')->enabled = false;
 
@@ -182,7 +182,7 @@ class UserActionTest extends \Atk4\Schema\PhpunitTestCase
     public function testDisabled2()
     {
         $client = new UaClient($this->pers);
-        $client->load(1);
+        $client = $client->load(1);
 
         $client->getUserAction('send_reminder')->enabled = function () {
             return false;
@@ -195,7 +195,7 @@ class UserActionTest extends \Atk4\Schema\PhpunitTestCase
     public function testDisabled3()
     {
         $client = new UaClient($this->pers);
-        $client->load(1);
+        $client = $client->load(1);
 
         $client->getUserAction('send_reminder')->enabled = function () {
             return true;
@@ -210,7 +210,7 @@ class UserActionTest extends \Atk4\Schema\PhpunitTestCase
         $client = new UaClient($this->pers);
         $a = $client->addUserAction('change_details', ['callback' => 'save', 'fields' => ['name']]);
 
-        $client->load(1);
+        $client = $client->load(1);
 
         $this->assertNotSame('Peter', $client->get('name'));
         $client->set('name', 'Peter');
@@ -223,7 +223,7 @@ class UserActionTest extends \Atk4\Schema\PhpunitTestCase
         $client = new UaClient($this->pers);
         $a = $client->addUserAction('change_details', ['callback' => 'save', 'fields' => ['name']]);
 
-        $client->load(1);
+        $client = $client->load(1);
 
         $this->assertNotSame('Peter', $client->get('name'));
         $client->set('name', 'Peter');
@@ -238,7 +238,7 @@ class UserActionTest extends \Atk4\Schema\PhpunitTestCase
         $client = new UaClient($this->pers);
         $a = $client->addUserAction('change_details', ['callback' => 'save', 'fields' => 'whops_forgot_brackets']);
 
-        $client->load(1);
+        $client = $client->load(1);
 
         $this->assertNotSame('Peter', $client->get('name'));
         $client->set('name', 'Peter');
@@ -250,7 +250,7 @@ class UserActionTest extends \Atk4\Schema\PhpunitTestCase
     public function testConfirmation()
     {
         $client = new UaClient($this->pers);
-        $client->load(1);
+        $client = $client->load(1);
         $action = $client->addUserAction('test');
 
         $this->assertFalse($action->getConfirmation());

--- a/tests/UserActionTest.php
+++ b/tests/UserActionTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Atk4\Data\Tests;
 
-use Atk4\Core\Exception;
 use Atk4\Data\Model;
 use Atk4\Data\Persistence\Static_ as Persistence_Static;
 
@@ -54,6 +53,7 @@ class UaClient extends Model
  */
 class UserActionTest extends \Atk4\Schema\PhpunitTestCase
 {
+    /** @var Persistence_Static */
     public $pers;
 
     protected function setUp(): void
@@ -70,19 +70,18 @@ class UserActionTest extends \Atk4\Schema\PhpunitTestCase
     {
         $client = new UaClient($this->pers);
 
-        $actions = $client->getUserActions();
-        $this->assertCount(4, $actions); // don't return system actions here, but include add/edit/delete
+        $this->assertCount(4, $client->getUserActions()); // don't return system actions here, but include add/edit/delete
         $this->assertCount(0, $client->getUserActions(Model\UserAction::APPLIES_TO_ALL_RECORDS)); // don't return system actions here
 
-        $act1 = $actions['send_reminder'];
-
         // action takes no arguments. If it would, we should be able to find info about those
+        $act1 = $client->getUserActions()['send_reminder'];
         $this->assertSame([], $act1->args);
         $this->assertSame(Model\UserAction::APPLIES_TO_SINGLE_RECORD, $act1->appliesTo);
 
         // load record, before executing, because scope is single record
         $client = $client->load(1);
 
+        $act1 = $client->getUserActions()['send_reminder'];
         $this->assertNotTrue($client->get('reminder_sent'));
         $res = $act1->execute();
         $this->assertTrue($client->get('reminder_sent'));

--- a/tests/UserActionTest.php
+++ b/tests/UserActionTest.php
@@ -7,11 +7,6 @@ namespace Atk4\Data\Tests;
 use Atk4\Data\Model;
 use Atk4\Data\Persistence\Static_ as Persistence_Static;
 
-/**
- * Sample trait designed to extend model.
- *
- * @target Model
- */
 trait UaReminder
 {
     public function send_reminder()
@@ -48,9 +43,6 @@ class UaClient extends Model
     }
 }
 
-/**
- * Implements various tests for UserAction.
- */
 class UserActionTest extends \Atk4\Schema\PhpunitTestCase
 {
     /** @var Persistence_Static */
@@ -137,6 +129,8 @@ class UserActionTest extends \Atk4\Schema\PhpunitTestCase
     public function testAppliesTo1()
     {
         $client = new UaClient($this->pers);
+        $client = $client->createEntity();
+
         $this->expectExceptionMessage('load existing record');
         $client->executeUserAction('send_reminder');
     }
@@ -155,6 +149,7 @@ class UserActionTest extends \Atk4\Schema\PhpunitTestCase
     {
         $client = new UaClient($this->pers);
         $client->addUserAction('new_client', ['appliesTo' => Model\UserAction::APPLIES_TO_NO_RECORDS, 'atomic' => false]);
+        $client = $client->createEntity();
 
         $this->expectExceptionMessage('not defined');
         $client->executeUserAction('new_client');

--- a/tests/UserActionTest.php
+++ b/tests/UserActionTest.php
@@ -256,7 +256,7 @@ class UserActionTest extends \Atk4\Schema\PhpunitTestCase
         $this->assertSame('Are you sure?', $action->getConfirmation());
 
         $action->confirmation = function ($action) {
-            return 'Proceed with Test: ' . $action->getModel()->getTitle();
+            return 'Proceed with Test: ' . $action->getEntity()->getTitle();
         };
         $this->assertSame('Proceed with Test: John', $action->getConfirmation());
     }

--- a/tests/UserActionTest.php
+++ b/tests/UserActionTest.php
@@ -207,20 +207,20 @@ class UserActionTest extends \Atk4\Schema\PhpunitTestCase
     public function testFields()
     {
         $client = new UaClient($this->pers);
-        $a = $client->addUserAction('change_details', ['callback' => 'save', 'fields' => ['name']]);
+        $client->addUserAction('change_details', ['callback' => 'save', 'fields' => ['name']]);
 
         $client = $client->load(1);
 
         $this->assertNotSame('Peter', $client->get('name'));
         $client->set('name', 'Peter');
-        $a->execute();
+        $client->getUserAction('change_details')->execute();
         $this->assertSame('Peter', $client->get('name'));
     }
 
     public function testFieldsTooDirty1()
     {
         $client = new UaClient($this->pers);
-        $a = $client->addUserAction('change_details', ['callback' => 'save', 'fields' => ['name']]);
+        $client->addUserAction('change_details', ['callback' => 'save', 'fields' => ['name']]);
 
         $client = $client->load(1);
 
@@ -228,21 +228,21 @@ class UserActionTest extends \Atk4\Schema\PhpunitTestCase
         $client->set('name', 'Peter');
         $client->set('reminder_sent', true);
         $this->expectExceptionMessage('dirty fields');
-        $a->execute();
+        $client->getUserAction('change_details')->execute();
         $this->assertSame('Peter', $client->get('name'));
     }
 
     public function testFieldsIncorrect()
     {
         $client = new UaClient($this->pers);
-        $a = $client->addUserAction('change_details', ['callback' => 'save', 'fields' => 'whops_forgot_brackets']);
+        $client->addUserAction('change_details', ['callback' => 'save', 'fields' => 'whops_forgot_brackets']);
 
         $client = $client->load(1);
 
         $this->assertNotSame('Peter', $client->get('name'));
         $client->set('name', 'Peter');
         $this->expectExceptionMessage('array');
-        $a->execute();
+        $client->getUserAction('change_details')->execute();
         $this->assertSame('Peter', $client->get('name'));
     }
 

--- a/tests/ValidationTest.php
+++ b/tests/ValidationTest.php
@@ -50,6 +50,7 @@ class BadValidationModel extends Model
 
 class ValidationTest extends AtkPhpunit\TestCase
 {
+    /** @var Model */
     public $m;
 
     protected function setUp(): void
@@ -62,35 +63,39 @@ class ValidationTest extends AtkPhpunit\TestCase
 
     public function testValidate1()
     {
-        $this->m->set('name', 'john');
-        $this->m->set('domain', 'gmail.com');
-        $this->m->save();
+        $m = $this->m->createEntity();
+        $m->set('name', 'john');
+        $m->set('domain', 'gmail.com');
+        $m->save();
         $this->assertTrue(true); // no exception
     }
 
     public function testValidate2()
     {
-        $this->m->set('name', 'Python');
+        $m = $this->m->createEntity();
+        $m->set('name', 'Python');
         $this->expectException(ValidationException::class);
         $this->expectExceptionMessage('Snakes');
-        $this->m->save();
+        $m->save();
     }
 
     public function testValidate3()
     {
-        $this->m->set('name', 'Python');
-        $this->m->set('domain', 'example.com');
+        $m = $this->m->createEntity();
+        $m->set('name', 'Python');
+        $m->set('domain', 'example.com');
         $this->expectException(ValidationException::class);
         $this->expectExceptionMessage('Multiple');
-        $this->m->save();
+        $m->save();
     }
 
     public function testValidate4()
     {
+        $m = $this->m->createEntity();
         try {
-            $this->m->set('name', 'Python');
-            $this->m->set('domain', 'example.com');
-            $this->m->save();
+            $m->set('name', 'Python');
+            $m->set('domain', 'example.com');
+            $m->save();
             $this->fail('Expected exception');
         } catch (\Atk4\Data\ValidationException $e) {
             $this->assertSame('This domain is reserved for examples only', $e->getParams()['errors']['domain']);
@@ -103,6 +108,7 @@ class ValidationTest extends AtkPhpunit\TestCase
     {
         $p = new Persistence\Array_();
         $m = new BadValidationModel($p);
+        $m = $m->createEntity();
 
         $this->expectException(\TypeError::class);
         $m->set('name', 'john');
@@ -111,27 +117,29 @@ class ValidationTest extends AtkPhpunit\TestCase
 
     public function testValidateHook()
     {
-        $this->m->onHook(Model::HOOK_VALIDATE, static function ($m) {
+        $m = $this->m->createEntity();
+
+        $m->onHook(Model::HOOK_VALIDATE, static function ($m) {
             if ($m->get('name') === 'C#') {
                 return ['name' => 'No sharp objects allowed'];
             }
         });
 
-        $this->m->set('name', 'Swift');
-        $this->m->save();
+        $m->set('name', 'Swift');
+        $m->save();
 
         try {
-            $this->m->set('name', 'C#');
-            $this->m->save();
+            $m->set('name', 'C#');
+            $m->save();
             $this->fail('Expected exception');
         } catch (\Atk4\Data\ValidationException $e) {
             $this->assertSame('No sharp objects allowed', $e->errors['name']);
         }
 
         try {
-            $this->m->set('name', 'Python');
-            $this->m->set('domain', 'example.com');
-            $this->m->save();
+            $m->set('name', 'Python');
+            $m->set('domain', 'example.com');
+            $m->save();
             $this->fail('Expected exception');
         } catch (\Atk4\Data\ValidationException $e) {
             $this->assertCount(2, $e->errors);


### PR DESCRIPTION
# For 3.0 release 🚀 

# Definitions

### MODEL

Instance of `Model` class that is supposed to model data/relations, but can not hold/contain any record data.

### ENTITY

Instance of `Model` class that is supposed to hold/contain record data, but they can be modelled only using MODEL (described above).

The instance/object is locked with specific ID once it is loaded/inserted from/to DB.

# Migration

Model data like now. To manipulate with the actual data, you need to create another instance from MODEL using `createEntity()` method to create a new entity or using `{,try}load{,One,Any}()` methods which now return a new instance - ENTITY.

# Mistake safety

If and only if we can distinguish strictly between model and entity, then all wrong usage will throw and no code can keep working if used wrongly.