### PR TITLE
Deduplicate Reference from entity

### DIFF
--- a/src/Model.php
+++ b/src/Model.php
@@ -382,14 +382,8 @@ class Model implements \IteratorAggregate
         if (!$this->isEntity()) {
             $this->scope = (clone $this->scope)->setModel($this);
             $this->_cloneCollection('fields');
-        } else {
-            foreach ($this->{'elements'} as $k => $v) {
-                if ($v instanceof Reference || $v instanceof Model\Join) {
-                    unset($this->elements[$k]);
-                }
-            }
+            $this->_cloneCollection('elements');
         }
-        $this->_cloneCollection('elements');
         $this->_cloneCollection('userActions');
 
         // check for clone errors immediately, otherwise not strictly needed
@@ -417,9 +411,6 @@ class Model implements \IteratorAggregate
                 'data',
                 'dirty',
                 'dirtyAfterReload',
-
-                'elements',
-                '_element_name_counts',
 
                 'hooks',
                 '_hookIndexCounter',

--- a/src/Model.php
+++ b/src/Model.php
@@ -384,7 +384,7 @@ class Model implements \IteratorAggregate
             $this->_cloneCollection('fields');
         } else {
             foreach ($this->{'elements'} as $k => $v) {
-                if ($v instanceof Model\Join) {
+                if ($v instanceof Reference || $v instanceof Model\Join) {
                     unset($this->elements[$k]);
                 }
             }

--- a/src/Model/ReferencesTrait.php
+++ b/src/Model/ReferencesTrait.php
@@ -162,7 +162,7 @@ trait ReferencesTrait
      */
     public function ref(string $link, array $defaults = []): Model
     {
-        return $this->getRef($link)->ref($defaults);
+        return $this->getRef($link)->ref($this, $defaults);
     }
 
     /**
@@ -170,7 +170,7 @@ trait ReferencesTrait
      */
     public function refModel(string $link, array $defaults = []): Model
     {
-        return $this->getRef($link)->refModel($defaults);
+        return $this->getRef($link)->refModel($this, $defaults);
     }
 
     /**
@@ -178,6 +178,6 @@ trait ReferencesTrait
      */
     public function refLink(string $link, array $defaults = []): Model
     {
-        return $this->getRef($link)->refLink($defaults);
+        return $this->getRef($link)->refLink($this, $defaults);
     }
 }

--- a/src/Model/ReferencesTrait.php
+++ b/src/Model/ReferencesTrait.php
@@ -129,14 +129,7 @@ trait ReferencesTrait
      */
     public function getRef(string $link): Reference
     {
-        // reference added to model after entity was forked
-        if ($this->isEntity() && !$this->hasElement('#ref_' . $link)) {
-            $entityRef = clone $this->getModel()->getRef($link);
-            $entityRef->unsetOwner();
-            $this->_add($entityRef);
-        }
-
-        return $this->getElement('#ref_' . $link);
+        return $this->getModel(true)->getElement('#ref_' . $link);
     }
 
     /**
@@ -147,7 +140,7 @@ trait ReferencesTrait
     public function getRefs(): array
     {
         $refs = [];
-        foreach (array_keys($this->elements) as $k) {
+        foreach (array_keys($this->getModel(true)->elements) as $k) {
             if (str_starts_with($k, '#ref_')) {
                 $link = substr($k, strlen('#ref_'));
                 $refs[$link] = $this->getRef($link);

--- a/src/Model/Scope/Condition.php
+++ b/src/Model/Scope/Condition.php
@@ -389,7 +389,7 @@ class Condition extends AbstractScope
             $model->set($field->short_name, $value);
 
             // then take the title
-            $title = $model->getRef($field->getReference()->link)->ref()->getTitle();
+            $title = $model->ref($field->getReference()->link)->getTitle();
             if ($title === $value) {
                 $title = null;
             }

--- a/src/Reference.php
+++ b/src/Reference.php
@@ -97,6 +97,24 @@ class Reference
         return $this->_setOwner($owner);
     }
 
+    protected function getOurFieldName(): string
+    {
+        return $this->our_field ?: $this->getOurModel(null)->id_field;
+    }
+
+    final protected function getOurField(): Field
+    {
+        return $this->getOurModel(null)->getField($this->getOurFieldName());
+    }
+
+    /**
+     * @return mixed
+     */
+    final protected function getOurFieldValue(Model $ourEntity)
+    {
+        return $this->getOurModel($ourEntity)->get($this->getOurFieldName());
+    }
+
     public function getTheirFieldName(): string
     {
         return $this->their_field ?? $this->model->id_field;
@@ -197,24 +215,6 @@ class Reference
         $this->addToPersistence($theirModel, $defaults);
 
         return $theirModel;
-    }
-
-    protected function getOurFieldName(): string
-    {
-        return $this->our_field ?: $this->getOurModel(null)->id_field;
-    }
-
-    final protected function getOurField(): Field
-    {
-        return $this->getOurModel(null)->getField($this->getOurFieldName());
-    }
-
-    /**
-     * @return mixed
-     */
-    final protected function getOurFieldValue(Model $ourEntity)
-    {
-        return $this->getOurModel($ourEntity)->get($this->getOurFieldName());
     }
 
     protected function initTableAlias(): void

--- a/src/Reference.php
+++ b/src/Reference.php
@@ -206,9 +206,9 @@ class Reference
     /**
      * @return mixed
      */
-    final protected function getOurFieldValue()
+    final protected function getOurFieldValue(Model $ourEntity)
     {
-        return $this->getOurModel()->get($this->getOurFieldName());
+        return $this->getOurModel($ourEntity)->get($this->getOurFieldName());
     }
 
     protected function initTableAlias(): void

--- a/src/Reference.php
+++ b/src/Reference.php
@@ -24,7 +24,9 @@ class Reference
     use InitializerTrait {
         init as private _init;
     }
-    use TrackableTrait;
+    use TrackableTrait {
+        setOwner as private _setOwner;
+    }
 
     /**
      * Use this alias for related entity by default. This can help you
@@ -81,6 +83,18 @@ class Reference
     public function __construct(string $link)
     {
         $this->link = $link;
+    }
+
+    /**
+     * @param Model $owner
+     *
+     * @return $this
+     */
+    public function setOwner(object $owner)
+    {
+//        $owner->assertIsModel();
+
+        return $this->_setOwner($owner);
     }
 
     public function getTheirFieldName(): string
@@ -248,7 +262,7 @@ class Reference
      * Returns referenced model without any extra conditions. However other
      * relationship types may override this to imply conditions.
      */
-    public function ref(array $defaults = []): Model
+    public function ref(Model $ourBoth, array $defaults = []): Model
     {
         return $this->createTheirModel($defaults);
     }
@@ -258,7 +272,7 @@ class Reference
      * must always respond with Model that does not look into current record
      * or scope.
      */
-    public function refModel(array $defaults = []): Model
+    public function refModel(Model $ourBoth, array $defaults = []): Model
     {
         return $this->createTheirModel($defaults);
     }

--- a/src/Reference.php
+++ b/src/Reference.php
@@ -154,15 +154,15 @@ class Reference
         return '#ref_' . $this->link;
     }
 
-    public function getOurModel(?Model $ourBoth): Model
+    public function getOurModel(?Model $ourModel): Model
     {
-        if ($ourBoth === null) {
-            $ourBoth = $this->getOwner();
+        if ($ourModel === null) {
+            $ourModel = $this->getOwner();
         }
 
-        $this->getOwner()->assertIsModel($ourBoth->getModel(true));
+        $this->getOwner()->assertIsModel($ourModel->getModel(true));
 
-        return $ourBoth;
+        return $ourModel;
     }
 
     /**
@@ -268,7 +268,7 @@ class Reference
      * Returns referenced model without any extra conditions. However other
      * relationship types may override this to imply conditions.
      */
-    public function ref(Model $ourBoth, array $defaults = []): Model
+    public function ref(Model $ourModel, array $defaults = []): Model
     {
         return $this->createTheirModel($defaults);
     }
@@ -278,7 +278,7 @@ class Reference
      * must always respond with Model that does not look into current record
      * or scope.
      */
-    public function refModel(Model $ourBoth, array $defaults = []): Model
+    public function refModel(Model $ourModel, array $defaults = []): Model
     {
         return $this->createTheirModel($defaults);
     }

--- a/src/Reference.php
+++ b/src/Reference.php
@@ -92,7 +92,7 @@ class Reference
      */
     public function setOwner(object $owner)
     {
-//        $owner->assertIsModel();
+        $owner->assertIsModel();
 
         return $this->_setOwner($owner);
     }
@@ -109,7 +109,7 @@ class Reference
         return $model->onHookDynamic(
             $spot,
             static function (Model $model) use ($name): self {
-                return $model->getElement($name);
+                return $model->getModel(true)->getElement($name);
             },
             $fx,
             $args,
@@ -154,9 +154,15 @@ class Reference
         return '#ref_' . $this->link;
     }
 
-    public function getOurModel(): Model
+    public function getOurModel(?Model $ourBoth): Model
     {
-        return $this->getOwner();
+        if ($ourBoth === null) {
+            $ourBoth = $this->getOwner();
+        }
+
+        $this->getOwner()->assertIsModel($ourBoth->getModel(true));
+
+        return $ourBoth;
     }
 
     /**

--- a/src/Reference.php
+++ b/src/Reference.php
@@ -179,7 +179,7 @@ class Reference
         if (is_object($this->model)) {
             if ($this->model instanceof \Closure) {
                 // if model is Closure, then call the closure and whci should return a model
-                $theirModel = ($this->model)($this->getOurModel(), $this, $defaults);
+                $theirModel = ($this->model)($this->getOurModel(null), $this, $defaults);
             } else {
                 // if model is set, then use clone of this model
                 $theirModel = clone $this->model;
@@ -201,12 +201,12 @@ class Reference
 
     protected function getOurFieldName(): string
     {
-        return $this->our_field ?: $this->getOurModel()->id_field;
+        return $this->our_field ?: $this->getOurModel(null)->id_field;
     }
 
     final protected function getOurField(): Field
     {
-        return $this->getOurModel()->getField($this->getOurFieldName());
+        return $this->getOurModel(null)->getField($this->getOurFieldName());
     }
 
     /**
@@ -220,7 +220,7 @@ class Reference
     protected function initTableAlias(): void
     {
         if (!$this->table_alias) {
-            $ourModel = $this->getOurModel();
+            $ourModel = $this->getOurModel(null);
 
             $aliasFull = $this->link;
             $alias = preg_replace('~_(' . preg_quote($ourModel->id_field, '~') . '|id)$~', '', $aliasFull);
@@ -252,7 +252,7 @@ class Reference
      */
     protected function getDefaultPersistence(Model $theirModel)
     {
-        $ourModel = $this->getOurModel();
+        $ourModel = $this->getOurModel(null);
 
         // this will be useful for containsOne/Many implementation in case when you have
         // SQL_Model->containsOne()->hasOne() structure to get back to SQL persistence

--- a/src/Reference/ContainsMany.php
+++ b/src/Reference/ContainsMany.php
@@ -22,7 +22,7 @@ class ContainsMany extends ContainsOne
     /**
      * Returns referenced model.
      */
-    public function ref(array $defaults = []): Model
+    public function ref(Model $ourBoth, array $defaults = []): Model
     {
         $ourModel = $this->getOurModel();
 

--- a/src/Reference/ContainsMany.php
+++ b/src/Reference/ContainsMany.php
@@ -26,9 +26,9 @@ class ContainsMany extends ContainsOne
     /**
      * Returns referenced model.
      */
-    public function ref(Model $ourBoth, array $defaults = []): Model
+    public function ref(Model $ourModel, array $defaults = []): Model
     {
-        $ourModel = $this->getOurModel($ourBoth);
+        $ourModel = $this->getOurModel($ourModel);
 
         // get model
         $theirModel = $this->createTheirModel(array_merge($defaults, [

--- a/src/Reference/ContainsMany.php
+++ b/src/Reference/ContainsMany.php
@@ -12,10 +12,14 @@ use Atk4\Data\Persistence;
  */
 class ContainsMany extends ContainsOne
 {
+    use ContainsSeedHackTrait;
+
     protected function getDefaultPersistence(Model $theirModel): Persistence
     {
+        $ourModel = $this->getOurModelPassedToRefXxx();
+
         return new Persistence\Array_([
-            $this->table_alias => $this->getOurModel()->isEntity() && $this->getOurFieldValue() !== null ? $this->getOurFieldValue() : [],
+            $this->table_alias => $ourModel->isEntity() && $this->getOurFieldValue($ourModel) !== null ? $this->getOurFieldValue($ourModel) : [],
         ]);
     }
 

--- a/src/Reference/ContainsMany.php
+++ b/src/Reference/ContainsMany.php
@@ -28,7 +28,7 @@ class ContainsMany extends ContainsOne
      */
     public function ref(Model $ourBoth, array $defaults = []): Model
     {
-        $ourModel = $this->getOurModel();
+        $ourModel = $this->getOurModel($ourBoth);
 
         // get model
         $theirModel = $this->createTheirModel(array_merge($defaults, [
@@ -38,11 +38,11 @@ class ContainsMany extends ContainsOne
 
         // set some hooks for ref_model
         foreach ([Model::HOOK_AFTER_SAVE, Model::HOOK_AFTER_DELETE] as $spot) {
-            $this->onHookToTheirModel($theirModel, $spot, function (Model $theirModel) {
+            $this->onHookToTheirModel($theirModel, $spot, function (Model $theirModel) use ($ourModel) {
                 /** @var Persistence\Array_ */
                 $persistence = $theirModel->persistence;
                 $rows = $persistence->getRawDataByTable($theirModel, $this->table_alias);
-                $this->getOurModel()->save([
+                $this->getOurModel($ourModel)->save([
                     $this->getOurFieldName() => $rows ?: null,
                 ]);
             });

--- a/src/Reference/ContainsOne.php
+++ b/src/Reference/ContainsOne.php
@@ -83,7 +83,7 @@ class ContainsOne extends Reference
     /**
      * Returns referenced model with loaded data record.
      */
-    public function ref(array $defaults = []): Model
+    public function ref(Model $ourBoth, array $defaults = []): Model
     {
         $ourModel = $this->getOurModel();
 

--- a/src/Reference/ContainsOne.php
+++ b/src/Reference/ContainsOne.php
@@ -13,6 +13,8 @@ use Atk4\Data\Reference;
  */
 class ContainsOne extends Reference
 {
+    use ContainsSeedHackTrait;
+
     /**
      * Field type.
      *
@@ -75,8 +77,10 @@ class ContainsOne extends Reference
 
     protected function getDefaultPersistence(Model $theirModel): Persistence
     {
+        $ourModel = $this->getOurModelPassedToRefXxx();
+
         return new Persistence\Array_([
-            $this->table_alias => $this->getOurModel()->isEntity() && $this->getOurFieldValue() !== null ? [1 => $this->getOurFieldValue()] : [],
+            $this->table_alias => $ourModel->isEntity() && $this->getOurFieldValue($ourModel) !== null ? [1 => $this->getOurFieldValue($ourModel)] : [],
         ]);
     }
 

--- a/src/Reference/ContainsOne.php
+++ b/src/Reference/ContainsOne.php
@@ -58,7 +58,7 @@ class ContainsOne extends Reference
             $this->our_field = $this->link;
         }
 
-        $ourModel = $this->getOurModel();
+        $ourModel = $this->getOurModel(null);
         $ourField = $this->getOurFieldName();
 
         if (!$ourModel->hasElement($ourField)) {
@@ -89,7 +89,7 @@ class ContainsOne extends Reference
      */
     public function ref(Model $ourBoth, array $defaults = []): Model
     {
-        $ourModel = $this->getOurModel();
+        $ourModel = $this->getOurModel($ourBoth);
 
         $theirModel = $this->createTheirModel(array_merge($defaults, [
             'contained_in_root_model' => $ourModel->contained_in_root_model ?: $ourModel,
@@ -97,12 +97,12 @@ class ContainsOne extends Reference
         ]));
 
         foreach ([Model::HOOK_AFTER_SAVE, Model::HOOK_AFTER_DELETE] as $spot) {
-            $this->onHookToTheirModel($theirModel, $spot, function (Model $theirModel) {
+            $this->onHookToTheirModel($theirModel, $spot, function (Model $theirModel) use ($ourModel) {
                 /** @var Persistence\Array_ */
                 $persistence = $theirModel->persistence;
                 $row = $persistence->getRawDataByTable($theirModel, $this->table_alias);
                 $row = $row ? array_shift($row) : null; // get first and only one record from array persistence
-                $this->getOurModel()->save([$this->getOurFieldName() => $row]);
+                $this->getOurModel($ourModel)->save([$this->getOurFieldName() => $row]);
             });
         }
 

--- a/src/Reference/ContainsOne.php
+++ b/src/Reference/ContainsOne.php
@@ -87,9 +87,9 @@ class ContainsOne extends Reference
     /**
      * Returns referenced model with loaded data record.
      */
-    public function ref(Model $ourBoth, array $defaults = []): Model
+    public function ref(Model $ourModel, array $defaults = []): Model
     {
-        $ourModel = $this->getOurModel($ourBoth);
+        $ourModel = $this->getOurModel($ourModel);
 
         $theirModel = $this->createTheirModel(array_merge($defaults, [
             'contained_in_root_model' => $ourModel->contained_in_root_model ?: $ourModel,

--- a/src/Reference/ContainsSeedHackTrait.php
+++ b/src/Reference/ContainsSeedHackTrait.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Atk4\Data\Reference;
+
+use Atk4\Data\Model;
+
+trait ContainsSeedHackTrait
+{
+    // TODO horrible getter for our possibly entity, for ContainsOne/ContainsMany, remove asap
+    public function getOurModelPassedToRefXxx(): Model
+    {
+        $trace = debug_backtrace(\DEBUG_BACKTRACE_PROVIDE_OBJECT, 10);
+        $expectedCalls = [
+            'getOurModelPassedToRefXxx',
+            'getDefaultPersistence',
+            'addToPersistence',
+            'createTheirModel',
+        ];
+        $lastExpectedCall = null;
+        foreach ($trace as $frame) {
+            if ($frame['object'] === $this) {
+                if ($frame['function'] === $lastExpectedCall) {
+                    continue;
+                }
+
+                $expectedCall = array_shift($expectedCalls);
+                if ($frame['function'] === $expectedCall) {
+                    $lastExpectedCall = $expectedCall;
+
+                    continue;
+                }
+
+                if (in_array($frame['function'], ['ref', 'refModel', 'refLink'], true)) {
+                    return $frame['args'][0];
+                }
+            }
+
+            throw new \Error('Unexpected "' . $frame['function'] . '" method call in stacktrace');
+        }
+
+        throw new \Error('"createTheirModel" call not found in stacktrace');
+    }
+}

--- a/src/Reference/ContainsSeedHackTrait.php
+++ b/src/Reference/ContainsSeedHackTrait.php
@@ -33,7 +33,7 @@ trait ContainsSeedHackTrait
                 }
 
                 if (in_array($frame['function'], ['ref', 'refModel', 'refLink'], true)) {
-                    return $frame['args'][0];
+                    return $this->getOurModel($frame['args'][0]);
                 }
             }
 

--- a/src/Reference/HasMany.php
+++ b/src/Reference/HasMany.php
@@ -63,7 +63,7 @@ class HasMany extends Reference
     /**
      * Returns referenced model with condition set.
      */
-    public function ref(array $defaults = []): Model
+    public function ref(Model $ourBoth, array $defaults = []): Model
     {
         $ourModel = $this->getOurModel();
 
@@ -76,7 +76,7 @@ class HasMany extends Reference
     /**
      * Creates model that can be used for generating sub-query actions.
      */
-    public function refLink(array $defaults = []): Model
+    public function refLink(?Model $ourBoth, array $defaults = []): Model
     {
         $ourModel = $this->getOurModel();
 
@@ -113,7 +113,7 @@ class HasMany extends Reference
 
         if (isset($defaults['expr'])) {
             $fx = function () use ($defaults, $alias) {
-                $theirModelLinked = $this->refLink();
+                $theirModelLinked = $this->refLink(null);
 
                 return $theirModelLinked->action('field', [$theirModelLinked->expr(
                     $defaults['expr'],
@@ -123,19 +123,19 @@ class HasMany extends Reference
             unset($defaults['args']);
         } elseif (is_object($defaults['aggregate'])) {
             $fx = function () use ($defaults, $alias) {
-                return $this->refLink()->action('field', [$defaults['aggregate'], 'alias' => $alias]);
+                return $this->refLink(null)->action('field', [$defaults['aggregate'], 'alias' => $alias]);
             };
         } elseif ($defaults['aggregate'] === 'count' && !isset($defaults['field'])) {
             $fx = function () use ($alias) {
-                return $this->refLink()->action('count', ['alias' => $alias]);
+                return $this->refLink(null)->action('count', ['alias' => $alias]);
             };
         } elseif (in_array($defaults['aggregate'], ['sum', 'avg', 'min', 'max', 'count'], true)) {
             $fx = function () use ($defaults, $field) {
-                return $this->refLink()->action('fx0', [$defaults['aggregate'], $field]);
+                return $this->refLink(null)->action('fx0', [$defaults['aggregate'], $field]);
             };
         } else {
             $fx = function () use ($defaults, $field) {
-                return $this->refLink()->action('fx', [$defaults['aggregate'], $field]);
+                return $this->refLink(null)->action('fx', [$defaults['aggregate'], $field]);
             };
         }
 

--- a/src/Reference/HasMany.php
+++ b/src/Reference/HasMany.php
@@ -34,7 +34,7 @@ class HasMany extends Reference
      *
      * @return mixed
      */
-    protected function getOurValue(Model $ourModel)
+    protected function getOurFieldValueForRefCondition(Model $ourModel)
     {
         $ourModel = $this->getOurModel($ourModel);
 
@@ -69,7 +69,7 @@ class HasMany extends Reference
 
         return $this->createTheirModel($defaults)->addCondition(
             $this->getTheirFieldName(),
-            $this->getOurValue($ourModel)
+            $this->getOurFieldValueForRefCondition($ourModel)
         );
     }
 

--- a/src/Reference/HasMany.php
+++ b/src/Reference/HasMany.php
@@ -34,9 +34,9 @@ class HasMany extends Reference
      *
      * @return mixed
      */
-    protected function getOurValue(Model $ourBoth)
+    protected function getOurValue(Model $ourModel)
     {
-        $ourModel = $this->getOurModel($ourBoth);
+        $ourModel = $this->getOurModel($ourModel);
 
         if ($ourModel->isEntity() && $ourModel->loaded()) {
             return $this->our_field
@@ -63,22 +63,22 @@ class HasMany extends Reference
     /**
      * Returns referenced model with condition set.
      */
-    public function ref(Model $ourBoth, array $defaults = []): Model
+    public function ref(Model $ourModel, array $defaults = []): Model
     {
-        $ourModel = $this->getOurModel($ourBoth);
+        $ourModel = $this->getOurModel($ourModel);
 
         return $this->createTheirModel($defaults)->addCondition(
             $this->getTheirFieldName(),
-            $this->getOurValue($ourBoth)
+            $this->getOurValue($ourModel)
         );
     }
 
     /**
      * Creates model that can be used for generating sub-query actions.
      */
-    public function refLink(?Model $ourBoth, array $defaults = []): Model
+    public function refLink(?Model $ourModel, array $defaults = []): Model
     {
-        $ourModel = $this->getOurModel($ourBoth);
+        $ourModel = $this->getOurModel($ourModel);
 
         $theirModelLinked = $this->createTheirModel($defaults)->addCondition(
             $this->getTheirFieldName(),

--- a/src/Reference/HasMany.php
+++ b/src/Reference/HasMany.php
@@ -19,7 +19,7 @@ class HasMany extends Reference
 
         // this is pure guess, verify if such field exist, otherwise throw
         // TODO probably remove completely in the future
-        $ourModel = $this->getOurModel();
+        $ourModel = $this->getOurModel(null);
         $theirFieldName = $ourModel->table . '_' . $ourModel->id_field;
         if (!$this->createTheirModel()->hasField($theirFieldName)) {
             throw (new Exception('Their model does not contain fallback field'))
@@ -34,9 +34,9 @@ class HasMany extends Reference
      *
      * @return mixed
      */
-    protected function getOurValue()
+    protected function getOurValue(Model $ourBoth)
     {
-        $ourModel = $this->getOurModel();
+        $ourModel = $this->getOurModel($ourBoth);
 
         if ($ourModel->isEntity() && $ourModel->loaded()) {
             return $this->our_field
@@ -55,7 +55,7 @@ class HasMany extends Reference
      */
     protected function referenceOurValue(): Field
     {
-        $this->getOurModel()->persistence_data['use_table_prefixes'] = true;
+        $this->getOurModel(null)->persistence_data['use_table_prefixes'] = true;
 
         return $this->getOurField();
     }
@@ -65,11 +65,11 @@ class HasMany extends Reference
      */
     public function ref(Model $ourBoth, array $defaults = []): Model
     {
-        $ourModel = $this->getOurModel();
+        $ourModel = $this->getOurModel($ourBoth);
 
         return $this->createTheirModel($defaults)->addCondition(
             $this->getTheirFieldName(),
-            $this->getOurValue()
+            $this->getOurValue($ourBoth)
         );
     }
 
@@ -78,7 +78,7 @@ class HasMany extends Reference
      */
     public function refLink(?Model $ourBoth, array $defaults = []): Model
     {
-        $ourModel = $this->getOurModel();
+        $ourModel = $this->getOurModel($ourBoth);
 
         $theirModelLinked = $this->createTheirModel($defaults)->addCondition(
             $this->getTheirFieldName(),
@@ -106,7 +106,7 @@ class HasMany extends Reference
         $field = $alias ?? $fieldName;
 
         if (isset($defaults['concat'])) {
-            $defaults['aggregate'] = $this->getOurModel()->dsql()->groupConcat($field, $defaults['concat']);
+            $defaults['aggregate'] = $this->getOurModel(null)->dsql()->groupConcat($field, $defaults['concat']);
             $defaults['read_only'] = false;
             $defaults['never_save'] = true;
         }
@@ -139,7 +139,7 @@ class HasMany extends Reference
             };
         }
 
-        return $this->getOurModel()->addExpression($fieldName, array_merge([$fx], $defaults));
+        return $this->getOurModel(null)->addExpression($fieldName, array_merge([$fx], $defaults));
     }
 
     /**

--- a/src/Reference/HasOne.php
+++ b/src/Reference/HasOne.php
@@ -85,7 +85,7 @@ class HasOne extends Reference
         });
 
         if ($this->getOurModel()->isEntity()) {
-            if ($ourValue = $this->getOurFieldValue()) {
+            if ($ourValue = $this->getOurFieldValue($ourBoth)) {
                 // if our model is loaded, then try to load referenced model
                 if ($this->their_field) {
                     $theirModel = $theirModel->tryLoadBy($this->their_field, $ourValue);
@@ -100,10 +100,10 @@ class HasOne extends Reference
         // their model will be reloaded after saving our model to reflect changes in referenced fields
         $theirModel->reload_after_save = false;
 
-        $this->onHookToTheirModel($theirModel, Model::HOOK_AFTER_SAVE, function (Model $theirModel) {
+        $this->onHookToTheirModel($theirModel, Model::HOOK_AFTER_SAVE, function (Model $theirModel) use ($ourBoth) {
             $theirValue = $this->their_field ? $theirModel->get($this->their_field) : $theirModel->getId();
 
-            if ($this->getOurFieldValue() !== $theirValue) {
+            if ($this->getOurFieldValue($ourBoth) !== $theirValue) { // TODO compare should be used here
                 $this->getOurModel()->set($this->getOurFieldName(), $theirValue)->save();
             }
 

--- a/src/Reference/HasOne.php
+++ b/src/Reference/HasOne.php
@@ -75,7 +75,7 @@ class HasOne extends Reference
      * If our model is not loaded, then return their model with condition set.
      * This can happen in case of deep traversal $model->ref('Many')->ref('one_id'), for example.
      */
-    public function ref(array $defaults = []): Model
+    public function ref(Model $ourBoth, array $defaults = []): Model
     {
         $theirModel = $this->createTheirModel($defaults);
 

--- a/src/Reference/HasOne.php
+++ b/src/Reference/HasOne.php
@@ -75,9 +75,9 @@ class HasOne extends Reference
      * If our model is not loaded, then return their model with condition set.
      * This can happen in case of deep traversal $model->ref('Many')->ref('one_id'), for example.
      */
-    public function ref(Model $ourBoth, array $defaults = []): Model
+    public function ref(Model $ourModel, array $defaults = []): Model
     {
-        $ourModel = $this->getOurModel($ourBoth);
+        $ourModel = $this->getOurModel($ourModel);
         $theirModel = $this->createTheirModel($defaults);
 
         // add hook to set our_field = null when record of referenced model is deleted
@@ -86,7 +86,7 @@ class HasOne extends Reference
         });
 
         if ($ourModel->isEntity()) {
-            if ($ourValue = $this->getOurFieldValue($ourBoth)) {
+            if ($ourValue = $this->getOurFieldValue($ourModel)) {
                 // if our model is loaded, then try to load referenced model
                 if ($this->their_field) {
                     $theirModel = $theirModel->tryLoadBy($this->their_field, $ourValue);

--- a/src/Reference/HasOne.php
+++ b/src/Reference/HasOne.php
@@ -104,7 +104,7 @@ class HasOne extends Reference
         $this->onHookToTheirModel($theirModel, Model::HOOK_AFTER_SAVE, function (Model $theirModel) use ($ourModel) {
             $theirValue = $this->their_field ? $theirModel->get($this->their_field) : $theirModel->getId();
 
-            if ($this->getOurFieldValue($ourModel) !== $theirValue) { // TODO compare should be used here
+            if (!$this->getOurField()->compare($this->getOurFieldValue($ourModel), $theirValue)) {
                 $ourModel->set($this->getOurFieldName(), $theirValue)->save();
             }
 

--- a/src/Reference/HasOneSql.php
+++ b/src/Reference/HasOneSql.php
@@ -125,7 +125,7 @@ class HasOneSql extends HasOne
         if ($ourModel->isEntity() && $ourModel->loaded() && !$theirModel->loaded()) {
             if ($ourModel->id_field === $this->getOurFieldName()) {
                 return $theirModel->getModel()
-                    ->addCondition($theirFieldName, $this->getOurFieldValue());
+                    ->addCondition($theirFieldName, $this->getOurFieldValue($ourBoth));
             }
         }
 

--- a/src/Reference/HasOneSql.php
+++ b/src/Reference/HasOneSql.php
@@ -18,7 +18,7 @@ class HasOneSql extends HasOne
             $theirFieldName = $ourFieldName;
         }
 
-        $ourModel = $this->getOurModel();
+        $ourModel = $this->getOurModel(null);
 
         // if caption/type is not defined in $defaults -> get it directly from the linked model field $theirFieldName
         $refModelField = $ourModel->refModel($this->link)->getField($theirFieldName);
@@ -114,7 +114,7 @@ class HasOneSql extends HasOne
     public function ref(Model $ourBoth, array $defaults = []): Model
     {
         $theirModel = parent::ref($ourBoth, $defaults);
-        $ourModel = $this->getOurModel();
+        $ourModel = $this->getOurModel($ourBoth);
 
         $theirFieldName = $this->their_field ?? $theirModel->id_field; // TODO why not $this->getTheirFieldName() ?
 
@@ -149,7 +149,7 @@ class HasOneSql extends HasOne
      */
     public function addTitle(array $defaults = []): FieldSqlExpression
     {
-        $ourModel = $this->getOurModel();
+        $ourModel = $this->getOurModel(null);
 
         $fieldName = $defaults['field'] ?? preg_replace('~_(' . preg_quote($ourModel->id_field, '~') . '|id)$~', '', $this->link);
 

--- a/src/Reference/HasOneSql.php
+++ b/src/Reference/HasOneSql.php
@@ -96,7 +96,7 @@ class HasOneSql extends HasOne
     /**
      * Creates model that can be used for generating sub-query actions.
      */
-    public function refLink(Model $ourBoth, array $defaults = []): Model
+    public function refLink(Model $ourModel, array $defaults = []): Model
     {
         $theirModel = $this->createTheirModel($defaults);
 
@@ -111,10 +111,10 @@ class HasOneSql extends HasOne
     /**
      * Navigate to referenced model.
      */
-    public function ref(Model $ourBoth, array $defaults = []): Model
+    public function ref(Model $ourModel, array $defaults = []): Model
     {
-        $theirModel = parent::ref($ourBoth, $defaults);
-        $ourModel = $this->getOurModel($ourBoth);
+        $theirModel = parent::ref($ourModel, $defaults);
+        $ourModel = $this->getOurModel($ourModel);
 
         $theirFieldName = $this->their_field ?? $theirModel->id_field; // TODO why not $this->getTheirFieldName() ?
 
@@ -125,7 +125,7 @@ class HasOneSql extends HasOne
         if ($ourModel->isEntity() && $ourModel->loaded() && !$theirModel->loaded()) {
             if ($ourModel->id_field === $this->getOurFieldName()) {
                 return $theirModel->getModel()
-                    ->addCondition($theirFieldName, $this->getOurFieldValue($ourBoth));
+                    ->addCondition($theirFieldName, $this->getOurFieldValue($ourModel));
             }
         }
 

--- a/src/Reference/HasOneSql.php
+++ b/src/Reference/HasOneSql.php
@@ -96,7 +96,7 @@ class HasOneSql extends HasOne
     /**
      * Creates model that can be used for generating sub-query actions.
      */
-    public function refLink(array $defaults = []): Model
+    public function refLink(Model $ourBoth, array $defaults = []): Model
     {
         $theirModel = $this->createTheirModel($defaults);
 
@@ -111,9 +111,9 @@ class HasOneSql extends HasOne
     /**
      * Navigate to referenced model.
      */
-    public function ref(array $defaults = []): Model
+    public function ref(Model $ourBoth, array $defaults = []): Model
     {
-        $theirModel = parent::ref($defaults);
+        $theirModel = parent::ref($ourBoth, $defaults);
         $ourModel = $this->getOurModel();
 
         $theirFieldName = $this->their_field ?? $theirModel->id_field; // TODO why not $this->getTheirFieldName() ?

--- a/src/Util/DeepCopy.php
+++ b/src/Util/DeepCopy.php
@@ -226,11 +226,11 @@ class DeepCopy
             foreach ($this->extractKeys($references) as $ref_key => $ref_val) {
                 $this->debug("Considering {$ref_key}");
 
-                if ($source->hasRef($ref_key) && ($ref = $source->getRef($ref_key)) instanceof HasOne) {
+                if ($source->hasRef($ref_key) && $source->getRef($ref_key) instanceof HasOne) {
                     $this->debug("Proceeding with {$ref_key}");
 
                     // load destination model through $source
-                    $source_table = $ref->refModel()->table;
+                    $source_table = $source->refModel($ref_key)->table;
 
                     if (
                         isset($this->mapping[$source_table])
@@ -280,7 +280,7 @@ class DeepCopy
             // Next look for hasMany relationships and copy those too
 
             foreach ($this->extractKeys($references) as $ref_key => $ref_val) {
-                if ($source->hasRef($ref_key) && ($ref = $source->getRef($ref_key)) instanceof HasMany) {
+                if ($source->hasRef($ref_key) && $source->getRef($ref_key) instanceof HasMany) {
                     // No mapping, will always copy
                     foreach ($source->ref($ref_key) as $ref_model) {
                         $this->_copy(


### PR DESCRIPTION
## BC break

`Reference` is no longer bound to an entity, thus methods `Reference::ref`, `Field::refModel`, `Field::refLink` requires entity provided as the 1st argument like `$ref->ref($entity)`. No change required if traversing from model/entity directly.