### PR TITLE
Clone user actions for entity lazily

### DIFF
--- a/src/Model.php
+++ b/src/Model.php
@@ -350,6 +350,8 @@ class Model implements \IteratorAggregate
         }
 
         if ($expectedModelInstance !== null && $expectedModelInstance !== $this) {
+            $expectedModelInstance->assertIsModel();
+
             throw new Exception('Unexpected entity model instance');
         }
     }

--- a/src/Model.php
+++ b/src/Model.php
@@ -443,7 +443,6 @@ class Model implements \IteratorAggregate
         try {
             $this->_model = $this;
             $this->userActions = [];
-
             $model = clone $this;
         } finally {
             $this->_model = null;

--- a/src/Model.php
+++ b/src/Model.php
@@ -469,41 +469,10 @@ class Model implements \IteratorAggregate
         $this->initEntityIdHooks();
 
         if ($this->read_only) {
-            return; // don't declare action for read-only model
+            return; // don't declare user action for read-only model
         }
 
-        // Declare our basic Crud actions for the model.
-        $this->addUserAction('add', [
-            'fields' => true,
-            'modifier' => Model\UserAction::MODIFIER_CREATE,
-            'appliesTo' => Model\UserAction::APPLIES_TO_NO_RECORDS,
-            'callback' => 'save',
-            'description' => 'Add ' . $this->getModelCaption(),
-        ]);
-
-        $this->addUserAction('edit', [
-            'fields' => true,
-            'modifier' => Model\UserAction::MODIFIER_UPDATE,
-            'appliesTo' => Model\UserAction::APPLIES_TO_SINGLE_RECORD,
-            'callback' => 'save',
-        ]);
-
-        $this->addUserAction('delete', [
-            'appliesTo' => Model\UserAction::APPLIES_TO_SINGLE_RECORD,
-            'modifier' => Model\UserAction::MODIFIER_DELETE,
-            'callback' => function ($model) {
-                return $model->delete();
-            },
-        ]);
-
-        $this->addUserAction('validate', [
-            //'appliesTo' => any!
-            'description' => 'Provided with modified values will validate them but will not save',
-            'modifier' => Model\UserAction::MODIFIER_READ,
-            'fields' => true,
-            'system' => true, // don't show by default
-            'args' => ['intent' => 'string'],
-        ]);
+        $this->initUserActions();
     }
 
     private function initEntityIdAndAssertUnchanged(): void

--- a/src/Model.php
+++ b/src/Model.php
@@ -437,11 +437,15 @@ class Model implements \IteratorAggregate
     {
         $this->assertIsModel();
 
-        $this->_model = $this;
+        $userActionsBackup = $this->userActions;
         try {
+            $this->_model = $this;
+            $this->userActions = [];
+
             $model = clone $this;
         } finally {
             $this->_model = null;
+            $this->userActions = $userActionsBackup;
         }
         $model->_entityId = null;
 
@@ -458,6 +462,8 @@ class Model implements \IteratorAggregate
      */
     protected function init(): void
     {
+        $this->assertIsModel();
+
         $this->_init();
 
         if ($this->id_field) {

--- a/src/Model/UserAction.php
+++ b/src/Model/UserAction.php
@@ -5,9 +5,10 @@ declare(strict_types=1);
 namespace Atk4\Data\Model;
 
 use Atk4\Core\DiContainerTrait;
-use Atk4\Core\Exception;
+use Atk4\Core\Exception as CoreException;
 use Atk4\Core\InitializerTrait;
 use Atk4\Core\TrackableTrait;
+use Atk4\Data\Exception;
 use Atk4\Data\Model;
 
 /**
@@ -128,7 +129,7 @@ class UserAction
             }
 
             return $run();
-        } catch (Exception $e) {
+        } catch (CoreException $e) {
             $e->addMoreInfo('action', $this);
 
             throw $e;

--- a/src/Model/UserAction.php
+++ b/src/Model/UserAction.php
@@ -25,9 +25,6 @@ class UserAction
     use InitializerTrait;
     use TrackableTrait;
 
-    /** @var Model|null */
-    private $entity;
-
     /** Defining records scope of the action */
     public const APPLIES_TO_NO_RECORDS = 'none'; // e.g. add
     public const APPLIES_TO_SINGLE_RECORD = 'single'; // e.g. archive
@@ -84,25 +81,20 @@ class UserAction
      */
     public function getModel(): Model
     {
-        return $this->getOwner()->getModel(true); // @phpstan-ignore-line
+        /** @var Model */
+        $owner = $this->getOwner();
+
+        return $owner->getModel(true);
     }
 
     public function getEntity(): Model
     {
-        if ($this->getOwner()->isEntity()) { // @phpstan-ignore-line
-            return $this->getOwner(); // @phpstan-ignore-line
-        }
+        /** @var Model */
+        $owner = $this->getOwner();
 
-        if ($this->entity === null) {
-            $this->setEntity($this->getOwner()->createEntity()); // @phpstan-ignore-line
-        }
+        $owner->assertIsEntity();
 
-        return $this->entity;
-    }
-
-    public function setEntity(Model $entity): void
-    {
-        $this->entity = $entity;
+        return $owner;
     }
 
     /**

--- a/src/Model/UserAction.php
+++ b/src/Model/UserAction.php
@@ -80,6 +80,32 @@ class UserAction
     public $atomic = true;
 
     /**
+     * Return model associated with this action.
+     */
+    public function getModel(): Model
+    {
+        return $this->getOwner()->getModel(true); // @phpstan-ignore-line
+    }
+
+    public function getEntity(): Model
+    {
+        if ($this->getOwner()->isEntity()) { // @phpstan-ignore-line
+            return $this->getOwner(); // @phpstan-ignore-line
+        }
+
+        if ($this->entity === null) {
+            $this->setEntity($this->getOwner()->createEntity()); // @phpstan-ignore-line
+        }
+
+        return $this->entity;
+    }
+
+    public function setEntity(Model $entity): void
+    {
+        $this->entity = $entity;
+    }
+
+    /**
      * Attempt to execute callback of the action.
      *
      * @param mixed ...$args
@@ -208,32 +234,6 @@ class UserAction
         }
 
         return $this->confirmation;
-    }
-
-    /**
-     * Return model associated with this action.
-     */
-    public function getModel(): Model
-    {
-        return $this->getOwner()->getModel(true); // @phpstan-ignore-line
-    }
-
-    public function getEntity(): Model
-    {
-        if ($this->getOwner()->isEntity()) { // @phpstan-ignore-line
-            return $this->getOwner(); // @phpstan-ignore-line
-        }
-
-        if ($this->entity === null) {
-            $this->setEntity($this->getOwner()->createEntity()); // @phpstan-ignore-line
-        }
-
-        return $this->entity;
-    }
-
-    public function setEntity(Model $entity): void
-    {
-        $this->entity = $entity;
     }
 
     public function getCaption(): string

--- a/src/Model/UserAction.php
+++ b/src/Model/UserAction.php
@@ -85,9 +85,6 @@ class UserAction
         return $owner->isEntity();
     }
 
-    /**
-     * Return model associated with this action.
-     */
     public function getModel(): Model
     {
         /** @var Model */

--- a/src/Model/UserAction.php
+++ b/src/Model/UserAction.php
@@ -77,6 +77,14 @@ class UserAction
     /** @var bool Atomic action will automatically begin transaction before and commit it after completing. */
     public $atomic = true;
 
+    public function isOwnerEntity(): bool
+    {
+        /** @var Model */
+        $owner = $this->getOwner();
+
+        return $owner->isEntity();
+    }
+
     /**
      * Return model associated with this action.
      */

--- a/src/Model/UserAction.php
+++ b/src/Model/UserAction.php
@@ -99,6 +99,24 @@ class UserAction
     }
 
     /**
+     * @return static
+     */
+    public function getActionForEntity(Model $entity): self
+    {
+        /** @var Model */
+        $owner = $this->getOwner();
+
+        $entity->assertIsEntity($owner);
+        foreach ($owner->getUserActions() as $name => $action) {
+            if ($action === $this) {
+                return $entity->getUserAction($name);
+            }
+        }
+
+        throw new Exception('Action instance not found in model');
+    }
+
+    /**
      * Attempt to execute callback of the action.
      *
      * @param mixed ...$args

--- a/src/Model/UserAction.php
+++ b/src/Model/UserAction.php
@@ -117,7 +117,7 @@ class UserAction
         $entity->assertIsEntity($owner);
         foreach ($owner->getUserActions() as $name => $action) {
             if ($action === $this) {
-                return $entity->getUserAction($name);
+                return $entity->getUserAction($name); // @phpstan-ignore-line
             }
         }
 

--- a/src/Model/UserActionsTrait.php
+++ b/src/Model/UserActionsTrait.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Atk4\Data\Model;
 
 use Atk4\Core\Factory;
-use Atk4\Data\Exception;
 
 trait UserActionsTrait
 {
@@ -29,9 +28,7 @@ trait UserActionsTrait
      */
     public function addUserAction(string $name, $defaults = []): UserAction
     {
-        if ($this->isEntity() && $this->getModel()->hasUserAction($name)) {
-            $this->assertIsModel();
-        }
+        $this->assertIsModel();
 
         if ($defaults instanceof \Closure) {
             $defaults = ['callback' => $defaults];
@@ -112,9 +109,7 @@ trait UserActionsTrait
      */
     public function removeUserAction(string $name)
     {
-        if ($this->isEntity() && $this->getModel()->hasUserAction($name)) {
-            $this->assertIsModel();
-        }
+        $this->assertIsModel();
 
         $this->_removeFromCollection($name, 'userActions');
 

--- a/src/Model/UserActionsTrait.php
+++ b/src/Model/UserActionsTrait.php
@@ -106,7 +106,7 @@ trait UserActionsTrait
     }
 
     /**
-     * Remove specified action(s).
+     * Remove specified action.
      *
      * @return $this
      */

--- a/src/Model/UserActionsTrait.php
+++ b/src/Model/UserActionsTrait.php
@@ -24,7 +24,6 @@ trait UserActionsTrait
      * Register new user action for this model. By default UI will allow users to trigger actions
      * from UI.
      *
-     * @param string         $name     Action name
      * @param array|\Closure $defaults
      */
     public function addUserAction(string $name, $defaults = []): UserAction
@@ -47,8 +46,6 @@ trait UserActionsTrait
 
     /**
      * Returns true if user action with a corresponding name exists.
-     *
-     * @param string $name UserAction name
      */
     public function hasUserAction(string $name): bool
     {
@@ -72,8 +69,6 @@ trait UserActionsTrait
 
     /**
      * Returns one action object of this model. If action not defined, then throws exception.
-     *
-     * @param string $name Action name
      */
     public function getUserAction(string $name): UserAction
     {
@@ -97,7 +92,6 @@ trait UserActionsTrait
     /**
      * Execute specified action with specified arguments.
      *
-     * @param string $name    UserAction name
      * @param mixed  ...$args
      *
      * @return mixed

--- a/src/Model/UserActionsTrait.php
+++ b/src/Model/UserActionsTrait.php
@@ -64,7 +64,7 @@ trait UserActionsTrait
     private function addUserActionFromModel(string $name, UserAction $action): void
     {
         $this->assertIsEntity();
-        $action->getOwner()->assertIsModel();
+        $action->getOwner()->assertIsModel(); // @phpstan-ignore-line
         if (\Closure::bind(fn () => $action->entity, null, UserAction::class)() !== null) {
             throw new Exception('Model action entity is expected to be null');
         }
@@ -127,7 +127,7 @@ trait UserActionsTrait
     /**
      * Execute specified action with specified arguments.
      *
-     * @param mixed  ...$args
+     * @param mixed ...$args
      *
      * @return mixed
      */

--- a/src/Model/UserActionsTrait.php
+++ b/src/Model/UserActionsTrait.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Atk4\Data\Model;
 
 use Atk4\Core\Factory;
-use Atk4\Data\Model;
 
 trait UserActionsTrait
 {
@@ -14,10 +13,10 @@ trait UserActionsTrait
      *
      * @var string|array
      */
-    public $_default_seed_action = [Model\UserAction::class];
+    public $_default_seed_action = [UserAction::class];
 
     /**
-     * @var array<string, Model\UserAction> Collection of user actions - using key as action system name
+     * @var array<string, UserAction> Collection of user actions - using key as action system name
      */
     protected $userActions = [];
 
@@ -28,7 +27,7 @@ trait UserActionsTrait
      * @param string         $name     Action name
      * @param array|\Closure $defaults
      */
-    public function addUserAction(string $name, $defaults = []): Model\UserAction
+    public function addUserAction(string $name, $defaults = []): UserAction
     {
         if ($defaults instanceof \Closure) {
             $defaults = ['callback' => $defaults];
@@ -38,7 +37,7 @@ trait UserActionsTrait
             $defaults['caption'] = $this->readableCaption($name);
         }
 
-        /** @var Model\UserAction $action */
+        /** @var UserAction $action */
         $action = Factory::factory($this->_default_seed_action, $defaults);
 
         $this->_addIntoCollection($name, $action, 'userActions');
@@ -60,9 +59,9 @@ trait UserActionsTrait
      * Returns list of actions for this model. Can filter actions by records they apply to.
      * It will also skip system user actions (where system === true).
      *
-     * @param string $appliesTo e.g. Model\UserAction::APPLIES_TO_ALL_RECORDS
+     * @param string $appliesTo e.g. UserAction::APPLIES_TO_ALL_RECORDS
      *
-     * @return array<string, Model\UserAction>
+     * @return array<string, UserAction>
      */
     public function getUserActions(string $appliesTo = null): array
     {
@@ -76,7 +75,7 @@ trait UserActionsTrait
      *
      * @param string $name Action name
      */
-    public function getUserAction(string $name): Model\UserAction
+    public function getUserAction(string $name): UserAction
     {
         return $this->_getFromCollection($name, 'userActions');
     }
@@ -113,22 +112,22 @@ trait UserActionsTrait
         // Declare our basic Crud actions for the model.
         $this->addUserAction('add', [
             'fields' => true,
-            'modifier' => Model\UserAction::MODIFIER_CREATE,
-            'appliesTo' => Model\UserAction::APPLIES_TO_NO_RECORDS,
+            'modifier' => UserAction::MODIFIER_CREATE,
+            'appliesTo' => UserAction::APPLIES_TO_NO_RECORDS,
             'callback' => 'save',
             'description' => 'Add ' . $this->getModelCaption(),
         ]);
 
         $this->addUserAction('edit', [
             'fields' => true,
-            'modifier' => Model\UserAction::MODIFIER_UPDATE,
-            'appliesTo' => Model\UserAction::APPLIES_TO_SINGLE_RECORD,
+            'modifier' => UserAction::MODIFIER_UPDATE,
+            'appliesTo' => UserAction::APPLIES_TO_SINGLE_RECORD,
             'callback' => 'save',
         ]);
 
         $this->addUserAction('delete', [
-            'appliesTo' => Model\UserAction::APPLIES_TO_SINGLE_RECORD,
-            'modifier' => Model\UserAction::MODIFIER_DELETE,
+            'appliesTo' => UserAction::APPLIES_TO_SINGLE_RECORD,
+            'modifier' => UserAction::MODIFIER_DELETE,
             'callback' => function ($model) {
                 return $model->delete();
             },
@@ -137,7 +136,7 @@ trait UserActionsTrait
         $this->addUserAction('validate', [
             //'appliesTo' => any!
             'description' => 'Provided with modified values will validate them but will not save',
-            'modifier' => Model\UserAction::MODIFIER_READ,
+            'modifier' => UserAction::MODIFIER_READ,
             'fields' => true,
             'system' => true, // don't show by default
             'args' => ['intent' => 'string'],

--- a/src/Model/UserActionsTrait.php
+++ b/src/Model/UserActionsTrait.php
@@ -72,22 +72,6 @@ trait UserActionsTrait
         $this->_addIntoCollection($name, $action, 'userActions');
     }
 
-    private function assertOrSetUserActionEntity(UserAction $action): void
-    {
-        $actionEntity = \Closure::bind(fn () => $action->entity, null, UserAction::class)();
-        if ($actionEntity !== null) {
-            if (!$this->isEntity()) {
-                throw new Exception('Action entity is expected to be null');
-            } elseif ($actionEntity !== $this) {
-                throw new Exception('Action entity is expected to be null or same instance');
-            }
-        } else {
-            if ($this->isEntity()) {
-                $action->setEntity($this);
-            }
-        }
-    }
-
     /**
      * Returns list of actions for this model. Can filter actions by records they apply to.
      * It will also skip system user actions (where system === true).
@@ -104,15 +88,9 @@ trait UserActionsTrait
             }
         }
 
-        $actions = array_filter($this->userActions, function ($action) use ($appliesTo) {
+        return array_filter($this->userActions, function ($action) use ($appliesTo) {
             return !$action->system && ($appliesTo === null || $action->appliesTo === $appliesTo);
         });
-
-        foreach ($actions as $action) {
-            $this->assertOrSetUserActionEntity($action);
-        }
-
-        return $actions;
     }
 
     /**
@@ -124,11 +102,7 @@ trait UserActionsTrait
             $this->addUserActionFromModel($name, $this->getModel()->getUserAction($name));
         }
 
-        $action = $this->_getFromCollection($name, 'userActions');
-
-        $this->assertOrSetUserActionEntity($action);
-
-        return $action;
+        return $this->_getFromCollection($name, 'userActions');
     }
 
     /**

--- a/tests/UserActionTest.php
+++ b/tests/UserActionTest.php
@@ -111,7 +111,7 @@ class UserActionTest extends TestCase
         };
         $this->assertSame('will say John', $client->getUserAction('say_name')->preview('x'));
 
-        $client->addUserAction('also_backup', ['callback' => 'backup_clients']);
+        $client->getModel()->addUserAction('also_backup', ['callback' => 'backup_clients']);
         $this->assertSame('backs up all clients', $client->getUserAction('also_backup')->execute());
 
         $client->getUserAction('also_backup')->preview = 'backup_clients';
@@ -245,9 +245,10 @@ class UserActionTest extends TestCase
     public function testConfirmation(): void
     {
         $client = new UaClient($this->pers);
+        $client->addUserAction('test');
         $client = $client->load(1);
-        $action = $client->addUserAction('test');
 
+        $action = $client->getUserAction('test');
         $this->assertFalse($action->getConfirmation());
 
         $action->confirmation = true;


### PR DESCRIPTION
clone and set new owner lazily (when the actual UA object is requested to be returned)

and remove `UserAction::entity` property