### PR TITLE
Allow Model::getUserActions() to be called only on model

### DIFF
--- a/src/Field/SqlExpressionField.php
+++ b/src/Field/SqlExpressionField.php
@@ -35,9 +35,6 @@ class SqlExpressionField extends Field
     /** @var string Specifies which field to use. */
     public $field;
 
-    /**
-     * Initialization.
-     */
     protected function init(): void
     {
         $this->_init();

--- a/src/Field/SqlExpressionField.php
+++ b/src/Field/SqlExpressionField.php
@@ -17,46 +17,22 @@ class SqlExpressionField extends Field
         init as private _init;
     }
 
-    /**
-     * Used expression.
-     *
-     * @var \Closure|string|Expressionable
-     */
+    /** @var \Closure|string|Expressionable Used expression. */
     public $expr;
 
-    /**
-     * Expressions are always read_only.
-     *
-     * @var bool
-     */
+    /** @var bool Expressions are always read_only. */
     public $read_only = true;
 
-    /**
-     * Specifies how to aggregate this.
-     *
-     * @var string
-     */
+    /** @var string Specifies how to aggregate this. */
     public $aggregate;
 
-    /**
-     * Aggregation by concatenation.
-     *
-     * @var string
-     */
+    /** @var string Aggregation by concatenation. */
     public $concat;
 
-    /**
-     * When defining as aggregate, this will point to relation object.
-     *
-     * @var Reference\HasMany|null
-     */
+    /** @var Reference\HasMany|null When defining as aggregate, this will point to relation object. */
     public $aggregate_relation;
 
-    /**
-     * Specifies which field to use.
-     *
-     * @var string
-     */
+    /** @var string Specifies which field to use. */
     public $field;
 
     /**

--- a/src/Model.php
+++ b/src/Model.php
@@ -99,14 +99,10 @@ class Model implements \IteratorAggregate
 
     // {{{ Properties of the class
 
-    /**
-     * @var static|null not-null if and only if this instance is an entity
-     */
+    /** @var static|null not-null if and only if this instance is an entity */
     private $_model;
 
-    /**
-     * @var mixed once set, loading a different ID will result in an error
-     */
+    /** @var mixed once set, loading a different ID will result in an error */
     private $_entityId;
 
     /** @var array<string, true> */
@@ -126,9 +122,7 @@ class Model implements \IteratorAggregate
      */
     public $_default_seed_addExpression = [CallbackField::class];
 
-    /**
-     * @var array<string, Field>
-     */
+    /** @var array<string, Field> */
     protected $fields = [];
 
     /**
@@ -147,9 +141,7 @@ class Model implements \IteratorAggregate
      */
     public $table_alias;
 
-    /**
-     * @var Persistence|Persistence\Sql|null
-     */
+    /** @var Persistence|Persistence\Sql|null */
     public $persistence;
 
     /**

--- a/src/Model.php
+++ b/src/Model.php
@@ -108,18 +108,10 @@ class Model implements \IteratorAggregate
     /** @var array<string, true> */
     private static $_modelOnlyProperties;
 
-    /**
-     * The class used by addField() method.
-     *
-     * @var string|array
-     */
+    /** @var string|array The class used by addField() method. */
     public $_default_seed_addField = [Field::class];
 
-    /**
-     * The class used by addExpression() method.
-     *
-     * @var string|array
-     */
+    /** @var string|array The class used by addExpression() method. */
     public $_default_seed_addExpression = [CallbackField::class];
 
     /** @var array<string, Field> */
@@ -134,11 +126,7 @@ class Model implements \IteratorAggregate
      */
     public $table;
 
-    /**
-     * Use alias for $table.
-     *
-     * @var string|null
-     */
+    /** @var string|null Use alias for $table. */
     public $table_alias;
 
     /** @var Persistence|Persistence\Sql|null */
@@ -155,25 +143,13 @@ class Model implements \IteratorAggregate
     /** @var Model\Scope\RootScope */
     private $scope;
 
-    /**
-     * Array of limit set.
-     *
-     * @var array
-     */
+    /** @var array Array of limit set. */
     public $limit = [];
 
-    /**
-     * Array of set order by.
-     *
-     * @var array
-     */
+    /** @var array Array of set order by. */
     public $order = [];
 
-    /**
-     * Array of WITH cursors set.
-     *
-     * @var array
-     */
+    /** @var array Array of WITH cursors set. */
     public $with = [];
 
     /**

--- a/src/Model.php
+++ b/src/Model.php
@@ -124,7 +124,7 @@ class Model implements \IteratorAggregate
      */
     public $table;
 
-    /** @var string|null Use alias for $table. */
+    /** @var string|null */
     public $table_alias;
 
     /** @var Persistence|Persistence\Sql|null */

--- a/src/Model.php
+++ b/src/Model.php
@@ -17,8 +17,6 @@ use Atk4\Data\Field\SqlExpressionField;
 use Mvorisek\Atk4\Hintable\Data\HintableModelTrait;
 
 /**
- * Data model class.
- *
  * @property int                 $id       @Atk4\Field(visibility="protected_set") Contains ID of the current record.
  *                                         If the value is null then the record is considered to be new.
  * @property Field[]|Reference[] $elements

--- a/src/Model/FieldPropertiesTrait.php
+++ b/src/Model/FieldPropertiesTrait.php
@@ -6,18 +6,10 @@ namespace Atk4\Data\Model;
 
 trait FieldPropertiesTrait
 {
-    /**
-     * Field type. Name of type registered in \Doctrine\DBAL\Types\Type.
-     *
-     * @var string|null
-     */
+    /** @var string|null Field type. Name of type registered in \Doctrine\DBAL\Types\Type. */
     public $type;
 
-    /**
-     * For several types enum can provide list of available options. ['blue', 'red'].
-     *
-     * @var array|null
-     */
+    /** @var array|null For several types enum can provide list of available options. ['blue', 'red']. */
     public $enum;
 
     /**
@@ -36,11 +28,7 @@ trait FieldPropertiesTrait
      */
     protected $referenceLink;
 
-    /**
-     * Actual field name.
-     *
-     * @var string|null
-     */
+    /** @var string|null Actual field name. */
     public $actual;
 
     /**
@@ -51,11 +39,7 @@ trait FieldPropertiesTrait
      */
     public $system = false;
 
-    /**
-     * Default value of field.
-     *
-     * @var mixed
-     */
+    /** @var mixed Default value of field. */
     public $default;
 
     /**

--- a/src/Model/Join.php
+++ b/src/Model/Join.php
@@ -190,9 +190,6 @@ class Join
         return '#join_' . $this->foreign_table;
     }
 
-    /**
-     * Initialization.
-     */
     protected function init(): void
     {
         $this->_init();

--- a/src/Model/Join.php
+++ b/src/Model/Join.php
@@ -65,11 +65,7 @@ class Join
      */
     protected $kind;
 
-    /**
-     * Is our join weak? Weak join will stop you from touching foreign table.
-     *
-     * @var bool
-     */
+    /** @var bool Is our join weak? Weak join will stop you from touching foreign table. */
     protected $weak = false;
 
     /**
@@ -107,11 +103,7 @@ class Join
      */
     protected $foreign_field;
 
-    /**
-     * A short symbolic name that will be used as an alias for the joined table.
-     *
-     * @var string
-     */
+    /** @var string A short symbolic name that will be used as an alias for the joined table. */
     public $foreign_alias;
 
     /**
@@ -122,18 +114,10 @@ class Join
      */
     protected $prefix = '';
 
-    /**
-     * ID indexed by spl_object_id(entity) used by a joined table.
-     *
-     * @var mixed
-     */
+    /** @var mixed ID indexed by spl_object_id(entity) used by a joined table. */
     protected $idByOid;
 
-    /**
-     * Data indexed by spl_object_id(entity) which is populated here as the save/insert progresses.
-     *
-     * @var array<int, array<string, mixed>>
-     */
+    /** @var array<int, array<string, mixed>> Data indexed by spl_object_id(entity) which is populated here as the save/insert progresses. */
     private $saveBufferByOid = [];
 
     public function __construct(string $foreign_table = null)

--- a/src/Model/JoinLinkTrait.php
+++ b/src/Model/JoinLinkTrait.php
@@ -6,11 +6,7 @@ namespace Atk4\Data\Model;
 
 trait JoinLinkTrait
 {
-    /**
-     * The short name of the join link.
-     *
-     * @var string|null
-     */
+    /** @var string|null The short name of the join link. */
     protected $joinName;
 
     public function hasJoin(): bool

--- a/src/Model/JoinsTrait.php
+++ b/src/Model/JoinsTrait.php
@@ -11,11 +11,7 @@ use Atk4\Data\Exception;
  */
 trait JoinsTrait
 {
-    /**
-     * The class used by join() method.
-     *
-     * @var array
-     */
+    /** @var array The class used by join() method. */
     public $_default_seed_join = [Join::class];
 
     /**

--- a/src/Model/ReferencesTrait.php
+++ b/src/Model/ReferencesTrait.php
@@ -13,39 +13,19 @@ use Atk4\Data\Reference;
  */
 trait ReferencesTrait
 {
-    /**
-     * The seed used by addRef() method.
-     *
-     * @var array
-     */
+    /** @var array The seed used by addRef() method. */
     public $_default_seed_addRef = [Reference::class];
 
-    /**
-     * The seed used by hasOne() method.
-     *
-     * @var array
-     */
+    /** @var array The seed used by hasOne() method. */
     public $_default_seed_hasOne = [Reference\HasOne::class];
 
-    /**
-     * The seed used by hasMany() method.
-     *
-     * @var array
-     */
+    /** @var array The seed used by hasMany() method. */
     public $_default_seed_hasMany = [Reference\HasMany::class];
 
-    /**
-     * The seed used by containsOne() method.
-     *
-     * @var array
-     */
+    /** @var array The seed used by containsOne() method. */
     public $_default_seed_containsOne = [Reference\ContainsOne::class];
 
-    /**
-     * The seed used by containsMany() method.
-     *
-     * @var array
-     */
+    /** @var array The seed used by containsMany() method. */
     public $_default_seed_containsMany = [Reference\ContainsMany::class];
 
     /**

--- a/src/Model/Scope/Condition.php
+++ b/src/Model/Scope/Condition.php
@@ -37,9 +37,7 @@ class Condition extends AbstractScope
     public const OPERATOR_REGEXP = 'REGEXP';
     public const OPERATOR_NOT_REGEXP = 'NOT REGEXP';
 
-    /**
-     * @var array<string, array<string, string>>
-     */
+    /** @var array<string, array<string, string>> */
     protected static $operators = [
         self::OPERATOR_EQUALS => [
             'negate' => self::OPERATOR_DOESNOT_EQUAL,

--- a/src/Model/UserActionsTrait.php
+++ b/src/Model/UserActionsTrait.php
@@ -8,11 +8,7 @@ use Atk4\Core\Factory;
 
 trait UserActionsTrait
 {
-    /**
-     * Default class for addUserAction().
-     *
-     * @var string|array
-     */
+    /** @var string|array Default class for addUserAction(). */
     public $_default_seed_action = [UserAction::class];
 
     /** @var array<string, UserAction> Collection of user actions - using key as action system name */

--- a/src/Model/UserActionsTrait.php
+++ b/src/Model/UserActionsTrait.php
@@ -15,9 +15,7 @@ trait UserActionsTrait
      */
     public $_default_seed_action = [UserAction::class];
 
-    /**
-     * @var array<string, UserAction> Collection of user actions - using key as action system name
-     */
+    /** @var array<string, UserAction> Collection of user actions - using key as action system name */
     protected $userActions = [];
 
     /**

--- a/src/Model/UserActionsTrait.php
+++ b/src/Model/UserActionsTrait.php
@@ -79,11 +79,7 @@ trait UserActionsTrait
      */
     public function getUserActions(string $appliesTo = null): array
     {
-        if ($this->isEntity()) {
-            foreach (array_diff_key($this->getModel()->getUserActions($appliesTo), $this->userActions) as $name => $action) {
-                $this->addUserActionFromModel($name, $action);
-            }
-        }
+        $this->assertIsModel();
 
         return array_filter($this->userActions, function ($action) use ($appliesTo) {
             return !$action->system && ($appliesTo === null || $action->appliesTo === $appliesTo);

--- a/src/Persistence/Csv.php
+++ b/src/Persistence/Csv.php
@@ -27,25 +27,13 @@ use Atk4\Data\Persistence;
  */
 class Csv extends Persistence
 {
-    /**
-     * Name of the file.
-     *
-     * @var string
-     */
+    /** @var string Name of the file. */
     public $file;
 
-    /**
-     * Line in CSV file.
-     *
-     * @var int
-     */
+    /** @var int Line in CSV file. */
     public $line = 0;
 
-    /**
-     * File handle, when the $file is opened.
-     *
-     * @var resource|null
-     */
+    /** @var resource|null File handle, when the $file is opened. */
     public $handle;
 
     /**
@@ -57,32 +45,16 @@ class Csv extends Persistence
      */
     public $mode;
 
-    /**
-     * Delimiter in CSV file.
-     *
-     * @var string
-     */
+    /** @var string Delimiter in CSV file. */
     public $delimiter = ',';
 
-    /**
-     * Enclosure in CSV file.
-     *
-     * @var string
-     */
+    /** @var string Enclosure in CSV file. */
     public $enclosure = '"';
 
-    /**
-     * Escape character in CSV file.
-     *
-     * @var string
-     */
+    /** @var string Escape character in CSV file. */
     public $escape_char = '\\';
 
-    /**
-     * Array of field names.
-     *
-     * @var array|null
-     */
+    /** @var array|null Array of field names. */
     public $header;
 
     public function __construct(string $file, array $defaults = [])

--- a/src/Persistence/Csv.php
+++ b/src/Persistence/Csv.php
@@ -33,7 +33,7 @@ class Csv extends Persistence
     /** @var int Line in CSV file. */
     public $line = 0;
 
-    /** @var resource|null File handle, when the $file is opened. */
+    /** @var resource|null File handle, when the file is opened. */
     public $handle;
 
     /**

--- a/src/Persistence/Sql.php
+++ b/src/Persistence/Sql.php
@@ -57,8 +57,6 @@ class Sql extends Persistence
     public $_default_seed_join = [Sql\Join::class];
 
     /**
-     * Constructor.
-     *
      * @param Connection|string|array|DbalConnection|DbalDriverConnection $connection
      * @param string                                                      $user
      * @param string                                                      $password

--- a/src/Persistence/Sql.php
+++ b/src/Persistence/Sql.php
@@ -38,46 +38,22 @@ class Sql extends Persistence
     /** @const string */
     public const HOOK_BEFORE_DELETE_QUERY = self::class . '@beforeDeleteQuery';
 
-    /**
-     * Connection object.
-     *
-     * @var Connection
-     */
+    /** @var Connection Connection object. */
     public $connection;
 
-    /**
-     * Default class when adding new field.
-     *
-     * @var array
-     */
+    /** @var array Default class when adding new field. */
     public $_default_seed_addField; // no custom seed needed
 
-    /**
-     * Default class when adding hasOne field.
-     *
-     * @var array
-     */
+    /** @var array Default class when adding hasOne field. */
     public $_default_seed_hasOne = [\Atk4\Data\Reference\HasOneSql::class];
 
-    /**
-     * Default class when adding hasMany field.
-     *
-     * @var array
-     */
+    /** @var array Default class when adding hasMany field. */
     public $_default_seed_hasMany; // no custom seed needed
 
-    /**
-     * Default class when adding Expression field.
-     *
-     * @var array
-     */
+    /** @var array Default class when adding Expression field. */
     public $_default_seed_addExpression = [SqlExpressionField::class];
 
-    /**
-     * Default class when adding join.
-     *
-     * @var array
-     */
+    /** @var array Default class when adding join. */
     public $_default_seed_join = [Sql\Join::class];
 
     /**

--- a/src/Persistence/Sql/Expression.php
+++ b/src/Persistence/Sql/Expression.php
@@ -45,11 +45,7 @@ class Expression implements Expressionable, \ArrayAccess
      */
     public $args = ['custom' => []];
 
-    /**
-     * As per PDO, escapeParam() will convert value into :a, :b, :c .. :aa .. etc.
-     *
-     * @var string
-     */
+    /** @var string As per PDO, escapeParam() will convert value into :a, :b, :c .. :aa .. etc. */
     protected $paramBase = 'a';
 
     /**

--- a/src/Persistence/Sql/Query.php
+++ b/src/Persistence/Sql/Query.php
@@ -20,11 +20,7 @@ class Query extends Expression
      */
     public $mode = 'select';
 
-    /**
-     * If no fields are defined, this field is used.
-     *
-     * @var string|Expression
-     */
+    /** @var string|Expression If no fields are defined, this field is used. */
     public $defaultField = '*';
 
     /** @var string Expression classname */

--- a/src/Persistence/Static_.php
+++ b/src/Persistence/Static_.php
@@ -16,18 +16,10 @@ use Atk4\Data\Model;
  */
 class Static_ extends Array_
 {
-    /**
-     * This will be the title field for the model.
-     *
-     * @var string
-     */
+    /** @var string This will be the title field for the model. */
     public $titleForModel;
 
-    /**
-     * Populate the following fields for the model.
-     *
-     * @var array<string, array>
-     */
+    /** @var array<string, array> Populate the following fields for the model. */
     public $fieldsForModel = [];
 
     /**

--- a/src/Reference.php
+++ b/src/Reference.php
@@ -154,9 +154,6 @@ class Reference
         );
     }
 
-    /**
-     * Initialization.
-     */
     protected function init(): void
     {
         $this->_init();

--- a/src/Reference.php
+++ b/src/Reference.php
@@ -284,11 +284,7 @@ class Reference
         return $this->createTheirModel($defaults);
     }
 
-    /**
-     * List of properties to show in var_dump.
-     *
-     * @var array<int|string, string>
-     */
+    /** @var array<int|string, string> List of properties to show in var_dump. */
     protected $__debug_fields = ['link', 'model', 'our_field', 'their_field'];
 
     /**

--- a/src/Reference/ContainsOne.php
+++ b/src/Reference/ContainsOne.php
@@ -15,18 +15,10 @@ class ContainsOne extends Reference
 {
     use ContainsSeedHackTrait;
 
-    /**
-     * Field type.
-     *
-     * @var string
-     */
+    /** @var string Field type. */
     public $type = 'json';
 
-    /**
-     * Is it system field?
-     *
-     * @var bool
-     */
+    /** @var bool Is it system field? */
     public $system = true;
 
     /**
@@ -39,11 +31,7 @@ class ContainsOne extends Reference
      */
     public $ui = [];
 
-    /**
-     * Required! We need table alias for internal use only.
-     *
-     * @var string
-     */
+    /** @var string Required! We need table alias for internal use only. */
     protected $table_alias = 'tbl';
 
     /**

--- a/src/Util/DeepCopy.php
+++ b/src/Util/DeepCopy.php
@@ -26,19 +26,13 @@ class DeepCopy
     /** @const string */
     public const HOOK_AFTER_COPY = self::class . '@afterCopy';
 
-    /**
-     * @var Model from which we want to copy records
-     */
+    /** @var Model from which we want to copy records */
     protected $source;
 
-    /**
-     * @var Model in which we want to copy records into
-     */
+    /** @var Model in which we want to copy records into */
     protected $destination;
 
-    /**
-     * @var array containing references which we need to copy. May contain sub-arrays: ['Invoices' => ['Lines']]
-     */
+    /** @var array containing references which we need to copy. May contain sub-arrays: ['Invoices' => ['Lines']] */
     protected $references = [];
 
     /**
@@ -56,9 +50,7 @@ class DeepCopy
      */
     protected $transforms = [];
 
-    /**
-     * @var array while copying, will record mapped records in format [$table => ['old_id' => 'new_id']]
-     */
+    /** @var array while copying, will record mapped records in format [$table => ['old_id' => 'new_id']] */
     public $mapping = [];
 
     /**

--- a/tests/UserActionTest.php
+++ b/tests/UserActionTest.php
@@ -74,7 +74,7 @@ class UserActionTest extends TestCase
         // load record, before executing, because scope is single record
         $client = $client->load(1);
 
-        $act1 = $client->getUserActions()['send_reminder'];
+        $act1 = $client->getUserAction('send_reminder');
         $this->assertNotTrue($client->get('reminder_sent'));
         $res = $act1->execute();
         $this->assertTrue($client->get('reminder_sent'));

--- a/tests/UserActionTest.php
+++ b/tests/UserActionTest.php
@@ -74,7 +74,8 @@ class UserActionTest extends TestCase
         // load record, before executing, because scope is single record
         $client = $client->load(1);
 
-        $act1 = $client->getUserAction('send_reminder');
+        $act1 = $client->getModel()->getUserActions()['send_reminder'];
+        $act1 = $act1->getActionForEntity($client);
         $this->assertNotTrue($client->get('reminder_sent'));
         $res = $act1->execute();
         $this->assertTrue($client->get('reminder_sent'));


### PR DESCRIPTION
related with https://github.com/atk4/data/pull/943

Calling `Model::getUserActions()` on entity might have small negative impact and in most cases it is unneded/unwanted.

If action for entity is rellay wanted/needed, it can be always get using `Model::getUserAction($name)` or even with `UserAction::getActionForEntity` when the `$name` is not known (easily gettable).