### PR TITLE
Drop Oracle 11g support

### DIFF
--- a/.github/workflows/test-unit.yml
+++ b/.github/workflows/test-unit.yml
@@ -111,9 +111,9 @@ jobs:
           ACCEPT_EULA: Y
           SA_PASSWORD: atk4_pass
       oracle:
-        image: ghcr.io/mvorisek/docker-oracle-xe-11g
+        image: gvenzl/oracle-xe:18
         env:
-          ORACLE_ALLOW_REMOTE: true
+          ORACLE_PASSWORD: atk4_pass
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -218,11 +218,10 @@ jobs:
         env:
           DB_DSN: "pdo_oci:dbname=oracle/xe"
           DB_USER: system
-          DB_PASSWORD: oracle
+          DB_PASSWORD: atk4_pass
           NLS_LANG: AMERICAN_AMERICA.AL32UTF8
         run: |
-          php -d opcache.enable_cli=1 vendor/bin/phpunit --exclude-group none $(if [ -n "$LOG_COVERAGE" ]; then echo --coverage-text; else echo --no-coverage; fi) -v \
-          || php -d opcache.enable_cli=1 vendor/bin/phpunit --exclude-group none $(if [ -n "$LOG_COVERAGE" ]; then echo --coverage-text; else echo --no-coverage; fi) -v
+          php -d opcache.enable_cli=1 vendor/bin/phpunit --exclude-group none $(if [ -n "$LOG_COVERAGE" ]; then echo --coverage-text; else echo --no-coverage; fi) -v
           if [ -n "$LOG_COVERAGE" ]; then mv coverage/phpunit.cov coverage/phpunit-oracle-pdo.cov; fi
 
       - name: "Run tests: Oracle - OCI8 (only for coverage or cron)"
@@ -230,11 +229,10 @@ jobs:
         env:
           DB_DSN: "oci8:dbname=oracle/xe"
           DB_USER: system
-          DB_PASSWORD: oracle
+          DB_PASSWORD: atk4_pass
           NLS_LANG: AMERICAN_AMERICA.AL32UTF8
         run: |
-          php -d opcache.enable_cli=1 vendor/bin/phpunit --exclude-group none $(if [ -n "$LOG_COVERAGE" ]; then echo --coverage-text; else echo --no-coverage; fi) -v \
-          || php -d opcache.enable_cli=1 vendor/bin/phpunit --exclude-group none $(if [ -n "$LOG_COVERAGE" ]; then echo --coverage-text; else echo --no-coverage; fi) -v
+          php -d opcache.enable_cli=1 vendor/bin/phpunit --exclude-group none $(if [ -n "$LOG_COVERAGE" ]; then echo --coverage-text; else echo --no-coverage; fi) -v
           if [ -n "$LOG_COVERAGE" ]; then mv coverage/phpunit.cov coverage/phpunit-oracle-oci8.cov; fi
 
       - name: Upload coverage logs 1/2 (only for latest Phpunit)

--- a/composer.json
+++ b/composer.json
@@ -42,7 +42,7 @@
     "require-release": {
         "php": ">=7.4 <8.2",
         "atk4/core": "~3.2.0",
-        "doctrine/dbal": "^3.š",
+        "doctrine/dbal": "^3.3",
         "mvorisek/atk4-hintable": "~1.7.1"
     },
     "require-dev": {

--- a/src/Persistence/Sql/Connection.php
+++ b/src/Persistence/Sql/Connection.php
@@ -316,7 +316,7 @@ abstract class Connection
     public function execute(Expression $expr): DbalResult
     {
         if ($this->connection === null) {
-            throw new Exception('Queries cannot be executed through this connection');
+            throw new Exception('DBAL connection is not set');
         }
 
         return $expr->execute($this->connection);


### PR DESCRIPTION
because of https://github.com/doctrine/dbal/pull/5109 and https://www.dsp.co.uk/oracle-11g-end-of-life

NLS_LANG env. var. is still needed, tested