### PR TITLE
Fix PR 891

### DIFF
--- a/src/Field.php
+++ b/src/Field.php
@@ -352,7 +352,9 @@ class Field implements Expressionable
                 return null;
             }
 
-            return (string) $this->typecastSaveField($value, true);
+            $valueDb = $this->typecastSaveField($value, true);
+
+            return is_object($valueDb) ? serialize($valueDb) : (string) $valueDb;
         };
 
         // compare if typecasted values are the same using strict comparison


### PR DESCRIPTION
fix https://github.com/atk4/data/pull/891, serialize was used here as a fallback originally, atk4/ui `Scopebuilder` sets one field to a `Scope` object, which is probably wrong, but let's allow it for now. Issue is present only in Behat testing.