### PR TITLE
Expression::render must not mutate the state

### DIFF
--- a/docs/persistence/sql/advanced.rst
+++ b/docs/persistence/sql/advanced.rst
@@ -185,8 +185,8 @@ Manual Query Execution
 If you are not satisfied with :php:meth:`Expression::execute` you can execute
 query yourself.
 
-1. :php:meth:`Expression::render` query, then send it into PDO::prepare();
-2. use new $statement to bindValue with the contents of :php:attr:`Expression::params`;
+1. :php:meth:`Expression::render` query, then send the 1st element into PDO::prepare();
+2. use new $statement to bindValue with the contents of 2nd element;
 3. set result fetch mode and parameters;
 4. execute() your statement
 

--- a/docs/persistence/sql/expressions.rst
+++ b/docs/persistence/sql/expressions.rst
@@ -74,12 +74,6 @@ instead. DSQL can consist of multiple objects and each object may have
 some parameters. During `rendering`_ those parameters are joined together to
 produce one complete query.
 
-.. php:attr:: params
-
-    This public property will contain the actual values of all the parameters.
-    When multiple queries are merged together, their parameters are
-    `interlinked <http://php.net/manual/en/language.references.php>`_.
-
 
 Creating Expression
 ===================
@@ -151,13 +145,12 @@ Rendering
 =========
 
 An expression can be rendered into a valid SQL code by calling render() method.
-The method will return a string, however it will use references for `parameters`_.
+The method will return an array with string and params.
 
 .. php:method:: render()
 
-    Converts :php:class:`Expression` object to a string. Parameters are
-    replaced with :a, :b, etc. Their original values can be found in
-    :php:attr:`params`.
+    Converts :php:class:`Expression` object to an array with string and params.
+    Parameters are replaced with :a, :b, etc.
 
 
 Executing Expressions

--- a/docs/persistence/sql/quickstart.rst
+++ b/docs/persistence/sql/quickstart.rst
@@ -131,13 +131,12 @@ Creating Objects and PDO
 DSQL classes does not need database connection for most of it's work. Once you
 create new instance of :ref:`Expression <expr>` or :ref:`Query <query>` you can
 perform operation and finally call :php:meth:`Expression::render()` to get the
-final query string::
+final query string with params:
 
     use Atk4\Data\Persistence\Sql\Query;
 
     $q = (new Query())->table('user')->where('id', 1)->field('name');
-    $query = $q->render();
-    $params = $q->params;
+    [$query, $params] = $q->render();
 
 When used in application you would typically generate queries with the
 purpose of executing them, which makes it very useful to create a

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -36,7 +36,7 @@ parameters:
             message: '~^(Call to an undefined method Doctrine\\DBAL\\Driver\\Connection::getWrappedConnection\(\)\.|Call to an undefined method Doctrine\\DBAL\\Connection::createSchemaManager\(\)\.|Call to an undefined static method Doctrine\\DBAL\\Exception::invalidPdoInstance\(\)\.|Call to method getCreateTableSQL\(\) of deprecated class Doctrine\\DBAL\\Platforms\\AbstractPlatform:\n.+|Anonymous class extends deprecated class Doctrine\\DBAL\\Platforms\\PostgreSQL94Platform:\n.+|Call to deprecated method fetch(|All)\(\) of class Doctrine\\DBAL\\Result:\n.+|Call to deprecated method getSchemaManager\(\) of class Doctrine\\DBAL\\Connection:\n.+|Access to an undefined property Doctrine\\DBAL\\Driver\\PDO\\Connection::\$connection\.|Parameter #1 \$dsn of class Doctrine\\DBAL\\Driver\\PDO\\SQLSrv\\Connection constructor expects string, Doctrine\\DBAL\\Driver\\PDO\\Connection given\.|Method Atk4\\Data\\Persistence\\Sql\\Expression::execute\(\) should return Doctrine\\DBAL\\Result\|PDOStatement but returns bool\.|PHPDoc tag @return contains generic type Doctrine\\DBAL\\Schema\\AbstractSchemaManager<Doctrine\\DBAL\\Platforms\\AbstractPlatform> but class Doctrine\\DBAL\\Schema\\AbstractSchemaManager is not generic\.|Class Doctrine\\DBAL\\Platforms\\(MySqlPlatform|PostgreSqlPlatform) referenced with incorrect case: Doctrine\\DBAL\\Platforms\\(MySQLPlatform|PostgreSQLPlatform)\.)$~'
             path: '*'
             # count for DBAL 3.x matched in "src/Persistence/GenericPlatform.php" file
-            count: 40
+            count: 42
 
         # TODO these rules are generated, this ignores should be fixed in the code
         # for src/Schema/TestCase.php

--- a/src/Persistence/GenericPlatform.php
+++ b/src/Persistence/GenericPlatform.php
@@ -50,6 +50,8 @@ class GenericPlatform extends Platforms\AbstractPlatform
                 $connection->getSchemaManager();
                 $connection->getSchemaManager();
                 $connection->getSchemaManager();
+                $connection->getSchemaManager();
+                $connection->getSchemaManager();
             }
         }
 

--- a/src/Persistence/Sql/Expression.php
+++ b/src/Persistence/Sql/Expression.php
@@ -363,21 +363,9 @@ class Expression implements Expressionable, \ArrayAccess
                 || strpos($value, $this->escape_char) !== false;
     }
 
-    /**
-     * Render expression and return it as string.
-     */
-    public function render(): string
+
+    private function _render(): string
     {
-        $hadUnderscoreParamBase = $this->_paramBase !== null;
-        if (!$hadUnderscoreParamBase) {
-            $hadUnderscoreParamBase = false;
-            $this->_paramBase = $this->paramBase;
-        }
-
-        if ($this->template === null) {
-            throw new Exception('Template is not defined for Expression');
-        }
-
         $nameless_count = 0;
 
         // - [xxx] = param
@@ -435,8 +423,29 @@ class Expression implements Expressionable, \ArrayAccess
             $this->template
         );
 
-        if (!$hadUnderscoreParamBase) {
-            $this->_paramBase = null;
+        return trim($res);
+    }
+
+    /**
+     * Render expression and return it as string.
+     */
+    public function render(): string
+    {
+        if ($this->template === null) {
+            throw new Exception('Template is not defined for Expression');
+        }
+
+        $fromConsume = $this->_paramBase !== null;
+        if (!$fromConsume) {
+            $this->_paramBase = $this->paramBase;
+        }
+
+        try {
+            $res = $this->_render();
+        } finally {
+            if (!$fromConsume) {
+                $this->_paramBase = null;
+            }
         }
 
         return trim($res);

--- a/src/Persistence/Sql/Expression.php
+++ b/src/Persistence/Sql/Expression.php
@@ -433,9 +433,11 @@ class Expression implements Expressionable, \ArrayAccess
     }
 
     /**
-     * Render expression and return it as string.
+     * Render expression to an array with SQL string and its params.
+     *
+     * @return array{string, array<string, mixed>}
      */
-    public function render(): string
+    public function render(): array
     {
         $keepParams = $this->_paramBase !== null; // for renderWithParams(), TODO, render should always return an array
         if (!$keepParams) {
@@ -452,7 +454,7 @@ class Expression implements Expressionable, \ArrayAccess
             }
         }
 
-        return trim($res);
+        return [trim($res), $this->params];
     }
 
     /**
@@ -463,7 +465,7 @@ class Expression implements Expressionable, \ArrayAccess
         try {
             $this->_paramBase = $this->paramBase; // hack to keep params from render()
 
-            return [$this->render(), $this->params];
+            return [$this->render()[0], $this->params];
         } finally {
             $this->_paramBase = null;
             $this->params = [];

--- a/src/Persistence/Sql/Join.php
+++ b/src/Persistence/Sql/Join.php
@@ -35,7 +35,7 @@ class Join extends Model\Join
     {
         parent::init();
 
-        $this->getOwner()->persistence_data['use_table_prefixes'] = true;
+        $this->getOwner()->persistence_data['use_table_prefixes'] = true; // TODO thus mutates the owner model!
 
         // our short name will be unique
         if (!$this->foreign_alias) {

--- a/src/Persistence/Sql/Mssql/ExpressionTrait.php
+++ b/src/Persistence/Sql/Mssql/ExpressionTrait.php
@@ -21,9 +21,9 @@ trait ExpressionTrait
         return preg_replace('~(?:\'(?:\'\'|\\\\\'|[^\'])*\')?+\K\]([^\[\]\'"(){}]*?)\]~s', '[$1]', $v);
     }
 
-    public function renderWithParams(): array
+    public function render(): array
     {
-        [$sql, $params] = parent::renderWithParams();
+        [$sql, $params] = parent::render();
 
         // convert all SQL strings to NVARCHAR, eg 'text' to N'text'
         $sql = preg_replace_callback('~(^|.)(\'(?:\'\'|\\\\\'|[^\'])*\')~s', function ($matches) {
@@ -35,7 +35,7 @@ trait ExpressionTrait
         $calledFromExecute = false;
         foreach ($trace as $frame) {
             if (($frame['object'] ?? null) === $this) {
-                if (($frame['function'] ?? null) === 'renderWithParams') {
+                if (($frame['function'] ?? null) === 'render') {
                     continue;
                 } elseif (($frame['function'] ?? null) === 'execute') {
                     $calledFromExecute = true;

--- a/src/Persistence/Sql/Mssql/ExpressionTrait.php
+++ b/src/Persistence/Sql/Mssql/ExpressionTrait.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace Atk4\Data\Persistence\Sql\Mssql;
 
-use Doctrine\DBAL\Result as DbalResult;
-
 trait ExpressionTrait
 {
     protected function escapeIdentifier(string $value): string
@@ -23,84 +21,46 @@ trait ExpressionTrait
         return preg_replace('~(?:\'(?:\'\'|\\\\\'|[^\'])*\')?+\K\]([^\[\]\'"(){}]*?)\]~s', '[$1]', $v);
     }
 
-    private function _render(): string
+    public function renderWithParams(): array
     {
+        [$sql, $params] = parent::renderWithParams();
+
         // convert all SQL strings to NVARCHAR, eg 'text' to N'text'
-        return preg_replace_callback('~(^|.)(\'(?:\'\'|\\\\\'|[^\'])*\')~s', function ($matches) {
+        $sql = preg_replace_callback('~(^|.)(\'(?:\'\'|\\\\\'|[^\'])*\')~s', function ($matches) {
             return $matches[1] . (!in_array($matches[1], ['N', '\'', '\\'], true) ? 'N' : '') . $matches[2];
-        }, parent::render());
-    }
+        }, $sql);
 
-    // {{{ MSSQL does not support named parameters, so convert them to numerical inside execute
+        // MSSQL does not support named parameters, so convert them to numerical when called from execute
+        $trace = debug_backtrace(\DEBUG_BACKTRACE_PROVIDE_OBJECT | \DEBUG_BACKTRACE_IGNORE_ARGS, 10);
+        $calledFromExecute = false;
+        foreach ($trace as $frame) {
+            if (($frame['object'] ?? null) === $this) {
+                if (($frame['function'] ?? null) === 'renderWithParams') {
+                    continue;
+                } elseif (($frame['function'] ?? null) === 'execute') {
+                    $calledFromExecute = true;
+                }
+            }
 
-    /** @var array|null */
-    private $numQueryParamsBackup;
-    /** @var string|null */
-    private $numQueryRender;
-
-    /**
-     * @return DbalResult|\PDOStatement PDOStatement iff for DBAL 2.x
-     */
-    public function execute(object $connection = null): object
-    {
-        if ($this->numQueryParamsBackup !== null) {
-            return parent::execute($connection);
+            break;
         }
 
-        $this->numQueryParamsBackup = $this->params;
-        try {
+        if ($calledFromExecute) {
             $numParams = [];
             $i = 0;
             $j = 0;
-            $this->numQueryRender = preg_replace_callback(
+            $sql = preg_replace_callback(
                 '~(?:\'(?:\'\'|\\\\\'|[^\'])*\')?+\K(?:\?|:\w+)~s',
-                function ($matches) use (&$numParams, &$i, &$j) {
-                    $numParams[++$i] = $this->params[$matches[0] === '?' ? ++$j : $matches[0]];
+                function ($matches) use ($params, &$numParams, &$i, &$j) {
+                    $numParams[++$i] = $params[$matches[0] === '?' ? ++$j : $matches[0]];
 
                     return '?';
                 },
-                $this->_render()
+                $sql
             );
-            $this->params = $numParams;
-
-            return parent::execute($connection);
-        } finally {
-            $this->params = $this->numQueryParamsBackup;
-            $this->numQueryParamsBackup = null;
-            $this->numQueryRender = null;
+            $params = $numParams;
         }
+
+        return [$sql, $params];
     }
-
-    public function render(): string
-    {
-        if ($this->numQueryParamsBackup !== null) {
-            return $this->numQueryRender;
-        }
-
-        return $this->_render();
-    }
-
-    public function getDebugQuery(): string
-    {
-        if ($this->numQueryParamsBackup === null) {
-            return parent::getDebugQuery();
-        }
-
-        $paramsBackup = $this->params;
-        $numQueryRenderBackupBackup = $this->numQueryParamsBackup;
-        $numQueryRenderBackup = $this->numQueryRender;
-        try {
-            $this->params = $this->numQueryParamsBackup;
-            $this->numQueryParamsBackup = null;
-            $this->numQueryRender = null;
-
-            return parent::getDebugQuery();
-        } finally {
-            $this->params = $paramsBackup;
-            $this->numQueryParamsBackup = $numQueryRenderBackupBackup;
-            $this->numQueryRender = $numQueryRenderBackup;
-        }
-    }
-
-    /// }}}
 }

--- a/src/Persistence/Sql/Oracle/PlatformTrait.php
+++ b/src/Persistence/Sql/Oracle/PlatformTrait.php
@@ -80,7 +80,7 @@ trait PlatformTrait
                 'pk' => $nameIdentifier->getName(),
                 'pk_seq' => $pkSeq,
             ]
-        )->render();
+        )->render()[0];
 
         return $sqls;
     }

--- a/src/Persistence/Sql/Oracle/Query.php
+++ b/src/Persistence/Sql/Oracle/Query.php
@@ -13,7 +13,7 @@ class Query extends BaseQuery
 {
     protected $paramBase = 'xxaaaa';
 
-    public function render(): string
+    public function render(): array
     {
         if ($this->mode === 'select' && $this->main_table === null) {
             $this->table('DUAL');

--- a/src/Persistence/Sql/Oracle/Query.php
+++ b/src/Persistence/Sql/Oracle/Query.php
@@ -15,7 +15,7 @@ class Query extends BaseQuery
 
     public function render(): array
     {
-        if ($this->mode === 'select' && $this->main_table === null) {
+        if ($this->mode === 'select' && count($this->args['table'] ?? []) === 0) {
             $this->table('DUAL');
         }
 

--- a/src/Persistence/Sql/Oracle/Query.php
+++ b/src/Persistence/Sql/Oracle/Query.php
@@ -16,7 +16,13 @@ class Query extends BaseQuery
     public function render(): array
     {
         if ($this->mode === 'select' && count($this->args['table'] ?? []) === 0) {
-            $this->table('DUAL');
+            try {
+                $this->table('DUAL');
+
+                return parent::render();
+            } finally {
+                unset($this->args['table']);
+            }
         }
 
         return parent::render();

--- a/src/Persistence/Sql/Postgresql/PlatformTrait.php
+++ b/src/Persistence/Sql/Postgresql/PlatformTrait.php
@@ -88,7 +88,7 @@ trait PlatformTrait
                 'pk_seq' => $pkSeqName,
                 'trigger_func' => $table->getName() . '_AI_FUNC', // TODO create only one function per schema
             ]
-        )->render();
+        )->render()[0];
 
         $sqls[] = $conn->expr(
             <<<'EOF'
@@ -103,7 +103,7 @@ trait PlatformTrait
                 'trigger' => $table->getName() . '_AI_PK',
                 'trigger_func' => $table->getName() . '_AI_FUNC',
             ]
-        )->render();
+        )->render()[0];
 
         return $sqls;
     }

--- a/src/Persistence/Sql/Query.php
+++ b/src/Persistence/Sql/Query.php
@@ -1065,19 +1065,18 @@ class Query extends Expression
     public function __debugInfo(): array
     {
         $arr = [
-            'R' => false,
-            'mode' => $this->mode,
+            //'mode' => $this->mode,
+            'R' => 'n/a',
+            'R_params' => 'n/a',
             //'template' => $this->template,
-            //'params' => $this->params, // available only after render
-            //'connection' => $this->connection,
-            //'main_table' => $this->main_table,
-            //'args' => $this->args,
+            //'templateArgs' => $this->args,
         ];
 
         try {
             $arr['R'] = $this->getDebugQuery();
+            $arr['R_params'] = $this->render()[1];
         } catch (\Exception $e) {
-            $arr['R'] = $e->getMessage();
+            $arr['R'] = get_class($e) . ': ' . $e->getMessage();
         }
 
         return $arr;

--- a/src/Persistence/Sql/Query.php
+++ b/src/Persistence/Sql/Query.php
@@ -1088,7 +1088,7 @@ class Query extends Expression
     /**
      * Renders query template. If the template is not explicitly set will use "select" mode.
      */
-    public function render(): string
+    public function render(): array
     {
         if (!$this->template) {
             $this->mode('select');

--- a/src/Persistence/Sql/Query.php
+++ b/src/Persistence/Sql/Query.php
@@ -1068,7 +1068,7 @@ class Query extends Expression
             'R' => false,
             'mode' => $this->mode,
             //'template' => $this->template,
-            //'params' => $this->params,
+            //'params' => $this->params, // available only after render
             //'connection' => $this->connection,
             //'main_table' => $this->main_table,
             //'args' => $this->args,

--- a/src/Reference/HasMany.php
+++ b/src/Reference/HasMany.php
@@ -55,9 +55,12 @@ class HasMany extends Reference
      */
     protected function referenceOurValue(): Field
     {
-        $this->getOurModel(null)->persistence_data['use_table_prefixes'] = true;
+        // TODO horrible hack to render the field with a table prefix,
+        // find a solution how to wrap the field inside custom Field (without owner?)
+        $ourModelCloned = clone $this->getOurModel(null);
+        $ourModelCloned->persistence_data['use_table_prefixes'] = true;
 
-        return $this->getOurField();
+        return $ourModelCloned->getRef($this->link)->getOurField();
     }
 
     /**

--- a/src/Reference/HasOne.php
+++ b/src/Reference/HasOne.php
@@ -63,9 +63,12 @@ class HasOne extends Reference
      */
     protected function referenceOurValue(): Field
     {
-        $this->getOurModel(null)->persistence_data['use_table_prefixes'] = true;
+        // TODO horrible hack to render the field with a table prefix,
+        // find a solution how to wrap the field inside custom Field (without owner?)
+        $ourModelCloned = clone $this->getOurModel(null);
+        $ourModelCloned->persistence_data['use_table_prefixes'] = true;
 
-        return $this->getOurField();
+        return $ourModelCloned->getRef($this->link)->getOurField();
     }
 
     /**

--- a/src/Schema/Migrator.php
+++ b/src/Schema/Migrator.php
@@ -78,7 +78,7 @@ class Migrator
 
     public function table(string $tableName): self
     {
-        $this->table = new Table($this->getDatabasePlatform()->quoteSingleIdentifier($tableName));
+        $this->table = new Table($this->getDatabasePlatform()->quoteIdentifier($tableName));
         if ($this->getDatabasePlatform() instanceof MySQLPlatform) {
             $this->table->addOption('charset', 'utf8mb4');
         }
@@ -105,7 +105,7 @@ class Migrator
     public function drop(): self
     {
         $this->createSchemaManager()
-            ->dropTable($this->getDatabasePlatform()->quoteSingleIdentifier($this->table->getName()));
+            ->dropTable($this->getDatabasePlatform()->quoteIdentifier($this->table->getName()));
 
         $this->createdTableNames = array_diff($this->createdTableNames, [$this->table->getName()]);
 

--- a/src/Schema/Migrator.php
+++ b/src/Schema/Migrator.php
@@ -223,7 +223,7 @@ class Migrator
 
             $modelSeed = is_array($reference->model)
                 ? $reference->model
-                : [get_class($reference->model)];
+                : clone $reference->model;
             $referenceModel = Model::fromSeed($modelSeed, [new Persistence\Sql($this->connection)]);
 
             return $referenceModel->getField($referenceField);

--- a/src/Schema/TestCase.php
+++ b/src/Schema/TestCase.php
@@ -14,7 +14,7 @@ use Doctrine\DBAL\Platforms\MySQLPlatform;
 use Doctrine\DBAL\Platforms\OraclePlatform;
 use Doctrine\DBAL\Schema\AbstractSchemaManager;
 
-class TestCase extends BaseTestCase
+abstract class TestCase extends BaseTestCase
 {
     /** @var Persistence|Persistence\Sql */
     public $db;

--- a/tests/ConditionSqlTest.php
+++ b/tests/ConditionSqlTest.php
@@ -38,7 +38,7 @@ class ConditionSqlTest extends TestCase
         if ($this->getDatabasePlatform() instanceof SqlitePlatform) {
             $this->assertSame(
                 'select "id", "name", "gender" from "user" where "gender" = :a',
-                $mm->action('select')->render()
+                $mm->action('select')->render()[0]
             );
         }
 

--- a/tests/ExpressionSqlTest.php
+++ b/tests/ExpressionSqlTest.php
@@ -35,7 +35,7 @@ class ExpressionSqlTest extends TestCase
         if ($this->getDatabasePlatform() instanceof SqlitePlatform) {
             $this->assertSame(
                 'select "id", "total_net", "total_vat", ("total_net"+"total_vat") "total_gross" from "invoice"',
-                $i->action('select')->render()
+                $i->action('select')->render()[0]
             );
         }
 
@@ -52,7 +52,7 @@ class ExpressionSqlTest extends TestCase
         if ($this->getDatabasePlatform() instanceof SqlitePlatform) {
             $this->assertEquals(
                 'select "id", "total_net", "total_vat", ("total_net"+"total_vat") "total_gross", (("total_net"+"total_vat")*2) "double_total_gross" from "invoice"',
-                $i->action('select')->render()
+                $i->action('select')->render()[0]
             );
         }
 
@@ -77,7 +77,7 @@ class ExpressionSqlTest extends TestCase
         if ($this->getDatabasePlatform() instanceof SqlitePlatform) {
             $this->assertSame(
                 'select "id", "total_net", "total_vat", ("total_net"+"total_vat") "total_gross" from "invoice"',
-                $i->action('select')->render()
+                $i->action('select')->render()[0]
             );
         }
 
@@ -105,7 +105,7 @@ class ExpressionSqlTest extends TestCase
         if ($this->getDatabasePlatform() instanceof SqlitePlatform) {
             $this->assertSame(
                 'select "id", "total_net", "total_vat", (select sum("total_net") from "invoice") "sum_net" from "invoice"',
-                $i->action('select')->render()
+                $i->action('select')->render()[0]
             );
         }
 
@@ -147,17 +147,17 @@ class ExpressionSqlTest extends TestCase
         if ($this->getDatabasePlatform() instanceof SqlitePlatform) {
             $this->assertSame(
                 'select "id", "name", "surname", "cached_name", ("name" || " " || "surname") "full_name" from "user" where (("name" || " " || "surname") != "cached_name")',
-                $m->action('select')->render()
+                $m->action('select')->render()[0]
             );
         } elseif ($this->getDatabasePlatform() instanceof OraclePlatform) {
             $this->assertSame(
                 'select "id", "name", "surname", "cached_name", ("name" || \' \' || "surname") "full_name" from "user" where (("name" || \' \' || "surname") != "cached_name")',
-                $m->action('select')->render()
+                $m->action('select')->render()[0]
             );
         } elseif ($this->getDatabasePlatform() instanceof MySQLPlatform) {
             $this->assertSame(
                 'select `id`, `name`, `surname`, `cached_name`, (CONCAT(`name`, \' \', `surname`)) `full_name` from `user` where ((CONCAT(`name`, \' \', `surname`)) != `cached_name`)',
-                $m->action('select')->render()
+                $m->action('select')->render()[0]
             );
         }
 

--- a/tests/Persistence/Sql/ConnectionTest.php
+++ b/tests/Persistence/Sql/ConnectionTest.php
@@ -142,7 +142,7 @@ class ConnectionTest extends TestCase
 
         $this->assertSame(
             'select (2+2)',
-            $q->render()
+            $q->render()[0]
         );
 
         $this->expectException(\Atk4\Data\Persistence\Sql\Exception::class);

--- a/tests/Persistence/Sql/ExceptionTest.php
+++ b/tests/Persistence/Sql/ExceptionTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Atk4\Data\Tests\Persistence\Sql;
 
 use Atk4\Core\Phpunit\TestCase;
+use Atk4\Data\Persistence\Sql\Exception as SqlException;
 use Atk4\Data\Persistence\Sql\Expression;
 
 /**
@@ -17,15 +18,15 @@ class ExceptionTest extends TestCase
      */
     public function testException1(): void
     {
-        $this->expectException(\Atk4\Data\Persistence\Sql\Exception::class);
+        $this->expectException(SqlException::class);
 
-        throw new \Atk4\Data\Persistence\Sql\Exception();
+        throw new SqlException();
     }
 
     public function testException2(): void
     {
-        $this->expectException(\Atk4\Data\Persistence\Sql\Exception::class);
         $e = new Expression('hello, [world]');
+        $this->expectException(SqlException::class);
         $e->render();
     }
 
@@ -34,16 +35,9 @@ class ExceptionTest extends TestCase
         try {
             $e = new Expression('hello, [world]');
             $e->render();
-        } catch (\Atk4\Data\Persistence\Sql\Exception $e) {
-            $this->assertSame(
-                'Expression could not render tag',
-                $e->getMessage()
-            );
-
-            $this->assertSame(
-                'world',
-                $e->getParams()['tag']
-            );
+        } catch (SqlException $e) {
+            $this->assertSame('Expression could not render tag', $e->getMessage());
+            $this->assertSame('world', $e->getParams()['tag']);
         }
     }
 }

--- a/tests/Persistence/Sql/ExpressionTest.php
+++ b/tests/Persistence/Sql/ExpressionTest.php
@@ -397,7 +397,7 @@ class ExpressionTest extends TestCase
         );
         $this->assertSame(
             ':x',
-            $this->callProtected($this->e(['_paramBase' => 'x']), 'consume', 123, $constants['ESCAPE_PARAM'])
+            $this->callProtected($this->e(['renderParamBase' => 'x']), 'consume', 123, $constants['ESCAPE_PARAM'])
         );
         $this->assertSame(
             123,

--- a/tests/Persistence/Sql/ExpressionTest.php
+++ b/tests/Persistence/Sql/ExpressionTest.php
@@ -131,12 +131,14 @@ class ExpressionTest extends TestCase
     public function testConstructor3(): void
     {
         $e = $this->e('hello, [who]', ['who' => 'world']);
-        $this->assertSame('hello, :a', $e->render());
-        $this->assertSame('world', $e->params[':a']);
+        [$renderQuery, $renderParams] = $e->renderWithParams();
+        $this->assertSame('hello, :a', $renderQuery);
+        $this->assertSame([':a' => 'world'], $renderParams);
 
         $e = $this->e('hello, {who}', ['who' => 'world']);
-        $this->assertSame('hello, "world"', $e->render());
-        $this->assertSame([], $e->params);
+        [$renderQuery, $renderParams] = $e->renderWithParams();
+        $this->assertSame('hello, "world"', $renderQuery);
+        $this->assertSame([], $renderParams);
     }
 
     /**
@@ -377,14 +379,9 @@ class ExpressionTest extends TestCase
     public function testParam(): void
     {
         $e = new Expression('hello, [who]', ['who' => 'world']);
-        $this->assertSame(
-            'hello, :a',
-            $e->render()
-        );
-        $this->assertSame(
-            [':a' => 'world'],
-            $e->params
-        );
+        [$renderQuery, $renderParams] = $e->renderWithParams();
+        $this->assertSame('hello, :a', $renderQuery);
+        $this->assertSame([':a' => 'world'], $renderParams);
     }
 
     /**

--- a/tests/Persistence/Sql/ExpressionTest.php
+++ b/tests/Persistence/Sql/ExpressionTest.php
@@ -65,11 +65,10 @@ class ExpressionTest extends TestCase
     }
 
     /**
-     * Test constructor exception - no arguments.
+     * Test constructor exception - no arguments (template is not defined).
      */
     public function testConstructorException0arg(): void
     {
-        // Template is not defined for Expression
         $this->expectException(Exception::class);
         $this->e()->render();
     }
@@ -83,7 +82,7 @@ class ExpressionTest extends TestCase
     {
         $this->assertSame(
             '',
-            $this->e('')->render()
+            $this->e('')->render()[0]
         );
     }
 
@@ -99,27 +98,27 @@ class ExpressionTest extends TestCase
         // pass as string
         $this->assertSame(
             'now()',
-            $this->e('now()')->render()
+            $this->e('now()')->render()[0]
         );
         // pass as array without key
         $this->assertSame(
             'now()',
-            $this->e(['now()'])->render()
+            $this->e(['now()'])->render()[0]
         );
         // pass as array with template key
         $this->assertSame(
             'now()',
-            $this->e(['template' => 'now()'])->render()
+            $this->e(['template' => 'now()'])->render()[0]
         );
         // pass as array without key
         $this->assertSame(
             ':a Name',
-            $this->e(['[] Name'], ['First'])->render()
+            $this->e(['[] Name'], ['First'])->render()[0]
         );
         // pass as array with template key
         $this->assertSame(
             ':a Name',
-            $this->e(['template' => '[] Name'], ['Last'])->render()
+            $this->e(['template' => '[] Name'], ['Last'])->render()[0]
         );
     }
 
@@ -151,7 +150,7 @@ class ExpressionTest extends TestCase
         // argument = Expression
         $this->assertSame(
             'hello, world',
-            $this->e('hello, [who]', ['who' => $this->e('world')])->render()
+            $this->e('hello, [who]', ['who' => $this->e('world')])->render()[0]
         );
 
         // multiple arguments = Expression
@@ -163,7 +162,7 @@ class ExpressionTest extends TestCase
                     'what' => $this->e('hello'),
                     'who' => $this->e('world'),
                 ]
-            )->render()
+            )->render()[0]
         );
 
         // numeric argument = Expression
@@ -180,7 +179,7 @@ class ExpressionTest extends TestCase
                         ]
                     ),
                 ]
-            )->render()
+            )->render()[0]
         );
 
         // pass template as array
@@ -189,7 +188,7 @@ class ExpressionTest extends TestCase
             $this->e(
                 ['template' => 'hello, [who]'],
                 ['who' => $this->e('world')]
-            )->render()
+            )->render()[0]
         );
     }
 
@@ -198,7 +197,7 @@ class ExpressionTest extends TestCase
      */
     public function testNoTemplatingInSqlString(string $expectedStr, string $exprStr, array $exprArgs): void
     {
-        $this->assertSame($expectedStr, $this->e($exprStr, $exprArgs)->render());
+        $this->assertSame($expectedStr, $this->e($exprStr, $exprArgs)->render()[0]);
     }
 
     /**
@@ -252,13 +251,13 @@ class ExpressionTest extends TestCase
             $this->e('--[]', [2]),
         ]);
 
-        $this->assertSame('++:a and --:b', $e1->render());
+        $this->assertSame('++:a and --:b', $e1->render()[0]);
 
         $e2 = $this->e('=== [foo] ===', ['foo' => $e1]);
 
-        $this->assertSame('=== ++:a and --:b ===', $e2->render());
+        $this->assertSame('=== ++:a and --:b ===', $e2->render()[0]);
 
-        $this->assertSame('++:a and --:b', $e1->render());
+        $this->assertSame('++:a and --:b', $e1->render()[0]);
     }
 
     /**
@@ -274,11 +273,11 @@ class ExpressionTest extends TestCase
         $e2 = $this->e('[greeting]! How are you.', ['greeting' => $e1]);
         $e3 = $this->e('It is me again. [greeting]', ['greeting' => $e1]);
 
-        $s2 = $e2->render(); // Hello :a! How are you.
-        $s3 = $e3->render(); // It is me again. Hello :a
+        $s2 = $e2->render()[0]; // Hello :a! How are you.
+        $s3 = $e3->render()[0]; // It is me again. Hello :a
 
         $e4 = $this->e('[] and good night', [$e1]);
-        $s4 = $e4->render(); // Hello :a and good night
+        $s4 = $e4->render()[0]; // Hello :a and good night
 
         $this->assertSame('Hello :a! How are you.', $s2);
         $this->assertSame('It is me again. Hello :a', $s3);
@@ -359,15 +358,15 @@ class ExpressionTest extends TestCase
 
         $this->assertSame(
             '"first_name"',
-            $this->e()->escape('first_name')->render()
+            $this->e()->escape('first_name')->render()[0]
         );
         $this->assertSame(
             '"first""_name"',
-            $this->e()->escape('first"_name')->render()
+            $this->e()->escape('first"_name')->render()[0]
         );
         $this->assertSame(
             '"first""_name {}"',
-            $this->e()->escape('first"_name {}')->render()
+            $this->e()->escape('first"_name {}')->render()[0]
         );
     }
 
@@ -411,7 +410,7 @@ class ExpressionTest extends TestCase
 
         $this->assertSame(
             'hello, "myfield"',
-            $this->e('hello, []', [new MyField()])->render()
+            $this->e('hello, []', [new MyField()])->render()[0]
         );
     }
 
@@ -466,13 +465,13 @@ class ExpressionTest extends TestCase
         $e = $this->e('[], []');
         $e[] = 'Hello';
         $e[] = 'World';
-        $this->assertSame(':a, :b', $e->render());
+        $this->assertSame(':a, :b', $e->render()[0]);
 
         // real-life example
         $age = $this->e('coalesce([age], [default_age])');
         $age['age'] = $this->e('year(now()) - year(birth_date)');
         $age['default_age'] = 18;
-        $this->assertSame('coalesce(year(now()) - year(birth_date), :a)', $age->render());
+        $this->assertSame('coalesce(year(now()) - year(birth_date), :a)', $age->render()[0]);
     }
 
     /**
@@ -496,14 +495,9 @@ class ExpressionTest extends TestCase
     {
         $e = new JsonExpression('hello, [who]', ['who' => 'world']);
 
-        $this->assertSame(
-            'hello, "world"',
-            $e->render()
-        );
-        $this->assertSame(
-            [],
-            $e->params
-        );
+        [$sql, $params] = $e->renderWithParams();
+        $this->assertSame('hello, "world"', $sql);
+        $this->assertSame([], $params);
     }
 
     /**

--- a/tests/Persistence/Sql/ExpressionTest.php
+++ b/tests/Persistence/Sql/ExpressionTest.php
@@ -130,12 +130,12 @@ class ExpressionTest extends TestCase
     public function testConstructor3(): void
     {
         $e = $this->e('hello, [who]', ['who' => 'world']);
-        [$renderQuery, $renderParams] = $e->renderWithParams();
+        [$renderQuery, $renderParams] = $e->render();
         $this->assertSame('hello, :a', $renderQuery);
         $this->assertSame([':a' => 'world'], $renderParams);
 
         $e = $this->e('hello, {who}', ['who' => 'world']);
-        [$renderQuery, $renderParams] = $e->renderWithParams();
+        [$renderQuery, $renderParams] = $e->render();
         $this->assertSame('hello, "world"', $renderQuery);
         $this->assertSame([], $renderParams);
     }
@@ -378,7 +378,7 @@ class ExpressionTest extends TestCase
     public function testParam(): void
     {
         $e = new Expression('hello, [who]', ['who' => 'world']);
-        [$renderQuery, $renderParams] = $e->renderWithParams();
+        [$renderQuery, $renderParams] = $e->render();
         $this->assertSame('hello, :a', $renderQuery);
         $this->assertSame([':a' => 'world'], $renderParams);
     }
@@ -495,7 +495,7 @@ class ExpressionTest extends TestCase
     {
         $e = new JsonExpression('hello, [who]', ['who' => 'world']);
 
-        [$sql, $params] = $e->renderWithParams();
+        [$sql, $params] = $e->render();
         $this->assertSame('hello, "world"', $sql);
         $this->assertSame([], $params);
     }

--- a/tests/Persistence/Sql/QueryTest.php
+++ b/tests/Persistence/Sql/QueryTest.php
@@ -1652,12 +1652,12 @@ class QueryTest extends TestCase
         $quotes = $this->q()
             ->table('quotes')
             ->field('emp_id')
-            ->field($this->q()->expr('sum([])', ['total_net']))
+            ->field($this->q()->expr('sum({})', ['total_net']))
             ->group('emp_id');
         $invoices = $this->q()
             ->table('invoices')
             ->field('emp_id')
-            ->field($this->q()->expr('sum([])', ['total_net']))
+            ->field($this->q()->expr('sum({})', ['total_net']))
             ->group('emp_id');
         $q = $this->q()
             ->with($quotes, 'q', ['emp', 'quoted'])
@@ -1671,8 +1671,8 @@ class QueryTest extends TestCase
             ->field('i.invoiced');
         $this->assertSame(
             'with '
-                . '"q" ("emp", "quoted") as (select "emp_id", sum(:a) from "quotes" group by "emp_id"),' . "\n"
-                . '"i" ("emp", "invoiced") as (select "emp_id", sum(:b) from "invoices" group by "emp_id")' . "\n"
+                . '"q" ("emp", "quoted") as (select "emp_id", sum("total_net") from "quotes" group by "emp_id"),' . "\n"
+                . '"i" ("emp", "invoiced") as (select "emp_id", sum("total_net") from "invoices" group by "emp_id")' . "\n"
             . 'select "name", "salary", "q"."quoted", "i"."invoiced" '
             . 'from "employees" '
                 . 'left join "q" on "q"."emp" = "employees"."id" '

--- a/tests/Persistence/Sql/QueryTest.php
+++ b/tests/Persistence/Sql/QueryTest.php
@@ -147,32 +147,32 @@ class QueryTest extends TestCase
     {
         $this->assertSame(
             '"name"',
-            $this->q('[field]')->field('name')->render()
+            $this->q('[field]')->field('name')->render()[0]
         );
         $this->assertSame(
             '"first name"',
-            $this->q('[field]')->field('first name')->render()
+            $this->q('[field]')->field('first name')->render()[0]
         );
         $this->assertSame(
             '"first"."name"',
-            $this->q('[field]')->field('first.name')->render()
+            $this->q('[field]')->field('first.name')->render()[0]
         );
         $this->assertSame(
             'now()',
-            $this->q('[field]')->field('now()')->render()
+            $this->q('[field]')->field('now()')->render()[0]
         );
         $this->assertSame(
             'now()',
-            $this->q('[field]')->field(new Expression('now()'))->render()
+            $this->q('[field]')->field(new Expression('now()'))->render()[0]
         );
         // Usage of field aliases
         $this->assertSame(
             'now() "time"',
-            $this->q('[field]')->field('now()', 'time')->render()
+            $this->q('[field]')->field('now()', 'time')->render()[0]
         );
         $this->assertSame(// alias can be passed as 2nd argument
             'now() "time"',
-            $this->q('[field]')->field(new Expression('now()'), 'time')->render()
+            $this->q('[field]')->field(new Expression('now()'), 'time')->render()[0]
         );
     }
 
@@ -346,7 +346,7 @@ class QueryTest extends TestCase
             'select now()',
             $this->q()
                 ->field(new Expression('now()'))
-                ->render()
+                ->render()[0]
         );
 
         // one table
@@ -354,45 +354,45 @@ class QueryTest extends TestCase
             'select "name" from "employee"',
             $this->q()
                 ->field('name')->table('employee')
-                ->render()
+                ->render()[0]
         );
 
         $this->assertSame(
             'select "na#me" from "employee"',
             $this->q()
                 ->field('"na#me"')->table('employee')
-                ->render()
+                ->render()[0]
         );
         $this->assertSame(
             'select "na""me" from "employee"',
             $this->q()
                 ->field(new Expression('{}', ['na"me']))->table('employee')
-                ->render()
+                ->render()[0]
         );
         $this->assertSame(
             'select "жук" from "employee"',
             $this->q()
                 ->field(new Expression('{}', ['жук']))->table('employee')
-                ->render()
+                ->render()[0]
         );
         $this->assertSame(
             'select "this is 💩" from "employee"',
             $this->q()
                 ->field(new Expression('{}', ['this is 💩']))->table('employee')
-                ->render()
+                ->render()[0]
         );
 
         $this->assertSame(
             'select "name" from "employee" "e"',
             $this->q()
                 ->field('name')->table('employee', 'e')
-                ->render()
+                ->render()[0]
         );
         $this->assertSame(
             'select * from "employee" "e"',
             $this->q()
                 ->table('employee', 'e')
-                ->render()
+                ->render()[0]
         );
 
         // multiple tables
@@ -400,7 +400,7 @@ class QueryTest extends TestCase
             'select "employee"."name" from "employee", "jobs"',
             $this->q()
                 ->field('employee.name')->table('employee')->table('jobs')
-                ->render()
+                ->render()[0]
         );
 
         // multiple tables with aliases
@@ -408,13 +408,13 @@ class QueryTest extends TestCase
             'select "name" from "employee", "jobs" "j"',
             $this->q()
                 ->field('name')->table('employee')->table('jobs', 'j')
-                ->render()
+                ->render()[0]
         );
         $this->assertSame(
             'select "name" from "employee" "e", "jobs" "j"',
             $this->q()
                 ->field('name')->table('employee', 'e')->table('jobs', 'j')
-                ->render()
+                ->render()[0]
         );
         // testing _render_table_noalias, shouldn't render table alias 'emp'
         $this->assertSame(
@@ -422,14 +422,14 @@ class QueryTest extends TestCase
             $this->q()
                 ->field('name')->table('employee', 'emp')->set('name', 1)
                 ->mode('insert')
-                ->render()
+                ->render()[0]
         );
         $this->assertSame(
             'update "employee" set "name"=:a',
             $this->q()
                 ->field('name')->table('employee', 'emp')->set('name', 1)
                 ->mode('update')
-                ->render()
+                ->render()[0]
         );
     }
 
@@ -446,14 +446,14 @@ class QueryTest extends TestCase
             'select "name" from (select * from "employee") "e"',
             $this->q()
                 ->field('name')->table($q, 'e')
-                ->render()
+                ->render()[0]
         );
 
         $this->assertSame(
             'select "name" from "myt""able"',
             $this->q()
                 ->field('name')->table(new Expression('{}', ['myt"able']))
-                ->render()
+                ->render()[0]
         );
 
         // test with multiple sub-queries as tables
@@ -470,7 +470,7 @@ class QueryTest extends TestCase
                 ->table($q1, 'e')
                 ->table($q2, 'c')
                 ->where('e.last_name', $this->q()->expr('c.last_name'))
-                ->render()
+                ->render()[0]
         );
     }
 
@@ -489,7 +489,7 @@ class QueryTest extends TestCase
 
         $this->assertSame(
             'select coalesce(year(now()) - year(birth_date), :a) "calculated_age" from "user"',
-            $q->render()
+            $q->render()[0]
         );
     }
 
@@ -576,7 +576,7 @@ class QueryTest extends TestCase
             ->field($this->q()->expr('0'), 'credit'); // simply 0
         $this->assertSame(
             'select "date", "amount" "debit", 0 "credit" from "sales"',
-            $q1->render()
+            $q1->render()[0]
         );
 
         // 2nd query
@@ -587,14 +587,14 @@ class QueryTest extends TestCase
             ->field('amount', 'credit');
         $this->assertSame(
             'select "date", 0 "debit", "amount" "credit" from "purchases"',
-            $q2->render()
+            $q2->render()[0]
         );
 
         // $q1 union $q2
         $u = new Expression('([] union [])', [$q1, $q2]);
         $this->assertSame(
             '((select "date", "amount" "debit", 0 "credit" from "sales") union (select "date", 0 "debit", "amount" "credit" from "purchases"))',
-            $u->render()
+            $u->render()[0]
         );
 
         // SELECT date, debit, credit FROM ($q1 union $q2)
@@ -605,7 +605,7 @@ class QueryTest extends TestCase
             ->table($u, 'derrivedTable');
         $this->assertSame(
             'select "date", "debit", "credit" from ((select "date", "amount" "debit", 0 "credit" from "sales") union (select "date", 0 "debit", "amount" "credit" from "purchases")) "derrivedTable"',
-            $q->render()
+            $q->render()[0]
         );
 
         // SQLite do not support (($q1) union ($q2)) syntax. Correct syntax is ($q1 union $q2) without additional braces
@@ -616,7 +616,7 @@ class QueryTest extends TestCase
         $u = new Expression('([] union [])', [$q1, $q2]);
         $this->assertSame(
             '(select "date", "amount" "debit", 0 "credit" from "sales" union select "date", 0 "debit", "amount" "credit" from "purchases")',
-            $u->render()
+            $u->render()[0]
         );
 
         // SELECT date, debit, credit FROM ($q1 union $q2)
@@ -627,7 +627,7 @@ class QueryTest extends TestCase
             ->table($u, 'derrivedTable');
         $this->assertSame(
             'select "date", "debit", "credit" from (select "date", "amount" "debit", 0 "credit" from "sales" union select "date", 0 "debit", "amount" "credit" from "purchases") "derrivedTable"',
-            $q->render()
+            $q->render()[0]
         );
     }
 
@@ -665,77 +665,77 @@ class QueryTest extends TestCase
         // one parameter as a string - treat as expression
         $this->assertSame(
             'where (now())',
-            $this->q('[where]')->where('now()')->render()
+            $this->q('[where]')->where('now()')->render()[0]
         );
         $this->assertSame(
             'where (foo >=    bar)',
-            $this->q('[where]')->where('foo >=    bar')->render()
+            $this->q('[where]')->where('foo >=    bar')->render()[0]
         );
 
         // two parameters - field, value
         $this->assertSame(
             'where "id" = :a',
-            $this->q('[where]')->where('id', 1)->render()
+            $this->q('[where]')->where('id', 1)->render()[0]
         );
         $this->assertSame(
             'where "user"."id" = :a',
-            $this->q('[where]')->where('user.id', 1)->render()
+            $this->q('[where]')->where('user.id', 1)->render()[0]
         );
         $this->assertSame(
             'where "db"."user"."id" = :a',
-            $this->q('[where]')->where('db.user.id', 1)->render()
+            $this->q('[where]')->where('db.user.id', 1)->render()[0]
         );
         $this->assertSame(
             'where "id" is null',
-            $this->q('[where]')->where('id', null)->render()
+            $this->q('[where]')->where('id', null)->render()[0]
         );
         $this->assertSame(
             'where "id" is not null',
-            $this->q('[where]')->where('id', '!=', null)->render()
+            $this->q('[where]')->where('id', '!=', null)->render()[0]
         );
 
         // three parameters - field, condition, value
         $this->assertSame(
             'where "id" > :a',
-            $this->q('[where]')->where('id', '>', 1)->render()
+            $this->q('[where]')->where('id', '>', 1)->render()[0]
         );
         $this->assertSame(
             'where "id" < :a',
-            $this->q('[where]')->where('id', '<', 1)->render()
+            $this->q('[where]')->where('id', '<', 1)->render()[0]
         );
         $this->assertSame(
             'where "id" = :a',
-            $this->q('[where]')->where('id', '=', 1)->render()
+            $this->q('[where]')->where('id', '=', 1)->render()[0]
         );
         $this->assertSame(
             'where "id" in (:a, :b)',
-            $this->q('[where]')->where('id', '=', [1, 2])->render()
+            $this->q('[where]')->where('id', '=', [1, 2])->render()[0]
         );
         $this->assertSame(
             'where "id" in (:a, :b)',
-            $this->q('[where]')->where('id', [1, 2])->render()
+            $this->q('[where]')->where('id', [1, 2])->render()[0]
         );
         $this->assertSame(
             'where "id" in (select * from "user")',
-            $this->q('[where]')->where('id', $this->q()->table('user'))->render()
+            $this->q('[where]')->where('id', $this->q()->table('user'))->render()[0]
         );
 
         // field name with special symbols - not escape
         $this->assertSame(
             'where now() = :a',
-            $this->q('[where]')->where('now()', 1)->render()
+            $this->q('[where]')->where('now()', 1)->render()[0]
         );
 
         // field name as expression
         $this->assertSame(
             'where now = :a',
-            $this->q('[where]')->where(new Expression('now'), 1)->render()
+            $this->q('[where]')->where(new Expression('now'), 1)->render()[0]
         );
 
         // more than one where condition - join with AND keyword
         $this->assertSame(
             'where "a" = :a and "b" is null',
-            $this->q('[where]')->where('a', 1)->where('b', null)->render()
+            $this->q('[where]')->where('a', 1)->where('b', null)->render()[0]
         );
     }
 
@@ -743,7 +743,7 @@ class QueryTest extends TestCase
     {
         $this->assertSame(
             'where (a = 5 or b = 6) and (c = 3 or d = 1)',
-            $this->q('[where]')->where('a = 5 or b = 6')->where('c = 3 or d = 1')->render()
+            $this->q('[where]')->where('a = 5 or b = 6')->where('c = 3 or d = 1')->render()[0]
         );
     }
 
@@ -798,85 +798,85 @@ class QueryTest extends TestCase
         // in | not in
         $this->assertSame(
             'where "id" in (:a, :b)',
-            $this->q('[where]')->where('id', 'in', [1, 2])->render()
+            $this->q('[where]')->where('id', 'in', [1, 2])->render()[0]
         );
         $this->assertSame(
             'where "id" not in (:a, :b)',
-            $this->q('[where]')->where('id', 'not in', [1, 2])->render()
+            $this->q('[where]')->where('id', 'not in', [1, 2])->render()[0]
         );
         $this->assertSame(
             'where "id" not in (:a, :b)',
-            $this->q('[where]')->where('id', 'not', [1, 2])->render()
+            $this->q('[where]')->where('id', 'not', [1, 2])->render()[0]
         );
         $this->assertSame(
             'where "id" in (:a, :b)',
-            $this->q('[where]')->where('id', '=', [1, 2])->render()
+            $this->q('[where]')->where('id', '=', [1, 2])->render()[0]
         );
         $this->assertSame(
             'where "id" not in (:a, :b)',
-            $this->q('[where]')->where('id', '<>', [1, 2])->render()
+            $this->q('[where]')->where('id', '<>', [1, 2])->render()[0]
         );
         $this->assertSame(
             'where "id" not in (:a, :b)',
-            $this->q('[where]')->where('id', '!=', [1, 2])->render()
+            $this->q('[where]')->where('id', '!=', [1, 2])->render()[0]
         );
         // speacial treatment for empty array values
         $this->assertSame(
             'where 1 = 0',
-            $this->q('[where]')->where('id', '=', [])->render()
+            $this->q('[where]')->where('id', '=', [])->render()[0]
         );
         $this->assertSame(
             'where 1 = 1',
-            $this->q('[where]')->where('id', '<>', [])->render()
+            $this->q('[where]')->where('id', '<>', [])->render()[0]
         );
         // pass array as CSV
         $this->assertSame(
             'where "id" in (:a, :b)',
-            $this->q('[where]')->where('id', 'in', '1,2')->render()
+            $this->q('[where]')->where('id', 'in', '1,2')->render()[0]
         );
         $this->assertSame(
             'where "id" not in (:a, :b)',
-            $this->q('[where]')->where('id', 'not in', '1,    2')->render()
+            $this->q('[where]')->where('id', 'not in', '1,    2')->render()[0]
         );
         $this->assertSame(
             'where "id" not in (:a, :b)',
-            $this->q('[where]')->where('id', 'not', '1,2')->render()
+            $this->q('[where]')->where('id', 'not', '1,2')->render()[0]
         );
 
         // is | is not
         $this->assertSame(
             'where "id" is null',
-            $this->q('[where]')->where('id', 'is', null)->render()
+            $this->q('[where]')->where('id', 'is', null)->render()[0]
         );
         $this->assertSame(
             'where "id" is not null',
-            $this->q('[where]')->where('id', 'is not', null)->render()
+            $this->q('[where]')->where('id', 'is not', null)->render()[0]
         );
         $this->assertSame(
             'where "id" is not null',
-            $this->q('[where]')->where('id', 'not', null)->render()
+            $this->q('[where]')->where('id', 'not', null)->render()[0]
         );
         $this->assertSame(
             'where "id" is null',
-            $this->q('[where]')->where('id', '=', null)->render()
+            $this->q('[where]')->where('id', '=', null)->render()[0]
         );
         $this->assertSame(
             'where "id" is not null',
-            $this->q('[where]')->where('id', '<>', null)->render()
+            $this->q('[where]')->where('id', '<>', null)->render()[0]
         );
         $this->assertSame(
             'where "id" is not null',
-            $this->q('[where]')->where('id', '!=', null)->render()
+            $this->q('[where]')->where('id', '!=', null)->render()[0]
         );
 
         // like | not like
         $this->assertSame(
             'where "name" like :a',
-            $this->q('[where]')->where('name', 'like', 'foo')->render()
+            $this->q('[where]')->where('name', 'like', 'foo')->render()[0]
         );
         $this->assertSame(
             'where "name" not like :a',
-            $this->q('[where]')->where('name', 'not like', 'foo')->render()
+            $this->q('[where]')->where('name', 'not like', 'foo')->render()[0]
         );
     }
 
@@ -890,15 +890,15 @@ class QueryTest extends TestCase
     {
         $this->assertSame(
             'having "id" = :a',
-            $this->q('[having]')->having('id', 1)->render()
+            $this->q('[having]')->having('id', 1)->render()[0]
         );
         $this->assertSame(
             'having "id" > :a',
-            $this->q('[having]')->having('id', '>', 1)->render()
+            $this->q('[having]')->having('id', '>', 1)->render()[0]
         );
         $this->assertSame(
             'where "id" = :a having "id" > :b',
-            $this->q('[where][having]')->where('id', 1)->having('id', '>', 1)->render()
+            $this->q('[where][having]')->where('id', 1)->having('id', '>', 1)->render()[0]
         );
     }
 
@@ -912,11 +912,11 @@ class QueryTest extends TestCase
     {
         $this->assertSame(
             'limit 0, 100',
-            $this->q('[limit]')->limit(100)->render()
+            $this->q('[limit]')->limit(100)->render()[0]
         );
         $this->assertSame(
             'limit 200, 100',
-            $this->q('[limit]')->limit(100, 200)->render()
+            $this->q('[limit]')->limit(100, 200)->render()[0]
         );
     }
 
@@ -930,78 +930,78 @@ class QueryTest extends TestCase
     {
         $this->assertSame(
             'order by "name"',
-            $this->q('[order]')->order('name')->render()
+            $this->q('[order]')->order('name')->render()[0]
         );
         $this->assertSame(
             'order by "name", "surname"',
-            $this->q('[order]')->order('surname')->order('name')->render()
+            $this->q('[order]')->order('surname')->order('name')->render()[0]
         );
         $this->assertSame(
             'order by "name" desc, "surname" desc',
-            $this->q('[order]')->order('surname desc')->order('name desc')->render()
+            $this->q('[order]')->order('surname desc')->order('name desc')->render()[0]
         );
         $this->assertSame(
             'order by "name" desc, "surname"',
-            $this->q('[order]')->order(['name desc', 'surname'])->render()
+            $this->q('[order]')->order(['name desc', 'surname'])->render()[0]
         );
         $this->assertSame(
             'order by "name" desc, "surname"',
-            $this->q('[order]')->order('surname')->order('name desc')->render()
+            $this->q('[order]')->order('surname')->order('name desc')->render()[0]
         );
         $this->assertSame(
             'order by "name" desc, "surname"',
-            $this->q('[order]')->order('surname', false)->order('name', true)->render()
+            $this->q('[order]')->order('surname', false)->order('name', true)->render()[0]
         );
         // table name|alias included
         $this->assertSame(
             'order by "users"."name"',
-            $this->q('[order]')->order('users.name')->render()
+            $this->q('[order]')->order('users.name')->render()[0]
         );
         // strange field names
         $this->assertSame(
             'order by "my name" desc',
-            $this->q('[order]')->order('"my name" desc')->render()
+            $this->q('[order]')->order('"my name" desc')->render()[0]
         );
         $this->assertSame(
             'order by "жук"',
-            $this->q('[order]')->order('жук asc')->render()
+            $this->q('[order]')->order('жук asc')->render()[0]
         );
         $this->assertSame(
             'order by "this is 💩"',
-            $this->q('[order]')->order('this is 💩')->render()
+            $this->q('[order]')->order('this is 💩')->render()[0]
         );
         $this->assertSame(
             'order by "this is жук" desc',
-            $this->q('[order]')->order('this is жук desc')->render()
+            $this->q('[order]')->order('this is жук desc')->render()[0]
         );
         $this->assertSame(
             'order by * desc',
-            $this->q('[order]')->order(['* desc'])->render()
+            $this->q('[order]')->order(['* desc'])->render()[0]
         );
         $this->assertSame(
             'order by "{}" desc',
-            $this->q('[order]')->order(['{} desc'])->render()
+            $this->q('[order]')->order(['{} desc'])->render()[0]
         );
         $this->assertSame(
             'order by "* desc"',
-            $this->q('[order]')->order(new Expression('"* desc"'))->render()
+            $this->q('[order]')->order(new Expression('"* desc"'))->render()[0]
         );
         $this->assertSame(
             'order by "* desc"',
-            $this->q('[order]')->order($this->q()->escape('* desc'))->render()
+            $this->q('[order]')->order($this->q()->escape('* desc'))->render()[0]
         );
         $this->assertSame(
             'order by "* desc {}"',
-            $this->q('[order]')->order($this->q()->escape('* desc {}'))->render()
+            $this->q('[order]')->order($this->q()->escape('* desc {}'))->render()[0]
         );
         // custom sort order
         $this->assertSame(
             'order by "name" desc nulls last',
-            $this->q('[order]')->order('name', 'desc nulls last')->render()
+            $this->q('[order]')->order('name', 'desc nulls last')->render()[0]
         );
         $this->assertSame(
             'order by "name" nulls last',
-            $this->q('[order]')->order('name', 'nulls last')->render()
+            $this->q('[order]')->order('name', 'nulls last')->render()[0]
         );
     }
 
@@ -1026,41 +1026,41 @@ class QueryTest extends TestCase
     {
         $this->assertSame(
             'group by "gender"',
-            $this->q('[group]')->group('gender')->render()
+            $this->q('[group]')->group('gender')->render()[0]
         );
         $this->assertSame(
             'group by "gender", "age"',
-            $this->q('[group]')->group('gender')->group('age')->render()
+            $this->q('[group]')->group('gender')->group('age')->render()[0]
         );
         // table name|alias included
         $this->assertSame(
             'group by "users"."gender"',
-            $this->q('[group]')->group('users.gender')->render()
+            $this->q('[group]')->group('users.gender')->render()[0]
         );
         // strange field names
         $this->assertSame(
             'group by "my name"',
-            $this->q('[group]')->group('"my name"')->render()
+            $this->q('[group]')->group('"my name"')->render()[0]
         );
         $this->assertSame(
             'group by "жук"',
-            $this->q('[group]')->group('жук')->render()
+            $this->q('[group]')->group('жук')->render()[0]
         );
         $this->assertSame(
             'group by "this is 💩"',
-            $this->q('[group]')->group('this is 💩')->render()
+            $this->q('[group]')->group('this is 💩')->render()[0]
         );
         $this->assertSame(
             'group by "this is жук"',
-            $this->q('[group]')->group('this is жук')->render()
+            $this->q('[group]')->group('this is жук')->render()[0]
         );
         $this->assertSame(
             'group by date_format(dat, "%Y")',
-            $this->q('[group]')->group(new Expression('date_format(dat, "%Y")'))->render()
+            $this->q('[group]')->group(new Expression('date_format(dat, "%Y")'))->render()[0]
         );
         $this->assertSame(
             'group by date_format(dat, "%Y")',
-            $this->q('[group]')->group('date_format(dat, "%Y")')->render()
+            $this->q('[group]')->group('date_format(dat, "%Y")')->render()[0]
         );
     }
 
@@ -1082,16 +1082,16 @@ class QueryTest extends TestCase
     public function testGroupConcat(): void
     {
         $q = new Mysql\Query();
-        $this->assertSame('group_concat(`foo` separator :a)', $q->groupConcat('foo', '-')->render());
+        $this->assertSame('group_concat(`foo` separator :a)', $q->groupConcat('foo', '-')->render()[0]);
 
         $q = new Oracle\Query();
-        $this->assertSame('listagg("foo", :a) within group (order by "foo")', $q->groupConcat('foo', '-')->render());
+        $this->assertSame('listagg("foo", :a) within group (order by "foo")', $q->groupConcat('foo', '-')->render()[0]);
 
         $q = new Postgresql\Query();
-        $this->assertSame('string_agg("foo", :a)', $q->groupConcat('foo', '-')->render());
+        $this->assertSame('string_agg("foo", :a)', $q->groupConcat('foo', '-')->render()[0]);
 
         $q = new Sqlite\Query();
-        $this->assertSame('group_concat("foo", :a)', $q->groupConcat('foo', '-')->render());
+        $this->assertSame('group_concat("foo", :a)', $q->groupConcat('foo', '-')->render()[0]);
     }
 
     /**
@@ -1117,40 +1117,40 @@ class QueryTest extends TestCase
     {
         $this->assertSame(
             'left join "address" on "address"."id" = "address_id"',
-            $this->q('[join]')->join('address')->render()
+            $this->q('[join]')->join('address')->render()[0]
         );
         $this->assertSame(
             'left join "address" "a" on "a"."id" = "address_id"',
-            $this->q('[join]')->join('address a')->render()
+            $this->q('[join]')->join('address a')->render()[0]
         );
         $this->assertSame(
             'left join "address" "a" on "a"."id" = "user"."address_id"',
-            $this->q('[join]')->table('user')->join('address a')->render()
+            $this->q('[join]')->table('user')->join('address a')->render()[0]
         );
         $this->assertSame(
             'left join "address" "a" on "a"."id" = "user"."my_address_id"',
-            $this->q('[join]')->table('user')->join('address a', 'my_address_id')->render()
+            $this->q('[join]')->table('user')->join('address a', 'my_address_id')->render()[0]
         );
         $this->assertSame(
             'left join "address" "a" on "a"."id" = "u"."address_id"',
-            $this->q('[join]')->table('user', 'u')->join('address a')->render()
+            $this->q('[join]')->table('user', 'u')->join('address a')->render()[0]
         );
         $this->assertSame(
             'left join "address" "a" on "a"."user_id" = "u"."id"',
-            $this->q('[join]')->table('user', 'u')->join('address.user_id a')->render()
+            $this->q('[join]')->table('user', 'u')->join('address.user_id a')->render()[0]
         );
         $this->assertSame(
             'left join "address" "a" on "a"."user_id" = "u"."id" '
             . 'left join "bank" "b" on "b"."id" = "u"."bank_id"',
             $this->q('[join]')->table('user', 'u')
                 ->join('address.user_id', null, null, 'a')->join('bank', null, null, 'b')
-                ->render()
+                ->render()[0]
         );
         $this->assertSame(
             'left join "address" on "address"."user_id" = "u"."id" '
             . 'left join "bank" on "bank"."id" = "u"."bank_id"',
             $this->q('[join]')->table('user', 'u')
-                ->join('address.user_id')->join('bank')->render()
+                ->join('address.user_id')->join('bank')->render()[0]
         );
         $this->assertSame(
             'left join "address" "a" on "a"."user_id" = "u"."id" '
@@ -1158,13 +1158,13 @@ class QueryTest extends TestCase
             . 'left join "bank_details" on "bank_details"."id" = "bank"."details_id"',
             $this->q('[join]')->table('user', 'u')
                 ->join('address.user_id', null, null, 'a')->join('bank', null, null, 'b')
-                ->join('bank_details', 'bank.details_id')->render()
+                ->join('bank_details', 'bank.details_id')->render()[0]
         );
 
         $this->assertSame(
             'left join "address" "a" on a.name like u.pattern',
             $this->q('[join]')->table('user', 'u')
-                ->join('address a', new Expression('a.name like u.pattern'))->render()
+                ->join('address a', new Expression('a.name like u.pattern'))->render()[0]
         );
     }
 
@@ -1181,14 +1181,14 @@ class QueryTest extends TestCase
             'select "name" from "employee" where "a" = :a',
             $this->q()
                 ->field('name')->table('employee')->where('a', 1)
-                ->render()
+                ->render()[0]
         );
 
         $this->assertSame(
             'select "name" from "employee" where "employee"."a" = :a',
             $this->q()
                 ->field('name')->table('employee')->where('employee.a', 1)
-                ->render()
+                ->render()[0]
         );
 
         /*
@@ -1196,7 +1196,7 @@ class QueryTest extends TestCase
             'select "name" from "db"."employee" where "db"."employee"."a" = :a',
             $this->q()
                 ->field('name')->table('db.employee')->where('db.employee.a',1)
-                ->render()
+                ->render()[0]
         );
          */
 
@@ -1205,7 +1205,7 @@ class QueryTest extends TestCase
             $this->q()
                 ->mode('delete')
                 ->field('name')->table('employee')->where('employee.a', 1)
-                ->render()
+                ->render()[0]
         );
 
         $user_ids = $this->q()->table('expired_users')->field('user_id');
@@ -1217,7 +1217,7 @@ class QueryTest extends TestCase
                 ->where('id', 'in', $user_ids)
                 ->set('active', 0)
                 ->mode('update')
-                ->render()
+                ->render()[0]
         );
     }
 
@@ -1235,12 +1235,12 @@ class QueryTest extends TestCase
     {
         $this->assertSame(
             '',
-            $this->q()->orExpr()->render()
+            $this->q()->orExpr()->render()[0]
         );
 
         $this->assertSame(
             '',
-            $this->q()->andExpr()->render()
+            $this->q()->andExpr()->render()[0]
         );
     }
 
@@ -1262,7 +1262,7 @@ class QueryTest extends TestCase
             $this->q()
                 ->field('name')->table('employee')->where('name', 1)
                 ->mode('delete')
-                ->render()
+                ->render()[0]
         );
 
         // update template
@@ -1271,7 +1271,7 @@ class QueryTest extends TestCase
             $this->q()
                 ->field('name')->table('employee')->set('name', 1)
                 ->mode('update')
-                ->render()
+                ->render()[0]
         );
 
         $this->assertSame(
@@ -1279,7 +1279,7 @@ class QueryTest extends TestCase
             $this->q()
                 ->field('name')->table('employee')->set('name', new Expression('"name"+1'))
                 ->mode('update')
-                ->render()
+                ->render()[0]
         );
 
         // insert template
@@ -1288,7 +1288,7 @@ class QueryTest extends TestCase
             $this->q()
                 ->field('name')->table('employee')->set('name', 1)
                 ->mode('insert')
-                ->render()
+                ->render()[0]
         );
 
         // set multiple fields
@@ -1299,7 +1299,7 @@ class QueryTest extends TestCase
                 ->set('time', new Expression('now()'))
                 ->set('name', 'unknown')
                 ->mode('insert')
-                ->render()
+                ->render()[0]
         );
 
         // set as array
@@ -1309,7 +1309,7 @@ class QueryTest extends TestCase
                 ->field('time')->field('name')->table('employee')
                 ->setMulti(['time' => new Expression('now()'), 'name' => 'unknown'])
                 ->mode('insert')
-                ->render()
+                ->render()[0]
         );
     }
 
@@ -1369,7 +1369,7 @@ class QueryTest extends TestCase
         );
         $this->assertSame(
             'select "name" from "employee" where ("a" = :a or "b" = :b)',
-            $q->render()
+            $q->render()[0]
         );
 
         // test 2
@@ -1388,7 +1388,7 @@ class QueryTest extends TestCase
         );
         $this->assertSame(
             'select "name" from "employee" where ("a" = :a or "b" = :b or ((true) and (false)))',
-            $q->render()
+            $q->render()[0]
         );
     }
 
@@ -1404,7 +1404,7 @@ class QueryTest extends TestCase
         );
         $this->assertSame(
             'select sum(:a) "salary" from "employee" group by "type" having ("a" = :b or "b" = :c)',
-            $q->render()
+            $q->render()[0]
         );
     }
 
@@ -1433,7 +1433,7 @@ class QueryTest extends TestCase
         // reset everything
         $q = $this->q()->table('user')->where('name', 'John');
         $q->reset();
-        $this->assertSame('select *', $q->render());
+        $this->assertSame('select *', $q->render()[0]);
 
         // reset particular tag
         $q = $this->q()
@@ -1441,7 +1441,7 @@ class QueryTest extends TestCase
             ->where('name', 'John')
             ->reset('where')
             ->where('surname', 'Doe');
-        $this->assertSame('select * from "user" where "surname" = :a', $q->render());
+        $this->assertSame('select * from "user" where "surname" = :a', $q->render()[0]);
     }
 
     /**
@@ -1455,12 +1455,12 @@ class QueryTest extends TestCase
         // single option
         $this->assertSame(
             'select calc_found_rows * from "test"',
-            $this->q()->table('test')->option('calc_found_rows')->render()
+            $this->q()->table('test')->option('calc_found_rows')->render()[0]
         );
         // multiple options
         $this->assertSame(
             'select calc_found_rows ignore * from "test"',
-            $this->q()->table('test')->option('calc_found_rows')->option('ignore')->render()
+            $this->q()->table('test')->option('calc_found_rows')->option('ignore')->render()[0]
         );
         // options for specific modes
         $q = $this->q()
@@ -1472,15 +1472,15 @@ class QueryTest extends TestCase
 
         $this->assertSame(
             'select calc_found_rows "name" from "test"',
-            $q->mode('select')->render()
+            $q->mode('select')->render()[0]
         );
         $this->assertSame(
             'insert ignore into "test" ("name") values (:a)',
-            $q->mode('insert')->render()
+            $q->mode('insert')->render()[0]
         );
         $this->assertSame(
             'update "test" set "name"=:a',
-            $q->mode('update')->render()
+            $q->mode('update')->render()[0]
         );
     }
 
@@ -1499,7 +1499,7 @@ class QueryTest extends TestCase
             ->caseWhen(['status', 'New'], 't2.expose_new')
             ->caseWhen(['status', 'like', '%Used%'], 't2.expose_used')
             ->caseElse(null)
-            ->render();
+            ->render()[0];
         $this->assertSame('case when "status" = :a then :b when "status" like :c then :d else :e end', $s);
 
         // with subqueries
@@ -1509,7 +1509,7 @@ class QueryTest extends TestCase
         $s = $this->q()->caseExpr()
             ->caseWhen(['age', '>', $q], 'Older')
             ->caseElse('Younger')
-            ->render();
+            ->render()[0];
         $this->assertSame('case when "age" > (select year(now()) - year(birth_date) "calc_age" from "user") then :a else :b end', $s);
     }
 
@@ -1527,7 +1527,7 @@ class QueryTest extends TestCase
             ->caseWhen('New', 't2.expose_new')
             ->caseWhen('Used', 't2.expose_used')
             ->caseElse(null)
-            ->render();
+            ->render()[0];
         $this->assertSame('case "status" when :a then :b when :c then :d else :e end', $s);
 
         // with subqueries
@@ -1537,7 +1537,7 @@ class QueryTest extends TestCase
         $s = $this->q()->caseExpr($q)
             ->caseWhen(100, 'Very old')
             ->caseElse('Younger')
-            ->render();
+            ->render()[0];
         $this->assertSame('case (select year(now()) - year(birth_date) "calc_age" from "user") when :a then :b else :c end', $s);
     }
 
@@ -1577,7 +1577,7 @@ class QueryTest extends TestCase
             $this->q()
                 ->field('hired')->table('employee')->set('hired', $this->q()->exprNow())
                 ->mode('update')
-                ->render()
+                ->render()[0]
         );
 
         $this->assertSame(
@@ -1585,7 +1585,7 @@ class QueryTest extends TestCase
             $this->q()
                 ->field('hired')->table('employee')->set('hired', $this->q()->exprNow(2))
                 ->mode('update')
-                ->render()
+                ->render()[0]
         );
     }
 
@@ -1610,14 +1610,14 @@ class QueryTest extends TestCase
             'select "name" from "db1"."employee" where "a" = :a',
             $this->q()
                 ->field('name')->table('db1.employee')->where('a', 1)
-                ->render()
+                ->render()[0]
         );
 
         $this->assertSame(
             'select "name" from "db1"."employee" where "db1"."employee"."a" = :a',
             $this->q()
                 ->field('name')->table('db1.employee')->where('db1.employee.a', 1)
-                ->render()
+                ->render()[0]
         );
     }
 
@@ -1632,13 +1632,13 @@ class QueryTest extends TestCase
             ->with($q1, 'q1')
             ->table('q1');
         $this->assertSame('with "q1" as (select "salary" from "salaries")' . "\n"
-            . 'select * from "q1"', $q2->render());
+            . 'select * from "q1"', $q2->render()[0]);
 
         $q2 = $this->q()
             ->with($q1, 'q1', null, true)
             ->table('q1');
         $this->assertSame('with recursive "q1" as (select "salary" from "salaries")' . "\n"
-            . 'select * from "q1"', $q2->render());
+            . 'select * from "q1"', $q2->render()[0]);
 
         $q2 = $this->q()
             ->with($q1, 'q11', ['foo', 'qwe"ry'])
@@ -1646,7 +1646,7 @@ class QueryTest extends TestCase
             ->table('q11')
             ->table('q12');
         $this->assertSame('with recursive "q11" ("foo", "qwe""ry") as (select "salary" from "salaries"),' . "\n"
-            . '"q12" ("bar", "baz") as (select "salary" from "salaries")' . "\n" . 'select * from "q11", "q12"', $q2->render());
+            . '"q12" ("bar", "baz") as (select "salary" from "salaries")' . "\n" . 'select * from "q11", "q12"', $q2->render()[0]);
 
         // now test some more useful reql life query
         $quotes = $this->q()
@@ -1677,7 +1677,7 @@ class QueryTest extends TestCase
             . 'from "employees" '
                 . 'left join "q" on "q"."emp" = "employees"."id" '
                 . 'left join "i" on "i"."emp" = "employees"."id"',
-            $q->render()
+            $q->render()[0]
         );
     }
 
@@ -1685,19 +1685,19 @@ class QueryTest extends TestCase
     {
         $this->assertSame(
             'select exists (select * from "contacts" where "first_name" = :a)',
-            $this->q()->table('contacts')->where('first_name', 'John')->exists()->render()
+            $this->q()->table('contacts')->where('first_name', 'John')->exists()->render()[0]
         );
 
         $q = new Oracle\Query();
         $this->assertSame(
             'select case when exists(select * from "contacts" where "first_name" = :xxaaaa) then 1 else 0 end from "DUAL"',
-            $q->table('contacts')->where('first_name', 'John')->exists()->render()
+            $q->table('contacts')->where('first_name', 'John')->exists()->render()[0]
         );
 
         $q = new Mssql\Query();
         $this->assertSame(
             'select case when exists(select * from [contacts] where [first_name] = :a) then 1 else 0 end',
-            $q->table('contacts')->where('first_name', 'John')->exists()->render()
+            $q->table('contacts')->where('first_name', 'John')->exists()->render()[0]
         );
     }
 }

--- a/tests/Persistence/Sql/RandomTest.php
+++ b/tests/Persistence/Sql/RandomTest.php
@@ -65,7 +65,7 @@ class RandomTest extends TestCase
         }
         $this->assertSame(
             'insert into  ("' . implode('", "', array_keys($data)) . '") values (:a, :b, :c, :d, :e, :f, :g, :h, :i, :j, :k, :l, :m, :n, :o, :p, :q, :r, :s, :t, :u, :v, :w, :x, :y, :z, :aa, :ab, :ac, :ad)',
-            $q->render()
+            $q->render()[0]
         );
     }
 
@@ -82,7 +82,7 @@ class RandomTest extends TestCase
 
         $q->groupConcat('name', ',');
 
-        $this->assertSame($expected, $q->render());
+        $this->assertSame($expected, $q->render()[0]);
     }
 
     public function testGroupConcat(): void

--- a/tests/Persistence/Sql/WithDb/SelectTest.php
+++ b/tests/Persistence/Sql/WithDb/SelectTest.php
@@ -288,7 +288,7 @@ class SelectTest extends TestCase
             )
                 ->where($columnAlias, 'žlutý_😀') // as param
                 ->group($tableAlias . '.' . $columnAlias)
-                ->having($this->e('{}', [$columnAlias])->render() . ' = \'žlutý_😀\'') // as string literal (mapped to N'xxx' with MSSQL platform)
+                ->having($this->e('{}', [$columnAlias])->render()[0] . ' = \'žlutý_😀\'') // as string literal (mapped to N'xxx' with MSSQL platform)
                 ->getRow()
         );
     }
@@ -307,7 +307,7 @@ class SelectTest extends TestCase
             $maxIdExpr = $this->c->dsql()->table($table)->field($this->c->expr('max({})', [$pk]));
             if ($this->getDatabasePlatform() instanceof MySQLPlatform) {
                 $query = $this->c->dsql()->table('INFORMATION_SCHEMA.TABLES')
-                    ->field($this->c->expr('greatest({} - 1, (' . $maxIdExpr->render() . '))', ['AUTO_INCREMENT']))
+                    ->field($this->c->expr('greatest({} - 1, (' . $maxIdExpr->render()[0] . '))', ['AUTO_INCREMENT']))
                     ->where('TABLE_NAME', $table);
             } elseif ($this->getDatabasePlatform() instanceof PostgreSQLPlatform) {
                 $query = $this->c->dsql()->field($this->c->expr('currval(pg_get_serial_sequence([], []))', [$table, $pk]));

--- a/tests/ReferenceSqlTest.php
+++ b/tests/ReferenceSqlTest.php
@@ -224,7 +224,7 @@ class ReferenceSqlTest extends TestCase
         $i->addExpression('total_net', $i->refLink('line')->action('fx', ['sum', 'total_net']));
 
         $this->assertSameSql(
-            'select "invoice"."id", "invoice"."ref_no", (select sum("total_net") from "invoice_line" "_l_6438c669e0d0" where "invoice_id" = "invoice"."id") "total_net" from "invoice"',
+            'select "id", "ref_no", (select sum("total_net") from "invoice_line" "_l_6438c669e0d0" where "invoice_id" = "invoice"."id") "total_net" from "invoice"',
             $i->action('select')->render()
         );
     }

--- a/tests/ReferenceSqlTest.php
+++ b/tests/ReferenceSqlTest.php
@@ -57,7 +57,7 @@ class ReferenceSqlTest extends TestCase
 
         $this->assertSameSql(
             'select "id", "amount", "user_id" from "order" "_O_7442e29d7d53" where "user_id" in (select "id" from "user" where "id" > :a)',
-            $oo->action('select')->render()
+            $oo->action('select')->render()[0]
         );
     }
 
@@ -73,7 +73,7 @@ class ReferenceSqlTest extends TestCase
 
         $this->assertSameSql(
             'select "id", "amount", "user_id" from "order" "_O_7442e29d7d53" where "user_id" = "user"."id"',
-            $u->refLink('Orders')->action('select')->render()
+            $u->refLink('Orders')->action('select')->render()[0]
         );
     }
 
@@ -114,7 +114,7 @@ class ReferenceSqlTest extends TestCase
 
         $this->assertSameSql(
             'select "id", "code", "name" from "currency" "_c_b5fddf1ef601" where "code" = "user"."currency_code"',
-            $u->refLink('cur')->action('select')->render()
+            $u->refLink('cur')->action('select')->render()[0]
         );
     }
 
@@ -153,7 +153,7 @@ class ReferenceSqlTest extends TestCase
 
         $this->assertSameSql(
             'select "id", "name" from "user" "_u_e8701ad48ba0" where "id" in (select "user_id" from "order" where ("amount" > :a and "amount" < :b))',
-            $o->ref('user_id')->action('select')->render()
+            $o->ref('user_id')->action('select')->render()[0]
         );
     }
 
@@ -225,7 +225,7 @@ class ReferenceSqlTest extends TestCase
 
         $this->assertSameSql(
             'select "id", "ref_no", (select sum("total_net") from "invoice_line" "_l_6438c669e0d0" where "invoice_id" = "invoice"."id") "total_net" from "invoice"',
-            $i->action('select')->render()
+            $i->action('select')->render()[0]
         );
     }
 

--- a/tests/Schema/ModelTest.php
+++ b/tests/Schema/ModelTest.php
@@ -72,8 +72,8 @@ class ModelTest extends TestCase
 
         $migrator2->mode('create');
 
-        $q1 = preg_replace('/\([0-9,]*\)/i', '', $migrator->render()); // remove parenthesis otherwise we can't differ money from float etc.
-        $q2 = preg_replace('/\([0-9,]*\)/i', '', $migrator2->render());
+        $q1 = preg_replace('/\([0-9,]*\)/i', '', $migrator->render()[0]); // remove parenthesis otherwise we can't differ money from float etc.
+        $q2 = preg_replace('/\([0-9,]*\)/i', '', $migrator2->render()[0]);
         $this->assertSame($q1, $q2);
     }
 

--- a/tests/ScopeTest.php
+++ b/tests/ScopeTest.php
@@ -140,7 +140,7 @@ class ScopeTest extends TestCase
         if ($this->getDatabasePlatform() instanceof SqlitePlatform) {
             $condition = new Condition('name', $user->expr('[surname]'));
 
-            $this->assertEquals('Name is equal to expression \'"user"."surname"\'', $condition->toWords($user));
+            $this->assertEquals('Name is equal to expression \'"surname"\'', $condition->toWords($user));
         }
 
         $condition = new Condition('country_id', null);

--- a/tests/WithTest.php
+++ b/tests/WithTest.php
@@ -44,7 +44,7 @@ class WithTest extends TestCase
         $this->assertSameSql(
             'with "i" ("user_id", "invoiced") as (select "user_id", "net" from "invoice" where "net" > :a)' . "\n"
                 . 'select "user"."id", "user"."name", "user"."salary", "_i"."invoiced" from "user" inner join "i" "_i" on "_i"."user_id" = "user"."id"',
-            $m->action('select')->render()
+            $m->action('select')->render()[0]
         );
         $this->assertSame([
             ['id' => 10, 'name' => 'John', 'salary' => 2500, 'invoiced' => 500],


### PR DESCRIPTION
fixes several hidden bugs and also https://github.com/atk4/data/pull/784

### BC break

`Expression::render()` does no longer mutate the instance state, the result of the method is now an array with a rendered SQL and corresponding params

this method is expected to be not used in a higer level code thus the impact should be minimal