### PR TITLE
Rename "money" type to "atk4_money" type

### DIFF
--- a/.github/workflows/test-unit.yml
+++ b/.github/workflows/test-unit.yml
@@ -64,8 +64,8 @@ jobs:
       - name: "Run tests: SQLite Hintable (only for Phpunit)"
         if: matrix.type == 'Phpunit'
         run: |
-          sed -i 's~"psr-4": {~"psr-4": { "Mvorisek\\\\Atk4\\\\Hintable\\\\Tests\\\\": "vendor/mahalux/atk4-hintable/tests/",~' composer.json && composer dump
-          vendor/bin/phpunit --configuration vendor/mahalux/atk4-hintable/phpunit.xml.dist --bootstrap vendor/autoload.php --no-coverage -v
+          sed -i 's~"psr-4": {~"psr-4": { "Mvorisek\\\\Atk4\\\\Hintable\\\\Tests\\\\": "vendor/mvorisek/atk4-hintable/tests/",~' composer.json && composer dump
+          vendor/bin/phpunit --configuration vendor/mvorisek/atk4-hintable/phpunit.xml.dist --bootstrap vendor/autoload.php --no-coverage -v
 
       - name: Check Coding Style (only for CodingStyle)
         if: matrix.type == 'CodingStyle'

--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ class JobReport extends Job {
 
     // Build relation between job and invoice line
     $this->hasMany('InvoiceLines', ['model' => $invoice_lines])
-      ->addField('invoiced', ['aggregate' => 'sum', 'field' => 'total', 'type' => 'money']);
+      ->addField('invoiced', ['aggregate' => 'sum', 'field' => 'total', 'type' => 'atk4_money']);
 
     // Next we need to see how much is reported through timesheets
     $timesheet = new Timesheet($this->persistence);
@@ -153,7 +153,7 @@ class JobReport extends Job {
 
     // Build relation between Job and Timesheets
     $this->hasMany('Timesheets', ['model' => $timesheet])
-      ->addField('reported', ['aggregate' => 'sum', 'field' => 'cost', 'type' => 'money']);
+      ->addField('reported', ['aggregate' => 'sum', 'field' => 'cost', 'type' => 'atk4_money']);
 
 	// Finally lets calculate profit
     $this->addExpression('profit', '[invoiced]-[reported]');

--- a/README.md
+++ b/README.md
@@ -565,6 +565,7 @@ Define your first model class:
 
 ``` php
 namespace my;
+
 class User extends \Atk4\Data\Model
 {
     public $table = 'user';
@@ -572,7 +573,7 @@ class User extends \Atk4\Data\Model
     {
         parent::init();
 
-        $this->addFields(['email','name','password']);
+        $this->addFields(['email', 'name', 'password']);
         // use your table fields here
     }
 }
@@ -599,7 +600,7 @@ Now you can explore. Try typing:
 > $m = new \my\User($db);
 > $m->loadBy('email', 'example@example.com')
 > $m->get()
-> $m->export(['email','name'])
+> $m->export(['email', 'name'])
 > $m->action('count')
 > $m->action('count')->getOne()
 ```

--- a/bootstrap-types.php
+++ b/bootstrap-types.php
@@ -7,11 +7,9 @@ namespace Atk4\Data\Types;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Types as DbalTypes;
 
-// TODO types to migration to DBAL, might be removed later
-
 final class Types
 {
-    public const MONEY = 'money';
+    public const MONEY = 'atk4_money';
 }
 
 class MoneyType extends DbalTypes\Type
@@ -24,6 +22,22 @@ class MoneyType extends DbalTypes\Type
     public function getSQLDeclaration(array $fieldDeclaration, AbstractPlatform $platform): string
     {
         return DbalTypes\Type::getType(DbalTypes\Types::FLOAT)->getSQLDeclaration($fieldDeclaration, $platform);
+    }
+
+    public function convertToDatabaseValue($value, AbstractPlatform $platform): ?string
+    {
+        if ($value === null || trim((string) $value) === '') {
+            return null;
+        }
+
+        return (string) round((float) $value, 4);
+    }
+
+    public function convertToPHPValue($value, AbstractPlatform $platform): float
+    {
+        $v = $this->convertToDatabaseValue($value, $platform);
+
+        return $v === null ? null : (float) $v;
     }
 }
 

--- a/composer.json
+++ b/composer.json
@@ -49,10 +49,6 @@
         "doctrine/dbal": "^2.13.3 || ^3.0",
         "mahalux/atk4-hintable": "~1.3.2"
     },
-    "conflict": {
-        "atk4/dsql": "*",
-        "atk4/schema": "*"
-    },
     "require-dev": {
         "ergebnis/composer-normalize": "^2.13",
         "friendsofphp/php-cs-fixer": "^3.0",
@@ -69,8 +65,7 @@
     },
     "autoload": {
         "psr-4": {
-            "Atk4\\Data\\": "src/",
-            "Atk4\\Schema\\": "src-schema/"
+            "Atk4\\Data\\": "src/"
         },
         "files": [
             "bootstrap-types.php"
@@ -78,8 +73,7 @@
     },
     "autoload-dev": {
         "psr-4": {
-            "Atk4\\Data\\Tests\\": "tests/",
-            "Atk4\\Schema\\Tests\\": "tests-schema/"
+            "Atk4\\Data\\Tests\\": "tests/"
         }
     },
     "minimum-stability": "dev",

--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,7 @@
         "ext-pdo": "*",
         "atk4/core": "dev-develop",
         "doctrine/dbal": "^2.13.3 || ^3.0",
-        "mahalux/atk4-hintable": "~1.4.0"
+        "mvorisek/atk4-hintable": "~1.5.0"
     },
     "require-release": {
         "php": ">=7.4.0",
@@ -47,7 +47,7 @@
         "ext-pdo": "*",
         "atk4/core": "~3.1.0",
         "doctrine/dbal": "^2.13.3 || ^3.0",
-        "mahalux/atk4-hintable": "~1.4.0"
+        "mvorisek/atk4-hintable": "~1.5.0"
     },
     "require-dev": {
         "ergebnis/composer-normalize": "^2.13",

--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,7 @@
         "ext-pdo": "*",
         "atk4/core": "dev-develop",
         "doctrine/dbal": "^2.13.3 || ^3.0",
-        "mahalux/atk4-hintable": "~1.3.2"
+        "mahalux/atk4-hintable": "~1.4.0"
     },
     "require-release": {
         "php": ">=7.4.0",
@@ -47,7 +47,7 @@
         "ext-pdo": "*",
         "atk4/core": "~3.1.0",
         "doctrine/dbal": "^2.13.3 || ^3.0",
-        "mahalux/atk4-hintable": "~1.3.2"
+        "mahalux/atk4-hintable": "~1.4.0"
     },
     "require-dev": {
         "ergebnis/composer-normalize": "^2.13",

--- a/docs/design.rst
+++ b/docs/design.rst
@@ -162,7 +162,7 @@ Code::
     class Model_Client extends Model_User {
         public function sendPasswordReminder() {
 
-            mail($this->get('email'), 'Your password is: '.$this->get('password'));
+            mail($this->get('email'), 'Your password is: ' . $this->get('password'));
         }
     }
 

--- a/docs/design.rst
+++ b/docs/design.rst
@@ -206,7 +206,7 @@ Code to declare fields::
             parent::init();
 
             $this->addField('description');
-            $this->addField('amount')->type('money');
+            $this->addField('amount')->type('atk4_money');
             $this->addField('is_paid')->type('boolean');
         }
     }

--- a/docs/model.rst
+++ b/docs/model.rst
@@ -252,9 +252,9 @@ Creates multiple field objects in one method call. See multiple syntax examples:
     $m->addFields([
         'last_name',
         'login' => ['default' => 'unknown'],
-        'salary' => ['type' => 'money', CustomField::class, 'default' => 100],
-        ['tax', CustomField::class, 'type' => 'money', 'default' => 20],
-        'vat' => new CustomField(['type' => 'money', 'default' => 15]),
+        'salary' => ['type' => 'atk4_money', CustomField::class, 'default' => 100],
+        ['tax', CustomField::class, 'type' => 'atk4_money', 'default' => 20],
+        'vat' => new CustomField(['type' => 'atk4_money', 'default' => 15]),
     ]);
 
 

--- a/docs/model.rst
+++ b/docs/model.rst
@@ -320,18 +320,6 @@ This can also be useful for calculating relative times::
    }
 
 
-Strict Fields
-^^^^^^^^^^^^^
-
-.. php:property:: strict_fields
-
-By default model will only allow you to operate with values for the fields
-that have been defined through addField(). If you attempt to get, set or
-otherwise access the value of any other field that has not been properly
-defined, you'll get an exception. Read more about :php:class:`Field`
-
-If you set `strict_fields` to false, then the check will not be performed.
-
 Actions
 -------
 Another common thing to define inside :php:meth:`Model::init()` would be
@@ -357,7 +345,7 @@ a user invokable actions::
 
          $this->save(['password' => .. ]);
 
-         return 'generated and sent password to '.$m->get('name');
+         return 'generated and sent password to ' . $m->get('name');
       }
    }
 

--- a/docs/persistence.rst
+++ b/docs/persistence.rst
@@ -158,7 +158,7 @@ It's not only the 'type' property, but 'enum' can also imply restrictions::
 
 There are also non-trivial types in Agile Data::
 
-    $m->addField('salary', ['type' => 'money']);
+    $m->addField('salary', ['type' => 'atk4_money']);
     $m->set('salary', "20");  // converts to 20.00
 
     $m->addField('date', ['type' => 'date']);
@@ -273,7 +273,7 @@ Your init() method for a Field_Currency might look like this::
 
         $this->getOwner()->addField(
             $f.'_amount',
-            ['type' => 'money', 'system' => true]
+            ['type' => 'atk4_money', 'system' => true]
         );
 
         $this->getOwner()->hasOne(

--- a/docs/persistence/csv.rst
+++ b/docs/persistence/csv.rst
@@ -51,7 +51,7 @@ which fields you would like to see in the CSV::
 
     foreach (new Model_User($db) as $m) {
         $m->withPersistence($csv)
-            ->onlyFields(['id','name','password'])
+            ->onlyFields(['id', 'name', 'password'])
             ->save();
     }
 

--- a/docs/references.rst
+++ b/docs/references.rst
@@ -199,7 +199,7 @@ for a sum.
 
 You can also specify a type yourself::
 
-    ->addField('paid_amount', ['aggregate' => 'sum', 'field' => 'amount', 'type' => 'money']);
+    ->addField('paid_amount', ['aggregate' => 'sum', 'field' => 'amount', 'type' => 'atk4_money']);
 
 Aggregate fields are always declared read-only, and if you try to
 change them (`$m->set('paid_amount', 123);`), you will receive exception.

--- a/docs/sql.rst
+++ b/docs/sql.rst
@@ -62,7 +62,7 @@ SQL Reference
     Second argument could be array containing additional settings for the field::
 
         $model->hasOne('account_id', ['model' => [Account::class]])
-            ->addField('account_balance', ['balance', 'type' => 'money']);
+            ->addField('account_balance', ['balance', 'type' => 'atk4_money']);
 
     Returns new field object.
 
@@ -79,7 +79,7 @@ SQL Reference
             ->addFields([
                 'opening_balance',
                 'balance'
-            ], ['type' => 'money']);
+            ], ['type' => 'atk4_money']);
 
     You can also specify aliases::
 
@@ -87,7 +87,7 @@ SQL Reference
             ->addFields([
                 'opening_balance',
                 'account_balance' => 'balance'
-            ], ['type' => 'money']);
+            ], ['type' => 'atk4_money']);
 
     If you need to pass more details to individual field, you can also use sub-array::
 
@@ -96,7 +96,7 @@ SQL Reference
             [
                 ['opening_balance', 'caption' => 'The Opening Balance'],
                 'account_balance' => 'balance'
-            ], ['type' => 'money']);
+            ], ['type' => 'atk4_money']);
 
     Returns $this.
 

--- a/docs/typecasting.rst
+++ b/docs/typecasting.rst
@@ -112,7 +112,7 @@ Supported types
 - 'text' - for storing long strings, suchas notes or description. Normalize will trim the value.
 - 'boolean' - normalize will cast value to boolean.
 - 'integer' - normalize will cast value to integer.
-- 'money' - normalize will round value with 4 digits after dot.
+- 'atk4_money' - normalize will round value with 4 digits after dot.
 - 'float' - normalize will cast value to float.
 - 'date' - normalize will convert value to DateTime object.
 - 'datetime' - normalize will convert value to DateTime object.

--- a/docs/types.rst
+++ b/docs/types.rst
@@ -56,7 +56,7 @@ as `['Number', 'precision' => 2, 'prefix' => '€']`
 Not only this allows us make a flexible and re-usable functionality for fields,
 but also allows for an easy way to override::
 
-    $model->addField('salary', ['type' => 'money', 'precision' => 4', 'prefix' => false, 'postfix' => 'Rub']);
+    $model->addField('salary', ['type' => 'atk4_money', 'precision' => 4', 'prefix' => false, 'postfix' => 'Rub']);
 
 Although some configuration of the field may appear irrelevant (prefix/postfix)
 to operations with data from inside PHP, those properties can be used by

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,5 +1,5 @@
 includes:
-    - vendor/mahalux/atk4-hintable/phpstan-ext.neon
+    - vendor/mvorisek/atk4-hintable/phpstan-ext.neon
 
 parameters:
     level: 6

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -37,7 +37,7 @@ parameters:
             count: 11
 
         # TODO these rules are generated, this ignores should be fixed in the code
-        # for src-schema/PhpunitTestCase.php
+        # for src/Schema/TestCase.php
         - '~^Access to an undefined property Atk4\\Data\\Persistence::\$connection\.$~'
         - '~^Call to an undefined method Atk4\\Data\\Persistence::dsql\(\)\.$~'
         # for src/FieldSqlExpression.php

--- a/phpunit-mariadb.xml.dist
+++ b/phpunit-mariadb.xml.dist
@@ -8,7 +8,6 @@
     <testsuites>
         <testsuite name="tests">
             <directory>tests</directory>
-            <directory>tests-schema</directory>
         </testsuite>
     </testsuites>
     <listeners>
@@ -17,7 +16,6 @@
     <coverage>
         <include>
             <directory suffix=".php">src</directory>
-            <directory suffix=".php">src-schema</directory>
         </include>
         <report>
             <php outputFile="build/logs/clover-mariadb.cov" />

--- a/phpunit-mssql.xml.dist
+++ b/phpunit-mssql.xml.dist
@@ -8,7 +8,6 @@
     <testsuites>
         <testsuite name="tests">
             <directory>tests</directory>
-            <directory>tests-schema</directory>
         </testsuite>
     </testsuites>
     <listeners>
@@ -17,7 +16,6 @@
     <coverage>
         <include>
             <directory suffix=".php">src</directory>
-            <directory suffix=".php">src-schema</directory>
         </include>
         <report>
             <php outputFile="build/logs/clover-mssql.cov" />

--- a/phpunit-mysql.xml.dist
+++ b/phpunit-mysql.xml.dist
@@ -8,7 +8,6 @@
     <testsuites>
         <testsuite name="tests">
             <directory>tests</directory>
-            <directory>tests-schema</directory>
         </testsuite>
     </testsuites>
     <listeners>
@@ -17,7 +16,6 @@
     <coverage>
         <include>
             <directory suffix=".php">src</directory>
-            <directory suffix=".php">src-schema</directory>
         </include>
         <report>
             <php outputFile="build/logs/clover-mysql.cov" />

--- a/phpunit-oracle.xml.dist
+++ b/phpunit-oracle.xml.dist
@@ -8,7 +8,6 @@
     <testsuites>
         <testsuite name="tests">
             <directory>tests</directory>
-            <directory>tests-schema</directory>
         </testsuite>
     </testsuites>
     <listeners>
@@ -17,7 +16,6 @@
     <coverage>
         <include>
             <directory suffix=".php">src</directory>
-            <directory suffix=".php">src-schema</directory>
         </include>
         <report>
             <php outputFile="build/logs/clover-oracle.cov" />

--- a/phpunit-pgsql.xml.dist
+++ b/phpunit-pgsql.xml.dist
@@ -8,7 +8,6 @@
     <testsuites>
         <testsuite name="tests">
             <directory>tests</directory>
-            <directory>tests-schema</directory>
         </testsuite>
     </testsuites>
     <listeners>
@@ -17,7 +16,6 @@
     <coverage>
         <include>
             <directory suffix=".php">src</directory>
-            <directory suffix=".php">src-schema</directory>
         </include>
         <report>
             <php outputFile="build/logs/clover-pgsql.cov" />

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -8,7 +8,6 @@
     <testsuites>
         <testsuite name="tests">
             <directory>tests</directory>
-            <directory>tests-schema</directory>
         </testsuite>
     </testsuites>
     <listeners>
@@ -17,7 +16,6 @@
     <coverage>
         <include>
             <directory suffix=".php">src</directory>
-            <directory suffix=".php">src-schema</directory>
         </include>
         <report>
             <php outputFile="build/logs/clover.cov" />

--- a/src/Field.php
+++ b/src/Field.php
@@ -119,7 +119,7 @@ class Field implements Expressionable
             }
 
             // validate scalar values
-            if (in_array($f->type, ['string', 'text', 'integer', 'money', 'float'], true)) {
+            if (in_array($f->type, ['string', 'text', 'integer', 'float', 'atk4_money'], true)) {
                 if (!is_scalar($value)) {
                     throw new ValidationException([$this->name => 'Must use scalar value'], $this->getOwner());
                 }
@@ -167,24 +167,13 @@ class Field implements Expressionable
 
                     break;
                 case 'float':
+                case 'atk4_money':
                     $value = trim(str_replace(["\r", "\n"], '', $value));
-                    $value = preg_replace('/[,`\']/', '', $value);
+                    $value = preg_replace('/[,`\'](?=.*\.)/', '', $value);
                     if (!is_numeric($value)) {
                         throw new ValidationException([$this->name => 'Must be numeric'], $this->getOwner());
                     }
-                    $value = (float) $value;
-                    if ($this->required && empty($value)) {
-                        throw new ValidationException([$this->name => 'Must not be a zero'], $this->getOwner());
-                    }
-
-                    break;
-                case 'money':
-                    $value = trim(str_replace(["\r", "\n"], '', $value));
-                    $value = preg_replace('/[,`\']/', '', $value);
-                    if (!is_numeric($value)) {
-                        throw new ValidationException([$this->name => 'Must be numeric'], $this->getOwner());
-                    }
-                    $value = round((float) $value, 4);
+                    $value = $this->getTypeObject()->convertToPHPValue($value, new Persistence\GenericPlatform());
                     if ($this->required && empty($value)) {
                         throw new ValidationException([$this->name => 'Must not be a zero'], $this->getOwner());
                     }

--- a/src/Field.php
+++ b/src/Field.php
@@ -119,7 +119,7 @@ class Field implements Expressionable
             }
 
             // validate scalar values
-            if (in_array($f->type, ['string', 'text', 'integer', 'float', 'atk4_money'], true)) {
+            if (in_array($f->type, [null, 'string', 'text', 'integer', 'float', 'atk4_money'], true)) {
                 if (!is_scalar($value)) {
                     throw new ValidationException([$this->name => 'Must use scalar value'], $this->getOwner());
                 }
@@ -129,12 +129,7 @@ class Field implements Expressionable
 
             // normalize
             switch ($f->type) {
-                case null: // loose comparison, but is OK here
-                    if ($this->required && empty($value)) {
-                        throw new ValidationException([$this->name => 'Must not be empty'], $this->getOwner());
-                    }
-
-                    break;
+                case null:
                 case 'string':
                     // remove all line-ends and trim
                     $value = trim(str_replace(["\r", "\n"], '', $value));
@@ -152,11 +147,7 @@ class Field implements Expressionable
 
                     break;
                 case 'integer':
-                    // we clear out thousand separator, but will change to
-                    // http://php.net/manual/en/numberformatter.parse.php
-                    // in the future with the introduction of locale
-                    $value = trim(str_replace(["\r", "\n"], '', $value));
-                    $value = preg_replace('/[,`\']/', '', $value);
+                    $value = preg_replace('/\s+|[,`\']/', '', $value);
                     if (!is_numeric($value)) {
                         throw new ValidationException([$this->name => 'Must be numeric'], $this->getOwner());
                     }
@@ -168,8 +159,7 @@ class Field implements Expressionable
                     break;
                 case 'float':
                 case 'atk4_money':
-                    $value = trim(str_replace(["\r", "\n"], '', $value));
-                    $value = preg_replace('/[,`\'](?=.*\.)/', '', $value);
+                    $value = preg_replace('/\s+|[,`\'](?=.*\.)/', '', $value);
                     if (!is_numeric($value)) {
                         throw new ValidationException([$this->name => 'Must be numeric'], $this->getOwner());
                     }

--- a/src/Field.php
+++ b/src/Field.php
@@ -86,6 +86,8 @@ class Field implements Expressionable
      */
     public function normalize($value)
     {
+        $this->getTypeObject(); // assert type exists
+
         try {
             if ($this->getOwner()->hook(Model::HOOK_NORMALIZE, [$this, $value]) === false) {
                 return $value;
@@ -96,30 +98,21 @@ class Field implements Expressionable
                     throw new ValidationException([$this->name => 'Must not be null'], $this->getOwner());
                 }
 
-                return;
+                return null;
             }
-
-            $f = $this;
-
-            $type = $this->getTypeObject();
-            // TODO - breaking tests
-            /*$platform = $this->getOwner()->persistence !== null
-                ? $this->getOwner()->persistence->getDatabasePlatform()
-                : new Persistence\GenericPlatform();
-            $value = $type->convertToPHPValue($type->convertToDatabaseValue($value, $platform), $platform);*/
 
             // only string type fields can use empty string as legit value, for all
             // other field types empty value is the same as no-value, nothing or null
-            if ($f->type && $f->type !== 'string' && $value === '') {
+            if ($this->type && $this->type !== 'string' && $value === '') {
                 if ($this->required && empty($value)) {
                     throw new ValidationException([$this->name => 'Must not be empty'], $this->getOwner());
                 }
 
-                return;
+                return null;
             }
 
             // validate scalar values
-            if (in_array($f->type, [null, 'string', 'text', 'integer', 'float', 'atk4_money'], true)) {
+            if (in_array($this->type, [null, 'string', 'text', 'integer', 'float', 'atk4_money'], true)) {
                 if (!is_scalar($value)) {
                     throw new ValidationException([$this->name => 'Must use scalar value'], $this->getOwner());
                 }
@@ -128,19 +121,17 @@ class Field implements Expressionable
             }
 
             // normalize
-            switch ($f->type) {
+            switch ($this->type) {
                 case null:
                 case 'string':
-                    // remove all line-ends and trim
-                    $value = trim(str_replace(["\r", "\n"], '', $value));
+                    $value = trim(str_replace(["\r", "\n"], '', $value)); // remove all line-ends and trim
                     if ($this->required && empty($value)) {
                         throw new ValidationException([$this->name => 'Must not be empty'], $this->getOwner());
                     }
 
                     break;
                 case 'text':
-                    // normalize line-ends to LF and trim
-                    $value = trim(str_replace(["\r\n", "\r"], "\n", $value));
+                    $value = trim(str_replace(["\r\n", "\r"], "\n", $value)); // normalize line-ends to LF and trim
                     if ($this->required && empty($value)) {
                         throw new ValidationException([$this->name => 'Must not be empty'], $this->getOwner());
                     }
@@ -174,58 +165,38 @@ class Field implements Expressionable
                 case 'date':
                 case 'datetime':
                 case 'time':
-                    if (is_string($value)) {
-                        $value = new \DateTime($value);
-                    } elseif (!$value instanceof \DateTime) {
-                        if ($value instanceof \DateTimeInterface) {
-                            $value = new \DateTime($value->format('Y-m-d H:i:s.u'), $value->getTimezone());
-                        } else {
-                            throw new ValidationException(['Must be an instance of DateTimeInterface', 'value type' => get_debug_type($value)], $this->getOwner());
-                        }
-                    }
-
-                    if ($f->type === 'date' && $value->format('H:i:s.u') !== '00:00:00.000000') {
-                        // remove time portion from date type value
-                        $value = (clone $value)->setTime(0, 0, 0);
-                    }
-                    if ($f->type === 'time' && $value->format('Y-m-d') !== '1970-01-01') {
-                        // remove date portion from date type value
-                        // need 1970 in place of 0 - DB
-                        $value = (clone $value)->setDate(1970, 1, 1);
+                    if (!$value instanceof \DateTimeInterface) {
+                        throw new ValidationException(['Must be an instance of DateTimeInterface', 'type' => get_debug_type($value)], $this->getOwner());
                     }
 
                     break;
                 case 'json':
-                    if (is_string($value) && $f->issetOwner() && $f->getOwner()->persistence) {
-                        $value = $f->getOwner()->persistence->typecastLoadField($f, $value);
-                    }
-
                     if (!is_array($value)) {
                         throw new ValidationException([$this->name => 'Must be an array'], $this->getOwner());
                     }
 
                     break;
                 case 'object':
-                   if (is_string($value) && $f->issetOwner() && $f->getOwner()->persistence) {
-                       $value = $f->getOwner()->persistence->typecastLoadField($f, $value);
-                   }
-
                     if (!is_object($value)) {
                         throw new ValidationException([$this->name => 'Must be an object'], $this->getOwner());
                     }
 
                     break;
-                case 'int':
-                case 'str':
-                case 'bool':
-                    throw (new Exception('Use of obsolete field type abbreviation. Use "integer", "string", "boolean" etc.'))
-                        ->addMoreInfo('type', $f->type);
             }
 
-            /*if ($f->issetOwner() && $f->getOwner()->persistence) {
-                $value = $f->getOwner()->persistence->typecastSaveField($f, $value);
-                $value = $f->getOwner()->persistence->typecastLoadField($f, $value);
-            }*/
+            // normalize using DBAL type
+            $persistence = $this->getOwner()->persistence
+                ?? new class() extends Persistence {
+                    public function __construct()
+                    {
+                    }
+                };
+            try {
+                $value = $persistence->typecastSaveField($this, $value);
+                $value = $persistence->typecastLoadField($this, $value);
+            } catch (\Exception $e) {
+                throw new ValidationException([$this->name => 'Invalid value: ' . $e->getMessage()], $this->getOwner());
+            }
 
             return $value;
         } catch (Exception $e) {

--- a/src/Persistence.php
+++ b/src/Persistence.php
@@ -372,11 +372,8 @@ abstract class Persistence
 
                 break;
             case 'float':
+            case 'atk4_money':
                 $value = (float) $value;
-
-                break;
-            case 'money':
-                $value = round((float) $value, 4);
 
                 break;
             case 'boolean':

--- a/src/Persistence.php
+++ b/src/Persistence.php
@@ -156,22 +156,7 @@ abstract class Persistence
     /**
      * Will convert one row of data from native PHP types into
      * persistence types. This will also take care of the "actual"
-     * field keys. Example:.
-     *
-     * In:
-     *  [
-     *    'name' => ' John Smith',
-     *    'age' => 30,
-     *    'password' => 'abc',
-     *    'is_married' => true,
-     *  ]
-     *
-     *  Out:
-     *   [
-     *     'first_name' => 'John Smith',
-     *     'age' => 30,
-     *     'is_married' => 1
-     *   ]
+     * field keys.
      *
      * @return array<scalar|Persistence\Sql\Expressionable|null>
      */

--- a/src/Persistence/Static_.php
+++ b/src/Persistence/Static_.php
@@ -12,7 +12,7 @@ use Atk4\Data\Model;
  * $m = new Model(Persistence\Static_(['hello', 'world']));
  * $m->load(1);
  *
- * echo $m['name'];  // world
+ * echo $m->get('name'); // world
  */
 class Static_ extends Array_
 {

--- a/src/Schema/Migration.php
+++ b/src/Schema/Migration.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Atk4\Schema;
+namespace Atk4\Data\Schema;
 
 use Atk4\Core\Exception;
 use Atk4\Data\Field;

--- a/src/Schema/Migration.php
+++ b/src/Schema/Migration.php
@@ -154,11 +154,6 @@ class Migration
 
     public function field(string $fieldName, array $options = []): self
     {
-        // TODO remove once we no longer support "money" database type
-        if (($options['type'] ?? null) === 'money') {
-            $options['type'] = 'float';
-        }
-
         $refType = $options['ref_type'] ?? self::REF_TYPE_NONE;
         unset($options['ref_type']);
 

--- a/src/Schema/TestCase.php
+++ b/src/Schema/TestCase.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace Atk4\Schema;
+namespace Atk4\Data\Schema;
 
-use Atk4\Core\Phpunit\TestCase;
+use Atk4\Core\Phpunit\TestCase as BaseTestCase;
 use Atk4\Data\Model;
 use Atk4\Data\Persistence;
 use Doctrine\DBAL\Logging\SQLLogger;
@@ -12,7 +12,7 @@ use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Platforms\MySQLPlatform;
 use Doctrine\DBAL\Schema\AbstractSchemaManager;
 
-class PhpunitTestCase extends TestCase
+class TestCase extends BaseTestCase
 {
     /** @var Persistence|Persistence\Sql Persistence instance */
     public $db;
@@ -45,10 +45,10 @@ class PhpunitTestCase extends TestCase
         if ($this->debug) {
             $this->db->connection->connection()->getConfiguration()->setSQLLogger(
                 new class($this) implements SQLLogger {
-                    /** @var PhpunitTestCase */
+                    /** @var TestCase */
                     public $testCase;
 
-                    public function __construct(PhpunitTestCase $testCase)
+                    public function __construct(TestCase $testCase)
                     {
                         $this->testCase = $testCase;
                     }
@@ -103,7 +103,7 @@ class PhpunitTestCase extends TestCase
 
     public function createMigrator(Model $model = null): Migration
     {
-        return new \Atk4\Schema\Migration($model ?: $this->db);
+        return new Migration($model ?: $this->db);
     }
 
     /**

--- a/tests/BusinessModelTest.php
+++ b/tests/BusinessModelTest.php
@@ -35,13 +35,13 @@ class BusinessModelTest extends TestCase
         $m = $m->createEntity();
 
         $m->set('name', 5);
-        $this->assertSame(5, $m->get('name'));
+        $this->assertSame('5', $m->get('name'));
 
         $m->set('surname', 'Bilbo');
-        $this->assertSame(5, $m->get('name'));
+        $this->assertSame('5', $m->get('name'));
         $this->assertSame('Bilbo', $m->get('surname'));
 
-        $this->assertSame(['name' => 5, 'surname' => 'Bilbo'], $m->get());
+        $this->assertSame(['name' => '5', 'surname' => 'Bilbo'], $m->get());
     }
 
     public function testNoFieldException(): void
@@ -76,7 +76,7 @@ class BusinessModelTest extends TestCase
         $this->assertSame([], $m->getDirtyRef());
 
         $m->set('name', '6');
-        $this->assertSame(['name' => 5], $m->getDirtyRef());
+        $this->assertSame(['name' => '5'], $m->getDirtyRef());
         $m->set('name', '5');
         $this->assertSame([], $m->getDirtyRef());
 
@@ -158,12 +158,9 @@ class BusinessModelTest extends TestCase
         $m->allFields();
 
         $m->set('name', 5);
-        $this->assertSame(5, $m->get('name'));
+        $this->assertSame('5', $m->get('name'));
     }
 
-    /**
-     * Sets title field.
-     */
     public function testSetTitle(): void
     {
         $m = new Model();
@@ -241,7 +238,7 @@ class BusinessModelTest extends TestCase
     {
         $m = new User();
 
-        $m->addField('salary', ['default' => 1000]);
+        $m->addField('salary', ['type' => 'integer', 'default' => 1000]);
         $m = $m->createEntity();
 
         $this->assertSame(1000, $m->get('salary'));

--- a/tests/ConditionSqlTest.php
+++ b/tests/ConditionSqlTest.php
@@ -5,10 +5,11 @@ declare(strict_types=1);
 namespace Atk4\Data\Tests;
 
 use Atk4\Data\Model;
+use Atk4\Data\Schema\TestCase;
 use Doctrine\DBAL\Platforms\PostgreSQL94Platform;
 use Doctrine\DBAL\Platforms\SqlitePlatform;
 
-class ConditionSqlTest extends \Atk4\Schema\PhpunitTestCase
+class ConditionSqlTest extends TestCase
 {
     public function testBasic(): void
     {

--- a/tests/ContainsMany/Invoice.php
+++ b/tests/ContainsMany/Invoice.php
@@ -26,7 +26,7 @@ class Invoice extends Model
         $this->title_field = $this->fieldName()->ref_no;
 
         $this->addField($this->fieldName()->ref_no, ['required' => true]);
-        $this->addField($this->fieldName()->amount, ['type' => 'money']);
+        $this->addField($this->fieldName()->amount, ['type' => 'atk4_money']);
 
         // will contain many Lines
         $this->containsMany($this->fieldName()->lines, ['model' => [Line::class], 'caption' => 'My Invoice Lines']);

--- a/tests/ContainsMany/Line.php
+++ b/tests/ContainsMany/Line.php
@@ -25,7 +25,7 @@ class Line extends Model
 
         $this->hasOne($this->fieldName()->vat_rate_id, ['model' => [VatRate::class]]);
 
-        $this->addField($this->fieldName()->price, ['type' => 'money', 'required' => true]);
+        $this->addField($this->fieldName()->price, ['type' => 'atk4_money', 'required' => true]);
         $this->addField($this->fieldName()->qty, ['type' => 'float', 'required' => true]);
         $this->addField($this->fieldName()->add_date, ['type' => 'datetime']);
 

--- a/tests/ContainsManyTest.php
+++ b/tests/ContainsManyTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Atk4\Data\Tests;
 
 use Atk4\Data\Exception;
+use Atk4\Data\Schema\TestCase;
 use Atk4\Data\Tests\ContainsMany\Invoice;
 use Atk4\Data\Tests\ContainsMany\VatRate;
 
@@ -21,7 +22,7 @@ use Atk4\Data\Tests\ContainsMany\VatRate;
  * ATK Data has support of containsOne / containsMany.
  * Basically data model can contain other data models with one or many records.
  */
-class ContainsManyTest extends \Atk4\Schema\PhpunitTestCase
+class ContainsManyTest extends TestCase
 {
     protected function setUp(): void
     {

--- a/tests/ContainsOneTest.php
+++ b/tests/ContainsOneTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Atk4\Data\Tests;
 
 use Atk4\Data\Exception;
+use Atk4\Data\Schema\TestCase;
 use Atk4\Data\Tests\ContainsOne\Country;
 use Atk4\Data\Tests\ContainsOne\Invoice;
 
@@ -21,7 +22,7 @@ use Atk4\Data\Tests\ContainsOne\Invoice;
  * ATK Data has support of containsOne / containsMany.
  * Basically data model can contain other data models with one or many records.
  */
-class ContainsOneTest extends \Atk4\Schema\PhpunitTestCase
+class ContainsOneTest extends TestCase
 {
     protected function setUp(): void
     {

--- a/tests/DeepCopyTest.php
+++ b/tests/DeepCopyTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Atk4\Data\Tests;
 
 use Atk4\Data\Model;
+use Atk4\Data\Schema\TestCase;
 use Atk4\Data\Util\DeepCopy;
 use Atk4\Data\Util\DeepCopyException;
 use Doctrine\DBAL\Platforms\SQLServer2012Platform;
@@ -137,7 +138,7 @@ class DcPayment extends Model
 /**
  * Implements various tests for deep copying objects.
  */
-class DeepCopyTest extends \Atk4\Schema\PhpunitTestCase
+class DeepCopyTest extends TestCase
 {
     protected function setUp(): void
     {

--- a/tests/DefaultTest.php
+++ b/tests/DefaultTest.php
@@ -5,8 +5,9 @@ declare(strict_types=1);
 namespace Atk4\Data\Tests;
 
 use Atk4\Data\Model;
+use Atk4\Data\Schema\TestCase;
 
-class DefaultTest extends \Atk4\Schema\PhpunitTestCase
+class DefaultTest extends TestCase
 {
     public function testDefaultValue(): void
     {

--- a/tests/ExpressionSqlTest.php
+++ b/tests/ExpressionSqlTest.php
@@ -6,11 +6,12 @@ namespace Atk4\Data\Tests;
 
 use Atk4\Data\Model;
 use Atk4\Data\Persistence;
+use Atk4\Data\Schema\TestCase;
 use Doctrine\DBAL\Platforms\MySQLPlatform;
 use Doctrine\DBAL\Platforms\OraclePlatform;
 use Doctrine\DBAL\Platforms\SqlitePlatform;
 
-class ExpressionSqlTest extends \Atk4\Schema\PhpunitTestCase
+class ExpressionSqlTest extends TestCase
 {
     public function testNakedExpression(): void
     {

--- a/tests/FieldHereditaryTest.php
+++ b/tests/FieldHereditaryTest.php
@@ -6,8 +6,9 @@ namespace Atk4\Data\Tests;
 
 use Atk4\Data\Model;
 use Atk4\Data\Persistence;
+use Atk4\Data\Schema\TestCase;
 
-class FieldHereditaryTest extends \Atk4\Schema\PhpunitTestCase
+class FieldHereditaryTest extends TestCase
 {
     public function testDirty1(): void
     {

--- a/tests/FieldTest.php
+++ b/tests/FieldTest.php
@@ -547,14 +547,6 @@ class FieldTest extends TestCase
         $this->assertFalse($m->get('boolean_enum'));
         $m->set('boolean_enum', 'Y');
         $this->assertTrue($m->get('boolean_enum'));
-
-        // date, datetime, time
-        $m->set('date', '2018-05-31');
-        $this->assertInstanceOf(\DateTime::class, $m->get('date'));
-        $m->set('datetime', '2018-05-31 12:13:14');
-        $this->assertInstanceOf(\DateTime::class, $m->get('datetime'));
-        $m->set('time', '12:13:14');
-        $this->assertInstanceOf(\DateTime::class, $m->get('time'));
     }
 
     public function testNormalizeException1(): void

--- a/tests/FieldTest.php
+++ b/tests/FieldTest.php
@@ -457,8 +457,8 @@ class FieldTest extends TestCase
         ]);
 
         $m = new Model($db, ['table' => 'invoice']);
-        $m->addField('net', ['type' => 'money']);
-        $m->addField('vat', ['type' => 'money']);
+        $m->addField('net', ['type' => 'atk4_money']);
+        $m->addField('vat', ['type' => 'atk4_money']);
         $m->addCalculatedField('total', function ($m) {
             return $m->get('net') + $m->get('vat');
         });
@@ -492,7 +492,7 @@ class FieldTest extends TestCase
         $m->addField('string', ['type' => 'string']);
         $m->addField('text', ['type' => 'text']);
         $m->addField('integer', ['type' => 'integer']);
-        $m->addField('money', ['type' => 'money']);
+        $m->addField('money', ['type' => 'atk4_money']);
         $m->addField('float', ['type' => 'float']);
         $m->addField('boolean', ['type' => 'boolean']);
         $m->addField('boolean_enum', ['type' => 'boolean', 'enum' => ['N', 'Y']]);
@@ -583,7 +583,7 @@ class FieldTest extends TestCase
     public function testNormalizeException4(): void
     {
         $m = new Model();
-        $m->addField('foo', ['type' => 'money']);
+        $m->addField('foo', ['type' => 'atk4_money']);
         $m = $m->createEntity();
         $this->expectException(ValidationException::class);
         $m->set('foo', []);
@@ -637,7 +637,7 @@ class FieldTest extends TestCase
     public function testNormalizeException10(): void
     {
         $m = new Model();
-        $m->addField('foo', ['type' => 'money']);
+        $m->addField('foo', ['type' => 'atk4_money']);
         $m = $m->createEntity();
         $this->expectException(ValidationException::class);
         $m->set('foo', '123---456');
@@ -686,7 +686,7 @@ class FieldTest extends TestCase
         $m->addField('string', ['type' => 'string']);
         $m->addField('text', ['type' => 'text']);
         $m->addField('integer', ['type' => 'integer']);
-        $m->addField('money', ['type' => 'money']);
+        $m->addField('money', ['type' => 'atk4_money']);
         $m->addField('float', ['type' => 'float']);
         $m->addField('boolean', ['type' => 'boolean']);
         $m->addField('boolean_enum', ['type' => 'boolean', 'enum' => ['N', 'Y']]);

--- a/tests/FieldTest.php
+++ b/tests/FieldTest.php
@@ -8,9 +8,10 @@ use Atk4\Data\Exception;
 use Atk4\Data\Field;
 use Atk4\Data\Model;
 use Atk4\Data\Persistence;
+use Atk4\Data\Schema\TestCase;
 use Atk4\Data\ValidationException;
 
-class FieldTest extends \Atk4\Schema\PhpunitTestCase
+class FieldTest extends TestCase
 {
     public function testDirty1(): void
     {

--- a/tests/FieldTest.php
+++ b/tests/FieldTest.php
@@ -217,14 +217,27 @@ class FieldTest extends TestCase
     public function testEnum2(): void
     {
         $m = new Model();
-        $m->addField('foo', ['enum' => [1, 'bar']]);
+        $m->addField('foo', ['enum' => ['1', 'bar']]);
+        $m = $m->createEntity();
+        $m->set('foo', '1');
+
+        $this->assertSame('1', $m->get('foo'));
+
+        $m->set('foo', 'bar');
+        $this->assertSame('bar', $m->get('foo'));
+    }
+
+    public function testEnum2b(): void
+    {
+        $m = new Model();
+        $m->addField('foo', ['type' => 'integer', 'enum' => [1, 2]]);
         $m = $m->createEntity();
         $m->set('foo', 1);
 
         $this->assertSame(1, $m->get('foo'));
 
-        $m->set('foo', 'bar');
-        $this->assertSame('bar', $m->get('foo'));
+        $m->set('foo', '2');
+        $this->assertSame(2, $m->get('foo'));
     }
 
     public function testEnum3(): void
@@ -261,7 +274,7 @@ class FieldTest extends TestCase
     public function testValues2(): void
     {
         $m = new Model();
-        $m->addField('foo', ['values' => [3 => 'bar']]);
+        $m->addField('foo', ['type' => 'integer', 'values' => [3 => 'bar']]);
         $m = $m->createEntity();
         $m->set('foo', 3);
 
@@ -272,15 +285,6 @@ class FieldTest extends TestCase
     }
 
     public function testValues3(): void
-    {
-        $m = new Model();
-        $m->addField('foo', ['values' => [1 => 'bar']]);
-        $m = $m->createEntity();
-        $this->expectException(Exception::class);
-        $m->set('foo', true);
-    }
-
-    public function testValues3a(): void
     {
         $m = new Model();
         $m->addField('foo', ['values' => [1 => 'bar']]);

--- a/tests/FieldTypesTest.php
+++ b/tests/FieldTypesTest.php
@@ -7,12 +7,10 @@ namespace Atk4\Data\Tests;
 use Atk4\Data\Field;
 use Atk4\Data\Model;
 use Atk4\Data\Persistence\Static_ as Persistence_Static;
+use Atk4\Data\Schema\TestCase;
 use Atk4\Data\ValidationException;
 
-/**
- * Test various Field.
- */
-class FieldTypesTest extends \Atk4\Schema\PhpunitTestCase
+class FieldTypesTest extends TestCase
 {
     /** @var Persistence_Static */
     public $pers;

--- a/tests/FolderTest.php
+++ b/tests/FolderTest.php
@@ -6,6 +6,7 @@ namespace Atk4\Data\Tests;
 
 use Atk4\Data\Model;
 use Atk4\Data\Persistence;
+use Atk4\Data\Schema\TestCase;
 
 class Folder extends Model
 {
@@ -27,7 +28,7 @@ class Folder extends Model
     }
 }
 
-class FolderTest extends \Atk4\Schema\PhpunitTestCase
+class FolderTest extends TestCase
 {
     public function testRate(): void
     {

--- a/tests/IteratorTest.php
+++ b/tests/IteratorTest.php
@@ -7,8 +7,9 @@ namespace Atk4\Data\Tests;
 use Atk4\Data\Exception;
 use Atk4\Data\Model;
 use Atk4\Data\Persistence;
+use Atk4\Data\Schema\TestCase;
 
-class IteratorTest extends \Atk4\Schema\PhpunitTestCase
+class IteratorTest extends TestCase
 {
     /**
      * If first argument is array, then second argument should not be used.

--- a/tests/JoinArrayTest.php
+++ b/tests/JoinArrayTest.php
@@ -67,7 +67,7 @@ class JoinArrayTest extends TestCase
     {
         $db = new Persistence\Array_(['user' => [], 'contact' => []]);
         $m_u = new Model($db, ['table' => 'user']);
-        $m_u->addField('contact_id');
+        $m_u->addField('contact_id', ['type' => 'integer']);
         $m_u->addField('name');
         $j = $m_u->join('contact');
         $j->addField('contact_phone');

--- a/tests/JoinSqlTest.php
+++ b/tests/JoinSqlTest.php
@@ -7,11 +7,12 @@ namespace Atk4\Data\Tests;
 use Atk4\Data\Exception;
 use Atk4\Data\Model;
 use Atk4\Data\Persistence;
+use Atk4\Data\Schema\TestCase;
 use Doctrine\DBAL\Platforms\OraclePlatform;
 use Doctrine\DBAL\Platforms\PostgreSQL94Platform;
 use Doctrine\DBAL\Platforms\SQLServer2012Platform;
 
-class JoinSqlTest extends \Atk4\Schema\PhpunitTestCase
+class JoinSqlTest extends TestCase
 {
     public function testDirection(): void
     {

--- a/tests/LimitOrderTest.php
+++ b/tests/LimitOrderTest.php
@@ -6,8 +6,9 @@ namespace Atk4\Data\Tests;
 
 use Atk4\Data\Exception;
 use Atk4\Data\Model;
+use Atk4\Data\Schema\TestCase;
 
-class LimitOrderTest extends \Atk4\Schema\PhpunitTestCase
+class LimitOrderTest extends TestCase
 {
     public function testBasic(): void
     {

--- a/tests/LookupSqlTest.php
+++ b/tests/LookupSqlTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Atk4\Data\Tests;
 
 use Atk4\Data\Model;
+use Atk4\Data\Schema\TestCase;
 
 /**
  * Country.
@@ -136,10 +137,7 @@ class LFriend extends Model
     }
 }
 
-/**
- * ATK Data has an option to lookup ID values if their "lookup" values are specified.
- */
-class LookupSqlTest extends \Atk4\Schema\PhpunitTestCase
+class LookupSqlTest extends TestCase
 {
     protected function setUp(): void
     {

--- a/tests/Model/Smbo/Document.php
+++ b/tests/Model/Smbo/Document.php
@@ -20,6 +20,6 @@ class Document extends Model
 
         $this->addField('doc_type', ['enum' => ['invoice', 'payment']]);
 
-        $this->addField('amount', ['type' => 'money']);
+        $this->addField('amount', ['type' => 'atk4_money']);
     }
 }

--- a/tests/ModelWithoutIdTest.php
+++ b/tests/ModelWithoutIdTest.php
@@ -7,12 +7,13 @@ namespace Atk4\Data\Tests;
 use Atk4\Data\Exception;
 use Atk4\Data\Model;
 use Atk4\Data\Persistence;
+use Atk4\Data\Schema\TestCase;
 use Doctrine\DBAL\Platforms\PostgreSQL94Platform;
 
 /**
  * Tests cases when model have to work with data that does not have ID field.
  */
-class ModelWithoutIdTest extends \Atk4\Schema\PhpunitTestCase
+class ModelWithoutIdTest extends TestCase
 {
     /** @var Model */
     public $m;

--- a/tests/Persistence/ArrayTest.php
+++ b/tests/Persistence/ArrayTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Atk4\Data\Tests;
+namespace Atk4\Data\Tests\Persistence;
 
 use Atk4\Core\Phpunit\TestCase;
 use Atk4\Data\Exception;
@@ -11,7 +11,7 @@ use Atk4\Data\Persistence;
 use Atk4\Data\Tests\Model\Female as Female;
 use Atk4\Data\Tests\Model\Male as Male;
 
-class PersistentArrayTest extends TestCase
+class ArrayTest extends TestCase
 {
     private function getInternalPersistenceData(Persistence\Array_ $db): array
     {

--- a/tests/Persistence/CsvTest.php
+++ b/tests/Persistence/CsvTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Atk4\Data\Tests;
+namespace Atk4\Data\Tests\Persistence;
 
 use Atk4\Core\Phpunit\TestCase;
 use Atk4\Data\Exception;
@@ -10,7 +10,7 @@ use Atk4\Data\Model;
 use Atk4\Data\Persistence;
 use Atk4\Data\Tests\Model\Person;
 
-class PersistenceCsvTest extends TestCase
+class CsvTest extends TestCase
 {
     /** @var resource */
     protected $file;

--- a/tests/Persistence/SqlTest.php
+++ b/tests/Persistence/SqlTest.php
@@ -2,13 +2,13 @@
 
 declare(strict_types=1);
 
-namespace Atk4\Data\Tests;
+namespace Atk4\Data\Tests\Persistence;
 
 use Atk4\Data\Exception;
 use Atk4\Data\Model;
 use Atk4\Data\Schema\TestCase;
 
-class PersistentSqlTest extends TestCase
+class SqlTest extends TestCase
 {
     public function testLoadArray(): void
     {

--- a/tests/Persistence/StaticTest.php
+++ b/tests/Persistence/StaticTest.php
@@ -2,13 +2,13 @@
 
 declare(strict_types=1);
 
-namespace Atk4\Data\Tests;
+namespace Atk4\Data\Tests\Persistence;
 
 use Atk4\Core\Phpunit\TestCase;
 use Atk4\Data\Model;
 use Atk4\Data\Persistence;
 
-class StaticPersistenceTest extends TestCase
+class StaticTest extends TestCase
 {
     public function testBasicStatic(): void
     {

--- a/tests/PersistentSqlTest.php
+++ b/tests/PersistentSqlTest.php
@@ -6,8 +6,9 @@ namespace Atk4\Data\Tests;
 
 use Atk4\Data\Exception;
 use Atk4\Data\Model;
+use Atk4\Data\Schema\TestCase;
 
-class PersistentSqlTest extends \Atk4\Schema\PhpunitTestCase
+class PersistentSqlTest extends TestCase
 {
     public function testLoadArray(): void
     {

--- a/tests/RandomTest.php
+++ b/tests/RandomTest.php
@@ -148,9 +148,9 @@ class RandomTest extends TestCase
         $m->addFields([
             'last_name',
             'login' => ['default' => 'unknown'],
-            'salary' => ['type' => 'money', CustomField::class, 'default' => 100],
-            ['tax', CustomField::class, 'type' => 'money', 'default' => 20],
-            'vat' => new CustomField(['type' => 'money', 'default' => 15]),
+            'salary' => ['type' => 'atk4_money', CustomField::class, 'default' => 100],
+            ['tax', CustomField::class, 'type' => 'atk4_money', 'default' => 20],
+            'vat' => new CustomField(['type' => 'atk4_money', 'default' => 15]),
         ]);
 
         $m->insert([]);

--- a/tests/RandomTest.php
+++ b/tests/RandomTest.php
@@ -7,6 +7,7 @@ namespace Atk4\Data\Tests;
 use Atk4\Data\Exception;
 use Atk4\Data\Model;
 use Atk4\Data\Persistence;
+use Atk4\Data\Schema\TestCase;
 
 class Model_Rate extends Model
 {
@@ -66,7 +67,7 @@ class Model_Item3 extends Model
     }
 }
 
-class RandomTest extends \Atk4\Schema\PhpunitTestCase
+class RandomTest extends TestCase
 {
     public function testRate(): void
     {

--- a/tests/ReadOnlyModeTest.php
+++ b/tests/ReadOnlyModeTest.php
@@ -7,11 +7,12 @@ namespace Atk4\Data\Tests;
 use Atk4\Data\Exception;
 use Atk4\Data\Model;
 use Atk4\Data\Persistence;
+use Atk4\Data\Schema\TestCase;
 
 /**
  * Tests cases when model have to work with data that does not have ID field.
  */
-class ReadOnlyModeTest extends \Atk4\Schema\PhpunitTestCase
+class ReadOnlyModeTest extends TestCase
 {
     /** @var Model */
     public $m;

--- a/tests/ReferenceSqlTest.php
+++ b/tests/ReferenceSqlTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Atk4\Data\Tests;
 
 use Atk4\Data\Model;
+use Atk4\Data\Schema\TestCase;
 use Doctrine\DBAL\Platforms\PostgreSQL94Platform;
 use Doctrine\DBAL\Platforms\SQLServer2012Platform;
 
@@ -13,7 +14,7 @@ use Doctrine\DBAL\Platforms\SQLServer2012Platform;
  * also that the original model can be re-loaded with a different
  * value without making any condition stick.
  */
-class ReferenceSqlTest extends \Atk4\Schema\PhpunitTestCase
+class ReferenceSqlTest extends TestCase
 {
     public function testBasic(): void
     {

--- a/tests/ReferenceSqlTest.php
+++ b/tests/ReferenceSqlTest.php
@@ -250,20 +250,20 @@ class ReferenceSqlTest extends TestCase
         $i = (new Model($this->db, ['table' => 'invoice']))->addFields(['ref_no']);
         $l = (new Model($this->db, ['table' => 'invoice_line']))->addFields([
             'invoice_id',
-            ['total_net', 'type' => 'money'],
-            ['total_vat', 'type' => 'money'],
-            ['total_gross', 'type' => 'money'],
+            ['total_net', 'type' => 'atk4_money'],
+            ['total_vat', 'type' => 'atk4_money'],
+            ['total_gross', 'type' => 'atk4_money'],
         ]);
         $i->hasMany('line', ['model' => $l])
             ->addFields([
-                ['total_vat', 'aggregate' => 'sum', 'type' => 'money'],
+                ['total_vat', 'aggregate' => 'sum', 'type' => 'atk4_money'],
                 ['total_net', 'aggregate' => 'sum'],
                 ['total_gross', 'aggregate' => 'sum'],
             ]);
         $i = $i->load('1');
 
         // type was set explicitly
-        $this->assertSame('money', $i->getField('total_vat')->type);
+        $this->assertSame('atk4_money', $i->getField('total_vat')->type);
 
         // type was not set and is not inherited
         $this->assertNull($i->getField('total_net')->type);

--- a/tests/ReferenceTest.php
+++ b/tests/ReferenceTest.php
@@ -14,7 +14,7 @@ class ReferenceTest extends TestCase
     public function testBasicReferences(): void
     {
         $user = new Model(null, ['table' => 'user']);
-        $user->addField('id');
+        $user->addField('id', ['type' => 'integer']);
         $user->addField('name');
         $user = $user->createEntity();
         $user->setId(1);
@@ -22,7 +22,7 @@ class ReferenceTest extends TestCase
         $order = new Model();
         $order->addField('id');
         $order->addField('amount', ['default' => 20]);
-        $order->addField('user_id');
+        $order->addField('user_id', ['type' => 'integer']);
 
         $user->hasMany('Orders', ['model' => $order, 'caption' => 'My Orders']);
         $o = $user->ref('Orders')->createEntity();

--- a/tests/Schema/BasicTest.php
+++ b/tests/Schema/BasicTest.php
@@ -2,11 +2,11 @@
 
 declare(strict_types=1);
 
-namespace Atk4\Schema\Tests;
+namespace Atk4\Data\Tests\Schema;
 
-use Atk4\Schema\PhpunitTestCase;
+use Atk4\Data\Schema\TestCase;
 
-class BasicTest extends PhpunitTestCase
+class BasicTest extends TestCase
 {
     /**
      * @doesNotPerformAssertions

--- a/tests/Schema/BasicTest.php
+++ b/tests/Schema/BasicTest.php
@@ -24,7 +24,7 @@ class BasicTest extends TestCase
             ->field('dt', ['type' => 'date'])
             ->field('dttm', ['type' => 'datetime'])
             ->field('fl', ['type' => 'float'])
-            ->field('mn', ['type' => 'money'])
+            ->field('mn', ['type' => 'atk4_money'])
             ->create();
     }
 
@@ -46,7 +46,7 @@ class BasicTest extends TestCase
             ->field('dt', ['type' => 'date'])
             ->field('dttm', ['type' => 'datetime'])
             ->field('fl', ['type' => 'float'])
-            ->field('mn', ['type' => 'money'])
+            ->field('mn', ['type' => 'atk4_money'])
             ->create();
 
         $this->createMigrator()->table('user')->drop();

--- a/tests/Schema/ModelTest.php
+++ b/tests/Schema/ModelTest.php
@@ -41,7 +41,7 @@ class ModelTest extends TestCase
             ->field('str', ['type' => 'string'])
             ->field('bool', ['type' => 'boolean'])
             ->field('int', ['type' => 'integer'])
-            ->field('mon', ['type' => 'money'])
+            ->field('mon', ['type' => 'atk4_money'])
             ->field('flt', ['type' => 'float'])
             ->field('date', ['type' => 'date'])
             ->field('datetime', ['type' => 'datetime'])

--- a/tests/Schema/ModelTest.php
+++ b/tests/Schema/ModelTest.php
@@ -2,15 +2,15 @@
 
 declare(strict_types=1);
 
-namespace Atk4\Schema\Tests;
+namespace Atk4\Data\Tests\Schema;
 
 use Atk4\Data\Model;
-use Atk4\Schema\PhpunitTestCase;
+use Atk4\Data\Schema\TestCase;
 use Doctrine\DBAL\Platforms\OraclePlatform;
 use Doctrine\DBAL\Platforms\PostgreSQL94Platform;
 use Doctrine\DBAL\Platforms\SQLServer2012Platform;
 
-class ModelTest extends PhpunitTestCase
+class ModelTest extends TestCase
 {
     /**
      * @doesNotPerformAssertions

--- a/tests/Schema/TestCaseTest.php
+++ b/tests/Schema/TestCaseTest.php
@@ -2,11 +2,11 @@
 
 declare(strict_types=1);
 
-namespace Atk4\Schema\Tests;
+namespace Atk4\Data\Tests\Schema;
 
-use Atk4\Schema\PhpunitTestCase;
+use Atk4\Data\Schema\TestCase;
 
-class PhpunitTestCaseTest extends PhpunitTestCase
+class TestCaseTest extends TestCase
 {
     public function testInit(): void
     {

--- a/tests/ScopeTest.php
+++ b/tests/ScopeTest.php
@@ -9,6 +9,7 @@ use Atk4\Data\Model;
 use Atk4\Data\Model\Scope;
 use Atk4\Data\Model\Scope\Condition;
 use Atk4\Data\Persistence\Sql\Expression;
+use Atk4\Data\Schema\TestCase;
 use Doctrine\DBAL\Platforms\SqlitePlatform;
 
 class SCountry extends Model
@@ -68,7 +69,7 @@ class STicket extends Model
     }
 }
 
-class ScopeTest extends \Atk4\Schema\PhpunitTestCase
+class ScopeTest extends TestCase
 {
     protected function setUp(): void
     {

--- a/tests/SerializeTest.php
+++ b/tests/SerializeTest.php
@@ -7,8 +7,9 @@ namespace Atk4\Data\Tests;
 use Atk4\Data\Exception;
 use Atk4\Data\Model;
 use Atk4\Data\Persistence;
+use Atk4\Data\Schema\TestCase;
 
-class SerializeTest extends \Atk4\Schema\PhpunitTestCase
+class SerializeTest extends TestCase
 {
     public function testBasicSerialize(): void
     {

--- a/tests/SmboTransferTest.php
+++ b/tests/SmboTransferTest.php
@@ -5,15 +5,13 @@ declare(strict_types=1);
 namespace Atk4\Data\Tests;
 
 use Atk4\Data\Persistence;
+use Atk4\Data\Schema\TestCase;
 use Atk4\Data\Tests\Model\Smbo\Account;
 use Atk4\Data\Tests\Model\Smbo\Company;
 use Atk4\Data\Tests\Model\Smbo\Payment;
 use Atk4\Data\Tests\Model\Smbo\Transfer;
 
-/**
- * Practical test contributed by Sortmybooks.com.
- */
-class SmboTransferTest extends \Atk4\Schema\PhpunitTestCase
+class SmboTransferTest extends TestCase
 {
     protected function setUp(): void
     {

--- a/tests/SubTypesTest.php
+++ b/tests/SubTypesTest.php
@@ -6,6 +6,7 @@ namespace Atk4\Data\Tests;
 
 use Atk4\Data\Model;
 use Atk4\Data\Persistence;
+use Atk4\Data\Schema\TestCase;
 
 class StAccount extends Model
 {
@@ -146,7 +147,7 @@ class StTransaction_TransferIn extends StGenericTransaction
 /**
  * Implements various tests for deep copying objects.
  */
-class SubTypesTest extends \Atk4\Schema\PhpunitTestCase
+class SubTypesTest extends TestCase
 {
     protected function setUp(): void
     {

--- a/tests/SubTypesTest.php
+++ b/tests/SubTypesTest.php
@@ -86,7 +86,7 @@ class StGenericTransaction extends Model
         if ($this->type) {
             $this->addCondition('type', $this->type);
         }
-        $this->addField('amount', ['type' => 'money']);
+        $this->addField('amount', ['type' => 'atk4_money']);
 
         $this->onHookShort(Model::HOOK_AFTER_LOAD, function () {
             if (static::class !== $this->getClassName()) {

--- a/tests/TransactionTest.php
+++ b/tests/TransactionTest.php
@@ -6,11 +6,9 @@ namespace Atk4\Data\Tests;
 
 use Atk4\Data\Model;
 use Atk4\Data\Persistence;
+use Atk4\Data\Schema\TestCase;
 
-/**
- * Various tests to make sure transactions work OK.
- */
-class TransactionTest extends \Atk4\Schema\PhpunitTestCase
+class TransactionTest extends TestCase
 {
     public function testAtomicOperations(): void
     {

--- a/tests/TypecastingTest.php
+++ b/tests/TypecastingTest.php
@@ -7,9 +7,10 @@ namespace Atk4\Data\Tests;
 use Atk4\Data\Exception;
 use Atk4\Data\Model;
 use Atk4\Data\Persistence;
+use Atk4\Data\Schema\TestCase;
 use Doctrine\DBAL\Platforms\OraclePlatform;
 
-class TypecastingTest extends \Atk4\Schema\PhpunitTestCase
+class TypecastingTest extends TestCase
 {
     /** @var string */
     private $defaultTzBackup;

--- a/tests/TypecastingTest.php
+++ b/tests/TypecastingTest.php
@@ -550,13 +550,13 @@ class TypecastingTest extends TestCase
 
     public function testDirtyTime(): void
     {
-        $sql_time = '11:44:08';
-        $sql_time_new = '12:34:56';
+        $sql_time = new \DateTime('11:44:08 GMT');
+        $sql_time_new = new \DateTime('12:34:56 GMT');
 
         $this->setDb([
             'types' => [
                 [
-                    'date' => $sql_time,
+                    'date' => $sql_time->format('H:i:s'),
                 ],
             ],
         ]);
@@ -578,8 +578,8 @@ class TypecastingTest extends TestCase
 
     public function testDirtyTimeAfterSave(): void
     {
-        $sql_time = '11:44:08';
-        $sql_time_new = '12:34:56';
+        $sql_time = new \DateTime('11:44:08 GMT');
+        $sql_time_new = new \DateTime('12:34:56 GMT');
 
         $this->setDb([
             'types' => [

--- a/tests/TypecastingTest.php
+++ b/tests/TypecastingTest.php
@@ -58,7 +58,7 @@ class TypecastingTest extends TestCase
         $m->addField('datetime', ['type' => 'datetime']);
         $m->addField('time', ['type' => 'time']);
         $m->addField('boolean', ['type' => 'boolean']);
-        $m->addField('money', ['type' => 'money']);
+        $m->addField('money', ['type' => 'atk4_money']);
         $m->addField('float', ['type' => 'float']);
         $m->addField('integer', ['type' => 'integer']);
         $m->addField('json', ['type' => 'json']);
@@ -152,7 +152,7 @@ class TypecastingTest extends TestCase
         $m->addField('time', ['type' => 'time']);
         $m->addField('boolean', ['type' => 'boolean']);
         $m->addField('integer', ['type' => 'integer']);
-        $m->addField('money', ['type' => 'money']);
+        $m->addField('money', ['type' => 'atk4_money']);
         $m->addField('float', ['type' => 'float']);
         $m->addField('json', ['type' => 'json']);
         $m->addField('object', ['type' => 'object']);
@@ -265,7 +265,7 @@ class TypecastingTest extends TestCase
         $m->addField('time', ['type' => 'time']);
         $m->addField('b1', ['type' => 'boolean', 'enum' => ['N', 'Y']]);
         $m->addField('b2', ['type' => 'boolean', 'enum' => ['N', 'Y']]);
-        $m->addField('money', ['type' => 'money']);
+        $m->addField('money', ['type' => 'atk4_money']);
         $m->addField('float', ['type' => 'float']);
         $m->addField('integer', ['type' => 'integer']);
 

--- a/tests/UserActionTest.php
+++ b/tests/UserActionTest.php
@@ -6,6 +6,7 @@ namespace Atk4\Data\Tests;
 
 use Atk4\Data\Model;
 use Atk4\Data\Persistence\Static_ as Persistence_Static;
+use Atk4\Data\Schema\TestCase;
 
 trait UaReminder
 {
@@ -43,7 +44,7 @@ class UaClient extends Model
     }
 }
 
-class UserActionTest extends \Atk4\Schema\PhpunitTestCase
+class UserActionTest extends TestCase
 {
     /** @var Persistence_Static */
     public $pers;

--- a/tests/Util/DeepCopyTest.php
+++ b/tests/Util/DeepCopyTest.php
@@ -89,7 +89,7 @@ class DcInvoiceLine extends Model
         $this->addCondition('type', '=', 'invoice');
 
         $this->addField('qty', ['type' => 'integer', 'mandatory' => true]);
-        $this->addField('price', ['type' => 'money']);
+        $this->addField('price', ['type' => 'atk4_money']);
         $this->addField('vat', ['type' => 'float', 'default' => 0.21]);
 
         // total is calculated with VAT
@@ -113,7 +113,7 @@ class DcQuoteLine extends Model
         $this->addCondition('type', '=', 'quote');
 
         $this->addField('qty', ['type' => 'integer']);
-        $this->addField('price', ['type' => 'money']);
+        $this->addField('price', ['type' => 'atk4_money']);
 
         // total is calculated WITHOUT VAT
         $this->addExpression('total', '[qty]*[price]');
@@ -131,7 +131,7 @@ class DcPayment extends Model
 
         $this->hasOne('invoice_id', ['model' => [DcInvoice::class]]);
 
-        $this->addField('amount', ['type' => 'money']);
+        $this->addField('amount', ['type' => 'atk4_money']);
     }
 }
 

--- a/tests/Util/DeepCopyTest.php
+++ b/tests/Util/DeepCopyTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Atk4\Data\Tests;
+namespace Atk4\Data\Tests\Util;
 
 use Atk4\Data\Model;
 use Atk4\Data\Schema\TestCase;

--- a/tests/WithTest.php
+++ b/tests/WithTest.php
@@ -7,9 +7,10 @@ namespace Atk4\Data\Tests;
 use Atk4\Data\Exception;
 use Atk4\Data\Model;
 use Atk4\Data\Persistence;
+use Atk4\Data\Schema\TestCase;
 use Doctrine\DBAL\Platforms\SQLServer2012Platform;
 
-class WithTest extends \Atk4\Schema\PhpunitTestCase
+class WithTest extends TestCase
 {
     public function testWith(): void
     {

--- a/tests/WithTest.php
+++ b/tests/WithTest.php
@@ -33,10 +33,10 @@ class WithTest extends TestCase
         // setup models
         $m_user = new Model($db, ['table' => 'user']);
         $m_user->addField('name');
-        $m_user->addField('salary', ['type' => 'money']);
+        $m_user->addField('salary', ['type' => 'atk4_money']);
 
         $m_invoice = new Model($db, ['table' => 'invoice']);
-        $m_invoice->addField('net', ['type' => 'money']);
+        $m_invoice->addField('net', ['type' => 'atk4_money']);
         $m_invoice->hasOne('user_id', ['model' => $m_user]);
         $m_invoice->addCondition('net', '>', 100);
 


### PR DESCRIPTION
- DBAL types are global and by including this library within composer generic `money` type should not be added to other projects.
 To keep this type we rename it to `atk4_money`. This type represents basic float type with rounding to 4 decimal places.

- We also drop `password` type as it does not provide any security. Password securtiy should be implemented using `string` type on higher app level.

- newly, when no `Field::type` is set, the value is normalized using `string` type

- `Atk4\Schema\PhpunitTestCase` class renamed to `Atk4\Data\Schema\TestCase`

- `Atk4\Schema\Migration` class renamed to `Atk4\Data\Schema\Migration`

- also adjust for renamed Hintable package name