### PR TITLE
Assert no traversing on unloaded entity field

### DIFF
--- a/src/Model/Join.php
+++ b/src/Model/Join.php
@@ -418,6 +418,17 @@ abstract class Join
     */
 
     /**
+     * @param mixed $value
+     */
+    protected function assertReferenceIdNotNull($value): void
+    {
+        if ($value === null) {
+            throw (new Exception('Reference ID is expected to be NOT null'))
+                ->addMoreInfo('value', $value);
+        }
+    }
+
+    /**
      * @return mixed
      *
      * @internal should be not used outside atk4/data
@@ -434,6 +445,8 @@ abstract class Join
      */
     protected function setId(Model $entity, $id): void
     {
+        $this->assertReferenceIdNotNull($id);
+
         $this->idByOid[spl_object_id($entity)] = $id;
     }
 
@@ -530,12 +543,14 @@ abstract class Join
             return;
         }
 
-        $this->setSaveBufferValue($entity, $this->foreign_field, $this->hasJoin() ? $this->getJoin()->getId($entity) : $entity->getId()); // TODO needed? from array persistence
+        $id = $this->hasJoin() ? $this->getJoin()->getId($entity) : $entity->getId();
+        $this->assertReferenceIdNotNull($id);
+        $this->setSaveBufferValue($entity, $this->foreign_field, $id); // TODO needed? from array persistence
 
         $foreignModel = $this->getForeignModel();
         $foreignEntity = $foreignModel->createEntity()
             ->setMulti($this->getAndUnsetSaveBuffer($entity))
-            ->set($this->foreign_field, $this->hasJoin() ? $this->getJoin()->getId($entity) : $entity->getId());
+            ->set($this->foreign_field, $id);
         $foreignEntity->save();
 
         $this->setId($entity, $entity->getId()); // TODO why is this here? it seems to be not needed
@@ -553,6 +568,7 @@ abstract class Join
 
         $foreignModel = $this->getForeignModel();
         $foreignId = $this->reverse ? $entity->getId() : $entity->get($this->master_field);
+        $this->assertReferenceIdNotNull($foreignId);
         $saveBuffer = $this->getAndUnsetSaveBuffer($entity);
         $foreignModel->atomic(function () use ($foreignModel, $foreignId, $saveBuffer) {
             $foreignModel = (clone $foreignModel)->addCondition($this->foreign_field, $foreignId);
@@ -573,6 +589,7 @@ abstract class Join
 
         $foreignModel = $this->getForeignModel();
         $foreignId = $this->reverse ? $entity->getId() : $entity->get($this->master_field);
+        $this->assertReferenceIdNotNull($foreignId);
         $foreignModel->atomic(function () use ($foreignModel, $foreignId) {
             $foreignModel = (clone $foreignModel)->addCondition($this->foreign_field, $foreignId);
             foreach ($foreignModel as $foreignEntity) {

--- a/src/Model/Join.php
+++ b/src/Model/Join.php
@@ -423,7 +423,7 @@ abstract class Join
     protected function assertReferenceIdNotNull($value): void
     {
         if ($value === null) {
-            throw (new Exception('Reference ID is expected to be NOT null'))
+            throw (new Exception('Unable to join on null value'))
                 ->addMoreInfo('value', $value);
         }
     }

--- a/src/Reference.php
+++ b/src/Reference.php
@@ -100,10 +100,10 @@ class Reference
     /**
      * @param mixed $value
      */
-    protected function assertReferenceIdNotNull($value): void
+    protected function assertReferenceValueNotNull($value): void
     {
         if ($value === null) {
-            throw (new Exception('Reference ID is expected to be NOT null'))
+            throw (new Exception('Unable to traverse on null value'))
                 ->addMoreInfo('value', $value);
         }
     }

--- a/src/Reference.php
+++ b/src/Reference.php
@@ -97,6 +97,17 @@ class Reference
         return $this->_setOwner($owner);
     }
 
+    /**
+     * @param mixed $value
+     */
+    protected function assertReferenceIdNotNull($value): void
+    {
+        if ($value === null) {
+            throw (new Exception('Reference ID is expected to be NOT null'))
+                ->addMoreInfo('value', $value);
+        }
+    }
+
     protected function getOurFieldName(): string
     {
         return $this->our_field ?: $this->getOurModel(null)->id_field;

--- a/src/Reference/HasMany.php
+++ b/src/Reference/HasMany.php
@@ -47,10 +47,13 @@ class HasMany extends Reference
     {
         $ourModel = $this->getOurModel($ourModel);
 
-        if ($ourModel->isEntity() && $ourModel->isLoaded()) {
-            return $this->our_field
+        if ($ourModel->isEntity()) {
+            $res = $this->our_field
                 ? $ourModel->get($this->our_field)
                 : $ourModel->getId();
+            $this->assertReferenceIdNotNull($res);
+
+            return $res;
         }
 
         // create expression based on existing conditions

--- a/src/Reference/HasMany.php
+++ b/src/Reference/HasMany.php
@@ -51,7 +51,7 @@ class HasMany extends Reference
             $res = $this->our_field
                 ? $ourModel->get($this->our_field)
                 : $ourModel->getId();
-            $this->assertReferenceIdNotNull($res);
+            $this->assertReferenceValueNotNull($res);
 
             return $res;
         }

--- a/src/Reference/HasOne.php
+++ b/src/Reference/HasOne.php
@@ -89,7 +89,7 @@ class HasOne extends Reference
 
         if ($ourModel->isEntity()) {
             $ourValue = $this->getOurFieldValue($ourModel);
-            $this->assertReferenceIdNotNull($ourValue);
+            $this->assertReferenceValueNotNull($ourValue);
 
             if ($this->their_field) {
                 $theirModel = $theirModel->tryLoadBy($this->their_field, $ourValue);

--- a/src/Reference/HasOneSql.php
+++ b/src/Reference/HasOneSql.php
@@ -117,22 +117,16 @@ class HasOneSql extends HasOne
 
         $theirFieldName = $this->their_field ?? $theirModel->id_field; // TODO why not $this->getTheirFieldName() ?
 
-        // At this point the reference
-        // if our_field is the id_field and is being used in the reference
-        // we should persist the relation in condtition
-        // example - $model->load(1)->ref('refLink')->import($rows);
-        if ($ourModel->isEntity() && $ourModel->isLoaded() && !$theirModel->isLoaded()) {
-            if ($ourModel->id_field === $this->getOurFieldName()) {
-                return $theirModel->getModel()
-                    ->addCondition($theirFieldName, $this->getOurFieldValue($ourModel));
-            }
+        if ($ourModel->isEntity()) {
+            $theirModel->getModel()
+                ->addCondition($theirFieldName, $this->getOurFieldValue($ourModel));
+        } else {
+            // handles the deep traversal using an expression
+            $ourFieldExpression = $ourModel->action('field', [$this->getOurField()]);
+
+            $theirModel->getModel(true)
+                ->addCondition($theirFieldName, $ourFieldExpression);
         }
-
-        // handles the deep traversal using an expression
-        $ourFieldExpression = $ourModel->action('field', [$this->getOurField()]);
-
-        $theirModel->getModel(true)
-            ->addCondition($theirFieldName, $ourFieldExpression);
 
         return $theirModel;
     }

--- a/tests/ReferenceSqlTest.php
+++ b/tests/ReferenceSqlTest.php
@@ -405,21 +405,16 @@ class ReferenceSqlTest extends TestCase
         $user = $this->setupDbForTraversing();
         $userEntity = $user->load(1);
 
-        $firstUserOrders = $userEntity->ref('Company')->ref('Orders');
-        $firstUserOrders->setOrder('id');
-
         $this->assertSameExportUnordered([
             ['id' => 1, 'company_id' => '1', 'description' => 'Vinny Company Order 1', 'amount' => 50.0],
             ['id' => 3, 'company_id' => '1', 'description' => 'Vinny Company Order 2', 'amount' => 15.0],
-        ], $firstUserOrders->export());
-
-        $userEntity->unload();
+        ], $userEntity->ref('Company')->ref('Orders')->export());
 
         $this->assertSameExportUnordered([
             ['id' => 1, 'company_id' => '1', 'description' => 'Vinny Company Order 1', 'amount' => 50.0],
             ['id' => 2, 'company_id' => '2', 'description' => 'Zoe Company Order', 'amount' => 10.0],
             ['id' => 3, 'company_id' => '1', 'description' => 'Vinny Company Order 2', 'amount' => 15.0],
-        ], $userEntity->getModel()->ref('Company')->ref('Orders')->setOrder('id')->export());
+        ], $userEntity->getModel()->ref('Company')->ref('Orders')->export());
     }
 
     public function testUnloadedEntityTraversingHasOnedEx(): void

--- a/tests/ReferenceSqlTest.php
+++ b/tests/ReferenceSqlTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Atk4\Data\Tests;
 
+use Atk4\Data\Exception;
 use Atk4\Data\Model;
 use Atk4\Data\Schema\TestCase;
 use Doctrine\DBAL\Platforms\PostgreSQLPlatform;
@@ -365,7 +366,7 @@ class ReferenceSqlTest extends TestCase
         $this->assertNull($ll->get('chicken5'));
     }
 
-    public function testReferenceHasOneTraversing(): void
+    protected function setupDbForTraversing(): Model
     {
         $this->setDb([
             'user' => [
@@ -396,9 +397,15 @@ class ReferenceSqlTest extends TestCase
 
         $company->hasMany('Orders', ['model' => $order]);
 
-        $user = $user->load(1);
+        return $user;
+    }
 
-        $firstUserOrders = $user->ref('Company')->ref('Orders');
+    public function testReferenceHasOneTraversing(): void
+    {
+        $user = $this->setupDbForTraversing();
+        $userEntity = $user->load(1);
+
+        $firstUserOrders = $userEntity->ref('Company')->ref('Orders');
         $firstUserOrders->setOrder('id');
 
         $this->assertSameExportUnordered([
@@ -406,13 +413,33 @@ class ReferenceSqlTest extends TestCase
             ['id' => 3, 'company_id' => '1', 'description' => 'Vinny Company Order 2', 'amount' => 15.0],
         ], $firstUserOrders->export());
 
-        $user->unload();
+        $userEntity->unload();
 
         $this->assertSameExportUnordered([
             ['id' => 1, 'company_id' => '1', 'description' => 'Vinny Company Order 1', 'amount' => 50.0],
             ['id' => 2, 'company_id' => '2', 'description' => 'Zoe Company Order', 'amount' => 10.0],
             ['id' => 3, 'company_id' => '1', 'description' => 'Vinny Company Order 2', 'amount' => 15.0],
-        ], $user->ref('Company')->ref('Orders')->setOrder('id')->export());
+        ], $userEntity->getModel()->ref('Company')->ref('Orders')->setOrder('id')->export());
+    }
+
+    public function testUnloadedEntityTraversingHasOnedEx(): void
+    {
+        $user = $this->setupDbForTraversing();
+        $userEntity = $user->createEntity();
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage('Reference ID is expected to be NOT null');
+        $userEntity->ref('Company');
+    }
+
+    public function testUnloadedEntityTraversingHasManyEx(): void
+    {
+        $user = $this->setupDbForTraversing();
+        $companyEntity = $user->ref('Company')->createEntity();
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage('Reference ID is expected to be NOT null');
+        $companyEntity->ref('Orders');
     }
 
     public function testReferenceHook(): void
@@ -443,14 +470,14 @@ class ReferenceSqlTest extends TestCase
         $uu = $u->load(2);
         $this->assertNull($uu->get('address'));
         $this->assertNull($uu->get('contact_id'));
-        $this->assertNull($uu->ref('contact_id')->get('address'));
 
         $uu = $u->load(3);
         $this->assertSame('Joe contact', $uu->get('address'));
         $this->assertSame('Joe contact', $uu->ref('contact_id')->get('address'));
 
         $uu = $u->load(2);
-        $uu->ref('contact_id')->save(['address' => 'Peters new contact']);
+        $cc = $uu->getModel()->ref('contact_id')->createEntity()->save(['address' => 'Peters new contact']);
+        $uu->set('contact_id', $cc->getId());
 
         $this->assertNotNull($uu->get('contact_id'));
         $this->assertSame('Peters new contact', $uu->ref('contact_id')->get('address'));

--- a/tests/ReferenceSqlTest.php
+++ b/tests/ReferenceSqlTest.php
@@ -428,7 +428,7 @@ class ReferenceSqlTest extends TestCase
         $userEntity = $user->createEntity();
 
         $this->expectException(Exception::class);
-        $this->expectExceptionMessage('Reference ID is expected to be NOT null');
+        $this->expectExceptionMessage('Unable to traverse on null value');
         $userEntity->ref('Company');
     }
 
@@ -438,7 +438,7 @@ class ReferenceSqlTest extends TestCase
         $companyEntity = $user->ref('Company')->createEntity();
 
         $this->expectException(Exception::class);
-        $this->expectExceptionMessage('Reference ID is expected to be NOT null');
+        $this->expectExceptionMessage('Unable to traverse on null value');
         $companyEntity->ref('Orders');
     }
 

--- a/tests/ReferenceSqlTest.php
+++ b/tests/ReferenceSqlTest.php
@@ -513,7 +513,7 @@ class ReferenceSqlTest extends TestCase
         $p->hasOne('Stadium', ['model' => $s, 'our_field' => 'id', 'their_field' => 'player_id']);
 
         $p = $p->load(2);
-        $p->ref('Stadium')->import([['name' => 'Nou camp nou']]);
+        $p->ref('Stadium')->getModel()->import([['name' => 'Nou camp nou']]);
         $this->assertSame('Nou camp nou', $p->ref('Stadium')->get('name'));
         $this->assertSame(2, $p->ref('Stadium')->get('player_id'));
     }

--- a/tests/ReferenceTest.php
+++ b/tests/ReferenceTest.php
@@ -69,7 +69,7 @@ class ReferenceTest extends TestCase
         $user = $user->createEntity();
         $user->setId(1);
         $user->getModel()->hasOne('order_id', ['model' => [Model::class, 'table' => 'order']]);
-        $o = $user->ref('order_id');
+        $o = $user->getModel()->ref('order_id');
         $this->assertSame('order', $o->table);
     }
 


### PR DESCRIPTION
I consider traversing of unloaded entity as a bug, as no condition was added and all records were filtered

if no conditional reference is wanted, simply traverse on model instead of an entity