### PR TITLE
Require field to be present when typecasting a row

### DIFF
--- a/src/Model.php
+++ b/src/Model.php
@@ -1511,10 +1511,6 @@ class Model implements \IteratorAggregate
                 $data = [];
                 $dirty_join = false;
                 foreach ($dirtyRef as $name => $ignore) {
-                    if (!$this->hasField($name)) {
-                        continue;
-                    }
-
                     $field = $this->getField($name);
                     if ($field->read_only || $field->never_persist || $field->never_save) {
                         continue;
@@ -1547,10 +1543,6 @@ class Model implements \IteratorAggregate
             } else {
                 $data = [];
                 foreach ($this->get() as $name => $value) {
-                    if (!$this->hasField($name)) {
-                        continue;
-                    }
-
                     $field = $this->getField($name);
                     if ($field->read_only || $field->never_persist || $field->never_save) {
                         continue;
@@ -2009,7 +2001,7 @@ class Model implements \IteratorAggregate
     {
         if ($this->isEntity()) {
             return [
-                'entityId' => $this->id_field && $this->hasField('id')
+                'entityId' => $this->id_field && $this->hasField($this->id_field)
                     ? (($this->_entityId !== null ? $this->_entityId . ($this->getId() !== null ? '' : ' (unloaded)') : 'null'))
                     : 'no id field',
                 'model' => $this->getModel()->__debugInfo(),

--- a/src/Persistence.php
+++ b/src/Persistence.php
@@ -172,14 +172,6 @@ abstract class Persistence
     {
         $result = [];
         foreach ($row as $fieldName => $value) {
-            // we have no knowledge of the field, it wasn't defined, leave it as-is
-            // TODO better to never happen
-            if (!$model->hasField($fieldName)) {
-                $result[$fieldName] = $value;
-
-                continue;
-            }
-
             $field = $model->getField($fieldName);
 
             $value = $this->typecastSaveField($field, $value);
@@ -211,14 +203,6 @@ abstract class Persistence
     {
         $result = [];
         foreach ($row as $fieldName => $value) {
-            // we have no knowledge of the field, it wasn't defined, leave it as-is
-            // TODO better to never happen
-            if (!$model->hasField($fieldName)) {
-                $result[$fieldName] = $value;
-
-                continue;
-            }
-
             $field = $model->getField($fieldName);
 
             $result[$fieldName] = $this->typecastLoadField($field, $value);

--- a/src/Persistence/Array_.php
+++ b/src/Persistence/Array_.php
@@ -189,7 +189,7 @@ class Array_ extends Persistence
         return $model;
     }
 
-    private function getOnlyModelFieldsFromRowData(Model $model, array $rowData): array
+    private function filterRowDataOnlyModelFields(Model $model, array $rowData): array
     {
         return array_intersect_key($rowData, array_map(fn (Field $f) => $f->name, $model->getFields()));
     }
@@ -223,7 +223,7 @@ class Array_ extends Persistence
             return null;
         }
 
-        return $this->typecastLoadRow($model, $this->getOnlyModelFieldsFromRowData($model, $row->getData()));
+        return $this->typecastLoadRow($model, $this->filterRowDataOnlyModelFields($model, $row->getData()));
     }
 
     /**
@@ -255,7 +255,7 @@ class Array_ extends Persistence
 
         $data = $this->typecastSaveRow($model, $data);
 
-        $this->saveRow($model, array_merge($this->getOnlyModelFieldsFromRowData($model, $table->getRowById($model, $id)->getData()), $data), $id);
+        $this->saveRow($model, array_merge($this->filterRowDataOnlyModelFields($model, $table->getRowById($model, $id)->getData()), $data), $id);
     }
 
     /**
@@ -346,7 +346,7 @@ class Array_ extends Persistence
 
         $rows = [];
         foreach ($table->getRows() as $row) {
-            $rows[$row->getValue($model->id_field)] = $this->getOnlyModelFieldsFromRowData($model, $row->getData());
+            $rows[$row->getValue($model->id_field)] = $this->filterRowDataOnlyModelFields($model, $row->getData());
         }
 
         if ($fields !== null) {

--- a/src/Persistence/Csv.php
+++ b/src/Persistence/Csv.php
@@ -228,9 +228,7 @@ class Csv extends Persistence
                 continue;
             }
 
-            if ($model->hasField($key)) {
-                $row[$key] = $this->typecastLoadField($model->getField($key), $value);
-            }
+            $row[$key] = $this->typecastLoadField($model->getField($key), $value);
         }
 
         return $row;

--- a/tests/JoinArrayTest.php
+++ b/tests/JoinArrayTest.php
@@ -122,6 +122,7 @@ class JoinArrayTest extends TestCase
         $m_u->addField('name');
         $j = $m_u->join('contact.test_id');
         $j->addField('contact_phone');
+        $j->addField('test_id');
 
         $m_u2 = $m_u->createEntity();
         $m_u2->set('name', 'John');
@@ -173,6 +174,7 @@ class JoinArrayTest extends TestCase
         $db = new Persistence\Array_(['user' => [], 'contact' => []]);
         $m_u = new Model($db, ['table' => 'user']);
         $m_u->addField('name');
+        $m_u->addField('test_id');
         $j = $m_u->join('contact', ['master_field' => 'test_id']);
         $j->addField('contact_phone');
         $m_u = $m_u->createEntity();

--- a/tests/Persistence/ArrayTest.php
+++ b/tests/Persistence/ArrayTest.php
@@ -296,7 +296,7 @@ class ArrayTest extends TestCase
 
         $dbDataCountries = $dbData['countries'];
         foreach ($dbDataCountries as $k => $v) {
-            $dbDataCountries[$k] = array_merge(['id' => $k], $v);
+            $dbDataCountries[$k] = array_merge(['id' => $k], array_diff_key($v, ['name' => true]));
         }
 
         $p = new Persistence\Array_($dbData);
@@ -406,7 +406,7 @@ class ArrayTest extends TestCase
 
         $dbDataCountries = $dbData['countries'];
         foreach ($dbDataCountries as $k => $v) {
-            $dbDataCountries[$k] = array_merge(['id' => $k], $v);
+            $dbDataCountries[$k] = array_merge(['id' => $k], array_diff_key($v, ['name' => true]));
         }
 
         $p = new Persistence\Array_($dbData);


### PR DESCRIPTION
Important for a security, we can not leave anything uncasted if not found.