### PR TITLE
Fix long string param support for Oracle

### DIFF
--- a/.github/workflows/test-unit.yml
+++ b/.github/workflows/test-unit.yml
@@ -77,7 +77,7 @@ jobs:
     name: Unit
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/mvorisek/image-php:${{ matrix.php }}
+      image: ghcr.io/mvorisek/image-php:${{ matrix.php }}-debian
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/test-unit.yml
+++ b/.github/workflows/test-unit.yml
@@ -77,6 +77,8 @@ jobs:
     name: Unit
     runs-on: ubuntu-latest
     container:
+      # Alpine support for newer pdo_oci is broken, see https://github.com/mlocati/docker-php-extension-installer/issues/523
+      # remove once config.m4 checks are working on Alpine
       image: ghcr.io/mvorisek/image-php:${{ matrix.php }}-debian
     strategy:
       fail-fast: false

--- a/src/Persistence/Sql/Mssql/ExpressionTrait.php
+++ b/src/Persistence/Sql/Mssql/ExpressionTrait.php
@@ -6,6 +6,11 @@ namespace Atk4\Data\Persistence\Sql\Mssql;
 
 trait ExpressionTrait
 {
+    private function fixOpenEscapeChar(string $v): string
+    {
+        return preg_replace('~(?:\'(?:\'\'|\\\\\'|[^\'])*\')?+\K\]([^\[\]\'"(){}]*?)\]~s', '[$1]', $v);
+    }
+
     protected function escapeIdentifier(string $value): string
     {
         return $this->fixOpenEscapeChar(parent::escapeIdentifier($value));
@@ -14,11 +19,6 @@ trait ExpressionTrait
     protected function escapeIdentifierSoft(string $value): string
     {
         return $this->fixOpenEscapeChar(parent::escapeIdentifierSoft($value));
-    }
-
-    private function fixOpenEscapeChar(string $v): string
-    {
-        return preg_replace('~(?:\'(?:\'\'|\\\\\'|[^\'])*\')?+\K\]([^\[\]\'"(){}]*?)\]~s', '[$1]', $v);
     }
 
     public function render(): array

--- a/src/Persistence/Sql/Oracle/Expression.php
+++ b/src/Persistence/Sql/Oracle/Expression.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Atk4\Data\Persistence\Sql\Oracle;
+
+use Atk4\Data\Persistence\Sql\Expression as BaseExpression;
+
+class Expression extends BaseExpression
+{
+    use ExpressionTrait;
+}

--- a/src/Persistence/Sql/Oracle/ExpressionTrait.php
+++ b/src/Persistence/Sql/Oracle/ExpressionTrait.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Atk4\Data\Persistence\Sql\Oracle;
+
+trait ExpressionTrait
+{
+    protected function castLongStringToClobExpr(string $value): Expression
+    {
+        $exprArgs = [];
+        $buildConcatExprFx = function (array $parts) use (&$buildConcatExprFx, &$exprArgs): string {
+            if (count($parts) > 1) {
+                $valueLeft = array_slice($parts, 0, intdiv(count($parts), 2));
+                $valueRight = array_slice($parts, count($valueLeft));
+
+                return 'CONCAT(' . $buildConcatExprFx($valueLeft) . ', ' . $buildConcatExprFx($valueRight) . ')';
+            }
+
+            $exprArgs[] = count($parts) > 0 ? reset($parts) : '';
+
+            return 'TO_CLOB([])';
+        };
+
+        // Oracle SQL (multibyte) string literal is limited to 1332 bytes
+        $parts = [];
+        foreach (mb_str_split($value, 10_000) as $shorterValue) {
+            $lengthBytes = strlen($shorterValue);
+            $startBytes = 0;
+            do {
+                $part = mb_strcut($shorterValue, $startBytes, 1000);
+                $startBytes += strlen($part);
+                $parts[] = $part;
+            } while ($startBytes < $lengthBytes);
+        }
+
+        $expr = $buildConcatExprFx($parts);
+
+        return $this->expr($expr, $exprArgs); // @phpstan-ignore-line
+    }
+
+    protected function updateRenderBeforeExecute(array $render): array
+    {
+        [$sql, $params] = parent::updateRenderBeforeExecute($render);
+
+        $newParamBase = $this->paramBase;
+        $newParams = [];
+        $sql = preg_replace_callback(
+            '~(?:\'(?:\'\'|\\\\\'|[^\'])*\')?+\K:\w+~s',
+            function ($matches) use ($params, &$newParams, &$newParamBase) {
+                $value = $params[$matches[0]];
+                if (is_string($value) && strlen($value) > 4000) {
+                    $expr = $this->castLongStringToClobExpr($value);
+                    unset($value);
+                    [$exprSql, $exprParams] = $expr->render();
+                    $sql = preg_replace_callback(
+                        '~(?:\'(?:\'\'|\\\\\'|[^\'])*\')?+\K:\w+~s',
+                        function ($matches) use ($exprParams, &$newParams, &$newParamBase) {
+                            $name = ':' . $newParamBase;
+                            ++$newParamBase;
+                            $newParams[$name] = $exprParams[$matches[0]];
+
+                            return $name;
+                        },
+                        $exprSql
+                    );
+                } else {
+                    $sql = ':' . $newParamBase;
+                    ++$newParamBase;
+
+                    $newParams[$sql] = $value;
+                }
+
+                return $sql;
+            },
+            $sql
+        );
+
+        return [$sql, $newParams];
+    }
+}


### PR DESCRIPTION
read needs https://github.com/php/php-src/pull/8018 for pdo_oci driver, oci8 driver is working

tested /w large value with size of 15 MiB, both text and blob DBAL types (~150 MB memory needed for Sqlite/Mysql, ~500 MB for Oracle and test took over 3 minutes to finish (vs. 1.5 second on Mysql))