### PR TITLE
Persistence::action() should be read only

### DIFF
--- a/README.md
+++ b/README.md
@@ -552,7 +552,7 @@ $client->ref('Order')->insert($_POST);
 
 
 
-Regardless of the content of the POST data, the order can only be created for the VIP client. Even if you perform a multi-row operation such as `action('update')` or `action('delete')` it will only apply to records that match all of the conditions.
+Regardless of the content of the POST data, the order can only be created for the VIP client. Even if you perform a multi-row operation such as `action('select')` or `action('fx')` it will only apply to records that match all of the conditions.
 
 Those security measures are there to protect you against human errors. We think that input sanitization is still quite important and you should do that.
 

--- a/docs/advanced.rst
+++ b/docs/advanced.rst
@@ -151,7 +151,7 @@ which I want to define like this::
     protected function init(): void {
         $this->_init();
 
-        if(isset($this->getOwner()->no_audit)){
+        if(isset($this->getOwner()->no_audit)) {
             return;
         }
 
@@ -223,7 +223,7 @@ Start by creating a class::
         function init(): void {
             $this->_init();
 
-            if(property_exists($this->getOwner(), 'no_soft_delete')){
+            if(property_exists($this->getOwner(), 'no_soft_delete')) {
                 return;
             }
 
@@ -334,7 +334,7 @@ before and just slightly modifying it::
         function init(): void {
             $this->_init();
 
-            if(property_exists($this->getOwner(), 'no_soft_delete')){
+            if(property_exists($this->getOwner(), 'no_soft_delete')) {
                 return;
             }
 
@@ -521,7 +521,7 @@ Next we need to define reference. Inside Model_Invoice add::
         $j->hasOne('invoice_id', 'Model_Invoice');
     }, 'their_field' => 'invoice_id']);
 
-    $this->onHookShort(Model::HOOK_BEFORE_DELETE, function() {
+    $this->onHookShort(Model::HOOK_BEFORE_DELETE, function () {
         foreach ($this->ref('InvoicePayment') as $payment) {
             $payment->delete();
         }
@@ -655,7 +655,7 @@ Here is how to add them. First you need to create fields::
 I have declared those fields with never_persist so they will never be used by
 persistence layer to load or save anything. Next I need a beforeSave handler::
 
-    $this->onHookShort(Model::HOOK_BEFORE_SAVE, function() {
+    $this->onHookShort(Model::HOOK_BEFORE_SAVE, function () {
         if($this->_isset('client_code') && !$this->_isset('client_id')) {
             $cl = $this->refModel('client_id');
             $cl->addCondition('code',$this->get('client_code'));
@@ -744,7 +744,7 @@ section. Add this into your Invoice Model::
 Next both payment and lines need to be added after invoice is actually created,
 so::
 
-    $this->onHookShort(Model::HOOK_AFTER_SAVE, function($is_update){
+    $this->onHookShort(Model::HOOK_AFTER_SAVE, function($is_update) {
         if($this->_isset('payment')) {
             $this->ref('Payment')->insert($this->get('payment'));
         }
@@ -800,7 +800,7 @@ field only to offer payments made by the same client. Inside Model_Invoice add::
 
     $this->hasOne('client_id', 'Client');
 
-    $this->hasOne('payment_invoice_id', ['model' => function($m){
+    $this->hasOne('payment_invoice_id', ['model' => function($m) {
         return $m->ref('client_id')->ref('Payment');
     }]);
 
@@ -826,7 +826,7 @@ Agile Data allow you to define multiple references between same entities, but
 sometimes that can be quite useful. Consider adding this inside your Model_Contact::
 
     $this->hasMany('Invoice', 'Model_Invoice');
-    $this->hasMany('OverdueInvoice', ['model' => function($m){
+    $this->hasMany('OverdueInvoice', ['model' => function($m) {
         return $m->ref('Invoice')->addCondition('due','<',date('Y-m-d'))
     }]);
 

--- a/docs/advanced.rst
+++ b/docs/advanced.rst
@@ -522,12 +522,9 @@ Next we need to define reference. Inside Model_Invoice add::
     }, 'their_field' => 'invoice_id']);
 
     $this->onHookShort(Model::HOOK_BEFORE_DELETE, function() {
-        $this->ref('InvoicePayment')->action('delete')->execute();
-
-        // If you have important per-row hooks in InvoicePayment
-        // foreach ($this->ref('InvoicePayment') as $payment) {
-        //     $payment->delete();
-        // }
+        foreach ($this->ref('InvoicePayment') as $payment) {
+            $payment->delete();
+        }
     });
 
 You'll have to do a similar change inside Payment model. The code for '$j->'

--- a/docs/design.rst
+++ b/docs/design.rst
@@ -338,7 +338,7 @@ Hooks can help you perform operations when object is being persisted::
             // addField() declaration
             // addExpression('is_password_expired')
 
-            $this->onHookShort(Model::HOOK_BEFORE_SAVE, function() {
+            $this->onHookShort(Model::HOOK_BEFORE_SAVE, function () {
                 if ($this->isDirty('password')) {
                     $this->set('password', encrypt_password($this->get('password')));
                     $this->set('password_change_date', $this->expr('now()'));

--- a/docs/hooks.rst
+++ b/docs/hooks.rst
@@ -238,7 +238,7 @@ This can be used in various situations.
 
 Save information into auditLog about failure:
 
-    $m->onHook(Model::HOOK_ROLLBACK, function($m){
+    $m->onHook(Model::HOOK_ROLLBACK, function($m) {
         $m->auditLog->registerFailure();
     });
 

--- a/docs/model.rst
+++ b/docs/model.rst
@@ -364,7 +364,7 @@ a hook::
 
    $this->addField('name');
 
-   $this->onHookShort(Model::HOOK_VALIDATE, function() {
+   $this->onHookShort(Model::HOOK_VALIDATE, function () {
       if ($this->get('name') === 'C#') {
          return ['name' => 'No sharp objects are allowed'];
       }

--- a/docs/model.rst
+++ b/docs/model.rst
@@ -29,14 +29,7 @@ object you can load/unload individual records (See Single record Operations belo
    $m = $m->load(8);
    ....
 
-and even perform operations on multiple records (See `Persistence Actions` below)::
-
-   $m = new User($db);
-   $m->addCondition('expired', true);
-
-   $m->action('delete')->execute(); // performs mass delete, hooks are not executed
-
-   foreach ($m as $entity) { $entity->delete(); } // deletes each record, hooks are executed
+and even perform operations on multiple records (See `Persistence Actions` below).
 
 When data is loaded from associated Persistence, it is automatically converted into
 a native PHP type (such as DateTime object) through a process called Typecasting. Various

--- a/docs/persistence.rst
+++ b/docs/persistence.rst
@@ -474,7 +474,7 @@ this ref, how do you do it?
 
 Start by creating a beforeSave handler for Order::
 
-    $this->onHookShort(Model::HOOK_BEFORE_SAVE, function() {
+    $this->onHookShort(Model::HOOK_BEFORE_SAVE, function () {
         if ($this->isDirty('ref')) {
 
             if (
@@ -589,11 +589,11 @@ application::
             $m = $m->withPersistence($this->mdb)->save();
         }
 
-        $m->onHook(Model::HOOK_BEFORE_SAVE, function($m){
+        $m->onHook(Model::HOOK_BEFORE_SAVE, function($m) {
             $m->withPersistence($this->sql)->save();
         });
 
-        $m->onHook(Model::HOOK_BEFORE_DELETE, function($m){
+        $m->onHook(Model::HOOK_BEFORE_DELETE, function($m) {
             $m->withPersistence($this->sql)->delete();
         });
 
@@ -634,11 +634,11 @@ records.
 The last two hooks are in order to replicate any changes into the SQL database
 also::
 
-    $m->onHook(Model::HOOK_BEFORE_SAVE, function($m){
+    $m->onHook(Model::HOOK_BEFORE_SAVE, function($m) {
         $m->withPersistence($this->sql)->save();
     });
 
-    $m->onHook(Model::HOOK_BEFORE_DELETE, function($m){
+    $m->onHook(Model::HOOK_BEFORE_DELETE, function($m) {
         $m->withPersistence($this->sql)->delete();
     });
 

--- a/docs/persistence.rst
+++ b/docs/persistence.rst
@@ -742,7 +742,7 @@ conditions)
 .. php:method:: action($action, $args = [])
 
     Prepares a special object representing "action" of a persistence layer based
-    around your current model::
+    around your current model.
 
 
 Action Types

--- a/docs/persistence.rst
+++ b/docs/persistence.rst
@@ -410,14 +410,13 @@ Create copy of existing record
     If you pass the `$id` parameter, then the new record will be saved under
     a new ID::
 
-        // First, lets delete all records except 123
-        (clone $m)->addCondition('id', '!=', 123)->action('delete')->execute();
+        // Assume DB with only one record with ID = 123
 
-        // Next we can duplicate
+        // Load and duplicate that record
         $m->load(123)->duplicate()->save();
 
         // Now you have 2 records:
-        // one with ID=123 and another with ID={next db generated id}
+        // one with ID = 123 and another with ID = {next db generated id}
         echo $m->action('count')->getOne();
 
 Duplicate then save under a new ID
@@ -745,11 +744,6 @@ conditions)
     Prepares a special object representing "action" of a persistence layer based
     around your current model::
 
-        $m = Model_User();
-        $m->addCondition('last_login', '<', date('Y-m-d', strtotime('-2 months')));
-
-        $m->action('delete')->execute();
-
 
 Action Types
 ------------
@@ -801,34 +795,9 @@ The default action type can be set when executing action, for example::
 SQL Actions
 -----------
 
-The following actions are currently supported by `Persistence\\Sql`:
+Currently only read-only actions are supported by `Persistence\\Sql`:
 
- - select - produces query that returns DataSet  (array of hashes)
- - delete - produces query for deleting DataSet (no result)
-
-The following two queries returns un-populated query, which means if you wish
-to use it, you'll have to populate it yourself with some values:
-
- - insert - produces an un-populated insert query (no result).
- - update - produces query for updating DataSet (no result)
-
-Example of using update::
-
-    $m = Model_Invoice($db);
-    $m->addCondition('has_discount', true);
-
-    $m->action('update')
-        ->set('has_dicount', false)
-        ->execute();
-
-You must be aware that set() operates on a DSQL object and will no longer
-work with your model fields. You should use the object like this if you can::
-
-    $m->action('update')
-        ->set($m->getField('has_discount'), false)
-        ->execute();
-
-See $actual for more details.
+ - select - produces query that returns DataSet (array of hashes)
 
 There are ability to execute aggregation functions::
 

--- a/docs/persistence/sql/transactions.rst
+++ b/docs/persistence/sql/transactions.rst
@@ -19,7 +19,7 @@ It is recommended to always use atomic() in your code.
     Execute callback within the SQL transaction. If callback encounters an
     exception, whole transaction will be automatically rolled back::
 
-        $c->atomic(function() use($c) {
+        $c->atomic(function () use ($c) {
             $c->dsql('user')->set('balance=balance+10')->where('id', 10)->update();
             $c->dsql('user')->set('balance=balance-10')->where('id', 14)->update();
         });

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -581,28 +581,6 @@ also build manually::
 
     $m->addExpression('country', $m->refLink('country_id')->action('field',['name']));
 
-Multi-record actions
---------------------
-
-Actions also allow you to perform operations on multiple records. This can be
-very handy with some deep traversal to improve query efficiency. Suppose you need
-to change Client/Supplier status to 'suspended' for a specific user. Fire up a
-console once away::
-
-    $m = new Model_User($db);
-    $m = $m->loadBy('username','john');
-    $m->hasMany('System');
-    $c = $m->ref('System')->ref('Client');
-    $s = $m->ref('System')->ref('Supplier');
-
-    $c->action('update')->set('status', 'suspended')->execute();
-    $s->action('update')->set('status', 'suspended')->execute();
-
-Note that I had to perform 2 updates here, because Agile Data considers Client
-and Supplier as separate models. In our implementation they happened to be in
-a same table, but technically that could also be implemented differently by
-persistence layer.
-
 Advanced Use of Actions
 -----------------------
 

--- a/docs/sql.rst
+++ b/docs/sql.rst
@@ -240,18 +240,6 @@ them yourself)::
     $action = $model->action('select', [false]);
     $action->field('count(*)', 'c);
 
-
-Action: insert
---------------
-
-Will prepare query for performing insert of a new record.
-
-Action: update, delete
-----------------------
-
-Will prepare query for performing update or delete of records.
-Applies conditions set.
-
 Action: count
 -------------
 

--- a/docs/sql.rst
+++ b/docs/sql.rst
@@ -169,7 +169,7 @@ This method allows you to execute code within a 'START TRANSACTION / COMMIT' blo
 
         function applyPayment(Payment $p) {
 
-            $this->persistence->atomic(function() use ($p) {
+            $this->persistence->atomic(function () use ($p) {
 
                 $this->set('paid', true);
                 $this->save();

--- a/docs/types.rst
+++ b/docs/types.rst
@@ -92,7 +92,7 @@ ATK Data prior to 1.5 supports the following types:
 
 In ATK Data the number of supported types has been extended with:
 
- - percent (34.2%) ([':php:class:`Number`', 'format' => function($v){ return $v*100; }, 'postfix' => '%'])
+ - percent (34.2%) ([':php:class:`Number`', 'format' => function($v) { return $v*100; }, 'postfix' => '%'])
  - rating (3 out of 5) ([':php:class:`Number`', 'max' => 5, 'precision' => 0])
  - uuid (xxxxxxxx-xxxx-...) ([':php:class:`Number`', 'base' => 16, 'mask' => '########-##..'])
  - hex (number with base 16) ([':php:class:`Number`', 'base' => 16])

--- a/src/Persistence/Sql.php
+++ b/src/Persistence/Sql.php
@@ -387,20 +387,6 @@ class Sql extends Persistence
     {
         $query = $this->initQuery($model);
         switch ($type) {
-            case 'insert':
-                return $query->mode('insert');
-                // cannot apply conditions now
-
-            case 'update':
-                $query->mode('update');
-
-                break;
-            case 'delete':
-                $query->mode('delete');
-                $this->initQueryConditions($model, $query);
-                $model->hook(self::HOOK_INIT_SELECT_QUERY, [$query, $type]);
-
-                return $query;
             case 'select':
                 $this->initQueryFields($model, $query, $args[0] ?? null);
 
@@ -528,7 +514,8 @@ class Sql extends Persistence
      */
     public function insert(Model $model, array $data): string
     {
-        $insert = $model->action('insert');
+        $insert = $this->initQuery($model);
+        $insert->mode('insert');
 
         if ($model->id_field && ($data[$model->id_field] ?? null) === null) {
             unset($data[$model->id_field]);

--- a/src/Util/DeepCopy.php
+++ b/src/Util/DeepCopy.php
@@ -43,7 +43,7 @@ class DeepCopy
 
     /**
      * @var array contains array similar to references but containing list of callback methods to transform fields/values:
-     *            e.g. ['Invoices' => ['Lines' => function($data){
+     *            e.g. ['Invoices' => ['Lines' => function($data) {
      *            $data['exchanged_amount'] = $data['amount'] * getExRate($data['date'], $data['currency']);
      *            return $data;
      *            }]]
@@ -112,15 +112,15 @@ class DeepCopy
      * May also contain arrays for related entries.
      *
      * ->transformData(
-     *      [function($data){ // for Client entity
-     *          $data['name'] => $data['last_name'].' '.$data['first_name'];
+     *      [function($data) { // for Client entity
+     *          $data['name'] => $data['last_name'] . ' ' . $data['first_name'];
      *          unset($data['first_name'], $data['last_name']);
      *          return $data;
      *      }],
-     *      'Invoices' => ['Lines' => function($data){ // for nested Client->Invoices->Lines hasMany entity
-     *              $data['exchanged_amount'] = $data['amount'] * getExRate($data['date'], $data['currency']);
-     *              return $data;
-     *          }]
+     *      'Invoices' => ['Lines' => function($data) { // for nested Client->Invoices->Lines hasMany entity
+     *          $data['exchanged_amount'] = $data['amount'] * getExRate($data['date'], $data['currency']);
+     *          return $data;
+     *      }]
      *  );
      *
      * @return $this

--- a/tests/IteratorTest.php
+++ b/tests/IteratorTest.php
@@ -78,7 +78,7 @@ class IteratorTest extends TestCase
     {
         $m = new Model();
         $this->expectException(Exception::class);
-        $m->action('insert');
+        $m->action('count');
     }
 
     public function testBasic(): void

--- a/tests/RandomTest.php
+++ b/tests/RandomTest.php
@@ -506,6 +506,27 @@ class RandomTest extends TestCase
         $m->duplicate(2)->save();
     }
 
+    public function testNoWriteActionInsert(): void
+    {
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage('Unsupported action mode');
+        $this->db->action(new Model(), 'insert');
+    }
+
+    public function testNoWriteActionUpdate(): void
+    {
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage('Unsupported action mode');
+        $this->db->action(new Model(), 'update');
+    }
+
+    public function testNoWriteActionDelete(): void
+    {
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage('Unsupported action mode');
+        $this->db->action(new Model(), 'delete');
+    }
+
     public function testTableWithSchema(): void
     {
         if ($this->getDatabasePlatform() instanceof SqlitePlatform || Connection::isComposerDbal2x()) {


### PR DESCRIPTION
when records are updated via SQL, php hooks can not be executed thus bypassing possible business logic checks

also SQL update statements has limited SQL support, for ex. table alias is not supported

it looks there was no use of them at all (one use in atk4/ui `demos/collection/multitable.php`)

in the future, `Persistence::action` should be renamed to `Persistence::toQuery` or even to `toSelectQuery`, related with https://github.com/atk4/data/pull/690