### PR TITLE
Allow recursively referencing models to be analysed

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,28 +137,29 @@ class JobReport extends Job
         // we need to ignore draft invoices
         $invoice->addCondition('status', '!=', 'draft');
 
-        // each invoice may have multiple lines, which is what we want
-        $invoiceLines = $invoice->ref('Lines');
-
         // build relation between job and invoice line
-        $this->hasMany('InvoiceLines', ['model' => $invoiceLines])
+        $this->hasMany('InvoiceLines', ['model' => static function () use ($invoice) {
+            return $invoice->ref('Lines');
+        }])
             ->addField('invoiced', [
                 'aggregate' => 'sum',
                 'field' => 'total',
                 'type' => 'atk4_money'
             ]);
 
-        // next we need to see how much is reported through timesheets
-        $timesheet = new Timesheet($this->getPersistence());
-
-        // timesheet relates to client, import client.hourly_rate as expression
-        $timesheet->getReference('client_id')->addField('hourly_rate');
-
-        // calculate timesheet cost expression
-        $timesheet->addExpression('cost', ['expr' => '[hours] * [hourly_rate]']);
-
         // build relation between Job and Timesheets
-        $this->hasMany('Timesheets', ['model' => $timesheet])
+        $this->hasMany('Timesheets', ['model' => static function (Persistence $persistence) {
+            // next we need to see how much is reported through timesheets
+            $timesheet = new Timesheet($persistence);
+
+            // timesheet relates to client, import client.hourly_rate as expression
+            $timesheet->getReference('client_id')->addField('hourly_rate');
+
+            // calculate timesheet cost expression
+            $timesheet->addExpression('cost', ['expr' => '[hours] * [hourly_rate]']);
+
+            return $timesheet;
+        }])
             ->addField('reported', [
                 'aggregate' => 'sum',
                 'field' => 'cost',

--- a/docs/references.md
+++ b/docs/references.md
@@ -129,15 +129,12 @@ It is possible to perform reference through an 3rd party table:
 
 ```
 $i = new Model_Invoice();
-$p = new Model_Payment();
 
-// table invoice_payment has 'invoice_id', 'payment_id' and 'amount_allocated'
-
-$p
-    ->join('invoice_payment.payment_id')
-    ->addFields(['amount_allocated', 'invoice_id']);
-
-$i->hasMany('Payments', ['model' => $p]);
+$i->hasMany('Payments', ['model' => static function () {
+    return (new Model_Payment())
+        ->join('invoice_payment.payment_id')
+        ->addFields(['amount_allocated', 'invoice_id']);
+}]);
 ```
 
 Now you can fetch all the payments associated with the invoice through:
@@ -195,7 +192,10 @@ inside `$m` that will correspond to the sum of all the orders. Here is another
 example:
 
 ```
-$u->hasMany('PaidOrders', (new Model_Order())->addCondition('is_paid', true))
+$u->hasMany('PaidOrders', ['model' => static function (Persistence $persistence) {
+    return (new Model_Order($persistence))
+        ->addCondition('is_paid', true);
+}])
     ->addField('paid_amount', ['aggregate' => 'sum', 'field' => 'amount']);
 ```
 

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -22,7 +22,7 @@ parameters:
             path: '*'
             count: 3
 
-        # https://github.com/phpstan/phpstan/issues/10686
+        # https://github.com/phpstan/phpstan/issues/5551
         -
             message: '~^(Static property Atk4\\Data\\Reference::\$analysingClosureMap \(Atk4\\Data\\Reference\\WeakAnalysingMap<list<mixed>, Closure, Atk4\\Data\\Model\|Atk4\\Data\\Persistence>\) does not accept Atk4\\Data\\Reference\\WeakAnalysingMap<array\|object, array\|object, object>\.|Static property Atk4\\Data\\Reference::\$analysingTheirModelMap \(Atk4\\Data\\Reference\\WeakAnalysingMap<array\{Atk4\\Data\\Persistence, array\|Atk4\\Data\\Model\|\(Closure\(Atk4\\Data\\Persistence, array<string, mixed>\): Atk4\\Data\\Model\), array\}, Atk4\\Data\\Model, Atk4\\Data\\Model\|Atk4\\Data\\Persistence>\) does not accept Atk4\\Data\\Reference\\WeakAnalysingMap<array\|object, array\|object, object>\.|Cannot call method assertIsInitialized\(\) on array\|object\.)$~'
             path: 'src/*'

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -24,9 +24,9 @@ parameters:
 
         # https://github.com/phpstan/phpstan/issues/10686
         -
-            message: '~^(Static property Atk4\\Data\\Reference::\$analysingTheirModelMap \(Atk4\\Data\\Reference\\WeakAnalysingMap<array\{Atk4\\Data\\Persistence, array\|Atk4\\Data\\Model\|\(Closure\(Atk4\\Data\\Persistence, array<string, mixed>\): Atk4\\Data\\Model\), array\}, Atk4\\Data\\Model, Atk4\\Data\\Model\|Atk4\\Data\\Persistence>\) does not accept Atk4\\Data\\Reference\\WeakAnalysingMap<array\|object, array\|object, object>\.|Cannot call method assertIsInitialized\(\) on array\|object\.)$~'
+            message: '~^(Static property Atk4\\Data\\Reference::\$analysingClosureMap \(Atk4\\Data\\Reference\\WeakAnalysingMap<list<mixed>, Closure, Atk4\\Data\\Model\|Atk4\\Data\\Persistence>\) does not accept Atk4\\Data\\Reference\\WeakAnalysingMap<array\|object, array\|object, object>\.|Static property Atk4\\Data\\Reference::\$analysingTheirModelMap \(Atk4\\Data\\Reference\\WeakAnalysingMap<array\{Atk4\\Data\\Persistence, array\|Atk4\\Data\\Model\|\(Closure\(Atk4\\Data\\Persistence, array<string, mixed>\): Atk4\\Data\\Model\), array\}, Atk4\\Data\\Model, Atk4\\Data\\Model\|Atk4\\Data\\Persistence>\) does not accept Atk4\\Data\\Reference\\WeakAnalysingMap<array\|object, array\|object, object>\.|Cannot call method assertIsInitialized\(\) on array\|object\.)$~'
             path: 'src/*'
-            count: 3
+            count: 5
 
         # fix https://github.com/phpstan/phpstan-deprecation-rules/issues/52 and https://github.com/phpstan/phpstan/issues/6444
         -

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -22,6 +22,12 @@ parameters:
             path: '*'
             count: 3
 
+        # https://github.com/phpstan/phpstan/issues/10686
+        -
+            message: '~^(Static property Atk4\\Data\\Reference::\$analysingTheirModelMap \(Atk4\\Data\\Reference\\WeakAnalysingMap<array\{Atk4\\Data\\Persistence, array\|Atk4\\Data\\Model\|\(Closure\(Atk4\\Data\\Persistence, array<string, mixed>\): Atk4\\Data\\Model\), array\}, Atk4\\Data\\Model, Atk4\\Data\\Model\|Atk4\\Data\\Persistence>\) does not accept Atk4\\Data\\Reference\\WeakAnalysingMap<array\|object, array\|object, object>\.|Cannot call method assertIsInitialized\(\) on array\|object\.)$~'
+            path: 'src/*'
+            count: 3
+
         # fix https://github.com/phpstan/phpstan-deprecation-rules/issues/52 and https://github.com/phpstan/phpstan/issues/6444
         -
             message: '~^Call to method (getVarcharTypeDeclarationSQL|getClobTypeDeclarationSQL|getCreateIndexSQL|getCreateTableSQL|getCurrentDatabaseExpression|initializeDoctrineTypeMappings)\(\) of deprecated class Doctrine\\DBAL\\Platforms\\(PostgreSQLPlatform|SQLServerPlatform|AbstractPlatform):\nUse.+instead\.$~'

--- a/src/Model.php
+++ b/src/Model.php
@@ -448,11 +448,11 @@ class Model implements \IteratorAggregate
         $this->_add($obj, $defaults);
     }
 
-    public function _addIntoCollection(string $name, object $item, string $collection): object
+    public function _addIntoCollection(string $name, object $item, string $collection): void
     {
         // TODO $this->assertIsModel();
 
-        return $this->__addIntoCollection($name, $item, $collection);
+        $this->__addIntoCollection($name, $item, $collection);
     }
 
     /**
@@ -545,7 +545,9 @@ class Model implements \IteratorAggregate
             $field = $this->fieldFactory($seed);
         }
 
-        return $this->_addIntoCollection($name, $field, 'fields');
+        $this->_addIntoCollection($name, $field, 'fields');
+
+        return $field;
     }
 
     /**

--- a/src/Reference.php
+++ b/src/Reference.php
@@ -7,6 +7,7 @@ namespace Atk4\Data;
 use Atk4\Core\DiContainerTrait;
 use Atk4\Core\InitializerTrait;
 use Atk4\Core\TrackableTrait;
+use Atk4\Data\Reference\WeakAnalysingMap;
 
 /**
  * Reference implements a link between our model and their model..
@@ -24,6 +25,9 @@ class Reference
     use TrackableTrait {
         setOwner as private _setOwner;
     }
+
+    /** @var WeakAnalysingMap<array{Persistence, array<mixed>|\Closure(Persistence, array<string, mixed>): Model|Model, array<mixed>}, Model, Model|Persistence> */
+    private static WeakAnalysingMap $analysingTheirModelMap;
 
     /**
      * Use this alias for their model by default. This can help you
@@ -318,6 +322,46 @@ class Reference
         $theirModel = $this->createTheirModelBeforeInit($defaults);
         $this->createTheirModelSetPersistence($theirModel);
         $this->createTheirModelAfterInit($theirModel);
+
+        return $theirModel;
+    }
+
+    /**
+     * Same as self::createTheirModel() but the created model is deduplicated based on our model persistence,
+     * self::$model seed and $defaults parameter to guard recursion from possibly recursively invoked Model::init()
+     * and also to improve performance when used for their field/reference analysing purposes.
+     *
+     * @param array<string, mixed> $defaults
+     */
+    public function createAnalysingTheirModel(array $defaults = []): Model
+    {
+        if ((self::$analysingTheirModelMap ?? null) === null) {
+            self::$analysingTheirModelMap = new WeakAnalysingMap();
+        }
+
+        $ourPersistence = $this->getOurModel()->getPersistence();
+        $analysingKey = [$ourPersistence, $this->model, $defaults];
+        $analysingOwner = $this->getOwner();
+
+        // optimization - keep referenced for whole persistence lifetime if seed is class name only
+        if (is_array($this->model) && count($this->model) === 1 && is_string($this->model[0] ?? null) && $defaults === []) {
+            $analysingOwner = $ourPersistence;
+        }
+
+        $theirModel = self::$analysingTheirModelMap->get($analysingKey, $analysingOwner);
+        if ($theirModel === null) {
+            $theirModel = $this->createTheirModelBeforeInit($defaults);
+            self::$analysingTheirModelMap->set($analysingKey, $theirModel, $analysingOwner);
+            $this->createTheirModelSetPersistence($theirModel);
+            $this->createTheirModelAfterInit($theirModel);
+
+            // make analysing model unusable
+            \Closure::bind(static function () use ($theirModel) {
+                unset($theirModel->{'_persistence'});
+            }, null, Model::class)();
+        }
+
+        $theirModel->assertIsInitialized();
 
         return $theirModel;
     }

--- a/src/Reference.php
+++ b/src/Reference.php
@@ -358,7 +358,7 @@ class Reference
                     \PHP_VERSION_ID < 80100 ? $fxRefl->getStaticVariables() : $fxRefl->getClosureUsedVariables(),
                 ];
 
-                // optimization - simplify key to improve hash speed
+                // optimization - simplify key to improve hashing speed
                 if ($fxKey[4] === []) {
                     unset($fxKey[4]);
                     if ($fxKey[3] === null) {

--- a/src/Reference/HasMany.php
+++ b/src/Reference/HasMany.php
@@ -32,7 +32,7 @@ class HasMany extends Reference
         // TODO probably remove completely in the future
         $ourModel = $this->getOurModel();
         $theirFieldName = preg_replace('~^.+\.~s', '', $this->getModelTableString($ourModel)) . '_' . $ourModel->idField;
-        if (!($theirModel ?? $this->createTheirModel())->hasField($theirFieldName)) {
+        if (!($theirModel ?? $this->createAnalysingTheirModel())->hasField($theirFieldName)) {
             throw (new Exception('Their model does not contain implicit field'))
                 ->addMoreInfo('theirImplicitField', $theirFieldName);
         }

--- a/src/Reference/HasOne.php
+++ b/src/Reference/HasOne.php
@@ -22,9 +22,17 @@ class HasOne extends Reference
             $this->ourField = $this->link;
         }
 
-        // for references use "integer" as a default type
+        $checkTheirTypeOrig = $this->checkTheirType;
+        $this->checkTheirType = false;
+        try {
+            $analysingTheirModel = $this->createAnalysingTheirModel();
+        } finally {
+            $this->checkTheirType = $checkTheirTypeOrig;
+        }
+
+        // infer our field type from their field
         if (($this->type ?? null) === null) {
-            $this->type = 'integer';
+            $this->type = $analysingTheirModel->getField($this->getTheirFieldName($analysingTheirModel))->type;
         }
 
         $this->referenceLink = $this->link; // named differently than in Model\FieldPropertiesTrait

--- a/src/Reference/HasOneSql.php
+++ b/src/Reference/HasOneSql.php
@@ -78,13 +78,13 @@ class HasOneSql extends HasOne
         $ourModel = $this->getOurModel();
 
         // if caption/type is not defined in $defaults then infer it from their field
-        $refModel = $ourModel->getReference($this->link)->createTheirModel();
-        $refModelField = $refModel->getField($theirFieldName);
-        $defaults['type'] ??= $refModelField->type;
-        $defaults['enum'] ??= $refModelField->enum;
-        $defaults['values'] ??= $refModelField->values;
-        $defaults['caption'] ??= $refModelField->caption;
-        $defaults['ui'] = array_merge($defaults['ui'] ?? $refModelField->ui, ['editable' => false]);
+        $analysingTheirModel = $ourModel->getReference($this->link)->createAnalysingTheirModel();
+        $analysingTheirField = $analysingTheirModel->getField($theirFieldName);
+        $defaults['type'] ??= $analysingTheirField->type;
+        $defaults['enum'] ??= $analysingTheirField->enum;
+        $defaults['values'] ??= $analysingTheirField->values;
+        $defaults['caption'] ??= $analysingTheirField->caption;
+        $defaults['ui'] = array_merge($defaults['ui'] ?? $analysingTheirField->ui, ['editable' => false]);
 
         $fieldExpression = $this->_addField($fieldName, false, $theirFieldName, $defaults);
 

--- a/src/Reference/WeakAnalysingBoxedArray.php
+++ b/src/Reference/WeakAnalysingBoxedArray.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Atk4\Data\Reference;
+
+/**
+ * @internal
+ *
+ * @template T of array<mixed>
+ */
+class WeakAnalysingBoxedArray
+{
+    /** @var T */
+    private array $value;
+
+    /**
+     * @param T $value
+     */
+    public function __construct(array $value)
+    {
+        $this->value = $value;
+    }
+
+    /**
+     * @return T
+     */
+    public function get(): array
+    {
+        return $this->value;
+    }
+}

--- a/src/Reference/WeakAnalysingMap.php
+++ b/src/Reference/WeakAnalysingMap.php
@@ -1,0 +1,247 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Atk4\Data\Reference;
+
+use Atk4\Core\WarnDynamicPropertyTrait;
+use Atk4\Data\Exception;
+use Atk4\Data\Persistence\Sql\Expression;
+
+/**
+ * @template TKey of object|array<mixed>
+ * @template TValue of object|array<mixed>
+ * @template TOwner of object
+ */
+class WeakAnalysingMap
+{
+    use WarnDynamicPropertyTrait;
+
+    /** @var WeakAnalysingBoxedArray<array{}> workaround https://github.com/php/php-src/issues/13612, remove once PHP 8.3 support is dropped */
+    private WeakAnalysingBoxedArray $destructedEarly;
+
+    private int $indexCounter = -1;
+
+    /** @var array<int, array<int, \WeakReference<(TKey is object ? TKey : WeakAnalysingBoxedArray<TKey>)>>> */
+    private array $keyByIndexByHash = [];
+    /** @var array<int, array{\WeakReference<(TValue is object ? TValue : WeakAnalysingBoxedArray<TValue>)>, int}> */
+    private array $valueWithOwnerCountByIndex = [];
+    /** @var \WeakMap<TOwner, object> */
+    private \WeakMap $ownerDestructorHandlers;
+
+    public function __construct()
+    {
+        $this->ownerDestructorHandlers = new \WeakMap();
+
+        $this->destructedEarly = new WeakAnalysingBoxedArray([]);
+    }
+
+    final protected function makeHashFromKeyUpdate(\HashContext $hashContext, string $value): void
+    {
+        if (str_contains($value, "\xff")) {
+            $value = str_replace("\xff", "\xff\xff", $value);
+        }
+        hash_update($hashContext, $value);
+        hash_update($hashContext, "-\xff");
+    }
+
+    /**
+     * @param ($hashContext is null ? TKey : mixed) $value
+     *
+     * @return ($hashContext is null ? int : null)
+     */
+    protected function makeHashFromKey($value, \HashContext $hashContext = null): ?int
+    {
+        if ($hashContext === null) {
+            $hashContext = hash_init('crc32c');
+            $return = true;
+        } else {
+            $return = false;
+        }
+
+        $this->makeHashFromKeyUpdate($hashContext, gettype($value));
+
+        if (is_array($value)) {
+            foreach ($value as $k => $v) {
+                $this->makeHashFromKeyUpdate($hashContext, (string) $k);
+                $this->makeHashFromKey($v, $hashContext);
+            }
+        } else {
+            if (is_object($value)) {
+                $value = spl_object_id($value);
+            } elseif (is_resource($value)) {
+                $value = get_resource_id($value);
+            }
+
+            $this->makeHashFromKeyUpdate(
+                $hashContext,
+                is_float($value)
+                    ? Expression::castFloatToString($value)
+                    : (string) $value
+            );
+        }
+
+        return $return
+            ? hexdec(hash_final($hashContext))
+            : null;
+    }
+
+    /**
+     * @template T of TKey|TValue
+     *
+     * @param T $value
+     *
+     * @return (T is object ? T : WeakAnalysingBoxedArray<T>)
+     */
+    protected function boxValue($value): object
+    {
+        return is_array($value)
+            ? new WeakAnalysingBoxedArray($value)
+            : $value;
+    }
+
+    /**
+     * @template T of TKey|TValue
+     *
+     * @param (T is object ? T : WeakAnalysingBoxedArray<T>) $value
+     *
+     * @return T
+     */
+    protected function unboxValue(object $value)
+    {
+        return $value instanceof WeakAnalysingBoxedArray
+            ? $value->get()
+            : $value;
+    }
+
+    /**
+     * @param TKey $keyA
+     * @param TKey $keyB
+     */
+    protected function isSameKey($keyA, $keyB): bool
+    {
+        return $keyA === $keyB;
+    }
+
+    /**
+     * @param TOwner $owner
+     */
+    protected function addKeyOwner(object $owner, int $hash, int $index): void
+    {
+        if (!$this->ownerDestructorHandlers->offsetExists($owner)) {
+            $this->ownerDestructorHandlers->offsetSet($owner, new class($this, $this->destructedEarly) {
+                /** @var \WeakReference<WeakAnalysingMap<TKey, TValue, TOwner>> */
+                private \WeakReference $weakAnalysingMap;
+                /** @var \WeakReference<WeakAnalysingBoxedArray<array{}>> */
+                private \WeakReference $weakAnalysingMapDestructedEarly;
+
+                /** @var array<int, array{int, (TKey is object ? TKey : WeakAnalysingBoxedArray<TKey>), (TValue is object ? TValue : WeakAnalysingBoxedArray<TValue>)}> */
+                private array $referencesByIndex = [];
+
+                /**
+                 * @param WeakAnalysingMap<TKey, TValue, TOwner> $analysingMap
+                 * @param WeakAnalysingBoxedArray<array{}>       $destructedEarly
+                 */
+                public function __construct(WeakAnalysingMap $analysingMap, WeakAnalysingBoxedArray $destructedEarly)
+                {
+                    $this->weakAnalysingMap = \WeakReference::create($analysingMap);
+                    $this->weakAnalysingMapDestructedEarly = \WeakReference::create($destructedEarly);
+                }
+
+                public function __destruct()
+                {
+                    if ($this->weakAnalysingMapDestructedEarly->get() === null) {
+                        return;
+                    }
+
+                    $analysingMap = $this->weakAnalysingMap->get();
+                    if ($analysingMap === null) {
+                        return;
+                    }
+
+                    $referencesByIndex = $this->referencesByIndex;
+                    \Closure::bind(static function () use ($analysingMap, $referencesByIndex) {
+                        foreach ($referencesByIndex as $index => [$hash]) {
+                            $ownerCount = --$analysingMap->valueWithOwnerCountByIndex[$index][1];
+                            if ($ownerCount === 0) {
+                                unset($analysingMap->keyByIndexByHash[$hash][$index]);
+                                if ($analysingMap->keyByIndexByHash[$hash] === []) {
+                                    unset($analysingMap->keyByIndexByHash[$hash]);
+                                }
+                                unset($analysingMap->valueWithOwnerCountByIndex[$index]);
+                            }
+                        }
+                    }, null, WeakAnalysingMap::class)();
+                }
+
+                public function addReference(int $hash, int $index): void
+                {
+                    if (!isset($this->referencesByIndex[$index])) {
+                        $analysingMap = $this->weakAnalysingMap->get();
+
+                        $this->referencesByIndex[$index] = \Closure::bind(static function () use ($analysingMap, $hash, $index) {
+                            ++$analysingMap->valueWithOwnerCountByIndex[$index][1];
+
+                            return [
+                                $hash,
+                                $analysingMap->keyByIndexByHash[$hash][$index]->get(),
+                                $analysingMap->valueWithOwnerCountByIndex[$index][0]->get(),
+                            ];
+                        }, null, WeakAnalysingMap::class)();
+                    }
+                }
+            });
+        }
+
+        $this->ownerDestructorHandlers->offsetGet($owner)
+            ->addReference($hash, $index);
+    }
+
+    /**
+     * @param TKey $key
+     *
+     * @return TValue|null
+     */
+    public function get($key, object $owner)
+    {
+        $hash = $this->makeHashFromKey($key);
+
+        foreach ($this->keyByIndexByHash[$hash] ?? [] as $index => $k) {
+            if ($this->isSameKey($this->unboxValue($k->get()), $key)) {
+                $value = $this->unboxValue($this->valueWithOwnerCountByIndex[$index][0]->get());
+
+                $this->addKeyOwner($owner, $hash, $index);
+
+                return $value;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * @param TKey   $key
+     * @param TValue $value
+     * @param TOwner $owner
+     */
+    public function set($key, $value, object $owner): void
+    {
+        $hash = $this->makeHashFromKey($key);
+
+        foreach ($this->keyByIndexByHash[$hash] ?? [] as $index => $k) {
+            if ($this->isSameKey($this->unboxValue($k->get()), $key)) {
+                throw (new Exception('Analysing key is already present'))
+                    ->addMoreInfo('key', $key);
+            }
+        }
+
+        $keyBoxed = $this->boxValue($key);
+        $valueBoxed = $this->boxValue($value);
+
+        $index = ++$this->indexCounter;
+        $this->keyByIndexByHash[$hash][$index] = \WeakReference::create($keyBoxed);
+        $this->valueWithOwnerCountByIndex[$index] = [\WeakReference::create($valueBoxed), 0];
+
+        $this->addKeyOwner($owner, $hash, $index);
+    }
+}

--- a/src/Reference/WeakAnalysingMap.php
+++ b/src/Reference/WeakAnalysingMap.php
@@ -115,15 +115,6 @@ class WeakAnalysingMap
     }
 
     /**
-     * @param TKey $keyA
-     * @param TKey $keyB
-     */
-    protected function isSameKey($keyA, $keyB): bool
-    {
-        return $keyA === $keyB;
-    }
-
-    /**
      * @param TOwner $owner
      */
     protected function addKeyOwner(object $owner, int $hash, int $index): void
@@ -207,7 +198,7 @@ class WeakAnalysingMap
         $hash = $this->makeHashFromKey($key);
 
         foreach ($this->keyByIndexByHash[$hash] ?? [] as $index => $k) {
-            if ($this->isSameKey($this->unboxValue($k->get()), $key)) {
+            if ($this->unboxValue($k->get()) === $key) {
                 $value = $this->unboxValue($this->valueWithOwnerCountByIndex[$index][0]->get());
 
                 $this->addKeyOwner($owner, $hash, $index);
@@ -229,7 +220,7 @@ class WeakAnalysingMap
         $hash = $this->makeHashFromKey($key);
 
         foreach ($this->keyByIndexByHash[$hash] ?? [] as $index => $k) {
-            if ($this->isSameKey($this->unboxValue($k->get()), $key)) {
+            if ($this->unboxValue($k->get()) === $key) {
                 throw (new Exception('Analysing key is already present'))
                     ->addMoreInfo('key', $key);
             }

--- a/src/Reference/WeakAnalysingMap.php
+++ b/src/Reference/WeakAnalysingMap.php
@@ -82,9 +82,16 @@ class WeakAnalysingMap
             );
         }
 
-        return $return
-            ? hexdec(hash_final($hashContext))
-            : null;
+        if (!$return) {
+            return null;
+        }
+
+        $hex = hash_final($hashContext);
+        if (\PHP_INT_SIZE === 4) {
+            $hex = dechex(hexdec(substr($hex, 0, 4)) & ((1 << 15) - 1)) . substr($hex, 4, 4);
+        }
+
+        return hexdec($hex);
     }
 
     /**

--- a/src/Reference/WeakAnalysingMap.php
+++ b/src/Reference/WeakAnalysingMap.php
@@ -62,6 +62,7 @@ class WeakAnalysingMap
         $this->makeHashFromKeyUpdate($hashContext, gettype($value));
 
         if (is_array($value)) {
+            $this->makeHashFromKeyUpdate($hashContext, (string) count($value));
             foreach ($value as $k => $v) {
                 $this->makeHashFromKeyUpdate($hashContext, (string) $k);
                 $this->makeHashFromKey($v, $hashContext);

--- a/src/Schema/TestCase.php
+++ b/src/Schema/TestCase.php
@@ -63,6 +63,9 @@ abstract class TestCase extends BaseTestCase
         if (\PHP_VERSION_ID < 80300) {
             // workaround https://github.com/php/php-src/issues/10043
             \Closure::bind(static function () {
+                if ((Reference::$analysingClosureMap ?? null) !== null) {
+                    Reference::$analysingClosureMap = new Reference\WeakAnalysingMap();
+                }
                 if ((Reference::$analysingTheirModelMap ?? null) !== null) {
                     Reference::$analysingTheirModelMap = new Reference\WeakAnalysingMap();
                 }

--- a/src/Schema/TestCase.php
+++ b/src/Schema/TestCase.php
@@ -8,6 +8,7 @@ use Atk4\Core\Phpunit\TestCase as BaseTestCase;
 use Atk4\Data\Model;
 use Atk4\Data\Persistence;
 use Atk4\Data\Persistence\Sql\Expression;
+use Atk4\Data\Reference;
 use Doctrine\DBAL\ParameterType;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Platforms\MySQLPlatform;
@@ -57,6 +58,15 @@ abstract class TestCase extends BaseTestCase
             $this->dropCreatedDb();
         } finally {
             $this->debug = $debugOrig;
+        }
+
+        if (\PHP_VERSION_ID < 80300) {
+            // workaround https://github.com/php/php-src/issues/10043
+            \Closure::bind(static function () {
+                if ((Reference::$analysingTheirModelMap ?? null) !== null) {
+                    Reference::$analysingTheirModelMap = new Reference\WeakAnalysingMap();
+                }
+            }, null, Reference::class)();
         }
 
         parent::tearDown();

--- a/src/Util/DeepCopy.php
+++ b/src/Util/DeepCopy.php
@@ -250,7 +250,7 @@ class DeepCopy
                     $this->debug('Proceeding with ' . $refKey);
 
                     // load destination model through $source
-                    $refSourceTable = $source->getModel()->getReference($refKey)->createTheirModel()->table;
+                    $refSourceTable = $source->getModel()->getReference($refKey)->createAnalysingTheirModel()->table;
 
                     if (isset($this->mapping[$refSourceTable])
                         && array_key_exists($source->get($refKey), $this->mapping[$refSourceTable])

--- a/tests/Persistence/ArrayTest.php
+++ b/tests/Persistence/ArrayTest.php
@@ -836,7 +836,7 @@ class ArrayTest extends TestCase
         $country = new Model($p, ['table' => 'country']);
         $country->addField('name');
 
-        $user = new Model();
+        $user = new Model($p);
         $user->table = 'user';
         $user->addField('name');
         $user->addField('surname');

--- a/tests/Reference/WeakAnalysingMapTest.php
+++ b/tests/Reference/WeakAnalysingMapTest.php
@@ -119,6 +119,18 @@ class WeakAnalysingMapTest extends TestCase
         self::assertNull($weakKey->get());
     }
 
+    public function testDestructBeforeOwner(): void
+    {
+        $owner = new \stdClass();
+
+        (new WeakAnalysingMap())
+            ->set(new \stdClass(), new \stdClass(), $owner);
+
+        $weakOwner = \WeakReference::create($owner);
+        unset($owner);
+        self::assertNull($weakOwner->get());
+    }
+
     public function testSetKeyAlreadyPresentException(): void
     {
         $map = new WeakAnalysingMap();

--- a/tests/Reference/WeakAnalysingMapTest.php
+++ b/tests/Reference/WeakAnalysingMapTest.php
@@ -1,0 +1,146 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Atk4\Data\Tests\Reference;
+
+use Atk4\Data\Exception;
+use Atk4\Data\Reference\WeakAnalysingMap;
+use Atk4\Data\Schema\TestCase;
+
+class WeakAnalysingMapTest extends TestCase
+{
+    /**
+     * @param WeakAnalysingMap<object|array<mixed>, object|array<mixed>, object> $map
+     */
+    private function forceWeakMapPolyfillHousekeeping(WeakAnalysingMap $map): void
+    {
+        // https://github.com/BenMorel/weakmap-polyfill/blob/0.4.0/src/WeakMap.php#L126
+        $weakMap = \Closure::bind(static fn () => $map->ownerDestructorHandlers, null, WeakAnalysingMap::class)();
+        count($weakMap); // @phpstan-ignore-line
+    }
+
+    public function testBasic(): void
+    {
+        $map = new WeakAnalysingMap();
+
+        self::assertNull($map->get(new \stdClass(), $map));
+        self::assertNull($map->get(new \stdClass(), new \stdClass()));
+
+        $key1 = new \stdClass();
+        $key2 = new \stdClass();
+        $key3 = new \stdClass();
+        $value1 = new \stdClass();
+        $value2 = new \stdClass();
+        $value3 = new \stdClass();
+        $owner1 = new \stdClass();
+        $owner2 = new \stdClass();
+        $weakKey = \WeakReference::create($key1);
+        $weakValue = \WeakReference::create($value1);
+        $weakOwner = \WeakReference::create($owner1);
+
+        $map->set($key1, $value1, $owner1);
+        $map->set($key2, $value2, $owner1);
+        $map->set($key3, $value3, $owner2);
+        self::assertSame($value1, $map->get($key1, $owner1));
+        self::assertSame($value2, $map->get($key2, $owner1));
+        self::assertSame($value3, $map->get($key3, $owner2));
+        self::assertSame($value1, $map->get($key1, new \stdClass()));
+        self::assertSame($value2, $map->get($key2, $owner2));
+
+        unset($owner1);
+        $this->forceWeakMapPolyfillHousekeeping($map);
+        self::assertNull($map->get($key1, new \stdClass()));
+        self::assertSame($value2, $map->get($key2, new \stdClass()));
+        self::assertSame($value3, $map->get($key3, new \stdClass()));
+
+        unset($owner2);
+        $this->forceWeakMapPolyfillHousekeeping($map);
+        self::assertNull($map->get($key1, new \stdClass()));
+        self::assertNull($map->get($key2, new \stdClass()));
+        self::assertNull($map->get($key3, new \stdClass()));
+
+        unset($key1);
+        unset($value1);
+        self::assertNull($weakKey->get());
+        self::assertNull($weakValue->get());
+        self::assertNull($weakOwner->get());
+    }
+
+    public function testBoxedArray(): void
+    {
+        $map = new WeakAnalysingMap();
+
+        $key1 = [];
+        $key2 = [null, false, true, 1, 1.5, 'foo', "\x00", "\xff"];
+        $key3 = [new \stdClass(), fopen('php://memory', 'r+')];
+        $value1 = [];
+        $value2 = [null];
+        $value3 = [new \stdClass()];
+        $owner1 = new \stdClass();
+        $owner2 = new \stdClass();
+        $weakKeyObject = \WeakReference::create($key3[0]);
+        $weakValueObject = \WeakReference::create($value3[0]);
+
+        $map->set($key1, $value1, $owner1);
+        $map->set($key2, $value2, $owner1);
+        $map->set($key3, $value3, $owner2);
+        self::assertSame($value1, $map->get($key1, $owner1));
+        self::assertSame($value2, $map->get($key2, $owner1));
+        self::assertSame($value3, $map->get($key3, $owner2));
+
+        unset($owner1);
+        $this->forceWeakMapPolyfillHousekeeping($map);
+        self::assertNull($map->get($key1, new \stdClass()));
+        self::assertNull($map->get($key2, new \stdClass()));
+        self::assertSame($value3, $map->get($key3, new \stdClass()));
+
+        unset($owner2);
+        $this->forceWeakMapPolyfillHousekeeping($map);
+        self::assertNull($map->get($key1, new \stdClass()));
+        self::assertNull($map->get($key2, new \stdClass()));
+        self::assertNull($map->get($key3, new \stdClass()));
+
+        unset($key3);
+        unset($value3);
+        self::assertNull($weakKeyObject->get());
+        self::assertNull($weakValueObject->get());
+    }
+
+    public function testDestructBeforeKey(): void
+    {
+        $key = new \stdClass();
+
+        (new WeakAnalysingMap())
+            ->set($key, new \stdClass(), new \stdClass());
+
+        $weakKey = \WeakReference::create($key);
+        unset($key);
+        self::assertNull($weakKey->get());
+    }
+
+    public function testSetKeyAlreadyPresentException(): void
+    {
+        $map = new WeakAnalysingMap();
+
+        $key = new \stdClass();
+        $value = new \stdClass();
+        $owner = new \stdClass();
+
+        $map->set($key, $value, $owner);
+
+        $e = false;
+        try {
+            $map->set($key, $value, $owner);
+        } catch (Exception $e) {
+            $e = $e->getMessage();
+        } finally {
+            self::assertSame($value, $map->get($key, $owner));
+
+            unset($owner);
+            $this->forceWeakMapPolyfillHousekeeping($map);
+            self::assertNull($map->get($key, $key));
+        }
+        self::assertSame('Analysing key is already present', $e);
+    }
+}

--- a/tests/Reference/WeakAnalysingMapTest.php
+++ b/tests/Reference/WeakAnalysingMapTest.php
@@ -155,4 +155,25 @@ class WeakAnalysingMapTest extends TestCase
         }
         self::assertSame('Analysing key is already present', $e);
     }
+
+    public function testGetSetKeyWithHashCollision(): void
+    {
+        $map = new WeakAnalysingMap();
+
+        $makeHashFromKeyFx = \Closure::bind(static fn ($v) => $map->makeHashFromKey($v), null, WeakAnalysingMap::class);
+
+        $hashes = array_map(static fn ($v) => $makeHashFromKeyFx([$v]), range(1, 2_000));
+        self::assertSameSize($hashes, array_unique($hashes));
+
+        $key1 = [5_371_838];
+        $key2 = [6_000_402];
+        self::assertSame($makeHashFromKeyFx($key1), $makeHashFromKeyFx($key2));
+
+        $value1 = new \stdClass();
+        $value2 = new \stdClass();
+        $map->set($key1, $value1, $map);
+        $map->set($key2, $value2, $map);
+        self::assertSame($value1, $map->get($key1, new \stdClass()));
+        self::assertSame($value2, $map->get($key2, new \stdClass()));
+    }
 }

--- a/tests/ReferenceSqlTest.php
+++ b/tests/ReferenceSqlTest.php
@@ -358,16 +358,14 @@ class ReferenceSqlTest extends TestCase
         $integerWrappedTypeName = $integerWrappedType->getName(); // @phpstan-ignore-line
 
         $this->executeFxWithTemporaryType($integerWrappedTypeName, $integerWrappedType, function () use ($integerWrappedType, $integerWrappedTypeName) {
-            $createFileModelFx = static function (Persistence $persistence) use ($integerWrappedTypeName /* , &$createFileModelFx */) {
-                $createFileModelFx = &$m; // TODO
-
+            $createFileModelFx = static function (Persistence $persistence) use ($integerWrappedTypeName) {
                 $m = new Model($persistence, ['table' => 'file']);
                 $m->getField('id')->type = $integerWrappedTypeName;
                 $m->addField('name');
-                $m->hasOne('parentDirectory', ['model' => $createFileModelFx, 'ourField' => 'parentDirectoryId']);
-                $m->hasMany('childFiles', ['model' => $createFileModelFx, 'theirField' => 'parentDirectoryId']);
+                $m->hasOne('parentDirectory', ['model' => $m, 'ourField' => 'parentDirectoryId']);
+                $m->hasMany('childFiles', ['model' => $m, 'theirField' => 'parentDirectoryId']);
 
-                return $m;
+                return clone $m;
             };
 
             $file = $createFileModelFx($this->db);

--- a/tests/ReferenceSqlTest.php
+++ b/tests/ReferenceSqlTest.php
@@ -358,11 +358,13 @@ class ReferenceSqlTest extends TestCase
         $integerWrappedTypeName = $integerWrappedType->getName(); // @phpstan-ignore-line
 
         $this->executeFxWithTemporaryType($integerWrappedTypeName, $integerWrappedType, function () use ($integerWrappedType, $integerWrappedTypeName) {
-            $createFileModelFx = static function (Persistence $persistence) use ($integerWrappedTypeName, &$createFileModelFx) {
+            $createFileModelFx = static function (Persistence $persistence) use ($integerWrappedTypeName /* , &$createFileModelFx */) {
+                $createFileModelFx = &$m; // TODO
+
                 $m = new Model($persistence, ['table' => 'file']);
                 $m->getField('id')->type = $integerWrappedTypeName;
                 $m->addField('name');
-                $m->hasOne('parentDirectory', ['model' => $createFileModelFx, 'ourField' => 'parentDirectoryId', 'type' => $integerWrappedTypeName]);
+                $m->hasOne('parentDirectory', ['model' => $createFileModelFx, 'ourField' => 'parentDirectoryId']);
                 $m->hasMany('childFiles', ['model' => $createFileModelFx, 'theirField' => 'parentDirectoryId']);
 
                 return $m;

--- a/tests/ScopeTest.php
+++ b/tests/ScopeTest.php
@@ -163,10 +163,10 @@ class ScopeTest extends TestCase
 
     public function testEditableHasOne(): void
     {
-        $gender = new Model();
+        $gender = new Model(null, ['table' => 'gender']);
         $gender->addField('name');
 
-        $m = new Model();
+        $m = new Model($this->db, ['table' => 'user']);
         $m->addField('name');
         $m->hasOne('gender_id', ['model' => $gender]);
 


### PR DESCRIPTION
Use dark magic to overcome natural recursion of recursively referenced models.

fix hardcoded HasOne type - https://github.com/atk4/data/blob/5.0.0/src/Reference/HasOne.php#L30

other examples are https://github.com/atk4/data/blob/5.0.0/tests/RandomTest.php#L70

## BC break - model init / persistence might be required earlier

HasOne cannot be traversed (via `->createTheirModel()` or `->ref()`) without persistence set. Newly, our field type is infered, and as their model needs to be created for that, persistence must be set early to make the their model initialized.

Also make sure `parent::init()` is called always as the first statement in all your `Model::init()` methods.

## BC break - possible infine recursion

As we now infer their field type in HasOne, recursive models must use the strictly the same seed.

If your code ends with infine recursion, you need to take an action. If not, there is no BC break.

If you define their model as `['model' => new TheirModel()]`, replace it with `['model' => [TheirModel::class]]`.

## BC break - persistence can be referenced forever (only for PHP 8.2 and lower)

WeakMap values do not participate in GC. If you do not reopen connections to DBs during (one request/script run), no action is needed.