### PR TITLE
Connection DSN can omit password

### DIFF
--- a/src/Persistence.php
+++ b/src/Persistence.php
@@ -52,7 +52,7 @@ abstract class Persistence
             case 'pdo_sqlsrv':
             case 'pdo_oci':
             case 'oci8':
-                $persistence = new Persistence\Sql($dsn, $dsn['user'], $dsn['password'], $args);
+                $persistence = new Persistence\Sql($dsn, $dsn['user'] ?? null, $dsn['password'] ?? null, $args);
 
                 return $persistence;
             default:


### PR DESCRIPTION
We can have connection string with empty password and in such case password is not set in dsn array.
This should fix that.

For example
```
'dsn' => "mysql://root@localhost:3307/my_dbase;charset=utf8mb4",
```