### PR TITLE
Fix Field clone with Reference and do not mutate model scope in Condition::toWords

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -18,34 +18,34 @@ parameters:
 
         # TODO these rules are generated, this ignores should be fixed in the code
         # for src-schema/PhpunitTestCase.php
-        - '~^Access to an undefined property Atk4\\Data\\Persistence\:\:\$connection\.$~'
-        - '~^Call to an undefined method Atk4\\Data\\Persistence\:\:dsql\(\)\.$~'
+        - '~^Access to an undefined property Atk4\\Data\\Persistence::\$connection\.$~'
+        - '~^Call to an undefined method Atk4\\Data\\Persistence::dsql\(\)\.$~'
         # for src/FieldSqlExpression.php
-        - '~^Call to an undefined method Atk4\\Data\\Model\:\:expr\(\)\.$~'
+        - '~^Call to an undefined method Atk4\\Data\\Model::expr\(\)\.$~'
         # for src/Model.php
-        - '~^Call to an undefined method Atk4\\Data\\Persistence\:\:update\(\)\.$~'
-        - '~^Call to an undefined method Atk4\\Data\\Persistence\:\:insert\(\)\.$~'
-        - '~^Call to an undefined method Atk4\\Data\\Persistence\:\:export\(\)\.$~'
-        - '~^Call to an undefined method Atk4\\Data\\Persistence\:\:prepareIterator\(\)\.$~'
-        - '~^Call to an undefined method Atk4\\Data\\Persistence\:\:delete\(\)\.$~'
-        - '~^Call to an undefined method Atk4\\Data\\Persistence\:\:action\(\)\.$~'
+        - '~^Call to an undefined method Atk4\\Data\\Persistence::update\(\)\.$~'
+        - '~^Call to an undefined method Atk4\\Data\\Persistence::insert\(\)\.$~'
+        - '~^Call to an undefined method Atk4\\Data\\Persistence::export\(\)\.$~'
+        - '~^Call to an undefined method Atk4\\Data\\Persistence::prepareIterator\(\)\.$~'
+        - '~^Call to an undefined method Atk4\\Data\\Persistence::delete\(\)\.$~'
+        - '~^Call to an undefined method Atk4\\Data\\Persistence::action\(\)\.$~'
         # for src/Model/ReferencesTrait.php (in context of class Atk4\Data\Model)
-        - '~^Call to an undefined method Atk4\\Data\\Reference\:\:refLink\(\)\.$~'
+        - '~^Call to an undefined method Atk4\\Data\\Reference::refLink\(\)\.$~'
         # for src/Persistence/Sql.php
-        - '~^Call to an undefined method Atk4\\Dsql\\Query\:\:sequence\(\)\.$~'
-        - '~^Call to an undefined method Atk4\\Data\\Persistence\:\:expr\(\)\.$~'
-        - '~^Call to an undefined method Atk4\\Data\\Persistence\:\:exprNow\(\)\.$~'
+        - '~^Call to an undefined method Atk4\\Dsql\\Query::sequence\(\)\.$~'
+        - '~^Call to an undefined method Atk4\\Data\\Persistence::expr\(\)\.$~'
+        - '~^Call to an undefined method Atk4\\Data\\Persistence::exprNow\(\)\.$~'
         # for src/Persistence/Sql/Join.php
-        - '~^Call to an undefined method Atk4\\Data\\Persistence\:\:initQuery\(\)\.$~'
-        - '~^Call to an undefined method Atk4\\Data\\Persistence\:\:lastInsertId\(\)\.$~'
+        - '~^Call to an undefined method Atk4\\Data\\Persistence::initQuery\(\)\.$~'
+        - '~^Call to an undefined method Atk4\\Data\\Persistence::lastInsertId\(\)\.$~'
         # for src/Reference/HasMany.php
-        - '~^Call to an undefined method Atk4\\Data\\Model\:\:dsql\(\)\.$~'
+        - '~^Call to an undefined method Atk4\\Data\\Model::dsql\(\)\.$~'
         # for tests/FieldTest.php
-        - '~^Call to an undefined method Atk4\\Data\\Reference\\HasOne\:\:addTitle\(\)\.$~'
+        - '~^Call to an undefined method Atk4\\Data\\Reference\\HasOne::addTitle\(\)\.$~'
         # for tests/JoinSqlTest.php
-        - '~^Call to an undefined method Atk4\\Data\\Reference\\HasOne\:\:addField\(\)\.$~'
+        - '~^Call to an undefined method Atk4\\Data\\Reference\\HasOne::addField\(\)\.$~'
         # for tests/LookupSqlTest.php
-        - '~^Call to an undefined method Atk4\\Data\\Reference\\HasOne\:\:withTitle\(\)\.$~'
+        - '~^Call to an undefined method Atk4\\Data\\Reference\\HasOne::withTitle\(\)\.$~'
         # for tests/ReferenceSqlTest.php
-        - '~^Call to an undefined method Atk4\\Data\\Reference\\HasOne\:\:addFields\(\)\.$~'
-        - '~^Call to an undefined method Atk4\\Data\\Reference\:\:addTitle\(\)\.$~'
+        - '~^Call to an undefined method Atk4\\Data\\Reference\\HasOne::addFields\(\)\.$~'
+        - '~^Call to an undefined method Atk4\\Data\\Reference::addTitle\(\)\.$~'

--- a/src-schema/Migration.php
+++ b/src-schema/Migration.php
@@ -232,16 +232,17 @@ class Migration
 
     protected function getReferenceField(Field $field): ?Field
     {
-        if ($field->reference instanceof HasOne) {
-            $referenceTheirField = \Closure::bind(function () use ($field) {
-                return $field->reference->their_field;
+        $fieldReference = $field->getReference();
+        if ($fieldReference instanceof HasOne) {
+            $referenceTheirField = \Closure::bind(function () use ($fieldReference) {
+                return $fieldReference->their_field;
             }, null, \Atk4\Data\Reference::class)();
 
-            $referenceField = $referenceTheirField ?? $field->reference->getOwner()->id_field;
+            $referenceField = $referenceTheirField ?? $fieldReference->getOwner()->id_field;
 
-            $modelSeed = is_array($field->reference->model)
-                ? $field->reference->model
-                : [get_class($field->reference->model)];
+            $modelSeed = is_array($fieldReference->model)
+                ? $fieldReference->model
+                : [get_class($fieldReference->model)];
             $referenceModel = Model::fromSeed($modelSeed, [new Persistence\Sql($this->connection)]);
 
             return $referenceModel->getField($referenceField);

--- a/src-schema/Migration.php
+++ b/src-schema/Migration.php
@@ -224,7 +224,7 @@ class Migration
                 'mandatory' => ($field->mandatory || $field->required) && ($persistField->mandatory || $persistField->required),
             ];
 
-            $this->field($field->actual ?: $field->short_name, $options);
+            $this->field($field->getPersistenceName(), $options);
         }
 
         return $model;
@@ -232,17 +232,17 @@ class Migration
 
     protected function getReferenceField(Field $field): ?Field
     {
-        $fieldReference = $field->getReference();
-        if ($fieldReference instanceof HasOne) {
-            $referenceTheirField = \Closure::bind(function () use ($fieldReference) {
-                return $fieldReference->their_field;
+        $reference = $field->getReference();
+        if ($reference instanceof HasOne) {
+            $referenceTheirField = \Closure::bind(function () use ($reference) {
+                return $reference->their_field;
             }, null, \Atk4\Data\Reference::class)();
 
-            $referenceField = $referenceTheirField ?? $fieldReference->getOwner()->id_field;
+            $referenceField = $referenceTheirField ?? $reference->getOwner()->id_field;
 
-            $modelSeed = is_array($fieldReference->model)
-                ? $fieldReference->model
-                : [get_class($fieldReference->model)];
+            $modelSeed = is_array($reference->model)
+                ? $reference->model
+                : [get_class($reference->model)];
             $referenceModel = Model::fromSeed($modelSeed, [new Persistence\Sql($this->connection)]);
 
             return $referenceModel->getField($referenceField);

--- a/src/Field.php
+++ b/src/Field.php
@@ -57,14 +57,12 @@ class Field implements Expressionable
     public $values;
 
     /**
-     * If value of this field can be described by a model, this property
-     * will contain reference to that model.
+     * If value of this field is defined by a model, this property
+     * will contain reference link.
      *
-     * It's used more in atk4/ui repository. See there.
-     *
-     * @var Reference|null
+     * @var string|null
      */
-    public $reference;
+    protected $referenceLink;
 
     /**
      * Actual field name.
@@ -530,6 +528,13 @@ class Field implements Expressionable
         };
 
         return $typecastFunc($value) === $typecastFunc($value2);
+    }
+
+    public function getReference(): ?Reference
+    {
+        return $this->referenceLink !== null
+            ? $this->getOwner()->getRef($this->referenceLink)
+            : null;
     }
 
     public function getPersistenceName(): string

--- a/src/Model/Scope/Condition.php
+++ b/src/Model/Scope/Condition.php
@@ -141,7 +141,8 @@ class Condition extends AbstractScope
 
     protected function onChangeModel(): void
     {
-        if ($model = $this->getModel()) {
+        $model = $this->getModel();
+        if ($model !== null) {
             // if we have a definitive scalar value for a field
             // sets it as default value for field and locks it
             // new records will automatically get this value assigned for the field
@@ -170,7 +171,8 @@ class Condition extends AbstractScope
         $operator = $this->operator;
         $value = $this->value;
 
-        if ($model = $this->getModel()) {
+        $model = $this->getModel();
+        if ($model !== null) {
             if (is_string($field)) {
                 // shorthand for adding conditions on references
                 // use chained reference names separated by "/"
@@ -265,7 +267,8 @@ class Condition extends AbstractScope
     {
         $words = [];
 
-        if (is_string($field = $this->key)) {
+        $field = $this->key;
+        if (is_string($field)) {
             if (str_contains($field, '/')) {
                 $references = explode('/', $field);
 
@@ -311,10 +314,10 @@ class Condition extends AbstractScope
             return $this->operator ? 'empty' : '';
         }
 
-        if (is_array($values = $value)) {
+        if (is_array($value)) {
             $ret = [];
-            foreach ($values as $value) {
-                $ret[] = $this->valueToWords($model, $value);
+            foreach ($value as $v) {
+                $ret[] = $this->valueToWords($model, $v);
             }
 
             return implode(' or ', $ret);

--- a/src/Model/Scope/Condition.php
+++ b/src/Model/Scope/Condition.php
@@ -350,14 +350,26 @@ class Condition extends AbstractScope
         }
 
         // use the referenced model title if such exists
+        $title = null;
         if ($field && ($field->reference ?? false)) {
             // make sure we set the value in the Model parent of the reference
             // it should be same class as $model but $model might be a clone
             $field->reference->getOwner()->set($field->short_name, $value);
 
-            $value = $field->reference->ref()->getTitle() ?: $value;
+            $title = $field->reference->ref()->getTitle();
+            if ($title === $value) {
+                $title = null;
+            }
         }
 
-        return "'" . (string) $value . "'";
+        if (is_bool($value)) {
+            $valueStr = $value ? 'true' : 'false';
+        } elseif (is_int($value) || is_float($value)) {
+            $valueStr = $value;
+        } else {
+            $valueStr = '\'' . (string) $value . '\'';
+        }
+
+        return $valueStr . ($title !== null ? ' (\'' . $title . '\')' : '');
     }
 }

--- a/src/Model/Scope/Condition.php
+++ b/src/Model/Scope/Condition.php
@@ -307,6 +307,8 @@ class Condition extends AbstractScope
 
     protected function valueToWords(Model $model, $value): string
     {
+        $model = clone $model;
+
         if ($value === null) {
             return $this->operator ? 'empty' : '';
         }
@@ -352,11 +354,11 @@ class Condition extends AbstractScope
         // use the referenced model title if such exists
         $title = null;
         if ($field && ($field->reference ?? false)) {
-            // make sure we set the value in the Model parent of the reference
-            // it should be same class as $model but $model might be a clone
-            $field->reference->getOwner()->set($field->short_name, $value);
+            // make sure we set the value in the Model
+            $model->set($field->short_name, $value);
 
-            $title = $field->reference->ref()->getTitle();
+            // then take the title
+            $title = $model->getRef($field->reference->link)->ref()->getTitle();
             if ($title === $value) {
                 $title = null;
             }

--- a/src/Model/Scope/Condition.php
+++ b/src/Model/Scope/Condition.php
@@ -307,8 +307,6 @@ class Condition extends AbstractScope
 
     protected function valueToWords(Model $model, $value): string
     {
-        $model = clone $model;
-
         if ($value === null) {
             return $this->operator ? 'empty' : '';
         }
@@ -335,7 +333,8 @@ class Condition extends AbstractScope
         }
 
         // handling of scope on references
-        if (is_string($field = $this->key)) {
+        $field = $this->key;
+        if (is_string($field)) {
             if (str_contains($field, '/')) {
                 $references = explode('/', $field);
 
@@ -353,12 +352,13 @@ class Condition extends AbstractScope
 
         // use the referenced model title if such exists
         $title = null;
-        if ($field && ($field->reference ?? false)) {
+        if (is_object($field) && $field->getReference() !== null) {
             // make sure we set the value in the Model
+            $model = clone $model;
             $model->set($field->short_name, $value);
 
             // then take the title
-            $title = $model->getRef($field->reference->link)->ref()->getTitle();
+            $title = $model->getRef($field->getReference()->link)->ref()->getTitle();
             if ($title === $value) {
                 $title = null;
             }

--- a/src/Reference/ContainsOne.php
+++ b/src/Reference/ContainsOne.php
@@ -62,7 +62,7 @@ class ContainsOne extends Reference
         if (!$ourModel->hasElement($ourField)) {
             $ourModel->addField($ourField, [
                 'type' => $this->type,
-                'reference' => $this,
+                'referenceLink' => $this->link,
                 'system' => $this->system,
                 'caption' => $this->caption, // it's ref models caption, but we can use it here for field too
                 'ui' => array_merge([

--- a/src/Reference/HasOne.php
+++ b/src/Reference/HasOne.php
@@ -162,7 +162,7 @@ class HasOne extends Reference
         if (!$ourModel->hasField($this->our_field)) {
             $ourModel->addField($this->our_field, [
                 'type' => $this->type,
-                'reference' => $this,
+                'referenceLink' => $this->link,
                 'system' => $this->system,
                 'joinName' => $this->joinName,
                 'default' => $this->default,

--- a/tests/ScopeTest.php
+++ b/tests/ScopeTest.php
@@ -148,7 +148,7 @@ class ScopeTest extends \Atk4\Schema\PhpunitTestCase
 
         $condition = new Condition('country_id', 2);
 
-        $this->assertEquals('Country Id is equal to \'Latvia\'', $condition->toWords($user));
+        $this->assertEquals('Country Id is equal to 2 (\'Latvia\')', $condition->toWords($user));
 
         if ($this->getDatabasePlatform() instanceof SqlitePlatform) {
             $condition = new Condition('name', $user->expr('[surname]'));
@@ -166,7 +166,7 @@ class ScopeTest extends \Atk4\Schema\PhpunitTestCase
 
         $condition = (new Condition('country_id', 2))->negate();
 
-        $this->assertEquals('Country Id is not equal to \'Latvia\'', $condition->toWords($user));
+        $this->assertEquals('Country Id is not equal to 2 (\'Latvia\')', $condition->toWords($user));
 
         $condition = new Condition($user->getField('surname'), $user->getField('name'));
 
@@ -176,7 +176,7 @@ class ScopeTest extends \Atk4\Schema\PhpunitTestCase
 
         $country->addCondition('Users/#', '>', 0);
 
-        $this->assertEquals('Country that has reference Users where number of records is greater than \'0\'', $country->scope()->toWords());
+        $this->assertEquals('Country that has reference Users where number of records is greater than 0', $country->scope()->toWords());
     }
 
     public function testContitionUnsupportedToWords()

--- a/tests/ScopeTest.php
+++ b/tests/ScopeTest.php
@@ -179,6 +179,19 @@ class ScopeTest extends \Atk4\Schema\PhpunitTestCase
         $this->assertEquals('Country that has reference Users where number of records is greater than 0', $country->scope()->toWords());
     }
 
+    public function testContitionToWordsImmutableReference()
+    {
+        $user = clone $this->user;
+
+        $condition = new Condition('country_id', 2);
+
+        $originalReferenceModelData = $user->getField('country_id')->reference->getOwner()->data;
+
+        $this->assertEquals('Country Id is equal to 2 (\'Latvia\')', $condition->toWords($user));
+
+        $this->assertSame($originalReferenceModelData, $user->getField('country_id')->reference->getOwner()->data);
+    }
+
     public function testConditionUnsupportedToWords()
     {
         $condition = new Condition('name', 'abc');

--- a/tests/ScopeTest.php
+++ b/tests/ScopeTest.php
@@ -134,7 +134,7 @@ class ScopeTest extends \Atk4\Schema\PhpunitTestCase
         $this->assertEquals('Smith', $user->get('surname'));
     }
 
-    public function testContitionToWords()
+    public function testConditionToWords()
     {
         $user = clone $this->user;
 
@@ -179,7 +179,7 @@ class ScopeTest extends \Atk4\Schema\PhpunitTestCase
         $this->assertEquals('Country that has reference Users where number of records is greater than 0', $country->scope()->toWords());
     }
 
-    public function testContitionUnsupportedToWords()
+    public function testConditionUnsupportedToWords()
     {
         $condition = new Condition('name', 'abc');
 
@@ -187,7 +187,7 @@ class ScopeTest extends \Atk4\Schema\PhpunitTestCase
         $condition->toWords();
     }
 
-    public function testContitionUnsupportedOperator()
+    public function testConditionUnsupportedOperator()
     {
         $country = clone $this->country;
 
@@ -195,7 +195,7 @@ class ScopeTest extends \Atk4\Schema\PhpunitTestCase
         $country->addCondition('name', '==', 'abc');
     }
 
-    public function testContitionUnsupportedNegate()
+    public function testConditionUnsupportedNegate()
     {
         $condition = new Condition(new Expression('false'));
 

--- a/tests/ScopeTest.php
+++ b/tests/ScopeTest.php
@@ -179,19 +179,6 @@ class ScopeTest extends \Atk4\Schema\PhpunitTestCase
         $this->assertEquals('Country that has reference Users where number of records is greater than 0', $country->scope()->toWords());
     }
 
-    public function testContitionToWordsImmutableReference()
-    {
-        $user = clone $this->user;
-
-        $condition = new Condition('country_id', 2);
-
-        $originalReferenceModelData = $user->getField('country_id')->reference->getOwner()->data;
-
-        $this->assertEquals('Country Id is equal to 2 (\'Latvia\')', $condition->toWords($user));
-
-        $this->assertSame($originalReferenceModelData, $user->getField('country_id')->reference->getOwner()->data);
-    }
-
     public function testConditionUnsupportedToWords()
     {
         $condition = new Condition('name', 'abc');


### PR DESCRIPTION
fixes #867 and https://github.com/atk4/data/blob/2.4.0/src/Model/Scope/Condition.php#L356 issue as well - Scope must not mutate Model in any sense, if something is desired to be set to gather data, it must be done on clone.

BC break:

`Field::reference` property was removed, replaced by `Field::getReference()` method.