### PR TITLE
Rename/prefix Model::{has, contains}{One, Many} and Model::join methods with add

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ class JobReport extends Job {
     $invoice_lines = $invoice->ref('Lines');
 
     // Build relation between job and invoice line
-    $this->hasMany('InvoiceLines', ['model' => $invoice_lines])
+    $this->addHasMany('InvoiceLines', ['model' => $invoice_lines])
       ->addField('invoiced', ['aggregate' => 'sum', 'field' => 'total', 'type' => 'atk4_money']);
 
     // Next we need to see how much is reported through timesheets
@@ -152,7 +152,7 @@ class JobReport extends Job {
     $timesheet->addExpression('cost', '[hours]*[hourly_rate]');
 
     // Build relation between Job and Timesheets
-    $this->hasMany('Timesheets', ['model' => $timesheet])
+    $this->addHasMany('Timesheets', ['model' => $timesheet])
       ->addField('reported', ['aggregate' => 'sum', 'field' => 'cost', 'type' => 'atk4_money']);
 
 	// Finally lets calculate profit
@@ -357,7 +357,7 @@ class Client extends \Atk4\Data\Model {
 
         $this->addFields(['name', 'address']);
 
-        $this->hasMany('Project', ['model' => [Project::class]]);
+        $this->addHasMany('Project', ['model' => [Project::class]]);
     }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -661,7 +661,7 @@ $salary->where('emp_no', $employees);
 
 // Join with another table for more data
 $salary
-    ->join('employees.emp_id','emp_id')
+    ->join('employees.emp_id', 'emp_id')
     ->field('employees.first_name');
 
 

--- a/docs/advanced.rst
+++ b/docs/advanced.rst
@@ -19,7 +19,7 @@ store extra fields there. In your code::
     class Transaction_Transfer extends Transaction {
         function init(): void {
             parent::init();
-            $j = $this->join('transaction_transfer.transaction_id');
+            $j = $this->addJoin('transaction_transfer.transaction_id');
             $j->addField('destination_account');
         }
     }
@@ -464,7 +464,7 @@ and even delete statements.
 
     $contacts = new Contact();
     $contacts->addWith($invoices, 'inv', ['contact_id' => 'cid', 'ref_no', 'total_net' => 'invoiced'], false);
-    $contacts->join('inv.cid');
+    $contacts->addJoin('inv.cid');
 
 .. code-block:: sql
 
@@ -512,7 +512,7 @@ Next we need to define reference. Inside Model_Invoice add::
 
     $this->hasMany('Payment', ['model' => function($m) {
         $p = new Model_Payment($m->persistence);
-        $j = $p->join('invoice_payment.payment_id');
+        $j = $p->addJoin('invoice_payment.payment_id');
         $j->addField('amount_closed');
         $j->hasOne('invoice_id', 'Model_Invoice');
     }, 'their_field' => 'invoice_id']);

--- a/docs/design.rst
+++ b/docs/design.rst
@@ -236,7 +236,7 @@ Code (add inside `init()`)::
         protected function init(): void {
             parent::init();
 
-            $this->hasMany('Order', ['model' => [Model_Order::class]]);
+            $this->addHasMany('Order', ['model' => [Model_Order::class]]);
         }
     }
 
@@ -244,7 +244,7 @@ Code (add inside `init()`)::
         protected function init(): void {
             parent::init();
 
-            $this->hasOne('Client', ['model' => [Model_Client::class]]);
+            $this->addHasOne('Client', ['model' => [Model_Client::class]]);
 
             // addField declarations
         }

--- a/docs/joins.rst
+++ b/docs/joins.rst
@@ -24,7 +24,7 @@ by using joins::
     $j_contact = $user->addJoin('contact');
     $j_contact->addField('address');
     $j_contact->addField('county');
-    $j_contact->hasOne('Country');
+    $j_contact->addHasOne('Country');
 
 This code will load data from two tables simultaneously and if you do change any
 of those fields they will be update in their respective tables. With SQL the

--- a/docs/joins.rst
+++ b/docs/joins.rst
@@ -21,7 +21,7 @@ Agile Data allows you to map multiple table fields into a single business model
 by using joins::
 
     $user->addField('username');
-    $j_contact = $user->join('contact');
+    $j_contact = $user->addJoin('contact');
     $j_contact->addField('address');
     $j_contact->addField('county');
     $j_contact->hasOne('Country');
@@ -66,7 +66,7 @@ but you wouldn't want that adding a new user would create a new country::
 
     $user->addField('username');
     $user->addField('country_id');
-    $j_country = $user->weakJoin('country', ['prefix' => 'country_']);
+    $j_country = $user->addWeakJoin('country', ['prefix' => 'country_']);
     $j_country->addField('code');
     $j_country->addField('name');
     $j_country->addField('default_currency', ['prefix' => false]);
@@ -87,7 +87,7 @@ Finally you can even join using existing models::
 
     $user->addField('username');
     $user->addField('country_id');
-    $user->weakJoin('country')->importModel('Country');
+    $user->addWeakJoin('country')->importModel('Country');
 
 This will automatically import fields, expressions, references and conditions
 from 'Country' model into $user model and will also re-map field names in
@@ -114,7 +114,7 @@ earlier examples, we the master table was "user" that contained reference to
 "contact". The condition would look like this ``user.contact_id=contact.id``.
 In some cases, however, a relation should be reversed::
 
-    $j_contact = $user->join('contact.user_id');
+    $j_contact = $user->addJoin('contact.user_id');
 
 This will result in the following join condition: ``user.id=contact.user_id``.
 The first argument to join defines both the table that we need to join and
@@ -128,7 +128,7 @@ specify which field to be used for matching. By default the field is calculated
 like this: foreign_table.'_id'. Here is usage example::
 
     $user->addField('username');
-    $j_cc = $user->join('credit_card', [
+    $j_cc = $user->addJoin('credit_card', [
         'prefix' => 'cc_',
         'master_field' => 'default_credit_card_id'
     ]);
@@ -155,11 +155,11 @@ with a foreign table.
 
 .. php:method:: join
 
-    same as :php:meth:`Model::join` but links new table with this foreign table.
+    same as :php:meth:`Model::addJoin` but links new table with this foreign table.
 
 .. php:method:: weakJoin
 
-    same as :php:meth:`Model::weakJoin` but links new table with this foreign
+    same as :php:meth:`Model::addWeakJoin` but links new table with this foreign
     table.
 
     Not yet implemented !
@@ -279,7 +279,7 @@ Specifying complex ON logic
 When you're dealing with SQL drivers, you can specify `\Atk4\Data\Persistence\Sql\Expression` for your
 "on" clause::
 
-    $stats = $user->join('stats', [
+    $stats = $user->addJoin('stats', [
         'on' => $user->expr('year({}) = _st.year'),
         'foreign_alias' => '_st'
     ]);

--- a/docs/model.rst
+++ b/docs/model.rst
@@ -119,7 +119,7 @@ When you declare a model Field you can also store some persistence-related meta-
    $model->addField('old_field', ['actual' => 'new_field']);
 
    // or even into a different table
-   $model->join('new_table')->addField('extra_field');
+   $model->addJoin('new_table')->addField('extra_field');
 
 Model also has a property `$table`, which indicate name of default table/collection/file to be
 used by persistence. (Name of property is decided to avoid beginner confusion)

--- a/docs/model.rst
+++ b/docs/model.rst
@@ -65,7 +65,7 @@ Model class can be seen as a "gateway" between your code and many other features
 For example - you may define fields and relations for the model::
 
    $model->addField('age', ['type' => 'integer']);
-   $model->hasMany('Children', ['model' => [Person::class]]);
+   $model->addHasMany('Children', ['model' => [Person::class]]);
 
 Methods `addField` and `hasMany` will ultimatelly create and link model with a corresponding
 `Field` object and `Reference` object. Those classes contain the logic, but in 95% of the use-cases,
@@ -140,7 +140,7 @@ We actually recommend you to use namespaces instead::
 
          $this->addField('name');
 
-         $this->hasMany('Invoices', ['model' => [Invoice::class]]);
+         $this->addHasMany('Invoices', ['model' => [Invoice::class]]);
       }
    }
 

--- a/docs/persistence.rst
+++ b/docs/persistence.rst
@@ -276,7 +276,7 @@ Your init() method for a Field_Currency might look like this::
             ['type' => 'atk4_money', 'system' => true]
         );
 
-        $this->getOwner()->hasOne(
+        $this->getOwner()->addHasOne(
             $f.'_currency_id',
             [
                 $this->currency_model ?: new Currency(),
@@ -845,7 +845,7 @@ SQL Actions on Linked Records
 In conjunction with Model::refLink() you can produce expressions for creating
 sub-selects. The functionality is nicely wrapped inside FieldSql_Many::addField()::
 
-    $client->hasMany('Invoice')
+    $client->addHasMany('Invoice')
         ->addField('total_gross', ['aggregate' => 'sum', 'field' => 'gross']);
 
 This operation is actually consisting of 3 following operations::
@@ -860,7 +860,7 @@ This operation is actually consisting of 3 following operations::
 
 Here is a way how to intervene with the process::
 
-    $client->hasMany('Invoice');
+    $client->addHasMany('Invoice');
     $client->addExpression('last_sale', function($m) {
         return $m->refLink('Invoice')
             ->setOrder('date desc')

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -15,7 +15,7 @@ unions but only if the database server supports those operations.
 
 Developer would normally create a declaration like this::
 
-    $user->hasMany('Order')->addField('total', ['aggregate' => 'sum']);
+    $user->addHasMany('Order')->addField('total', ['aggregate' => 'sum']);
 
 It is up to Agile Data to decide what's the most efficient way to implement
 the aggregation. Currently only SQL persistence is capable of constructing
@@ -286,7 +286,7 @@ like this::
             $j->addField('address_1');
             $j->addField('address_2');
             $j->addField('address_3');
-            $j->hasOne('country_id', 'Country');
+            $j->addHasOne('country_id', 'Country');
 
         }
     }
@@ -426,8 +426,8 @@ related to each-other.
 .. warning:: Do not mix-up business model references with database relations
     (foreign keys).
 
-References are defined by calling :php:meth:`Model::hasOne()` or
-:php:meth:`Model::hasMany()`. You always specify destination model and you can
+References are defined by calling :php:meth:`Model::addHasOne()` or
+:php:meth:`Model::addHasMany()`. You always specify destination model and you can
 optionally specify which fields are used for conditioning.
 
 One to Many
@@ -437,7 +437,7 @@ Launch up console again and let's create reference between 'User' and 'System'.
 As per our database design - one user can have multiple 'system' records::
 
     $m = new Model_User($db);
-    $m->hasMany('System');
+    $m->addHasMany('System');
 
 Next you can load a specific user and traverse into System model::
 
@@ -475,7 +475,7 @@ You can examine the this model further::
     $c->export();
     $c->action('count')->getDebugQuery();
 
-By looking at the code - both MtM and OtM references are defined with 'hasMany'.
+By looking at the code - both MtM and OtM references are defined with hasMany.
 The only difference is the loaded() state of the source model.
 
 Calling ref()->ref() is also called Deep Traversal.
@@ -497,11 +497,11 @@ country of user john::
 Implementation of References
 ----------------------------
 
-When reference is added using :php:meth:`Model::hasOne()` or :php:meth:`Model::hasMany()`,
+When reference is added using :php:meth:`Model::addHasOne()` or :php:meth:`Model::addHasMany()`,
 the new object is created and added into Model of class :php:class:`Reference\HasMany`
 or :php:class:`Reference\\HasOne` (or :php:class:`Reference\\HasOneSql` in case you
 use SQL database). The object itself is quite simple and you can fetch it from
-the model if you keep the return value of hasOne() / hasMany() or call
+the model if you keep the return value of addHasOne() / addHasMany() or call
 :php:meth:`Model::getRef()` with the same identifier later on.
 You can also use :php:meth:`Model::hasRef()` to check if reference exists in model.
 
@@ -591,7 +591,7 @@ console once away::
 
     $m = new Model_User($db);
     $m = $m->loadBy('username','john');
-    $m->hasMany('System');
+    $m->addHasMany('System');
     $c = $m->ref('System')->ref('Client');
     $s = $m->ref('System')->ref('Supplier');
 

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -282,7 +282,7 @@ like this::
             $this->addField('username');
             $this->addField('email');
 
-            $j = $this->join('contact_info', 'contact_info_id');
+            $j = $this->addJoin('contact_info', 'contact_info_id');
             $j->addField('address_1');
             $j->addField('address_2');
             $j->addField('address_3');
@@ -336,12 +336,12 @@ your field, but it also participates in some field-related activity.
 Table Joins
 -----------
 
-Similarly, :php:meth:`Model::join()` creates a Join object and stores it in $j.
+Similarly, :php:meth:`Model::addJoin()` creates a Join object and stores it in $j.
 The Join object defines a relationship between the master :php:attr:`Model::table`
 and some other table inside persistence domain. It makes sure relationship is
 maintained when objects are saved / loaded::
 
-    $j = $this->join('contact_info', 'contact_info_id');
+    $j = $this->addJoin('contact_info', 'contact_info_id');
     $j->addField('address_1');
     $j->addField('address_2');
 

--- a/docs/references.rst
+++ b/docs/references.rst
@@ -13,12 +13,12 @@ Models can relate one to another. The logic of traversing references, however,
 is slightly different to the traditional ORM implementation, because in Agile
 Data traversing also imposes :ref:`conditions`
 
-There are two basic types of references: hasOne() and hasMany(), but it's also
+There are two basic types of references: addHasOne() and addHasMany(), but it's also
 possible to add other reference types. The basic ones are really easy to
 use::
 
     $m = new Model_User($db, 'user');
-    $m->hasMany('Orders', ['model' => [Model_Order::class]]);
+    $m->addHasMany('Orders', ['model' => [Model_Order::class]]);
     $m = $m->load(13);
 
     $orders_for_user_13 = $m->ref('Orders');
@@ -28,7 +28,7 @@ so that you could only access orders for the user with ID=13. The following is
 also possible::
 
     $m = new Model_User($db, 'user');
-    $m->hasMany('Orders', ['model' => [Model_Order::class]]);
+    $m->addHasMany('Orders', ['model' => [Model_Order::class]]);
     $m->addCondition('is_vip', true);
 
     $orders_for_vips = $m->ref('Orders');
@@ -58,7 +58,7 @@ not reside inside the same database?
 You can specify it like this::
 
     $m = new Model_User($db_array_cache, 'user');
-    $m->hasMany('Orders', ['model' => [Model_Order::class, $db_sql]]);
+    $m->addHasMany('Orders', ['model' => [Model_Order::class, $db_sql]]);
     $m->addCondition('is_vip', true);
 
     $orders_for_vips = $m->ref('Orders');
@@ -100,13 +100,13 @@ If you are worried about performance you can keep 2 models in memory::
 hasMany Reference
 =================
 
-.. php:method:: hasMany($link, ['model' => $model]);
+.. php:method:: addHasMany($link, ['model' => $model]);
 
 There are several ways how to link models with hasMany::
 
-    $m->hasMany('Orders', ['model' => [Model_Order::class]]); // using seed
+    $m->addHasMany('Orders', ['model' => [Model_Order::class]]); // using seed
 
-    $m->hasMany('Order', ['model' => function($m, $r) {   // using callback
+    $m->addHasMany('Order', ['model' => function($m, $r) {   // using callback
         return new Model_Order();
     }]);
 
@@ -125,7 +125,7 @@ It is possible to perform reference through an 3rd party table::
         ->addJoin('invoice_payment.payment_id')
         ->addFields(['amount_allocated','invoice_id']);
 
-    $i->hasMany('Payments', ['model' => $p]);
+    $i->addHasMany('Payments', ['model' => $p]);
 
 Now you can fetch all the payments associated with the invoice through::
 
@@ -141,7 +141,7 @@ available. Both models will relate through ``currency.code = exchange.currency_c
     $c = new Model_Currency();
     $e = new Model_ExchangeRate();
 
-    $c->hasMany('Exchanges', ['model' => $e, 'their_field' => 'currency_code', 'our_field' => 'code']);
+    $c->addHasMany('Exchanges', ['model' => $e, 'their_field' => 'currency_code', 'our_field' => 'code']);
 
     $c->addCondition('is_convertable',true);
     $e = $c->ref('Exchanges');
@@ -160,7 +160,7 @@ Concatenating Fields
 
 You may want to display want to list your related entities by concatenating. For example::
 
-    $user->hasMany('Tags', ['model' => [Tag::class]])
+    $user->addHasMany('Tags', ['model' => [Tag::class]])
         ->addField('tags', ['concat' => ',', 'field' => 'name']);
 
 This will create a new field for your user, ``tags`` which will contain all comma-separated
@@ -173,20 +173,20 @@ Reference hasMany makes it a little simpler for you to define an aggregate field
 
     $u = new Model_User($db_array_cache, 'user');
 
-    $u->hasMany('Orders', ['model' => [Model_Order::class]])
+    $u->addHasMany('Orders', ['model' => [Model_Order::class]])
         ->addField('amount', ['aggregate' => 'sum']);
 
 It's important to define aggregation functions here. This will add another field
 inside ``$m`` that will correspond to the sum of all the orders. Here is another
 example::
 
-    $u->hasMany('PaidOrders', (new Model_Order())->addCondition('is_paid', true))
+    $u->addHasMany('PaidOrders', (new Model_Order())->addCondition('is_paid', true))
         ->addField('paid_amount', ['aggregate' => 'sum', 'field' => 'amount']);
 
 You can also define multiple fields, although you must remember that this will
 keep making your query bigger and bigger::
 
-    $invoice->hasMany('Invoice_Line', ['model' => [Model_Invoice_Line::class]])
+    $invoice->addHasMany('Invoice_Line', ['model' => [Model_Invoice_Line::class]])
         ->addFields([
             ['total_vat', 'aggregate' => 'sum'],
             ['total_net', 'aggregate' => 'sum'],
@@ -237,7 +237,7 @@ containing your optional arguments::
 
 Alternatively you may also specify either 'aggregate'::
 
-    $book->hasMany('Pages', ['model' => [Page::class]])
+    $book->addHasMany('Pages', ['model' => [Page::class]])
         ->addField('page_list', [
             'aggregate' => $book->refModel('Pages')->expr('group_concat([number], [])', ['-'])
         ]);
@@ -259,7 +259,7 @@ the conditioning will be done differently. refLink is useful when defining
 sub-queries::
 
     $m = new Model_User($db_array_cache, 'user');
-    $m->hasMany('Orders', ['model' => [Model_Order::class]]);
+    $m->addHasMany('Orders', ['model' => [Model_Order::class]]);
     $m->addCondition('is_vip', true);
 
     $sum = $m->refLink('Orders')->action('fx0', ['sum', 'amount']);
@@ -290,7 +290,7 @@ reference itself. In such case refModel() comes in as handy shortcut of doing
 hasOne reference
 ================
 
-.. php:method:: hasOne($link, ['model' => $model])
+.. php:method:: addHasOne($link, ['model' => $model])
 
     $model can be an array containing options: [$model, ...]
 
@@ -300,7 +300,7 @@ This reference allows you to attach a related model to a foreign key::
     $o = new Model_Order($db, 'order');
     $u = new Model_User($db, 'user');
 
-    $o->hasOne('user_id', ['model' => $u]);
+    $o->addHasOne('user_id', ['model' => $u]);
 
 This reference is similar to hasMany, but it does behave slightly different.
 Also this reference will define a system new field ``user_id`` if you haven't
@@ -336,15 +336,15 @@ process and the loadAny() will look like this:
     select * from user where id in
         (select user_id from order where status = 'failed')
 
-By passing options to hasOne() you can also differentiate field name::
+By passing options to addHasOne() you can also differentiate field name::
 
     $o->addField('user_id');
-    $o->hasOne('User', ['model' => $u, 'our_field' => 'user_id']);
+    $o->addHasOne('User', ['model' => $u, 'our_field' => 'user_id']);
 
     $o->load(1)->ref('User')['name'];
 
 You can also use ``their_field`` if you need non-id matching (see example above
-for hasMany()).
+for addHasMany()).
 
 Importing Fields
 ----------------
@@ -357,7 +357,7 @@ the field::
     $i = new Model_Invoice($db)
     $c = new Model_Currency($db);
 
-    $i->hasOne('currency_id', ['model' => $c])
+    $i->addHasOne('currency_id', ['model' => $c])
         ->addField('currency_name', 'name');
 
 
@@ -371,7 +371,7 @@ be renamed, just as we did above::
     $u = new Model_User($db)
     $a = new Model_Address($db);
 
-    $u->hasOne('address_id', ['model' => $a])
+    $u->addHasOne('address_id', ['model' => $a])
         ->addFields([
             'address_1',
             'address_2',
@@ -391,14 +391,14 @@ Above, all ``address_`` fields are copied with the same name, however field
 Importing hasOne Title
 ----------------------
 
-When you are using hasOne() in most cases the referenced object will be addressed
+When you are using addHasOne() in most cases the referenced object will be addressed
 through "ID" but will have a human-readable field as well. In the example above
 `Model_Currency` has a title field called `name`. Agile Data provides you an
 easier way how to define currency title::
 
     $i = new Invoice($db)
 
-    $i->hasOne('currency_id', ['model' => [Currency::class]])
+    $i->addHasOne('currency_id', ['model' => [Currency::class]])
         ->addTitle();
 
 This would create 'currency' field containing name of the currency::
@@ -422,7 +422,7 @@ By default name of the field will be calculated by removing "_id" from the end
 of hasOne field, but to override this, you can specify name of the title field
 explicitly::
 
-    $i->hasOne('currency_id', ['model' => [Currency::class]])
+    $i->addHasOne('currency_id', ['model' => [Currency::class]])
         ->addTitle(['field' => 'currency_name']);
 
 User-defined Reference
@@ -522,14 +522,14 @@ when SQL is confused about which table to use.
 To avoid this problem Agile Data will automatically alias tables in sub-queries.
 Here is how it works::
 
-    $item->hasMany('parent_item_id', ['model' => [Model_Item::class]])
+    $item->addHasMany('parent_item_id', ['model' => [Model_Item::class]])
         ->addField('parent', 'name');
 
 When generating expression for 'parent', the sub-query will use alias ``pi``
 consisting of first letters in 'parent_item_id'. (except _id). You can actually
 specify a custom table alias if you want::
 
-    $item->hasMany('parent_item_id', ['model' => [Model_Item::class], 'table_alias' => 'mypi'])
+    $item->addHasMany('parent_item_id', ['model' => [Model_Item::class], 'table_alias' => 'mypi'])
         ->addField('parent', 'name');
 
 Additionally you can pass table_alias as second argument into :php:meth:`Model::ref()`
@@ -546,10 +546,10 @@ that relate to itself. Here is example::
             $this->addField('name');
             $this->addField('age');
             $i2 = $this->addJoin('item2.item_id');
-            $i2->hasOne('parent_item_id', ['model' => $m, 'table_alias' => 'parent'])
+            $i2->addHasOne('parent_item_id', ['model' => $m, 'table_alias' => 'parent'])
                 ->addTitle();
 
-            $this->hasMany('Child', ['model' => $m, 'their_field' => 'parent_item_id', 'table_alias' => 'child'])
+            $this->addHasMany('Child', ['model' => $m, 'their_field' => 'parent_item_id', 'table_alias' => 'child'])
                 ->addField('child_age',['aggregate' => 'sum', 'field' => 'age']);
         }
     }
@@ -574,7 +574,7 @@ Loading model like that can produce a pretty sophisticated query:
 Various ways to specify options
 -------------------------------
 
-When calling `hasOne()->addFields()` there are various ways to pass options:
+When calling `addHasOne()->addFields()` there are various ways to pass options:
 
 - `addFields(['name', 'dob'])` - no options are passed, use defaults. Note that
   reference will not fetch the type of foreign field due to performance consideration.
@@ -605,7 +605,7 @@ Consider the following two models::
             parent::init();
             $this->addField('name');
 
-            $this->hasOne('contact_id', ['model' => [Model_Contact::class]]);
+            $this->addHasOne('contact_id', ['model' => [Model_Contact::class]]);
         }
     }
 

--- a/docs/references.rst
+++ b/docs/references.rst
@@ -122,7 +122,7 @@ It is possible to perform reference through an 3rd party table::
     // table invoice_payment has 'invoice_id', 'payment_id' and 'amount_allocated'
 
     $p
-        ->join('invoice_payment.payment_id')
+        ->addJoin('invoice_payment.payment_id')
         ->addFields(['amount_allocated','invoice_id']);
 
     $i->hasMany('Payments', ['model' => $p]);
@@ -545,7 +545,7 @@ that relate to itself. Here is example::
 
             $this->addField('name');
             $this->addField('age');
-            $i2 = $this->join('item2.item_id');
+            $i2 = $this->addJoin('item2.item_id');
             $i2->hasOne('parent_item_id', ['model' => $m, 'table_alias' => 'parent'])
                 ->addTitle();
 

--- a/docs/sql.rst
+++ b/docs/sql.rst
@@ -56,12 +56,12 @@ SQL Reference
 
     Allows importing field from a referenced model::
 
-        $model->hasOne('country_id', ['model' => [Country::class]])
+        $model->addHasOne('country_id', ['model' => [Country::class]])
             ->addField('country_name', 'name');
 
     Second argument could be array containing additional settings for the field::
 
-        $model->hasOne('account_id', ['model' => [Account::class]])
+        $model->addHasOne('account_id', ['model' => [Account::class]])
             ->addField('account_balance', ['balance', 'type' => 'atk4_money']);
 
     Returns new field object.
@@ -70,12 +70,12 @@ SQL Reference
 
     Allows importing multiple fields::
 
-        $model->hasOne('country_id', ['model' => [Country::class]])
+        $model->addHasOne('country_id', ['model' => [Country::class]])
             ->addFields(['country_name', 'country_code']);
 
     You can specify defaults to be applied on all fields::
 
-        $model->hasOne('account_id', ['model' => [Account::class]])
+        $model->addHasOne('account_id', ['model' => [Account::class]])
             ->addFields([
                 'opening_balance',
                 'balance'
@@ -83,7 +83,7 @@ SQL Reference
 
     You can also specify aliases::
 
-        $model->hasOne('account_id', ['model' => [Account::class]])
+        $model->addHasOne('account_id', ['model' => [Account::class]])
             ->addFields([
                 'opening_balance',
                 'account_balance' => 'balance'
@@ -91,7 +91,7 @@ SQL Reference
 
     If you need to pass more details to individual field, you can also use sub-array::
 
-        $model->hasOne('account_id', ['model' => [Account::class]])
+        $model->addHasOne('account_id', ['model' => [Account::class]])
             ->addFields([
             [
                 ['opening_balance', 'caption' => 'The Opening Balance'],
@@ -119,14 +119,14 @@ SQL Reference
     Similar to addField, but will import "title" field and will come up with
     good name for it::
 
-        $model->hasOne('country_id', ['model' => [Country::class]])
+        $model->addHasOne('country_id', ['model' => [Country::class]])
             ->addTitle();
 
         // creates 'country' field as sub-query for country.name
 
     You may pass defaults::
 
-        $model->hasOne('country_id', ['model' => [Country::class]])
+        $model->addHasOne('country_id', ['model' => [Country::class]])
             ->addTitle(['caption' => 'Country Name']);
 
     Returns new field object.
@@ -410,7 +410,7 @@ fetching like this::
         function init(): void {
             parent::init();
 
-            $this->hasOne('parent_id', ['model' => [self::class]]);
+            $this->addHasOne('parent_id', ['model' => [self::class]]);
             $this->addField('name');
 
             $this->addExpression('path', 'get_path([id])');

--- a/docs/typecasting.rst
+++ b/docs/typecasting.rst
@@ -103,7 +103,7 @@ Many databases will allow you to use different types for ID fields.
 In SQL the 'id' column will usually be "integer", but sometimes it can be of
 a different type.
 
-The same applies for references ($m->hasOne()).
+The same applies for references ($m->addHasOne()).
 
 Supported types
 ---------------

--- a/src/Model/Join.php
+++ b/src/Model/Join.php
@@ -79,7 +79,7 @@ class Join
      *
      * If you are using the following syntax:
      *
-     * $user->join('contact','default_contact_id');
+     * $user->addJoin('contact', 'default_contact_id');
      *
      * Then the ID connecting tables is stored in foreign table and the order
      * of saving and delete needs to be reversed. In this case $reverse
@@ -285,15 +285,39 @@ class Join
     }
 
     /**
+     * @param array<string, mixed> $defaults
+     *
+     * @deprecated to be removed in v3.3
+     */
+    public function join(string $foreign_table, array $defaults = []): self
+    {
+        'trigger_error'('Method is deprecated. Use addJoin() instead', \E_USER_DEPRECATED);
+
+        return $this->addJoin($foreign_table, $defaults);
+    }
+
+    /**
+     * @param array<string, mixed> $defaults
+     *
+     * @deprecated to be removed in v3.3
+     */
+    public function leftJoin(string $foreign_table, array $defaults = []): self
+    {
+        'trigger_error'('Method is deprecated. Use addLeftJoin() instead', \E_USER_DEPRECATED);
+
+        return $this->addLeftJoin($foreign_table, $defaults);
+    }
+
+    /**
      * Another join will be attached to a current join.
      *
      * @param array<string, mixed> $defaults
      */
-    public function join(string $foreign_table, array $defaults = []): self
+    public function addJoin(string $foreign_table, array $defaults = []): self
     {
         $defaults['joinName'] = $this->short_name;
 
-        return $this->getOwner()->join($foreign_table, $defaults);
+        return $this->getOwner()->addJoin($foreign_table, $defaults);
     }
 
     /**
@@ -301,11 +325,11 @@ class Join
      *
      * @param array<string, mixed> $defaults
      */
-    public function leftJoin(string $foreign_table, array $defaults = []): self
+    public function addLeftJoin(string $foreign_table, array $defaults = []): self
     {
         $defaults['joinName'] = $this->short_name;
 
-        return $this->getOwner()->leftJoin($foreign_table, $defaults);
+        return $this->getOwner()->addLeftJoin($foreign_table, $defaults);
     }
 
     /**

--- a/src/Model/Join.php
+++ b/src/Model/Join.php
@@ -309,6 +309,30 @@ class Join
     }
 
     /**
+     * @return Reference\HasOne|Reference\HasOneSql
+     *
+     * @deprecated to be removed in v3.3
+     */
+    public function hasOne(string $link, array $defaults = [])
+    {
+        'trigger_error'('Method is deprecated. Use addHasOne() instead', \E_USER_DEPRECATED);
+
+        return $this->addHasOne($link, $defaults);
+    }
+
+    /**
+     * @return Reference\HasMany
+     *
+     * @deprecated to be removed in v3.3
+     */
+    public function hasMany(string $link, array $defaults = [])
+    {
+        'trigger_error'('Method is deprecated. Use addHasMany() instead', \E_USER_DEPRECATED);
+
+        return $this->addHasMany($link, $defaults);
+    }
+
+    /**
      * Another join will be attached to a current join.
      *
      * @param array<string, mixed> $defaults
@@ -337,11 +361,11 @@ class Join
      *
      * @return Reference\HasOne
      */
-    public function hasOne(string $link, array $defaults = [])
+    public function addHasOne(string $link, array $defaults = [])
     {
         $defaults['joinName'] = $this->short_name;
 
-        return $this->getOwner()->hasOne($link, $defaults);
+        return $this->getOwner()->addHasOne($link, $defaults);
     }
 
     /**
@@ -349,18 +373,18 @@ class Join
      *
      * @return Reference\HasMany
      */
-    public function hasMany(string $link, array $defaults = [])
+    public function addHasMany(string $link, array $defaults = [])
     {
         $defaults = array_merge([
             'our_field' => $this->id_field,
             'their_field' => $this->getOwner()->table . '_' . $this->id_field,
         ], $defaults);
 
-        return $this->getOwner()->hasMany($link, $defaults);
+        return $this->getOwner()->addHasMany($link, $defaults);
     }
 
     /**
-     * Wrapper for containsOne that will associate field
+     * Wrapper for addContainsOne that will associate field
      * with join.
      *
      * @todo NOT IMPLEMENTED !
@@ -368,18 +392,18 @@ class Join
      * @return ???
      */
     /*
-    public function containsOne(Model $model, array $defaults = [])
+    public function addContainsOne(Model $model, array $defaults = [])
     {
         if (is_string($defaults[0])) {
             $defaults[0] = $this->addField($defaults[0], ['system' => true]);
         }
 
-        return parent::containsOne($model, $defaults);
+        return parent::addContainsOne($model, $defaults);
     }
     */
 
     /**
-     * Wrapper for containsMany that will associate field
+     * Wrapper for addContainsMany that will associate field
      * with join.
      *
      * @todo NOT IMPLEMENTED !
@@ -387,13 +411,13 @@ class Join
      * @return ???
      */
     /*
-    public function containsMany(Model $model, array $defaults = [])
+    public function addContainsMany(Model $model, array $defaults = [])
     {
         if (is_string($defaults[0])) {
             $defaults[0] = $this->addField($defaults[0], ['system' => true]);
         }
 
-        return parent::containsMany($model, $defaults);
+        return parent::addContainsMany($model, $defaults);
     }
     */
 

--- a/src/Model/JoinsTrait.php
+++ b/src/Model/JoinsTrait.php
@@ -19,6 +19,30 @@ trait JoinsTrait
     public $_default_seed_join = [Join::class];
 
     /**
+     * @param array<string, mixed> $defaults
+     *
+     * @deprecated to be removed in v3.3
+     */
+    public function join(string $foreignTable, array $defaults = []): Join
+    {
+        'trigger_error'('Method is deprecated. Use addJoin() instead', \E_USER_DEPRECATED);
+
+        return $this->addJoin($foreignTable, $defaults);
+    }
+
+    /**
+     * @param array<string, mixed> $defaults
+     *
+     * @deprecated to be removed in v3.3
+     */
+    public function leftJoin(string $foreignTable, array $defaults = []): Join
+    {
+        'trigger_error'('Method is deprecated. Use addLeftJoin() instead', \E_USER_DEPRECATED);
+
+        return $this->addLeftJoin($foreignTable, $defaults);
+    }
+
+    /**
      * Creates an objects that describes relationship between multiple tables (or collections).
      *
      * When object is loaded, then instead of pulling all the data from a single table,
@@ -27,7 +51,7 @@ trait JoinsTrait
      *
      * @param array<string, mixed> $defaults
      */
-    public function join(string $foreignTable, array $defaults = []): Join
+    public function addJoin(string $foreignTable, array $defaults = []): Join
     {
         $this->assertIsModel();
 
@@ -51,10 +75,10 @@ trait JoinsTrait
      *
      * @param array<string, mixed> $defaults
      */
-    public function leftJoin(string $foreignTable, array $defaults = []): Join
+    public function addLeftJoin(string $foreignTable, array $defaults = []): Join
     {
         $defaults['weak'] = true;
 
-        return $this->join($foreignTable, $defaults);
+        return $this->addJoin($foreignTable, $defaults);
     }
 }

--- a/src/Model/ReferencesTrait.php
+++ b/src/Model/ReferencesTrait.php
@@ -77,11 +77,59 @@ trait ReferencesTrait
     }
 
     /**
+     * @return Reference\HasOne|Reference\HasOneSql
+     *
+     * @deprecated to be removed in v3.3
+     */
+    public function hasOne(string $link, array $defaults = [])
+    {
+        'trigger_error'('Method is deprecated. Use addHasOne() instead', \E_USER_DEPRECATED);
+
+        return $this->addHasOne($link, $defaults);
+    }
+
+    /**
+     * @return Reference\HasMany
+     *
+     * @deprecated to be removed in v3.3
+     */
+    public function hasMany(string $link, array $defaults = [])
+    {
+        'trigger_error'('Method is deprecated. Use addHasMany() instead', \E_USER_DEPRECATED);
+
+        return $this->addHasMany($link, $defaults);
+    }
+
+    /**
+     * @return Reference\ContainsOne
+     *
+     * @deprecated to be removed in v3.3
+     */
+    public function containsOne(string $link, array $defaults = [])
+    {
+        'trigger_error'('Method is deprecated. Use addContainsOne() instead', \E_USER_DEPRECATED);
+
+        return $this->addContainsOne($link, $defaults);
+    }
+
+    /**
+     * @return Reference\ContainsMany
+     *
+     * @deprecated to be removed in v3.3
+     */
+    public function containsMany(string $link, array $defaults = [])
+    {
+        'trigger_error'('Method is deprecated. Use addContainsMany() instead', \E_USER_DEPRECATED);
+
+        return $this->addContainsMany($link, $defaults);
+    }
+
+    /**
      * Add hasOne reference.
      *
      * @return Reference\HasOne|Reference\HasOneSql
      */
-    public function hasOne(string $link, array $defaults = []) //: Reference
+    public function addHasOne(string $link, array $defaults = []) //: Reference
     {
         return $this->_addRef($this->_default_seed_hasOne, $link, $defaults); // @phpstan-ignore-line
     }
@@ -91,7 +139,7 @@ trait ReferencesTrait
      *
      * @return Reference\HasMany
      */
-    public function hasMany(string $link, array $defaults = []) //: Reference
+    public function addHasMany(string $link, array $defaults = []) //: Reference
     {
         return $this->_addRef($this->_default_seed_hasMany, $link, $defaults); // @phpstan-ignore-line
     }
@@ -101,7 +149,7 @@ trait ReferencesTrait
      *
      * @return Reference\ContainsOne
      */
-    public function containsOne(string $link, array $defaults = []) //: Reference
+    public function addContainsOne(string $link, array $defaults = []) //: Reference
     {
         return $this->_addRef($this->_default_seed_containsOne, $link, $defaults); // @phpstan-ignore-line
     }
@@ -111,7 +159,7 @@ trait ReferencesTrait
      *
      * @return Reference\ContainsMany
      */
-    public function containsMany(string $link, array $defaults = []) //: Reference
+    public function addContainsMany(string $link, array $defaults = []) //: Reference
     {
         return $this->_addRef($this->_default_seed_containsMany, $link, $defaults); // @phpstan-ignore-line
     }

--- a/src/Reference.php
+++ b/src/Reference.php
@@ -235,7 +235,7 @@ class Reference
         $ourModel = $this->getOurModel();
 
         // this will be useful for containsOne/Many implementation in case when you have
-        // SQL_Model->containsOne()->hasOne() structure to get back to SQL persistence
+        // SQL_Model->addContainsOne()->addHasOne() structure to get back to SQL persistence
         // from Array persistence used in containsOne model
         if ($ourModel->contained_in_root_model && $ourModel->contained_in_root_model->persistence) {
             return $ourModel->contained_in_root_model->persistence;

--- a/src/Reference/HasMany.php
+++ b/src/Reference/HasMany.php
@@ -95,7 +95,7 @@ class HasMany extends Reference
     public function addField(string $fieldName, array $defaults = []): Field
     {
         if (!isset($defaults['aggregate']) && !isset($defaults['concat']) && !isset($defaults['expr'])) {
-            throw (new Exception('Aggregate field requires "aggregate", "concat" or "expr" specified to hasMany()->addField()'))
+            throw (new Exception('Aggregate field requires "aggregate", "concat" or "expr" specified to HasMany->addField()'))
                 ->addMoreInfo('field', $fieldName)
                 ->addMoreInfo('defaults', $defaults);
         }

--- a/src/Reference/HasOneSql.php
+++ b/src/Reference/HasOneSql.php
@@ -141,7 +141,7 @@ class HasOneSql extends HasOne
     /**
      * Add a title of related entity as expression to our field.
      *
-     * $order->hasOne('user_id', 'User')->addTitle();
+     * $order->addHasOne('user_id', 'User')->addTitle();
      *
      * This will add expression 'user' equal to ref('user_id')['name'];
      *

--- a/tests/ConditionSqlTest.php
+++ b/tests/ConditionSqlTest.php
@@ -248,7 +248,7 @@ class ConditionSqlTest extends TestCase
         $m = new Model($this->db, ['table' => 'user']);
         $m->addFields(['name', 'gender', 'surname']);
 
-        $m->join('contact')->addField('contact_phone');
+        $m->addJoin('contact')->addField('contact_phone');
 
         $mm2 = $m->tryLoad(1);
         $this->assertSame('John', $mm2->get('name'));

--- a/tests/ConditionTest.php
+++ b/tests/ConditionTest.php
@@ -55,7 +55,7 @@ class ConditionTest extends TestCase
 
         $m = new Model();
         $m->addField('name');
-        $m->hasOne('gender_id', ['model' => $gender]);
+        $m->addHasOne('gender_id', ['model' => $gender]);
 
         $this->assertFalse($m->getField('gender_id')->system);
         $this->assertTrue($m->getField('gender_id')->isEditable());

--- a/tests/ContainsMany/Invoice.php
+++ b/tests/ContainsMany/Invoice.php
@@ -29,7 +29,7 @@ class Invoice extends Model
         $this->addField($this->fieldName()->amount, ['type' => 'atk4_money']);
 
         // will contain many Lines
-        $this->containsMany($this->fieldName()->lines, ['model' => [Line::class], 'caption' => 'My Invoice Lines']);
+        $this->addContainsMany($this->fieldName()->lines, ['model' => [Line::class], 'caption' => 'My Invoice Lines']);
 
         // total_gross - calculated by php callback not by SQL expression
         $this->addCalculatedField($this->fieldName()->total_gross, function (self $m) {

--- a/tests/ContainsMany/Line.php
+++ b/tests/ContainsMany/Line.php
@@ -23,7 +23,7 @@ class Line extends Model
     {
         parent::init();
 
-        $this->hasOne($this->fieldName()->vat_rate_id, ['model' => [VatRate::class]]);
+        $this->addHasOne($this->fieldName()->vat_rate_id, ['model' => [VatRate::class]]);
 
         $this->addField($this->fieldName()->price, ['type' => 'atk4_money', 'required' => true]);
         $this->addField($this->fieldName()->qty, ['type' => 'float', 'required' => true]);
@@ -34,7 +34,7 @@ class Line extends Model
         });
 
         // each line can have multiple discounts and calculate total of these discounts
-        $this->containsMany($this->fieldName()->discounts, ['model' => [Discount::class]]);
+        $this->addContainsMany($this->fieldName()->discounts, ['model' => [Discount::class]]);
 
         $this->addCalculatedField($this->fieldName()->discounts_percent, function ($m) {
             $total = 0;

--- a/tests/ContainsOne/Address.php
+++ b/tests/ContainsOne/Address.php
@@ -21,13 +21,12 @@ class Address extends Model
     {
         parent::init();
 
-        $this->hasOne($this->fieldName()->country_id, ['model' => [Country::class], 'type' => 'integer']);
+        $this->addHasOne($this->fieldName()->country_id, ['model' => [Country::class], 'type' => 'integer']);
 
         $this->addField($this->fieldName()->address);
         $this->addField($this->fieldName()->built_date, ['type' => 'datetime']);
         $this->addField($this->fieldName()->tags, ['type' => 'json', 'default' => []]);
 
-        // will contain one door code
-        $this->containsOne($this->fieldName()->door_code, ['model' => [DoorCode::class], 'caption' => 'Secret Code']);
+        $this->addContainsOne($this->fieldName()->door_code, ['model' => [DoorCode::class], 'caption' => 'Secret Code']);
     }
 }

--- a/tests/ContainsOne/Invoice.php
+++ b/tests/ContainsOne/Invoice.php
@@ -24,7 +24,6 @@ class Invoice extends Model
 
         $this->addField($this->fieldName()->ref_no, ['required' => true]);
 
-        // will contain one Address
-        $this->containsOne($this->fieldName()->addr, ['model' => [Address::class]]);
+        $this->addContainsOne($this->fieldName()->addr, ['model' => [Address::class]]);
     }
 }

--- a/tests/FieldTest.php
+++ b/tests/FieldTest.php
@@ -378,7 +378,7 @@ class FieldTest extends TestCase
 
         $m = new Model($db, ['table' => 'user']);
         $m->addField('name');
-        $m->hasOne('category_id', ['model' => $c])
+        $m->addHasOne('category_id', ['model' => $c])
             ->addTitle();
 
         $m = $m->load(1);

--- a/tests/FolderTest.php
+++ b/tests/FolderTest.php
@@ -17,10 +17,10 @@ class Folder extends Model
         parent::init();
         $this->addField('name');
 
-        $this->hasMany('SubFolder', ['model' => [self::class], 'their_field' => 'parent_id'])
+        $this->addHasMany('SubFolder', ['model' => [self::class], 'their_field' => 'parent_id'])
             ->addField('count', ['aggregate' => 'count', 'field' => $this->persistence->expr($this, '*')]);
 
-        $this->hasOne('parent_id', ['model' => [self::class]])
+        $this->addHasOne('parent_id', ['model' => [self::class]])
             ->addTitle();
 
         $this->addField('is_deleted', ['type' => 'boolean']);

--- a/tests/JoinArrayTest.php
+++ b/tests/JoinArrayTest.php
@@ -32,23 +32,23 @@ class JoinArrayTest extends TestCase
         $db = new Persistence\Array_(['user' => [], 'contact' => []]);
         $m = new Model($db, ['table' => 'user']);
 
-        $j = $m->join('contact');
+        $j = $m->addJoin('contact');
         $this->assertFalse($this->getProtected($j, 'reverse'));
         $this->assertSame('contact_id', $this->getProtected($j, 'master_field'));
         $this->assertSame('id', $this->getProtected($j, 'foreign_field'));
 
-        $j = $m->join('contact2.test_id');
+        $j = $m->addJoin('contact2.test_id');
         $this->assertTrue($this->getProtected($j, 'reverse'));
         $this->assertSame('id', $this->getProtected($j, 'master_field'));
         $this->assertSame('test_id', $this->getProtected($j, 'foreign_field'));
 
-        $j = $m->join('contact3', ['master_field' => 'test_id']);
+        $j = $m->addJoin('contact3', ['master_field' => 'test_id']);
         $this->assertFalse($this->getProtected($j, 'reverse'));
         $this->assertSame('test_id', $this->getProtected($j, 'master_field'));
         $this->assertSame('id', $this->getProtected($j, 'foreign_field'));
 
         $this->expectException(Exception::class); // TODO not implemented yet, see https://github.com/atk4/data/issues/803
-        $j = $m->join('contact4.foo_id', ['master_field' => 'test_id', 'reverse' => true]);
+        $j = $m->addJoin('contact4.foo_id', ['master_field' => 'test_id', 'reverse' => true]);
         $this->assertTrue($this->getProtected($j, 'reverse'));
         $this->assertSame('test_id', $this->getProtected($j, 'master_field'));
         $this->assertSame('foo_id', $this->getProtected($j, 'foreign_field'));
@@ -60,7 +60,7 @@ class JoinArrayTest extends TestCase
         $m = new Model($db, ['table' => 'user']);
 
         $this->expectException(Exception::class);
-        $j = $m->join('contact.foo_id', ['master_field' => 'test_id']);
+        $j = $m->addJoin('contact.foo_id', ['master_field' => 'test_id']);
     }
 
     public function testJoinSaving1(): void
@@ -69,7 +69,7 @@ class JoinArrayTest extends TestCase
         $m_u = new Model($db, ['table' => 'user']);
         $m_u->addField('contact_id', ['type' => 'integer']);
         $m_u->addField('name');
-        $j = $m_u->join('contact');
+        $j = $m_u->addJoin('contact');
         $j->addField('contact_phone');
 
         $m_u2 = $m_u->createEntity();
@@ -120,7 +120,7 @@ class JoinArrayTest extends TestCase
         $db = new Persistence\Array_(['user' => [], 'contact' => []]);
         $m_u = new Model($db, ['table' => 'user']);
         $m_u->addField('name');
-        $j = $m_u->join('contact.test_id');
+        $j = $m_u->addJoin('contact.test_id');
         $j->addField('contact_phone');
         $j->addField('test_id', ['type' => 'integer']);
 
@@ -175,7 +175,7 @@ class JoinArrayTest extends TestCase
         $m_u = new Model($db, ['table' => 'user']);
         $m_u->addField('name');
         $m_u->addField('test_id', ['type' => 'integer']);
-        $j = $m_u->join('contact', ['master_field' => 'test_id']);
+        $j = $m_u->addJoin('contact', ['master_field' => 'test_id']);
         $j->addField('contact_phone');
         $m_u = $m_u->createEntity();
 
@@ -196,7 +196,7 @@ class JoinArrayTest extends TestCase
         $m_u = new Model($db, ['table' => 'user']);
         $m_u->addField('name');
         $m_u->addField('code');
-        $j = $m_u->join('contact.code', ['master_field' => 'code']);
+        $j = $m_u->addJoin('contact.code', ['master_field' => 'code']);
         $j->addField('contact_phone');
         $m_u = $m_u->createEntity();
 
@@ -227,7 +227,7 @@ class JoinArrayTest extends TestCase
         $m_u = new Model($db, ['table' => 'user']);
         $m_u->addField('contact_id', ['type' => 'integer']);
         $m_u->addField('name');
-        $j = $m_u->join('contact');
+        $j = $m_u->addJoin('contact');
         $j->addField('contact_phone');
 
         $m_u2 = $m_u->load(1);
@@ -261,7 +261,7 @@ class JoinArrayTest extends TestCase
         $m_u = new Model($db, ['table' => 'user']);
         $m_u->addField('contact_id', ['type' => 'integer']);
         $m_u->addField('name');
-        $j = $m_u->join('contact');
+        $j = $m_u->addJoin('contact');
         $j->addField('contact_phone');
 
         $m_u2 = $m_u->load(1);
@@ -332,7 +332,7 @@ class JoinArrayTest extends TestCase
         $m_u = new Model($db, ['table' => 'user']);
         $m_u->addField('contact_id', ['type' => 'integer']);
         $m_u->addField('name');
-        $j = $m_u->join('contact');
+        $j = $m_u->addJoin('contact');
         $j->addField('contact_phone');
 
         $m_u = $m_u->load(1);
@@ -365,7 +365,7 @@ class JoinArrayTest extends TestCase
         $m_u = new Model($db, ['table' => 'user']);
         $m_u->addField('contact_id', ['type' => 'integer']);
         $m_u->addField('name');
-        $j = $m_u->join('contact');
+        $j = $m_u->addJoin('contact');
         $j->addField('contact_phone');
         $this->expectException(Exception::class);
         $m_u = $m_u->load(2);
@@ -379,7 +379,7 @@ class JoinArrayTest extends TestCase
 
         // tricky cases to testt
         //
-        //$m->join('foo.bar', ['master_field' => 'baz']);
+        //$m->addJoin('foo.bar', ['master_field' => 'baz']);
         // foreign_table = 'foo.bar'
     }
     */

--- a/tests/JoinSqlTest.php
+++ b/tests/JoinSqlTest.php
@@ -539,7 +539,7 @@ class JoinSqlTest extends TestCase
         // hasOne phone model
         $m_p = new Model($db, ['table' => 'phone']);
         $m_p->addField('number');
-        $ref_one = $j->hasOne('phone_id', ['model' => $m_p]); // hasOne on JOIN
+        $ref_one = $j->addHasOne('phone_id', ['model' => $m_p]); // hasOne on JOIN
         $ref_one->addField('number');
 
         $m_u2 = $m_u->load(1);
@@ -551,7 +551,7 @@ class JoinSqlTest extends TestCase
         $m_t = new Model($db, ['table' => 'token']);
         $m_t->addField('user_id');
         $m_t->addField('token');
-        $ref_many = $j->hasMany('Token', ['model' => $m_t]); // hasMany on JOIN (use default our_field, their_field)
+        $ref_many = $j->addHasMany('Token', ['model' => $m_t]); // hasMany on JOIN (use default our_field, their_field)
 
         $m_u2 = $m_u->load(1);
         $this->assertEquals([
@@ -563,7 +563,7 @@ class JoinSqlTest extends TestCase
         $m_e = new Model($db, ['table' => 'email']);
         $m_e->addField('contact_id');
         $m_e->addField('address');
-        $ref_many = $j->hasMany('Email', ['model' => $m_e, 'our_field' => 'contact_id', 'their_field' => 'contact_id']); // hasMany on JOIN (use custom our_field, their_field)
+        $ref_many = $j->addHasMany('Email', ['model' => $m_e, 'our_field' => 'contact_id', 'their_field' => 'contact_id']); // hasMany on JOIN (use custom our_field, their_field)
 
         $m_u2 = $m_u->load(1);
         $this->assertEquals([

--- a/tests/JoinSqlTest.php
+++ b/tests/JoinSqlTest.php
@@ -16,23 +16,23 @@ class JoinSqlTest extends TestCase
         $db = new Persistence\Sql($this->db->connection);
         $m = new Model($db, ['table' => 'user']);
 
-        $j = $m->join('contact');
+        $j = $m->addJoin('contact');
         $this->assertFalse($this->getProtected($j, 'reverse'));
         $this->assertSame('contact_id', $this->getProtected($j, 'master_field'));
         $this->assertSame('id', $this->getProtected($j, 'foreign_field'));
 
-        $j = $m->join('contact2.test_id');
+        $j = $m->addJoin('contact2.test_id');
         $this->assertTrue($this->getProtected($j, 'reverse'));
         $this->assertSame('id', $this->getProtected($j, 'master_field'));
         $this->assertSame('test_id', $this->getProtected($j, 'foreign_field'));
 
-        $j = $m->join('contact3', ['master_field' => 'test_id']);
+        $j = $m->addJoin('contact3', ['master_field' => 'test_id']);
         $this->assertFalse($this->getProtected($j, 'reverse'));
         $this->assertSame('test_id', $this->getProtected($j, 'master_field'));
         $this->assertSame('id', $this->getProtected($j, 'foreign_field'));
 
         $this->expectException(Exception::class); // TODO not implemented yet, see https://github.com/atk4/data/issues/803
-        $j = $m->join('contact4.foo_id', ['master_field' => 'test_id', 'reverse' => true]);
+        $j = $m->addJoin('contact4.foo_id', ['master_field' => 'test_id', 'reverse' => true]);
         $this->assertTrue($this->getProtected($j, 'reverse'));
         $this->assertSame('test_id', $this->getProtected($j, 'master_field'));
         $this->assertSame('foo_id', $this->getProtected($j, 'foreign_field'));
@@ -44,7 +44,7 @@ class JoinSqlTest extends TestCase
         $m = new Model($db, ['table' => 'user']);
 
         $this->expectException(Exception::class);
-        $j = $m->join('contact.foo_id', ['master_field' => 'test_id']);
+        $j = $m->addJoin('contact.foo_id', ['master_field' => 'test_id']);
     }
 
     public function testJoinSaving1(): void
@@ -61,7 +61,7 @@ class JoinSqlTest extends TestCase
 
         $m_u->addField('contact_id');
         $m_u->addField('name');
-        $j = $m_u->join('contact');
+        $j = $m_u->addJoin('contact');
         $j->addField('contact_phone');
 
         $m_u2 = $m_u->createEntity();
@@ -103,7 +103,7 @@ class JoinSqlTest extends TestCase
             ],
         ]);
         $m_u->addField('name');
-        $j = $m_u->join('contact.test_id');
+        $j = $m_u->addJoin('contact.test_id');
         $j->addFields(['contact_phone']);
 
         $m_u2 = $m_u->createEntity();
@@ -162,7 +162,7 @@ class JoinSqlTest extends TestCase
         ]);
 
         $m_u->addField('name');
-        $j = $m_u->join('contact', ['master_field' => 'test_id']);
+        $j = $m_u->addJoin('contact', ['master_field' => 'test_id']);
         $j->addField('contact_phone');
         $m_u = $m_u->createEntity();
 
@@ -193,7 +193,7 @@ class JoinSqlTest extends TestCase
         $db = new Persistence\Sql($this->db->connection);
         $m_u = new Model($db, ['table' => 'user']);
         $m_u->addField('name');
-        $j = $m_u->join('contact');
+        $j = $m_u->addJoin('contact');
         $j->addField('contact_phone');
 
         $m_u2 = $m_u->load(1);
@@ -229,7 +229,7 @@ class JoinSqlTest extends TestCase
         $m_u = new Model($db, ['table' => 'user']);
         $m_u->addField('contact_id');
         $m_u->addField('name');
-        $j = $m_u->join('contact');
+        $j = $m_u->addJoin('contact');
         $j->addField('contact_phone');
 
         $m_u2 = $m_u->load(1);
@@ -330,7 +330,7 @@ class JoinSqlTest extends TestCase
         $m_u = new Model($db, ['table' => 'user']);
         $m_u->addField('contact_id');
         $m_u->addField('name');
-        $j = $m_u->join('contact');
+        $j = $m_u->addJoin('contact');
         $j->addField('contact_phone');
 
         $m_u = $m_u->load(1);
@@ -363,7 +363,7 @@ class JoinSqlTest extends TestCase
             ],
         ]);
         $m_u->addField('name');
-        $j = $m_u->join('contact.test_id');
+        $j = $m_u->addJoin('contact.test_id');
         $j->addField('contact_phone');
 
         $m_u->onHook(Model::HOOK_AFTER_SAVE, static function ($m) {
@@ -405,9 +405,9 @@ class JoinSqlTest extends TestCase
         $m_u = new Model($db, ['table' => 'user']);
         $m_u->addField('contact_id');
         $m_u->addField('name');
-        $j_contact = $m_u->join('contact');
+        $j_contact = $m_u->addJoin('contact');
         $j_contact->addField('contact_phone');
-        $j_country = $j_contact->join('country');
+        $j_country = $j_contact->addJoin('country');
         $j_country->addField('country_name', ['actual' => 'name']);
 
         $m_u2 = $m_u->load(10);
@@ -469,9 +469,9 @@ class JoinSqlTest extends TestCase
         $m_u = new Model($db, ['table' => 'user']);
         $m_u->addField('contact_id');
         $m_u->addField('name');
-        $j = $m_u->join('contact');
+        $j = $m_u->addJoin('contact');
         $j->addField('contact_phone');
-        $c = $j->join('country');
+        $c = $j->addJoin('country');
         $c->addFields(['country_name' => ['actual' => 'name']]);
 
         $m_u2 = $m_u->load(10);
@@ -529,7 +529,7 @@ class JoinSqlTest extends TestCase
         $m_u = new Model($db, ['table' => 'user']);
         $m_u->addField('contact_id');
         $m_u->addField('name');
-        $j = $m_u->join('contact');
+        $j = $m_u->addJoin('contact');
 
         $m_u2 = $m_u->load(1);
         $this->assertEquals([
@@ -587,7 +587,7 @@ class JoinSqlTest extends TestCase
         $db = new Persistence\Sql($this->db->connection);
         $m_user = new Model($db, ['table' => 'user']);
         $m_user->addField('name');
-        $j = $m_user->join('detail.my_user_id', [
+        $j = $m_user->addJoin('detail.my_user_id', [
             //'reverse' => true, // this will be reverse join by default
             // also no need to set these (will be done automatically), but still let's do that for test sake
             'master_field' => 'id',
@@ -615,7 +615,7 @@ class JoinSqlTest extends TestCase
         // now test reverse join defined differently
         $m_user = new Model($db, ['table' => 'user']);
         $m_user->addField('name');
-        $j = $m_user->join('detail', [ // here we just set foreign table name without dot and foreign_field
+        $j = $m_user->addJoin('detail', [ // here we just set foreign table name without dot and foreign_field
             'reverse' => true, // and set it as revers join
             'foreign_field' => 'my_user_id', // this is custome name so we have to set it here otherwise it will generate user_id
         ]);
@@ -630,7 +630,7 @@ class JoinSqlTest extends TestCase
         // now test reverse join with table_alias and foreign_alias
         $m_user = new Model($db, ['table' => 'user', 'table_alias' => 'u']);
         $m_user->addField('name');
-        $j = $m_user->join('detail', [
+        $j = $m_user->addJoin('detail', [
             'reverse' => true,
             'foreign_field' => 'my_user_id',
             'foreign_alias' => 'a',
@@ -665,10 +665,10 @@ class JoinSqlTest extends TestCase
         $m_u->addField('contact_id', ['actual' => 'cid']);
         $m_u->addField('name', ['actual' => 'first_name']);
         // normal join
-        $j = $m_u->join('contact', ['prefix' => 'j1_']);
+        $j = $m_u->addJoin('contact', ['prefix' => 'j1_']);
         $j->addField('phone', ['actual' => 'contact_phone']);
         // reverse join
-        $j2 = $m_u->join('salaries.uid', ['prefix' => 'j2_']);
+        $j2 = $m_u->addJoin('salaries.uid', ['prefix' => 'j2_']);
         $j2->addField('salary', ['actual' => 'amount']);
 
         // update

--- a/tests/LookupSqlTest.php
+++ b/tests/LookupSqlTest.php
@@ -33,7 +33,7 @@ class LCountry extends Model
 
         $this->addField('is_eu', ['type' => 'boolean', 'default' => false]);
 
-        $this->hasMany('Users', ['model' => [LUser::class]])
+        $this->addHasMany('Users', ['model' => [LUser::class]])
             ->addField('user_names', ['field' => 'name', 'concat' => ',']);
     }
 }
@@ -67,11 +67,11 @@ class LUser extends Model
         $this->addField('name');
         $this->addField('is_vip', ['type' => 'boolean', 'default' => false]);
 
-        $ref = $this->hasOne('country_id', ['model' => [LCountry::class]])
+        $this->addHasOne('country_id', ['model' => [LCountry::class]])
             ->addFields(['country_code' => 'code', 'is_eu'])
             ->addTitle();
 
-        $this->hasMany('Friends', ['model' => [LFriend::class]])
+        $this->addHasMany('Friends', ['model' => [LFriend::class]])
             ->addField('friend_names', ['field' => 'friend_name', 'concat' => ',']);
     }
 }
@@ -100,9 +100,9 @@ class LFriend extends Model
     {
         parent::init();
 
-        $this->hasOne('user_id', ['model' => [LUser::class]])
+        $this->addHasOne('user_id', ['model' => [LUser::class]])
             ->addField('my_name', 'name');
-        $this->hasOne('friend_id', ['model' => [LUser::class]])
+        $this->addHasOne('friend_id', ['model' => [LUser::class]])
             ->addField('friend_name', 'name');
 
         // add or remove reverse friendships

--- a/tests/Model/Smbo/Account.php
+++ b/tests/Model/Smbo/Account.php
@@ -16,7 +16,7 @@ class Account extends Model
 
         $this->addField('name');
 
-        $this->hasMany('Payment', ['model' => [Payment::class]])
+        $this->addHasMany('Payment', ['model' => [Payment::class]])
             ->addField('balance', ['aggregate' => 'sum', 'field' => 'amount']);
     }
 

--- a/tests/Model/Smbo/Company.php
+++ b/tests/Model/Smbo/Company.php
@@ -15,8 +15,8 @@ class Company extends Model
         parent::init();
 
         // Company data is stored in 3 tables actually.
-        $j_contractor = $this->join('contractor');
-        $j_company = $j_contractor->join('company.contractor_id', ['prefix' => 'company_']);
+        $j_contractor = $this->addJoin('contractor');
+        $j_company = $j_contractor->addJoin('company.contractor_id', ['prefix' => 'company_']);
 
         $j_contractor->addFields([
             ['name', 'actual' => 'legal_name'],

--- a/tests/Model/Smbo/Document.php
+++ b/tests/Model/Smbo/Document.php
@@ -15,8 +15,8 @@ class Document extends Model
         parent::init();
 
         // Documest is sent from one Contact to Another
-        $this->hasOne('contact_from_id', ['model' => [Contact::class]]);
-        $this->hasOne('contact_to_id', ['model' => [Contact::class]]);
+        $this->addHasOne('contact_from_id', ['model' => [Contact::class]]);
+        $this->addHasOne('contact_to_id', ['model' => [Contact::class]]);
 
         $this->addField('doc_type', ['enum' => ['invoice', 'payment']]);
 

--- a/tests/Model/Smbo/Payment.php
+++ b/tests/Model/Smbo/Payment.php
@@ -20,7 +20,7 @@ class Payment extends Document
         $this->j_payment = $this->addJoin('payment.document_id');
 
         $this->j_payment->addField('cheque_no');
-        $this->j_payment->hasOne('account_id', ['model' => [Account::class]]);
+        $this->j_payment->addHasOne('account_id', ['model' => [Account::class]]);
 
         $this->j_payment->addField('misc_payment', ['type' => 'boolean']);
     }

--- a/tests/Model/Smbo/Payment.php
+++ b/tests/Model/Smbo/Payment.php
@@ -17,7 +17,7 @@ class Payment extends Document
 
         $this->addCondition('doc_type', 'payment');
 
-        $this->j_payment = $this->join('payment.document_id');
+        $this->j_payment = $this->addJoin('payment.document_id');
 
         $this->j_payment->addField('cheque_no');
         $this->j_payment->hasOne('account_id', ['model' => [Account::class]]);

--- a/tests/Model/Smbo/Transfer.php
+++ b/tests/Model/Smbo/Transfer.php
@@ -15,7 +15,7 @@ class Transfer extends Payment
     {
         parent::init();
 
-        $this->j_payment->hasOne('transfer_document_id', ['model' => [self::class]]);
+        $this->j_payment->addHasOne('transfer_document_id', ['model' => [self::class]]);
 
         // only used to create / destroy trasfer legs
         if (!$this->detached) {

--- a/tests/Persistence/ArrayTest.php
+++ b/tests/Persistence/ArrayTest.php
@@ -799,7 +799,7 @@ class ArrayTest extends TestCase
     }
 
     /**
-     * Test Model->hasOne().
+     * Test Model->addHasOne().
      */
     public function testHasOne(): void
     {
@@ -822,7 +822,7 @@ class ArrayTest extends TestCase
         $country->table = 'country';
         $country->addField('name');
 
-        $user->hasOne('country_id', ['model' => $country]);
+        $user->addHasOne('country_id', ['model' => $country]);
 
         $uu = $user->load(1);
         $this->assertSame('Latvia', $uu->ref('country_id')->get('name'));
@@ -832,7 +832,7 @@ class ArrayTest extends TestCase
     }
 
     /**
-     * Test Model->hasMany().
+     * Test Model->addHasMany().
      */
     public function testHasMany(): void
     {
@@ -856,8 +856,8 @@ class ArrayTest extends TestCase
         $user->addField('name');
         $user->addField('surname');
 
-        $country->hasMany('Users', ['model' => $user]);
-        $user->hasOne('country_id', ['model' => $country]);
+        $country->addHasMany('Users', ['model' => $user]);
+        $user->addHasOne('country_id', ['model' => $country]);
 
         $cc = $country->load(1);
         $this->assertSame(2, $cc->ref('Users')->action('count')->getOne());

--- a/tests/RandomTest.php
+++ b/tests/RandomTest.php
@@ -42,7 +42,7 @@ class Model_Item2 extends Model
     {
         parent::init();
         $this->addField('name');
-        $i2 = $this->join('item2.item_id');
+        $i2 = $this->addJoin('item2.item_id');
         $i2->hasOne('parent_item_id', ['model' => [self::class]])
             ->addTitle();
     }
@@ -59,7 +59,7 @@ class Model_Item3 extends Model
 
         $this->addField('name');
         $this->addField('age');
-        $i2 = $this->join('item2.item_id');
+        $i2 = $this->addJoin('item2.item_id');
         $i2->hasOne('parent_item_id', ['model' => $m, 'table_alias' => 'parent'])
             ->addTitle();
 

--- a/tests/RandomTest.php
+++ b/tests/RandomTest.php
@@ -30,7 +30,7 @@ class Model_Item extends Model
     {
         parent::init();
         $this->addField('name');
-        $this->hasOne('parent_item_id', ['model' => [self::class]])
+        $this->addHasOne('parent_item_id', ['model' => [self::class]])
             ->addTitle();
     }
 }
@@ -43,7 +43,7 @@ class Model_Item2 extends Model
         parent::init();
         $this->addField('name');
         $i2 = $this->addJoin('item2.item_id');
-        $i2->hasOne('parent_item_id', ['model' => [self::class]])
+        $i2->addHasOne('parent_item_id', ['model' => [self::class]])
             ->addTitle();
     }
 }
@@ -60,10 +60,10 @@ class Model_Item3 extends Model
         $this->addField('name');
         $this->addField('age');
         $i2 = $this->addJoin('item2.item_id');
-        $i2->hasOne('parent_item_id', ['model' => $m, 'table_alias' => 'parent'])
+        $i2->addHasOne('parent_item_id', ['model' => $m, 'table_alias' => 'parent'])
             ->addTitle();
 
-        $this->hasMany('Child', ['model' => $m, 'their_field' => 'parent_item_id', 'table_alias' => 'child'])
+        $this->addHasMany('Child', ['model' => $m, 'their_field' => 'parent_item_id', 'table_alias' => 'child'])
             ->addField('child_age', ['aggregate' => 'sum', 'field' => 'age']);
     }
 }
@@ -329,7 +329,7 @@ class RandomTest extends TestCase
         $m = new Model_Item($db);
 
         $this->expectException(CoreException::class);
-        $m->hasOne('foo', ['model' => [Model_Item::class]])
+        $m->addHasOne('foo', ['model' => [Model_Item::class]])
             ->addTitle(); // field foo already exists, so we can't add title with same name
     }
 
@@ -523,8 +523,8 @@ class RandomTest extends TestCase
         $m = new Model($this->db, ['table' => 'db1.user']);
         $m->addField('name');
 
-        $d->hasOne('user_id', ['model' => $m])->addTitle();
-        $m->hasMany('Documents', ['model' => $d]);
+        $d->addHasOne('user_id', ['model' => $m])->addTitle();
+        $m->addHasMany('Documents', ['model' => $d]);
 
         $d->addCondition('user', 'Sarah');
 

--- a/tests/ReferenceSqlTest.php
+++ b/tests/ReferenceSqlTest.php
@@ -35,7 +35,7 @@ class ReferenceSqlTest extends TestCase
         $u = (new Model($this->db, ['table' => 'user']))->addFields(['name']);
         $o = (new Model($this->db, ['table' => 'order']))->addFields(['amount', 'user_id']);
 
-        $u->hasMany('Orders', ['model' => $o]);
+        $u->addHasMany('Orders', ['model' => $o]);
 
         $oo = $u->load(1)->ref('Orders');
         $ooo = $oo->tryLoad(1);
@@ -69,7 +69,7 @@ class ReferenceSqlTest extends TestCase
         $u = (new Model($this->db, ['table' => 'user']))->addFields(['name']);
         $o = (new Model($this->db, ['table' => 'order']))->addFields(['amount', 'user_id']);
 
-        $u->hasMany('Orders', ['model' => $o]);
+        $u->addHasMany('Orders', ['model' => $o]);
 
         $this->assertSameSql(
             'select "id", "amount", "user_id" from "order" where "user_id" = "user"."id"',
@@ -94,7 +94,7 @@ class ReferenceSqlTest extends TestCase
         $u = (new Model($this->db, ['table' => 'user']))->addFields(['name', 'currency']);
         $c = (new Model($this->db, ['table' => 'currency']))->addFields(['currency', 'name']);
 
-        $u->hasMany('cur', ['model' => $c, 'our_field' => 'currency', 'their_field' => 'currency']);
+        $u->addHasMany('cur', ['model' => $c, 'our_field' => 'currency', 'their_field' => 'currency']);
 
         $cc = $u->load(1)->ref('cur');
         $cc = $cc->tryLoadOne();
@@ -110,7 +110,7 @@ class ReferenceSqlTest extends TestCase
         $u = (new Model($this->db, ['table' => 'user']))->addFields(['name', 'currency_code']);
         $c = (new Model($this->db, ['table' => 'currency']))->addFields(['code', 'name']);
 
-        $u->hasMany('cur', ['model' => $c, 'our_field' => 'currency_code', 'their_field' => 'code']);
+        $u->addHasMany('cur', ['model' => $c, 'our_field' => 'currency_code', 'their_field' => 'code']);
 
         $this->assertSameSql(
             'select "id", "code", "name" from "currency" where "code" = "user"."currency_code"',
@@ -141,7 +141,7 @@ class ReferenceSqlTest extends TestCase
         $u = (new Model($this->db, ['table' => 'user']))->addFields(['name']);
         $o = (new Model($this->db, ['table' => 'order']))->addFields(['amount']);
 
-        $o->hasOne('user_id', ['model' => $u]);
+        $o->addHasOne('user_id', ['model' => $u]);
 
         $this->assertSame('John', $o->load(1)->ref('user_id')->get('name'));
         $this->assertSame('Peter', $o->load(2)->ref('user_id')->get('name'));
@@ -179,7 +179,7 @@ class ReferenceSqlTest extends TestCase
         $u = (new Model($this->db, ['table' => 'user']))->addFields(['name', 'date' => ['type' => 'date']]);
 
         $o = (new Model($this->db, ['table' => 'order']))->addFields(['amount']);
-        $o->hasOne('user_id', ['model' => $u])->addFields(['username' => 'name', ['date', 'type' => 'date']]);
+        $o->addHasOne('user_id', ['model' => $u])->addFields(['username' => 'name', ['date', 'type' => 'date']]);
 
         $this->assertSame('John', $o->load(1)->get('username'));
         $this->assertEquals(new \DateTime('2001-01-02'), $o->load(1)->get('date'));
@@ -190,12 +190,12 @@ class ReferenceSqlTest extends TestCase
 
         // few more tests
         $o = (new Model($this->db, ['table' => 'order']))->addFields(['amount']);
-        $o->hasOne('user_id', ['model' => $u])->addFields(['username' => 'name', 'thedate' => ['date', 'type' => 'date']]);
+        $o->addHasOne('user_id', ['model' => $u])->addFields(['username' => 'name', 'thedate' => ['date', 'type' => 'date']]);
         $this->assertSame('John', $o->load(1)->get('username'));
         $this->assertEquals(new \DateTime('2001-01-02'), $o->load(1)->get('thedate'));
 
         $o = (new Model($this->db, ['table' => 'order']))->addFields(['amount']);
-        $o->hasOne('user_id', ['model' => $u])->addFields(['date'], ['type' => 'date']);
+        $o->addHasOne('user_id', ['model' => $u])->addFields(['date'], ['type' => 'date']);
         $this->assertEquals(new \DateTime('2001-01-02'), $o->load(1)->get('date'));
     }
 
@@ -219,7 +219,7 @@ class ReferenceSqlTest extends TestCase
 
         $i = (new Model($this->db, ['table' => 'invoice']))->addFields(['ref_no']);
         $l = (new Model($this->db, ['table' => 'invoice_line']))->addFields(['invoice_id', 'total_net', 'total_vat', 'total_gross']);
-        $i->hasMany('line', ['model' => $l]);
+        $i->addHasMany('line', ['model' => $l]);
 
         $i->addExpression('total_net', $i->refLink('line')->action('fx', ['sum', 'total_net']));
 
@@ -254,7 +254,7 @@ class ReferenceSqlTest extends TestCase
             'total_vat' => ['type' => 'atk4_money'],
             'total_gross' => ['type' => 'atk4_money'],
         ]);
-        $i->hasMany('line', ['model' => $l])
+        $i->addHasMany('line', ['model' => $l])
             ->addFields([
                 'total_vat' => ['aggregate' => 'sum', 'type' => 'atk4_money'],
                 'total_net' => ['aggregate' => 'sum'],
@@ -318,7 +318,7 @@ class ReferenceSqlTest extends TestCase
 
         $l = (new Model($this->db, ['table' => 'list']))->addFields(['name']);
         $i = (new Model($this->db, ['table' => 'item']))->addFields(['list_id', 'name', 'code']);
-        $l->hasMany('Items', ['model' => $i])
+        $l->addHasMany('Items', ['model' => $i])
             ->addFields([
                 'items_name' => ['aggregate' => 'count', 'field' => 'name'],
                 'items_code' => ['aggregate' => 'count', 'field' => 'code'], // counts only not-null values
@@ -373,14 +373,14 @@ class ReferenceSqlTest extends TestCase
 
         $company = (new Model($this->db, ['table' => 'company']))->addFields(['name']);
 
-        $user->hasOne('Company', ['model' => $company, 'our_field' => 'company_id', 'their_field' => 'id']);
+        $user->addHasOne('Company', ['model' => $company, 'our_field' => 'company_id', 'their_field' => 'id']);
 
         $order = new Model($this->db, ['table' => 'order']);
         $order->addField('company_id');
         $order->addField('description');
         $order->addField('amount', ['default' => 20, 'type' => 'float']);
 
-        $company->hasMany('Orders', ['model' => $order]);
+        $company->addHasMany('Orders', ['model' => $order]);
 
         $user = $user->load(1);
 
@@ -423,7 +423,7 @@ class ReferenceSqlTest extends TestCase
         $u = (new Model($this->db, ['table' => 'user']))->addFields(['name']);
         $c = (new Model($this->db, ['table' => 'contact']))->addFields(['address']);
 
-        $u->hasOne('contact_id', ['model' => $c])
+        $u->addHasOne('contact_id', ['model' => $c])
             ->addField('address');
 
         $uu = $u->load(1);
@@ -471,9 +471,9 @@ class ReferenceSqlTest extends TestCase
 
         $s = (new Model($this->db, ['table' => 'stadium']));
         $s->addFields(['name']);
-        $s->hasOne('player_id', ['model' => $p]);
+        $s->addHasOne('player_id', ['model' => $p]);
 
-        $p->hasOne('Stadium', ['model' => $s, 'our_field' => 'id', 'their_field' => 'player_id']);
+        $p->addHasOne('Stadium', ['model' => $s, 'our_field' => 'id', 'their_field' => 'player_id']);
 
         $p = $p->load(2);
         $p->ref('Stadium')->import([['name' => 'Nou camp nou']]);
@@ -484,7 +484,7 @@ class ReferenceSqlTest extends TestCase
     public function testModelProperty(): void
     {
         $user = new Model($this->db, ['table' => 'user']);
-        $user->hasMany('Orders', ['model' => [Model::class, 'table' => 'order'], 'their_field' => 'id']);
+        $user->addHasMany('Orders', ['model' => [Model::class, 'table' => 'order'], 'their_field' => 'id']);
         $o = $user->ref('Orders');
         $this->assertSame('order', $o->table);
     }
@@ -507,7 +507,7 @@ class ReferenceSqlTest extends TestCase
         $o = (new Model($this->db, ['table' => 'order']))->addFields(['amount']);
 
         // by default not set
-        $o->hasOne('user_id', ['model' => $u]);
+        $o->addHasOne('user_id', ['model' => $u]);
         $this->assertSame($o->getField('user_id')->isVisible(), true);
 
         $o->getRef('user_id')->addTitle();
@@ -517,7 +517,7 @@ class ReferenceSqlTest extends TestCase
 
         // if it is set manually then it will not be changed
         $o = (new Model($this->db, ['table' => 'order']))->addFields(['amount']);
-        $o->hasOne('user_id', ['model' => $u]);
+        $o->addHasOne('user_id', ['model' => $u]);
         $o->getField('user_id')->ui['visible'] = true;
         $o->getRef('user_id')->addTitle();
 
@@ -548,7 +548,7 @@ class ReferenceSqlTest extends TestCase
         // with default title_field='name'
         $u = (new Model($this->db, ['table' => 'user']))->addFields(['name', 'last_name']);
         $o = (new Model($this->db, ['table' => 'order']));
-        $o->hasOne('user_id', ['model' => $u])->addTitle();
+        $o->addHasOne('user_id', ['model' => $u])->addTitle();
 
         // change order user by changing title_field value
         $o = $o->load(1);
@@ -565,7 +565,7 @@ class ReferenceSqlTest extends TestCase
         // with custom title_field='last_name'
         $u = (new Model($this->db, ['table' => 'user', 'title_field' => 'last_name']))->addFields(['name', 'last_name']);
         $o = (new Model($this->db, ['table' => 'order']));
-        $o->hasOne('user_id', ['model' => $u])->addTitle();
+        $o->addHasOne('user_id', ['model' => $u])->addTitle();
 
         // change order user by changing title_field value
         $o = $o->load(1);
@@ -582,7 +582,7 @@ class ReferenceSqlTest extends TestCase
         // with custom title_field='last_name' and custom link name
         $u = (new Model($this->db, ['table' => 'user', 'title_field' => 'last_name']))->addFields(['name', 'last_name']);
         $o = (new Model($this->db, ['table' => 'order']));
-        $o->hasOne('my_user', ['model' => $u, 'our_field' => 'user_id'])->addTitle();
+        $o->addHasOne('my_user', ['model' => $u, 'our_field' => 'user_id'])->addTitle();
 
         // change order user by changing ref field value
         $o = $o->load(1);
@@ -599,7 +599,7 @@ class ReferenceSqlTest extends TestCase
         // with custom title_field='last_name' and custom link name
         $u = (new Model($this->db, ['table' => 'user', 'title_field' => 'last_name']))->addFields(['name', 'last_name']);
         $o = (new Model($this->db, ['table' => 'order']));
-        $o->hasOne('my_user', ['model' => $u, 'our_field' => 'user_id'])->addTitle();
+        $o->addHasOne('my_user', ['model' => $u, 'our_field' => 'user_id'])->addTitle();
 
         // change order user by changing ref field value
         $o = $o->load(1);
@@ -642,7 +642,7 @@ class ReferenceSqlTest extends TestCase
         $this->assertSame('Surname', $u->getField('last_name')->getCaption());
 
         $o = (new Model($this->db, ['table' => 'order']));
-        $order_user_ref = $o->hasOne('my_user', ['model' => $u, 'our_field' => 'user_id']);
+        $order_user_ref = $o->addHasOne('my_user', ['model' => $u, 'our_field' => 'user_id']);
         $order_user_ref->addField('user_last_name', 'last_name');
 
         $referenced_caption = $o->getField('user_last_name')->getCaption();
@@ -682,7 +682,7 @@ class ReferenceSqlTest extends TestCase
         $user->getField('some_number')->type = 'integer';
         $user->getField('some_other_number')->type = 'integer';
         $order = (new Model($this->db, ['table' => 'order']));
-        $order_UserRef = $order->hasOne('my_user', ['model' => $user, 'our_field' => 'user_id']);
+        $order_UserRef = $order->addHasOne('my_user', ['model' => $user, 'our_field' => 'user_id']);
 
         // no type set in defaults, should pull type integer from user model
         $order_UserRef->addField('some_number');

--- a/tests/ReferenceTest.php
+++ b/tests/ReferenceTest.php
@@ -24,13 +24,13 @@ class ReferenceTest extends TestCase
         $order->addField('amount', ['default' => 20]);
         $order->addField('user_id', ['type' => 'integer']);
 
-        $user->getModel()->hasMany('Orders', ['model' => $order, 'caption' => 'My Orders']);
+        $user->getModel()->addHasMany('Orders', ['model' => $order, 'caption' => 'My Orders']);
         $o = $user->ref('Orders')->createEntity();
 
         $this->assertSame(20, $o->get('amount'));
         $this->assertSame(1, $o->get('user_id'));
 
-        $user->getModel()->hasMany('BigOrders', ['model' => function () {
+        $user->getModel()->addHasMany('BigOrders', ['model' => function () {
             $m = new Model();
             $m->addField('amount', ['default' => 100]);
             $m->addField('user_id');
@@ -57,7 +57,7 @@ class ReferenceTest extends TestCase
         $order->addField('amount', ['default' => 20]);
         $order->addField('user_id');
 
-        $user->getModel()->hasMany('Orders', ['model' => $order, 'caption' => 'My Orders']);
+        $user->getModel()->addHasMany('Orders', ['model' => $order, 'caption' => 'My Orders']);
 
         // test caption of containsOne reference
         $this->assertSame('My Orders', $user->refModel('Orders')->getModelCaption());
@@ -70,7 +70,7 @@ class ReferenceTest extends TestCase
         $user = new Model($db, ['table' => 'user']);
         $user = $user->createEntity();
         $user->setId(1);
-        $user->getModel()->hasOne('order_id', ['model' => [Model::class, 'table' => 'order']]);
+        $user->getModel()->addHasOne('order_id', ['model' => [Model::class, 'table' => 'order']]);
         $o = $user->ref('order_id');
         $this->assertSame('order', $o->table);
     }
@@ -81,9 +81,9 @@ class ReferenceTest extends TestCase
         $order = new Model();
         $order->addField('user_id');
 
-        $user->hasMany('Orders', ['model' => $order]);
+        $user->addHasMany('Orders', ['model' => $order]);
         $this->expectException(Exception::class);
-        $user->hasMany('Orders', ['model' => $order]);
+        $user->addHasMany('Orders', ['model' => $order]);
     }
 
     public function testRefName2(): void
@@ -91,9 +91,9 @@ class ReferenceTest extends TestCase
         $order = new Model(null, ['table' => 'order']);
         $user = new Model(null, ['table' => 'user']);
 
-        $user->hasOne('user_id', ['model' => $user]);
+        $user->addHasOne('user_id', ['model' => $user]);
         $this->expectException(Exception::class);
-        $user->hasOne('user_id', ['model' => $user]);
+        $user->addHasOne('user_id', ['model' => $user]);
     }
 
     public function testRefName3(): void

--- a/tests/Schema/ModelTest.php
+++ b/tests/Schema/ModelTest.php
@@ -175,7 +175,7 @@ class TestUser extends \Atk4\Data\Model
         $this->addField('is_admin', ['type' => 'boolean']);
         $this->addField('notes', ['type' => 'text']);
 
-        $this->hasOne('role_id', ['model' => [TestRole::class], 'our_field' => 'main_role_id', 'their_field' => 'id']);
+        $this->addHasOne('role_id', ['model' => [TestRole::class], 'our_field' => 'main_role_id', 'their_field' => 'id']);
     }
 }
 
@@ -188,6 +188,6 @@ class TestRole extends \Atk4\Data\Model
         parent::init();
 
         $this->addField('name');
-        $this->hasMany('Users', [TestUser::class, 'our_field' => 'id', 'their_field' => 'main_role_id']);
+        $this->addHasMany('Users', [TestUser::class, 'our_field' => 'id', 'their_field' => 'main_role_id']);
     }
 }

--- a/tests/ScopeTest.php
+++ b/tests/ScopeTest.php
@@ -26,7 +26,7 @@ class SCountry extends Model
 
         $this->addField('is_eu', ['type' => 'boolean', 'default' => false]);
 
-        $this->hasMany('Users', ['model' => [SUser::class]])
+        $this->addHasMany('Users', ['model' => [SUser::class]])
             ->addField('user_names', ['field' => 'name', 'concat' => ',']);
     }
 }
@@ -44,11 +44,11 @@ class SUser extends Model
         $this->addField('surname');
         $this->addField('is_vip', ['type' => 'boolean', 'default' => false]);
 
-        $this->hasOne('country_id', ['model' => [SCountry::class]])
+        $this->addHasOne('country_id', ['model' => [SCountry::class]])
             ->addFields(['country_code' => 'code', 'is_eu'])
             ->addTitle();
 
-        $this->hasMany('Tickets', ['model' => [STicket::class], 'their_field' => 'user']);
+        $this->addHasMany('Tickets', ['model' => [STicket::class], 'their_field' => 'user']);
     }
 }
 
@@ -65,7 +65,7 @@ class STicket extends Model
         $this->addField('venue');
         $this->addField('is_vip', ['type' => 'boolean', 'default' => false]);
 
-        $this->hasOne('user', ['model' => [SUser::class]]);
+        $this->addHasOne('user', ['model' => [SUser::class]]);
     }
 }
 

--- a/tests/SubTypesTest.php
+++ b/tests/SubTypesTest.php
@@ -129,7 +129,7 @@ class StTransaction_TransferOut extends StGenericTransaction
         parent::init();
         $this->hasOne('link_id', ['model' => [StTransaction_TransferIn::class]]);
 
-        //$this->join('transaction', 'linked_transaction');
+        //$this->addJoin('transaction', 'linked_transaction');
     }
 }
 

--- a/tests/SubTypesTest.php
+++ b/tests/SubTypesTest.php
@@ -18,16 +18,16 @@ class StAccount extends Model
 
         $this->addField('name');
 
-        $this->hasMany('Transactions', ['model' => [StGenericTransaction::class]])
+        $this->addHasMany('Transactions', ['model' => [StGenericTransaction::class]])
             ->addField('balance', ['aggregate' => 'sum', 'field' => 'amount']);
 
-        $this->hasMany('Transactions:Deposit', ['model' => [StTransaction_Deposit::class]]);
-        $this->hasMany('Transactions:Withdrawal', ['model' => [StTransaction_Withdrawal::class]]);
-        $this->hasMany('Transactions:Ob', ['model' => [StTransaction_Ob::class]])
+        $this->addHasMany('Transactions:Deposit', ['model' => [StTransaction_Deposit::class]]);
+        $this->addHasMany('Transactions:Withdrawal', ['model' => [StTransaction_Withdrawal::class]]);
+        $this->addHasMany('Transactions:Ob', ['model' => [StTransaction_Ob::class]])
             ->addField('opening_balance', ['aggregate' => 'sum', 'field' => 'amount']);
 
-        $this->hasMany('Transactions:TransferOut', ['model' => [StTransaction_TransferOut::class]]);
-        $this->hasMany('Transactions:TransferIn', ['model' => [StTransaction_TransferIn::class]]);
+        $this->addHasMany('Transactions:TransferOut', ['model' => [StTransaction_TransferOut::class]]);
+        $this->addHasMany('Transactions:TransferIn', ['model' => [StTransaction_TransferIn::class]]);
     }
 
     /**
@@ -80,7 +80,7 @@ class StGenericTransaction extends Model
     {
         parent::init();
 
-        $this->hasOne('account_id', ['model' => [StAccount::class]]);
+        $this->addHasOne('account_id', ['model' => [StAccount::class]]);
         $this->addField('type', ['enum' => ['Ob', 'Deposit', 'Withdrawal', 'TransferOut', 'TransferIn']]);
 
         if ($this->type) {
@@ -127,7 +127,7 @@ class StTransaction_TransferOut extends StGenericTransaction
     protected function init(): void
     {
         parent::init();
-        $this->hasOne('link_id', ['model' => [StTransaction_TransferIn::class]]);
+        $this->addHasOne('link_id', ['model' => [StTransaction_TransferIn::class]]);
 
         //$this->addJoin('transaction', 'linked_transaction');
     }
@@ -140,7 +140,7 @@ class StTransaction_TransferIn extends StGenericTransaction
     protected function init(): void
     {
         parent::init();
-        $this->hasOne('link_id', ['model' => [StTransaction_TransferOut::class]]);
+        $this->addHasOne('link_id', ['model' => [StTransaction_TransferOut::class]]);
     }
 }
 

--- a/tests/Util/DeepCopyTest.php
+++ b/tests/Util/DeepCopyTest.php
@@ -20,9 +20,9 @@ class DcClient extends Model
 
         $this->addField('name');
 
-        $this->hasMany('Invoices', ['model' => [DcInvoice::class]]);
-        $this->hasMany('Quotes', ['model' => [DcQuote::class]]);
-        $this->hasMany('Payments', ['model' => [DcPayment::class]]);
+        $this->addHasMany('Invoices', ['model' => [DcInvoice::class]]);
+        $this->addHasMany('Quotes', ['model' => [DcQuote::class]]);
+        $this->addHasMany('Payments', ['model' => [DcPayment::class]]);
     }
 }
 
@@ -34,12 +34,12 @@ class DcInvoice extends Model
     {
         parent::init();
 
-        $this->hasOne('client_id', ['model' => [DcClient::class]]);
+        $this->addHasOne('client_id', ['model' => [DcClient::class]]);
 
-        $this->hasMany('Lines', ['model' => [DcInvoiceLine::class], 'their_field' => 'parent_id'])
+        $this->addHasMany('Lines', ['model' => [DcInvoiceLine::class], 'their_field' => 'parent_id'])
             ->addField('total', ['aggregate' => 'sum', 'field' => 'total']);
 
-        $this->hasMany('Payments', ['model' => [DcPayment::class]])
+        $this->addHasMany('Payments', ['model' => [DcPayment::class]])
             ->addField('paid', ['aggregate' => 'sum', 'field' => 'amount']);
 
         $this->addExpression('due', '[total]-[paid]');
@@ -63,9 +63,9 @@ class DcQuote extends Model
     protected function init(): void
     {
         parent::init();
-        $this->hasOne('client_id', ['model' => [DcClient::class]]);
+        $this->addHasOne('client_id', ['model' => [DcClient::class]]);
 
-        $this->hasMany('Lines', ['model' => [DcQuoteLine::class], 'their_field' => 'parent_id'])
+        $this->addHasMany('Lines', ['model' => [DcQuoteLine::class], 'their_field' => 'parent_id'])
             ->addField('total', ['aggregate' => 'sum', 'field' => 'total']);
 
         $this->addField('ref');
@@ -81,7 +81,7 @@ class DcInvoiceLine extends Model
     protected function init(): void
     {
         parent::init();
-        $this->hasOne('parent_id', ['model' => [DcInvoice::class]]);
+        $this->addHasOne('parent_id', ['model' => [DcInvoice::class]]);
 
         $this->addField('name');
 
@@ -105,7 +105,7 @@ class DcQuoteLine extends Model
     {
         parent::init();
 
-        $this->hasOne('parent_id', ['model' => [DcQuote::class]]);
+        $this->addHasOne('parent_id', ['model' => [DcQuote::class]]);
 
         $this->addField('name');
 
@@ -127,9 +127,9 @@ class DcPayment extends Model
     protected function init(): void
     {
         parent::init();
-        $this->hasOne('client_id', ['model' => [DcClient::class]]);
+        $this->addHasOne('client_id', ['model' => [DcClient::class]]);
 
-        $this->hasOne('invoice_id', ['model' => [DcInvoice::class]]);
+        $this->addHasOne('invoice_id', ['model' => [DcInvoice::class]]);
 
         $this->addField('amount', ['type' => 'atk4_money']);
     }
@@ -270,7 +270,7 @@ class DeepCopyTest extends TestCase
         $client_id = $client->insert(['name' => 'John']);
 
         $quote = new DcQuote($this->db);
-        $quote->hasMany('Lines2', ['model' => [DcQuoteLine::class], 'their_field' => 'parent_id']);
+        $quote->addHasMany('Lines2', ['model' => [DcQuoteLine::class], 'their_field' => 'parent_id']);
 
         $quote->insert(['ref' => 'q1', 'client_id' => $client_id, 'Lines' => [
             ['name' => 'tools', 'qty' => 5, 'price' => 10],

--- a/tests/WithTest.php
+++ b/tests/WithTest.php
@@ -43,7 +43,7 @@ class WithTest extends TestCase
         // setup test model
         $m = clone $m_user;
         $m->addWith($m_invoice, 'i', ['user_id', 'net' => 'invoiced']); // add cursor
-        $j_invoice = $m->join('i.user_id'); // join cursor
+        $j_invoice = $m->addJoin('i.user_id'); // join cursor
         $j_invoice->addField('invoiced');   // add field from joined cursor
 
         // tests

--- a/tests/WithTest.php
+++ b/tests/WithTest.php
@@ -37,7 +37,7 @@ class WithTest extends TestCase
 
         $m_invoice = new Model($db, ['table' => 'invoice']);
         $m_invoice->addField('net', ['type' => 'atk4_money']);
-        $m_invoice->hasOne('user_id', ['model' => $m_user]);
+        $m_invoice->addHasOne('user_id', ['model' => $m_user]);
         $m_invoice->addCondition('net', '>', 100);
 
         // setup test model


### PR DESCRIPTION
This change highly increases awareness of the user what the calls really do.

BC provided with deprecation warnings for the next 2 minor releases.