### PR TITLE
Stricter Model::{addExpression, addCalculatedField} seed

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ class JobReport extends Job {
         $timesheet->getRef('client_id')->addField('hourly_rate');
 
         // calculate timesheet cost expression
-        $timesheet->addExpression('cost', '[hours]*[hourly_rate]');
+        $timesheet->addExpression('cost', ['expr' => '[hours] * [hourly_rate]']);
 
         // build relation between Job and Timesheets
         $this->hasMany('Timesheets', ['model' => $timesheet])
@@ -159,10 +159,10 @@ class JobReport extends Job {
             );
 
         // finally lets calculate profit
-        $this->addExpression('profit', '[invoiced]-[reported]');
+        $this->addExpression('profit', ['expr' => '[invoiced] - [reported]']);
 
         // profit margin could be also useful
-        $this->addExpression('profit_margin', 'coalesce([profit] / [invoiced], 0)');
+        $this->addExpression('profit_margin', ['expr' => 'coalesce([profit] / [invoiced], 0)']);
     }
 }
 ```
@@ -189,7 +189,7 @@ $chart = new \Atk4\Chart\BarChart();
 $data = new JobReport($db);
 
 // BarChart wants aggregated data
-$data->addExpression('month', 'month([date])');
+$data->addExpression('month', ['expr' => 'month([date])']);
 $aggregate = new \Atk4\Report\GroupModel($data);
 $aggregate->groupBy('month', ['profit_margin' => 'sum']);
 

--- a/docs/advanced.rst
+++ b/docs/advanced.rst
@@ -549,7 +549,7 @@ that shows how much amount is closed and `amount_due`::
     // define field to see closed amount on invoice
     $this->hasMany('InvoicePayment')
         ->addField('total_payments', ['aggregate' => 'sum', 'field' => 'amount_closed']);
-    $this->addExpression('amount_due', '[total]-coalesce([total_payments],0)');
+    $this->addExpression('amount_due', ['expr' => '[total] - coalesce([total_payments], 0)']);
 
 Note that I'm using coalesce because without InvoicePayments the aggregate sum
 will return NULL. Finally let's build allocation method, that allocates new

--- a/docs/design.rst
+++ b/docs/design.rst
@@ -319,7 +319,7 @@ Code::
             $this->addField('password_change_date');
 
             $this->addExpression('is_password_expired', [
-                '[password_change_date] < (NOW() - INTERVAL 1 MONTH)',
+                'expr' => '[password_change_date] < (NOW() - INTERVAL 1 MONTH)',
                 'type' => 'boolean',
             ]);
         }

--- a/docs/expressions.rst
+++ b/docs/expressions.rst
@@ -101,9 +101,9 @@ Expression Callback
 
 You can use a callback method when defining expression::
 
-    $m->addExpression('total_gross', function($m, $q) {
-        return '[total_net]+[total_vat]';
-    });
+    $m->addExpression('total_gross', ['expr' => function ($m, $q) {
+        return '[total_net] + [total_vat]';
+    }, 'type' => 'float']);
 
 Model Reloading after Save
 --------------------------

--- a/docs/expressions.rst
+++ b/docs/expressions.rst
@@ -15,14 +15,14 @@ use result as an output.
 Expressions solve this problem by adding a read-only field to your model that
 corresponds to an expression:
 
-.. php:method:: addExpression($link, $model);
+.. php:method:: addExpression($name, $seed);
 
 Example will calculate "total_gross" by adding up values for "net" and "vat"::
 
     $m = new Model_Invoice($db);
     $m->addFields(['total_net', 'total_vat']);
 
-    $m->addExpression('total_gross', '[total_net]+[total_vat]');
+    $m->addExpression('total_gross', ['expr' => '[total_net] + [total_vat]']);
     $m = $m->load(1);
 
     echo $m->get('total_gross');
@@ -45,9 +45,9 @@ values for the other fields including other expressions.
 
 There are other ways how you can specify expression::
 
-    $m->addExpression('total_gross',
-        $m->expr('[total_net]+[total_vat] + [fee]', ['fee' => $fee])
-    );
+    $m->addExpression('total_gross', [
+        'expr' => $m->expr('[total_net] + [total_vat] + [fee]', ['fee' => $fee])
+    ]);
 
 This format allow you to supply additional parameters inside expression.
 You should always use parameters instead of appending values inside your
@@ -64,7 +64,7 @@ unite a few statistical queries. Let's start by looking a at a very basic
 example::
 
     $m = new Model($db, ['table' => false]);
-    $m->addExpression('now', 'now()');
+    $m->addExpression('now', ['expr' => 'now()']);
     $m = $m->loadAny();
     echo $m->get('now');
 
@@ -80,9 +80,9 @@ can be gained when you need to pull various statistical values from your
 database at once::
 
     $m = new Model($db, ['table' => false]);
-    $m->addExpression('total_orders', (new Model_Order($db))->action('count'));
-    $m->addExpression('total_payments', (new Model_Payment($db))->action('count'));
-    $m->addExpression('total_received', (new Model_Payment($db))->action('fx0', ['sum', 'amount']));
+    $m->addExpression('total_orders', ['expr' => (new Model_Order($db))->action('count')]);
+    $m->addExpression('total_payments', ['expr' => (new Model_Payment($db))->action('count')]);
+    $m->addExpression('total_received', ['expr' => (new Model_Payment($db))->action('fx0', ['sum', 'amount'])]);
 
     $data = $m->loadOne()->get();
 
@@ -123,7 +123,7 @@ the following model::
 
             $this->addFields(['a', 'b']);
 
-            $this->addExpression('sum', '[a]+[b]');
+            $this->addExpression('sum', ['expr' => '[a] + [b]']);
         }
     }
 

--- a/docs/model.rst
+++ b/docs/model.rst
@@ -273,7 +273,7 @@ You must make sure that expression is valid for current `$this->persistence`::
 
 For the times when you are not working with SQL persistence, you can calculate field in PHP.
 
-.. php:method:: addCalculatedField($name, $callback)
+.. php:method:: addCalculatedField($name, ['expr' => $callback])
 
 Creates new field object inside your model. Field value will be automatically
 calculated by your callback method right after individual record is loaded by the model::

--- a/docs/model.rst
+++ b/docs/model.rst
@@ -171,9 +171,9 @@ You may safely rely on `$this->persistence` property to make choices::
    } else {
 
       // Fallback
-      $this->addCalculatedField('total', function($m) {
+      $this->addCalculatedField('total', ['expr' => function ($m) {
          return $m->get('amount') + $m->get('vat');
-      } );
+      }, 'type' => 'float']);
    }
 
 To invoke code from `init()` methods of ALL models (for example soft-delete logic),
@@ -281,9 +281,9 @@ calculated by your callback method right after individual record is loaded by th
    $this->addField('term', ['caption' => 'Repayment term in months', 'default' => 36]);
    $this->addField('rate', ['caption' => 'APR %', 'default' => 5]);
 
-   $this->addCalculatedField('interest', function($m) {
+   $this->addCalculatedField('interest', ['expr' => function ($m) {
       return $m->calculateInterest();
-   });
+   }, 'type' => 'float']);
 
 .. important:: always use argument `$m` instead of `$this` inside your callbacks. If model is to be
    `clone`d, the code relying on `$this` would reference original model, but the code using
@@ -292,14 +292,14 @@ calculated by your callback method right after individual record is loaded by th
 This can also be useful for calculating relative times::
 
    class MyModel extends Model {
-      use HumanTiming; // See https://stackoverflow.com/questions/2915864/php-how-to-find-the-time-elapsed-since-a-date-time
+      use HumanTiming; // see https://stackoverflow.com/questions/2915864/php-how-to-find-the-time-elapsed-since-a-date-time
 
       function init(): void {
          parent::init();
 
-         $this->addCalculatedField('event_ts_human_friendly', function($m) {
+         $this->addCalculatedField('event_ts_human_friendly', ['expr' => function ($m) {
             return $this->humanTiming($m->get('event_ts'));
-         });
+         }]);
 
       }
    }

--- a/docs/model.rst
+++ b/docs/model.rst
@@ -167,7 +167,7 @@ You may safely rely on `$this->persistence` property to make choices::
    if ($this->persistence instanceof \Atk4\Data\Persistence\Sql) {
 
       // Calculating on SQL server is more efficient!!
-      $this->addExpression('total', '[amount] + [vat]');
+      $this->addExpression('total', ['expr' => '[amount] + [vat]']);
    } else {
 
       // Fallback
@@ -251,20 +251,20 @@ Although you may make any field read-only::
 
 There are two methods for adding dynamically calculated fields.
 
-.. php:method:: addExpression($name, $definition)
+.. php:method:: addExpression($name, $seed)
 
 Defines a field as server-side expression (e.g. SQL)::
 
-   $this->addExpression('total', '[amount] + [vat]');
+   $this->addExpression('total', ['expr' => '[amount] + [vat]']);
 
 The above code is executed on the server (SQL) and can be very powerful.
 You must make sure that expression is valid for current `$this->persistence`::
 
-   $product->addExpression('discount', $this->refLink('category_id')->fieldQuery('default_discount'));
+   $product->addExpression('discount', ['expr' => $this->refLink('category_id')->fieldQuery('default_discount')]);
    // expression as a sub-select from referenced model (Category) imported as a read-only field
    // of $product model
 
-   $product->addExpression('total', 'if([is_discounted], ([amount]+[vat])*[discount], [amount] + [vat])');
+   $product->addExpression('total', ['expr' => 'if ([is_discounted], ([amount] + [vat])*[discount], [amount] + [vat])']);
    // new "total" field now contains complex logic, which is executed in SQL
 
    $product->addCondition('total', '<', 10);

--- a/docs/overview.rst
+++ b/docs/overview.rst
@@ -160,7 +160,7 @@ This is a type of code which may change if you decide to switch from one
 persistence to another. For example, this is how you would define `gross` field
 for SQL::
 
-    $model->addExpression('gross', '[net]+[vat]');
+    $model->addExpression('gross', ['expr' => '[net]+[vat]']);
 
 If your persistence does not support expressions (e.g. you are using Redis or
 MongoDB), you would need to define the field differently::
@@ -180,7 +180,7 @@ you want it to work with NoSQL, then your solution might be::
     if ($model->hasMethod('addExpression')) {
 
         // method is injected by Persistence
-        $model->addExpression('gross', '[net]+[vat]');
+        $model->addExpression('gross', ['expr' => '[net] + [vat]']);
 
     } else {
 

--- a/docs/persistence.rst
+++ b/docs/persistence.rst
@@ -830,13 +830,13 @@ This operation is actually consisting of 3 following operations::
 Here is a way how to intervene with the process::
 
     $client->hasMany('Invoice');
-    $client->addExpression('last_sale', function($m) {
+    $client->addExpression('last_sale', ['expr' => function ($m) {
         return $m->refLink('Invoice')
             ->setOrder('date desc')
             ->setLimit(1)
             ->action('field', ['total_gross'], 'getOne');
 
-    });
+    }, 'type' => 'float']);
 
 The code above uses refLink and also creates expression, but it tweaks
 the action used.

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -134,7 +134,7 @@ It might be handy to use in-line definition of a model. Try the following
 inside console::
 
     $m = new \Atk4\Data\Model($db, 'contact_info');
-    $m->addFields(['address_1','address_2']);
+    $m->addFields(['address_1', 'address_2']);
     $m->addCondition('address_1', 'not', null);
     $m = $m->loadAny();
     $m->get();
@@ -150,8 +150,8 @@ Next, exit and create file `src/Model_ContactInfo.php`::
         {
             parent::init();
 
-            $this->addFields(['address_1','address_2']);
-            $this->addCondition('address_1','not', null);
+            $this->addFields(['address_1', 'address_2']);
+            $this->addCondition('address_1', 'not', null);
         }
     }
 
@@ -208,7 +208,7 @@ conditions is your way to specify which records to operate on::
     $m = new Model_User($db);
     $m->addCondition('country_id', '2');
 
-    myexport($m, ['id','username','country_id']);
+    myexport($m, ['id', 'username', 'country_id']);
 
 If you want to temporarily add conditions, then you can either clone the model
 or use :php:meth:`Model::tryLoadBy`.
@@ -353,7 +353,7 @@ Lets once again load up the console for some exercises::
 
     $m = new Model_User($db);
 
-    $m = $m->loadBy('username','john');
+    $m = $m->loadBy('username', 'john');
     $m->get();
 
 At this point you'll see that address has also been loaded for the user.
@@ -399,7 +399,7 @@ For some persistence classes, you should use constructor directly::
 There are several Persistence classes that deal with different data sources.
 Lets load up our console and try out a different persistence::
 
-    $a=['user' => [],'contact_info' => []];
+    $a=['user' => [], 'contact_info' => []];
     $ar = new \Atk4\Data\Persistence\Array_($a);
     $m = new Model_User($ar);
     $m->set('username', 'test');
@@ -539,15 +539,15 @@ can be brought into the original model as fields::
     $m = new Model_Client($db);
     $m->getRef('Invoice')->addField('max_delivery', ['aggregate' => 'max', 'field' => 'shipping']);
     $m->getRef('Payment')->addField('total_paid', ['aggregate' => 'sum', 'field' => 'amount']);
-    $m->export(['name','max_delivery','total_paid']);
+    $m->export(['name', 'max_delivery', 'total_paid']);
 
 The above code is more concise and can be used together with reference declaration,
 although this is how it works::
 
     $m = new Model_Client($db);
-    $m->addExpression('max_delivery', $m->refLink('Invoice')->action('fx', ['max', 'shipping']));
-    $m->addExpression('total_paid', $m->refLink('Payment')->action('fx', ['sum', 'amount']));
-    $m->export(['name','max_delivery','total_paid']);
+    $m->addExpression('max_delivery', ['expr' => $m->refLink('Invoice')->action('fx', ['max', 'shipping'])]);
+    $m->addExpression('total_paid', ['expr' => $m->refLink('Payment')->action('fx', ['sum', 'amount'])]);
+    $m->export(['name', 'max_delivery', 'total_paid']);
 
 In this example calling refLink is similar to traversing reference but instead
 of calculating DataSet based on Active Record or DataSet it references the actual
@@ -579,7 +579,7 @@ This is useful with hasMany references::
 hasMany::addField() again is a short-cut for creating expression, which you can
 also build manually::
 
-    $m->addExpression('country', $m->refLink('country_id')->action('field',['name']));
+    $m->addExpression('country', $m->refLink('country_id')->action('field', ['name']));
 
 Advanced Use of Actions
 -----------------------
@@ -600,7 +600,7 @@ you could do this::
     $m = new Model_User($db);
     $m->set('username', 'peter');
     $m->set('address_1', 'street 49');
-    $m->set('country_id', (new Model_Country($db))->addCondition('name','UK')->action('field',['id']));
+    $m->set('country_id', (new Model_Country($db))->addCondition('name', 'UK')->action('field', ['id']));
     $m->save();
 
 This way it will not execute any code, but instead it will provide expression
@@ -617,8 +617,8 @@ however if you're stuck with SQL you can use free-form pattern-based expressions
     $m->getRef('Invoice')->addField('total_purchase', ['aggregate' => 'sum', 'field' => 'total']);
     $m->getRef('Payment')->addField('total_paid', ['aggregate' => 'sum', 'field' => 'amount']);
 
-    $m->addExpression('balance','[total_purchase]+[total_paid]');
-    $m->export(['name','balance']);
+    $m->addExpression('balance', ['expr' => '[total_purchase] + [total_paid]']);
+    $m->export(['name', 'balance']);
 
 
 Conclusion

--- a/docs/sql.rst
+++ b/docs/sql.rst
@@ -144,14 +144,14 @@ Expression will map into the SQL code, but will perform as read-only field other
 
     Stores expression that you define through DSQL expression::
 
-        $model->addExpression('age', 'year(now())-[birth_year]');
+        $model->addExpression('age', ['expr' => 'year(now()) - [birth_year]']);
         // tag [birth_year] will be automatically replaced by respective model field
 
 .. php:method:: getDsqlExpression
 
     SQL Expressions can be used inside other SQL expressions::
 
-        $model->addExpression('can_buy_alcohol', ['if([age] > 25, 1, 0)', 'type' => 'boolean']);
+        $model->addExpression('can_buy_alcohol', ['expr' => 'if([age] > 25, 1, 0)', 'type' => 'boolean']);
 
 Adding expressions to model will make it automatically reload itself after save
 as default behavior, see :php:attr:`Model::reload_after_save`.
@@ -397,7 +397,7 @@ fetching like this::
             $this->hasOne('parent_id', ['model' => [self::class]]);
             $this->addField('name');
 
-            $this->addExpression('path', 'get_path([id])');
+            $this->addExpression('path', ['expr' => 'get_path([id])']);
         }
     }
 

--- a/src/Model.php
+++ b/src/Model.php
@@ -1918,16 +1918,12 @@ class Model implements \IteratorAggregate
     /**
      * Add expression field which will calculate its value by using callback.
      *
-     * @param string|array|\Closure $expression
+     * @param array $expression
      *
      * @return CallbackField
      */
     public function addCalculatedField(string $name, $expression)
     {
-        if (!is_array($expression)) {
-            $expression = ['expr' => $expression];
-        }
-
         $field = new CallbackField($expression);
 
         $this->addField($name, $field);

--- a/src/Model.php
+++ b/src/Model.php
@@ -1905,9 +1905,6 @@ class Model implements \IteratorAggregate
     {
         if (!is_array($expression)) {
             $expression = ['expr' => $expression];
-        } elseif (isset($expression[0])) {
-            $expression['expr'] = $expression[0];
-            unset($expression[0]);
         }
 
         /** @var CallbackField|SqlExpressionField */
@@ -1929,9 +1926,6 @@ class Model implements \IteratorAggregate
     {
         if (!is_array($expression)) {
             $expression = ['expr' => $expression];
-        } elseif (isset($expression[0])) {
-            $expression['expr'] = $expression[0];
-            unset($expression[0]);
         }
 
         $field = new CallbackField($expression);

--- a/src/Model.php
+++ b/src/Model.php
@@ -1897,18 +1897,14 @@ class Model implements \IteratorAggregate
     /**
      * Add expression field.
      *
-     * @param string|array|Persistence\Sql\Expressionable|\Closure $expression
+     * @param array $seed
      *
      * @return CallbackField|SqlExpressionField
      */
-    public function addExpression(string $name, $expression)
+    public function addExpression(string $name, $seed)
     {
-        if (!is_array($expression)) {
-            $expression = ['expr' => $expression];
-        }
-
         /** @var CallbackField|SqlExpressionField */
-        $field = Field::fromSeed($this->_default_seed_addExpression, $expression);
+        $field = Field::fromSeed($this->_default_seed_addExpression, $seed);
 
         $this->addField($name, $field);
 
@@ -1918,13 +1914,13 @@ class Model implements \IteratorAggregate
     /**
      * Add expression field which will calculate its value by using callback.
      *
-     * @param array $expression
+     * @param array $seed
      *
      * @return CallbackField
      */
-    public function addCalculatedField(string $name, $expression)
+    public function addCalculatedField(string $name, $seed)
     {
-        $field = new CallbackField($expression);
+        $field = new CallbackField($seed);
 
         $this->addField($name, $field);
 

--- a/src/Persistence/Sql.php
+++ b/src/Persistence/Sql.php
@@ -138,7 +138,7 @@ class Sql extends Persistence
         // When we work without table, we can't have any IDs
         if ($model->table === false) {
             $model->removeField($model->id_field);
-            $model->addExpression($model->id_field, '-1');
+            $model->addExpression($model->id_field, ['expr' => '-1', 'type' => 'integer']);
         }
     }
 

--- a/src/Reference/HasMany.php
+++ b/src/Reference/HasMany.php
@@ -151,7 +151,7 @@ class HasMany extends Reference
             };
         }
 
-        return $this->getOurModel(null)->addExpression($fieldName, array_merge([$fx], $defaults));
+        return $this->getOurModel(null)->addExpression($fieldName, array_merge(['expr' => $fx], $defaults));
     }
 
     /**

--- a/src/Reference/HasMany.php
+++ b/src/Reference/HasMany.php
@@ -151,7 +151,7 @@ class HasMany extends Reference
             };
         }
 
-        return $this->getOurModel(null)->addExpression($fieldName, array_merge(['expr' => $fx], $defaults));
+        return $this->getOurModel(null)->addExpression($fieldName, array_merge($defaults, ['expr' => $fx]));
     }
 
     /**

--- a/src/Reference/HasOneSql.php
+++ b/src/Reference/HasOneSql.php
@@ -30,7 +30,7 @@ class HasOneSql extends HasOne
 
         $fieldExpression = $ourModel->addExpression($fieldName, array_merge(
             [
-                function (Model $ourModel) use ($theirFieldName) {
+                'expr' => function (Model $ourModel) use ($theirFieldName) {
                     // remove order if we just select one field from hasOne model
                     // that is mandatory for Oracle
                     return $ourModel->refLink($this->link)->action('field', [$theirFieldName])->reset('order');
@@ -154,7 +154,7 @@ class HasOneSql extends HasOne
 
         $fieldExpression = $ourModel->addExpression($fieldName, array_replace_recursive(
             [
-                function (Model $ourModel) {
+                'expr' => function (Model $ourModel) {
                     $theirModel = $ourModel->refLink($this->link);
 
                     return $theirModel->action('field', [$theirModel->title_field])->reset('order');

--- a/tests/ContainsMany/Invoice.php
+++ b/tests/ContainsMany/Invoice.php
@@ -42,13 +42,13 @@ class Invoice extends Model
         }, 'type' => 'float']);
 
         // discounts_total_sum - calculated by php callback not by SQL expression
-        $this->addCalculatedField($this->fieldName()->discounts_total_sum, function (self $m) {
+        $this->addCalculatedField($this->fieldName()->discounts_total_sum, ['expr' => function (self $m) {
             $total = 0;
             foreach ($m->lines as $line) {
                 $total += $line->total_gross * $line->discounts_percent / 100;
             }
 
             return $total;
-        });
+        }, 'type' => 'float']);
     }
 }

--- a/tests/ContainsMany/Line.php
+++ b/tests/ContainsMany/Line.php
@@ -36,13 +36,13 @@ class Line extends Model
         // each line can have multiple discounts and calculate total of these discounts
         $this->containsMany($this->fieldName()->discounts, ['model' => [Discount::class]]);
 
-        $this->addCalculatedField($this->fieldName()->discounts_percent, function ($m) {
+        $this->addCalculatedField($this->fieldName()->discounts_percent, ['expr' => function ($m) {
             $total = 0;
             foreach ($m->discounts as $d) {
                 $total += $d->percent;
             }
 
             return $total;
-        });
+        }, 'type' => 'float']);
     }
 }

--- a/tests/ExpressionSqlTest.php
+++ b/tests/ExpressionSqlTest.php
@@ -69,13 +69,13 @@ class ExpressionSqlTest extends TestCase
         ]);
 
         $i = (new Model($this->db, ['table' => 'invoice']))->addFields(['total_net', 'total_vat']);
-        $i->addExpression('total_gross', function ($i, $q) {
-            return '[total_net]+[total_vat]';
-        });
+        $i->addExpression('total_gross', ['expr' => function ($i, $q) {
+            return '[total_net] + [total_vat]';
+        }, 'type' => 'float']);
 
         if ($this->getDatabasePlatform() instanceof SqlitePlatform) {
             $this->assertSame(
-                'select "id", "total_net", "total_vat", ("total_net"+"total_vat") "total_gross" from "invoice"',
+                'select "id", "total_net", "total_vat", ("total_net" + "total_vat") "total_gross" from "invoice"',
                 $i->action('select')->render()[0]
             );
         }
@@ -229,12 +229,12 @@ class ExpressionSqlTest extends TestCase
 
         $i = new Model($this->db, ['table' => 'invoice']);
 
-        $i->addExpression('zero_basic', [$i->expr('0'), 'type' => 'integer', 'system' => true]);
-        $i->addExpression('zero_never_save', [$i->expr('0'), 'type' => 'integer', 'system' => true, 'never_save' => true]);
-        $i->addExpression('zero_never_persist', [$i->expr('0'), 'type' => 'integer', 'system' => true, 'never_persist' => true]);
-        $i->addExpression('one_basic', [$i->expr('1'), 'type' => 'integer', 'system' => true]);
-        $i->addExpression('one_never_save', [$i->expr('1'), 'type' => 'integer', 'system' => true, 'never_save' => true]);
-        $i->addExpression('one_never_persist', [$i->expr('1'), 'type' => 'integer', 'system' => true, 'never_persist' => true]);
+        $i->addExpression('zero_basic', ['expr' => $i->expr('0'), 'type' => 'integer', 'system' => true]);
+        $i->addExpression('zero_never_save', ['expr' => $i->expr('0'), 'type' => 'integer', 'system' => true, 'never_save' => true]);
+        $i->addExpression('zero_never_persist', ['expr' => $i->expr('0'), 'type' => 'integer', 'system' => true, 'never_persist' => true]);
+        $i->addExpression('one_basic', ['expr' => $i->expr('1'), 'type' => 'integer', 'system' => true]);
+        $i->addExpression('one_never_save', ['expr' => $i->expr('1'), 'type' => 'integer', 'system' => true, 'never_save' => true]);
+        $i->addExpression('one_never_persist', ['expr' => $i->expr('1'), 'type' => 'integer', 'system' => true, 'never_persist' => true]);
         $i = $i->loadOne();
 
         // normal fields

--- a/tests/FieldTest.php
+++ b/tests/FieldTest.php
@@ -453,9 +453,9 @@ class FieldTest extends TestCase
         $m = new Model($this->db, ['table' => 'invoice']);
         $m->addField('net', ['type' => 'atk4_money']);
         $m->addField('vat', ['type' => 'atk4_money']);
-        $m->addCalculatedField('total', function ($m) {
+        $m->addCalculatedField('total', ['expr' => function ($m) {
             return $m->get('net') + $m->get('vat');
-        });
+        }, 'type' => 'atk4_money']);
         $m->insert(['net' => 30, 'vat' => 8]);
 
         $mm = $m->load(1);

--- a/tests/IteratorTest.php
+++ b/tests/IteratorTest.php
@@ -92,7 +92,7 @@ class IteratorTest extends TestCase
         ]);
 
         $i = (new Model($this->db, ['table' => 'invoice']))->addFields(['total_net', 'total_vat']);
-        $i->addExpression('total_gross', '[total_net]+[total_vat]');
+        $i->addExpression('total_gross', ['expr' => '[total_net] + [total_vat]']);
 
         $i->setOrder('total_net');
         $i->setOnlyFields(['total_net']);
@@ -135,7 +135,7 @@ class IteratorTest extends TestCase
         ]);
 
         $i = (new Model($this->db, ['table' => 'invoice']))->addFields(['total_net', 'total_vat']);
-        $i->addExpression('total_gross', '[total_net]+[total_vat]');
+        $i->addExpression('total_gross', ['expr' => '[total_net] + [total_vat]']);
 
         $i->setOrder('total_net');
         $i->setOnlyFields(['total_net']);
@@ -178,7 +178,7 @@ class IteratorTest extends TestCase
         ]);
 
         $i = (new Model($this->db, ['table' => 'invoice']))->addFields(['total_net', 'total_vat']);
-        $i->addExpression('total_gross', '[total_net]+[total_vat]');
+        $i->addExpression('total_gross', ['expr' => '[total_net] + [total_vat]']);
 
         $i->setOrder('total_net');
         $i->setOnlyFields(['total_net']);

--- a/tests/LimitOrderTest.php
+++ b/tests/LimitOrderTest.php
@@ -21,7 +21,7 @@ class LimitOrderTest extends TestCase
         ]);
 
         $i = (new Model($this->db, ['table' => 'invoice']))->addFields(['total_net', 'total_vat']);
-        $i->addExpression('total_gross', '[total_net]+[total_vat]');
+        $i->addExpression('total_gross', ['expr' => '[total_net] + [total_vat]']);
         $i->getField($i->id_field)->system = false;
         $i->id_field = null;
 
@@ -45,7 +45,7 @@ class LimitOrderTest extends TestCase
         ]);
 
         $ii = (new Model($this->db, ['table' => 'invoice']))->addFields(['total_net', 'total_vat']);
-        $ii->addExpression('total_gross', '[total_net]+[total_vat]');
+        $ii->addExpression('total_gross', ['expr' => '[total_net] + [total_vat]']);
         $ii->getField($ii->id_field)->system = false;
         $ii->id_field = null;
 
@@ -143,7 +143,7 @@ class LimitOrderTest extends TestCase
 
         // order by expression field
         $i = (new Model($this->db, ['table' => 'invoice']))->addFields(['code', 'net', 'vat']);
-        $i->addExpression('gross', '[net]+[vat]');
+        $i->addExpression('gross', ['expr' => '[net] + [vat]']);
         $i->getField($i->id_field)->system = false;
         $i->id_field = null;
 
@@ -224,7 +224,7 @@ class LimitOrderTest extends TestCase
         ]);
 
         $i = (new Model($this->db, ['table' => 'invoice']))->addFields(['total_net', 'total_vat']);
-        $i->addExpression('total_gross', '[total_net]+[total_vat]');
+        $i->addExpression('total_gross', ['expr' => '[total_net] + [total_vat]']);
         $i->getField($i->id_field)->system = false;
         $i->id_field = null;
 

--- a/tests/RandomTest.php
+++ b/tests/RandomTest.php
@@ -391,7 +391,7 @@ class RandomTest extends TestCase
         $this->assertEquals(2, $mm->getTitle()); // loaded returns id value
 
         // expression as title field
-        $m->addExpression('my_name', '[id]');
+        $m->addExpression('my_name', ['expr' => '[id]']);
         $m->title_field = 'my_name';
         $mm = $m->load(2);
         $this->assertEquals(2, $mm->getTitle()); // loaded returns id value

--- a/tests/RandomTest.php
+++ b/tests/RandomTest.php
@@ -244,9 +244,9 @@ class RandomTest extends TestCase
 
         // default title field
         $m = new Model($p);
-        $m->addExpression('caps', function ($m) {
+        $m->addExpression('caps', ['expr' => function ($m) {
             return strtoupper($m->get('name'));
-        });
+        }]);
 
         $m = $m->load(2);
         $this->assertSame('world', $m->get('name'));

--- a/tests/ReferenceSqlTest.php
+++ b/tests/ReferenceSqlTest.php
@@ -221,7 +221,7 @@ class ReferenceSqlTest extends TestCase
         $l = (new Model($this->db, ['table' => 'invoice_line']))->addFields(['invoice_id', 'total_net', 'total_vat', 'total_gross']);
         $i->hasMany('line', ['model' => $l]);
 
-        $i->addExpression('total_net', $i->refLink('line')->action('fx', ['sum', 'total_net']));
+        $i->addExpression('total_net', ['expr' => $i->refLink('line')->action('fx', ['sum', 'total_net'])]);
 
         $this->assertSameSql(
             'select "id", "ref_no", (select sum("total_net") from "invoice_line" "_l_6438c669e0d0" where "invoice_id" = "invoice"."id") "total_net" from "invoice"',

--- a/tests/Util/DeepCopyTest.php
+++ b/tests/Util/DeepCopyTest.php
@@ -42,7 +42,7 @@ class DcInvoice extends Model
         $this->hasMany('Payments', ['model' => [DcPayment::class]])
             ->addField('paid', ['aggregate' => 'sum', 'field' => 'amount']);
 
-        $this->addExpression('due', '[total]-[paid]');
+        $this->addExpression('due', ['expr' => '[total] - [paid]']);
 
         $this->addField('ref');
 
@@ -93,7 +93,7 @@ class DcInvoiceLine extends Model
         $this->addField('vat', ['type' => 'float', 'default' => 0.21]);
 
         // total is calculated with VAT
-        $this->addExpression('total', '[qty]*[price]*(1+[vat])');
+        $this->addExpression('total', ['expr' => '[qty] * [price] * (1 + [vat])']);
     }
 }
 
@@ -116,7 +116,7 @@ class DcQuoteLine extends Model
         $this->addField('price', ['type' => 'atk4_money']);
 
         // total is calculated WITHOUT VAT
-        $this->addExpression('total', '[qty]*[price]');
+        $this->addExpression('total', ['expr' => '[qty] * [price]']);
     }
 }
 


### PR DESCRIPTION
This change is motivated by stricter seed definition and the fact, that Field type should be always specified, thus requiring the seed to be an array. Also, overriding methods and/or merging seeds is much easier.