### PR TITLE
`HasOneSQL::addField` does not support save (editable)

### DIFF
--- a/src/Field.php
+++ b/src/Field.php
@@ -454,7 +454,7 @@ class Field implements Expressionable
      */
     public function isEditable(): bool
     {
-        return $this->ui['editable'] ?? !$this->read_only && !$this->never_persist && !$this->system;
+        return $this->ui['editable'] ?? !$this->read_only && !$this->never_persist && !$this->never_save && !$this->system;
     }
 
     /**

--- a/src/Reference/HasOneSql.php
+++ b/src/Reference/HasOneSql.php
@@ -28,6 +28,8 @@ class HasOneSql extends HasOne
         $defaults['caption'] ??= $refModelField->caption;
         $defaults['ui'] ??= $refModelField->ui;
 
+        $defaults['ui'] = array_merge($defaults['ui'], ['editable' => false]);
+
         $fieldExpression = $ourModel->addExpression($fieldName, array_merge(
             [
                 'expr' => function (Model $ourModel) use ($theirFieldName) {

--- a/src/Reference/HasOneSql.php
+++ b/src/Reference/HasOneSql.php
@@ -28,8 +28,6 @@ class HasOneSql extends HasOne
         $defaults['caption'] ??= $refModelField->caption;
         $defaults['ui'] ??= $refModelField->ui;
 
-        $defaults['ui'] = array_merge($defaults['ui'], ['editable' => false]);
-
         $fieldExpression = $ourModel->addExpression($fieldName, array_merge(
             [
                 'expr' => function (Model $ourModel) use ($theirFieldName) {


### PR DESCRIPTION
fixes https://github.com/atk4/data/issues/929

expected behaviour seems described in https://github.com/atk4/data/blob/5c411d2cd8430c84e7472219c0ec62909176d7ea/src/Model/FieldPropertiesTrait.php#L97-L105

but there are some hooks I do not fully understand their general purpose

https://github.com/atk4/data/blob/develop/src/Reference/HasOneSql.php#L49-L59

and `HasOne` class has these

https://github.com/atk4/data/blob/develop/src/Reference/HasOne.php#L77-L114

but these are not used for `HasOneSql::addField`, as field is created using `refLink` nad `ref` is not called at all

@georgehristov @DarkSide666 @ibelar what do you think, what should be the expected behaviour and how to resolve the issue above?