### PR TITLE
Drop addFields() methods in favor of addField() returning $this

### DIFF
--- a/docs/advanced.rst
+++ b/docs/advanced.rst
@@ -544,8 +544,8 @@ that shows how much amount is closed and `amount_due`::
 
     // define field to see closed amount on invoice
     $this->hasMany('InvoicePayment')
-        ->addField('total_payments', ['aggregate' => 'sum', 'field' => 'amount_closed']);
-    $this->addExpression('amount_due', ['expr' => '[total] - coalesce([total_payments], 0)']);
+        ->addField('total_payments', ['aggregate' => 'sum', 'field' => 'amount_closed'])
+        ->addExpression('amount_due', ['expr' => '[total] - coalesce([total_payments], 0)']);
 
 Note that I'm using coalesce because without InvoicePayments the aggregate sum
 will return NULL. Finally let's build allocation method, that allocates new

--- a/docs/model.rst
+++ b/docs/model.rst
@@ -223,20 +223,6 @@ You may also specify your own Field implementation::
 
 Read more about :php:class:`Field`
 
-.. php:method:: addFields(array $fields, $defaults = [])
-
-Creates multiple field objects in one method call. See multiple syntax examples::
-
-    $m->addFields(['name'], ['default' => 'anonymous']);
-
-    $m->addFields([
-        'last_name',
-        'login' => ['default' => 'unknown'],
-        'salary' => ['type' => 'atk4_money', CustomField::class, 'default' => 100],
-        ['tax', CustomField::class, 'type' => 'atk4_money', 'default' => 20],
-        'vat' => new CustomField(['type' => 'atk4_money', 'default' => 15]),
-    ]);
-
 
 Read-only Fields
 ^^^^^^^^^^^^^^^^

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -323,7 +323,7 @@ You cannot add conditions just yet, although you can pass in some of the default
 Adding Fields
 -------------
 
-Methods :php:meth:`Model::addField()` and :php:meth:`Model::addFields()` can
+Method :php:meth:`Model::addField()` can
 declare model fields. You need to declare them before you are able to use.
 You might think that some SQL reverse-engineering could be good at this point,
 but this would mimic your business logic after your presentation logic, while

--- a/docs/references.rst
+++ b/docs/references.rst
@@ -263,7 +263,8 @@ sub-queries::
     $m->addCondition('is_vip', true);
 
     $sum = $m->refLink('Orders')->action('fx0', ['sum', 'amount']);
-    $m->addExpression('sum_amount')->set($sum);
+    $m->addExpression('sum_amount');
+    $m->getField('sum_amount')->set($sum);
 
 The refLink would define a condition on a query like this:
 

--- a/docs/references.rst
+++ b/docs/references.rst
@@ -123,7 +123,8 @@ It is possible to perform reference through an 3rd party table::
 
     $p
         ->join('invoice_payment.payment_id')
-        ->addFields(['amount_allocated', 'invoice_id']);
+        ->addField('amount_allocated')
+        ->addField('invoice_id');
 
     $i->hasMany('Payments', ['model' => $p]);
 
@@ -187,11 +188,9 @@ You can also define multiple fields, although you must remember that this will
 keep making your query bigger and bigger::
 
     $invoice->hasMany('Invoice_Line', ['model' => [Model_Invoice_Line::class]])
-        ->addFields([
-            ['total_vat', 'aggregate' => 'sum'],
-            ['total_net', 'aggregate' => 'sum'],
-            ['total_gross', 'aggregate' => 'sum'],
-        ]);
+        ->addField('total_vat', ['aggregate' => 'sum'])
+        ->addField('total_net', ['aggregate' => 'sum'])
+        ->addField('total_gross', ['aggregate' => 'sum']);
 
 Imported fields will preserve format of the field they reference. In the example,
 if 'Invoice_line' field total_vat has type `money` then it will also be used
@@ -366,19 +365,15 @@ This code also resolves problem with a duplicate 'name' field. Since you might h
 a 'name' field inside 'Invoice' already, you can name the field 'currency_name'
 which will reference 'name' field inside Currency. You can also import multiple
 fields but keep in mind that this may make your query much longer.
-The argument is associative array and if key is specified, then the field will
-be renamed, just as we did above::
 
     $u = new Model_User($db)
     $a = new Model_Address($db);
 
     $u->hasOne('address_id', ['model' => $a])
-        ->addFields([
-            'address_1',
-            'address_2',
-            'address_3',
-            'address_notes' => ['notes', 'type' => 'text'],
-        ]);
+        ->addField('address_1')
+        ->addField('address_2')
+        ->addField('address_3')
+        ->addField('address_notes', 'notes', ['type' => 'text']);
 
 Above, all ``address_`` fields are copied with the same name, however field
 'notes' from Address model will be called 'address_notes' inside user model.
@@ -572,26 +567,6 @@ Loading model like that can produce a pretty sophisticated query:
          where `child_i`.`parent_item_id` = `pp`.`id`
         ) `child_age`, `pp`.`id` `_i`
     from `item` `pp`left join `item2` as `pp_i` on `pp_i`.`item_id` = `pp`.`id`
-
-Various ways to specify options
--------------------------------
-
-When calling `hasOne()->addFields()` there are various ways to pass options:
-
-- `addFields(['name', 'dob'])` - no options are passed, use defaults. Note that
-  reference will not fetch the type of foreign field due to performance consideration.
-
-- `addFields(['first_name' => 'name'])` - this indicates aliasing. Field `name`
-  will be added as `first_name`.
-
-- `addFields([['dob', 'type' => 'date']])` - wrap inside array to pass options to
-  field
-
-- `addFields(['the_date' => ['dob', 'type' => 'date']])` - combination of aliasing
-  and options
-
-- `addFields(['dob', 'dod'], ['type' => 'date'])` - passing defaults for multiple
-  fields
 
 
 References with New Records

--- a/docs/sql.rst
+++ b/docs/sql.rst
@@ -62,43 +62,7 @@ SQL Reference
     Second argument could be array containing additional settings for the field::
 
         $model->hasOne('account_id', ['model' => [Account::class]])
-            ->addField('account_balance', ['balance', 'type' => 'atk4_money']);
-
-    Returns new field object.
-
-.. php:method:: addFields
-
-    Allows importing multiple fields::
-
-        $model->hasOne('country_id', ['model' => [Country::class]])
-            ->addFields(['country_name', 'country_code']);
-
-    You can specify defaults to be applied on all fields::
-
-        $model->hasOne('account_id', ['model' => [Account::class]])
-            ->addFields([
-                'opening_balance',
-                'balance',
-            ], ['type' => 'atk4_money']);
-
-    You can also specify aliases::
-
-        $model->hasOne('account_id', ['model' => [Account::class]])
-            ->addFields([
-                'opening_balance',
-                'account_balance' => 'balance',
-            ], ['type' => 'atk4_money']);
-
-    If you need to pass more details to individual field, you can also use sub-array::
-
-        $model->hasOne('account_id', ['model' => [Account::class]])
-            ->addFields([
-            [
-                ['opening_balance', 'caption' => 'The Opening Balance'],
-                'account_balance' => 'balance',
-            ], ['type' => 'atk4_money']);
-
-    Returns $this.
+            ->addField('account_balance', 'balance', ['type' => 'atk4_money']);
 
 .. php:method:: ref
 

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -57,7 +57,6 @@ parameters:
         # for tests/JoinSqlTest.php
         - '~^Call to an undefined method Atk4\\Data\\Reference\\HasOne::addField\(\)\.$~'
         # for tests/ReferenceSqlTest.php
-        - '~^Call to an undefined method Atk4\\Data\\Reference\\HasOne::addFields\(\)\.$~'
         - '~^Call to an undefined method Atk4\\Data\\Reference::addTitle\(\)\.$~'
         # for tests/ScopeTest.php
         - '~^Call to an undefined method Atk4\\Data\\Tests\\SUser::expr\(\)\.$~'

--- a/src/Model.php
+++ b/src/Model.php
@@ -1879,16 +1879,15 @@ class Model implements \IteratorAggregate
      *
      * @param array{'expr': mixed} $seed
      *
-     * @return CallbackField|SqlExpressionField
+     * @return $this
      */
     public function addExpression(string $name, $seed)
     {
         /** @var CallbackField|SqlExpressionField */
         $field = Field::fromSeed($this->_defaultSeedAddExpression, $seed);
-
         $this->addField($name, $field);
 
-        return $field;
+        return $this;
     }
 
     /**
@@ -1896,15 +1895,14 @@ class Model implements \IteratorAggregate
      *
      * @param array{'expr': \Closure} $seed
      *
-     * @return CallbackField
+     * @return $this
      */
     public function addCalculatedField(string $name, $seed)
     {
         $field = new CallbackField($seed);
-
         $this->addField($name, $field);
 
-        return $field;
+        return $this;
     }
 
     // }}}

--- a/src/Model.php
+++ b/src/Model.php
@@ -545,8 +545,10 @@ class Model implements \IteratorAggregate
      * Adds new field into model.
      *
      * @param array|object $seed
+     *
+     * @return $this
      */
-    public function addField(string $name, $seed = []): Field
+    public function addField(string $name, $seed = [])
     {
         $this->assertIsModel();
 
@@ -556,24 +558,7 @@ class Model implements \IteratorAggregate
             $field = $this->fieldFactory($seed);
         }
 
-        return $this->_addIntoCollection($name, $field, 'fields');
-    }
-
-    /**
-     * Adds multiple fields into model.
-     *
-     * @return $this
-     */
-    public function addFields(array $fields, array $defaults = [])
-    {
-        foreach ($fields as $name => $seed) {
-            if (is_int($name)) {
-                $name = $seed;
-                $seed = [];
-            }
-
-            $this->addField($name, Factory::mergeSeeds($seed, $defaults));
-        }
+        $this->_addIntoCollection($name, $field, 'fields');
 
         return $this;
     }

--- a/src/Model/AggregateModel.php
+++ b/src/Model/AggregateModel.php
@@ -94,7 +94,7 @@ class AggregateModel extends Model
         return $this;
     }
 
-    public function addField(string $name, $seed = []): Field
+    public function addField(string $name, $seed = [])
     {
         if ($seed instanceof SqlExpressionField) {
             return parent::addField($name, $seed);

--- a/src/Model/Join.php
+++ b/src/Model/Join.php
@@ -5,11 +5,9 @@ declare(strict_types=1);
 namespace Atk4\Data\Model;
 
 use Atk4\Core\DiContainerTrait;
-use Atk4\Core\Factory;
 use Atk4\Core\InitializerTrait;
 use Atk4\Core\TrackableTrait;
 use Atk4\Data\Exception;
-use Atk4\Data\Field;
 use Atk4\Data\Model;
 use Atk4\Data\Reference;
 
@@ -275,29 +273,14 @@ abstract class Join
      * Adding field into join will automatically associate that field
      * with this join. That means it won't be loaded from $table, but
      * form the join instead.
-     */
-    public function addField(string $name, array $seed = []): Field
-    {
-        $seed['joinName'] = $this->getJoinNameFromShortName();
-
-        return $this->getOwner()->addField($this->prefix . $name, $seed);
-    }
-
-    /**
-     * Adds multiple fields.
      *
      * @return $this
      */
-    public function addFields(array $fields = [], array $defaults = [])
+    public function addField(string $name, array $seed = [])
     {
-        foreach ($fields as $name => $seed) {
-            if (is_int($name)) {
-                $name = $seed;
-                $seed = [];
-            }
+        $seed['joinName'] = $this->getJoinNameFromShortName();
 
-            $this->addField($name, Factory::mergeSeeds($seed, $defaults));
-        }
+        $this->getOwner()->addField($this->prefix . $name, $seed);
 
         return $this;
     }

--- a/src/Persistence/Sql/Join.php
+++ b/src/Persistence/Sql/Join.php
@@ -37,9 +37,11 @@ class Join extends Model\Join
         if (!$this->reverse && !$this->getOwner()->hasField($this->masterField)) {
             $owner = $this->hasJoin() ? $this->getJoin() : $this->getOwner();
 
-            $field = $owner->addField($this->masterField, ['system' => true, 'readOnly' => true]);
+            $owner->addField($this->masterField, ['system' => true, 'readOnly' => true]);
 
-            $this->masterField = $field->shortName;
+            if ($this->hasJoin()) {
+                $this->masterField = $this->getJoin()->prefix . $this->masterField;
+            }
         }
     }
 

--- a/src/Reference/HasMany.php
+++ b/src/Reference/HasMany.php
@@ -105,8 +105,10 @@ class HasMany extends Reference
 
     /**
      * Adds field as expression to our model. Used in aggregate strategy.
+     *
+     * @return $this
      */
-    public function addField(string $fieldName, array $defaults = []): Field
+    public function addField(string $fieldName, array $defaults = [])
     {
         if (!isset($defaults['aggregate']) && !isset($defaults['concat']) && !isset($defaults['expr'])) {
             throw (new Exception('Aggregate field requires "aggregate", "concat" or "expr" specified to hasMany()->addField()'))
@@ -151,26 +153,7 @@ class HasMany extends Reference
             };
         }
 
-        return $this->getOurModel(null)->addExpression($fieldName, array_merge($defaults, ['expr' => $fx]));
-    }
-
-    /**
-     * Adds multiple fields.
-     *
-     * @see addField()
-     *
-     * @return $this
-     */
-    public function addFields(array $fields = [])
-    {
-        foreach ($fields as $name => $seed) {
-            if (is_int($name)) {
-                $name = $seed;
-                $seed = [];
-            }
-
-            $this->addField($name, $seed);
-        }
+        $this->getOurModel(null)->addExpression($fieldName, array_merge($defaults, ['expr' => $fx]));
 
         return $this;
     }

--- a/src/Reference/HasOneSql.php
+++ b/src/Reference/HasOneSql.php
@@ -13,11 +13,11 @@ class HasOneSql extends HasOne
     /**
      * @param ($theirFieldIsTitle is true ? null : string) $theirFieldName
      */
-    private function _addField(string $fieldName, bool $theirFieldIsTitle, ?string $theirFieldName, array $defaults): SqlExpressionField
+    private function _addField(string $fieldName, bool $theirFieldIsTitle, ?string $theirFieldName, array $defaults): void
     {
         $ourModel = $this->getOurModel(null);
 
-        $fieldExpression = $ourModel->addExpression($fieldName, array_merge([
+        $ourModel->addExpression($fieldName, array_merge([
             'expr' => function (Model $ourModel) use ($theirFieldIsTitle, $theirFieldName) {
                 $theirModel = $ourModel->refLink($this->link);
                 if ($theirFieldIsTitle) {
@@ -61,8 +61,6 @@ class HasOneSql extends HasOne
                 }
             }
         }, [], 20);
-
-        return $fieldExpression;
     }
 
     /**
@@ -139,13 +137,13 @@ class HasOneSql extends HasOne
 
         $defaults['ui'] = array_merge(['visible' => true], $defaults['ui'] ?? [], ['editable' => false]);
 
-        $fieldExpression = $this->_addField($fieldName, true, null, $defaults);
+        $this->_addField($fieldName, true, null, $defaults);
 
         // set ID field as not visible in grid by default
         if (!array_key_exists('visible', $this->getOurField()->ui)) {
             $this->getOurField()->ui['visible'] = false;
         }
 
-        return $fieldExpression;
+        return $ourModel->getField($fieldName); // @phpstan-ignore-line
     }
 }

--- a/src/Reference/HasOneSql.php
+++ b/src/Reference/HasOneSql.php
@@ -67,8 +67,10 @@ class HasOneSql extends HasOne
 
     /**
      * Creates expression which sub-selects a field inside related model.
+     *
+     * @return $this
      */
-    public function addField(string $fieldName, string $theirFieldName = null, array $defaults = []): SqlExpressionField
+    public function addField(string $fieldName, string $theirFieldName = null, array $defaults = [])
     {
         if ($theirFieldName === null) {
             $theirFieldName = $fieldName;
@@ -84,34 +86,7 @@ class HasOneSql extends HasOne
         $defaults['caption'] ??= $refModelField->caption;
         $defaults['ui'] = array_merge($defaults['ui'] ?? $refModelField->ui, ['editable' => false]);
 
-        $fieldExpression = $this->_addField($fieldName, false, $theirFieldName, $defaults);
-
-        return $fieldExpression;
-    }
-
-    /**
-     * Add multiple expressions by calling addField several times. Fields
-     * may contain 3 types of elements:.
-     *
-     * ['name', 'surname'] - will import those fields as-is
-     * ['full_name' => 'name', 'day_of_birth' => ['dob', 'type' => 'date']] - use alias and options
-     * [['dob', 'type' => 'date']]  - use options
-     *
-     * @return $this
-     */
-    public function addFields(array $fields = [], array $defaults = [])
-    {
-        foreach ($fields as $ourFieldName => $ourFieldDefaults) {
-            $ourFieldDefaults = array_merge($defaults, (array) $ourFieldDefaults);
-
-            $theirFieldName = $ourFieldDefaults[0] ?? null;
-            unset($ourFieldDefaults[0]);
-            if (is_int($ourFieldName)) {
-                $ourFieldName = $theirFieldName;
-            }
-
-            $this->addField($ourFieldName, $theirFieldName, $ourFieldDefaults);
-        }
+        $this->_addField($fieldName, false, $theirFieldName, $defaults);
 
         return $this;
     }

--- a/tests/LookupSqlTest.php
+++ b/tests/LookupSqlTest.php
@@ -68,7 +68,8 @@ class LUser extends Model
         $this->addField('is_vip', ['type' => 'boolean', 'default' => false]);
 
         $this->hasOne('country_id', ['model' => [LCountry::class]])
-            ->addFields(['country_code' => 'code', 'is_eu'])
+            ->addField('country_code', 'code')
+            ->addField('is_eu')
             ->addTitle();
 
         $this->hasMany('Friends', ['model' => [LFriend::class]])

--- a/tests/RandomTest.php
+++ b/tests/RandomTest.php
@@ -112,61 +112,6 @@ class RandomTest extends TestCase
         ], $this->getDb());
     }
 
-    public function testAddFields(): void
-    {
-        $this->setDb([
-            'user' => [
-                1 => ['name' => 'John', 'login' => 'john@example.com'],
-            ],
-        ]);
-
-        $m = new Model($this->db, ['table' => 'user']);
-        $m->addFields(['name', 'login'], ['default' => 'unknown']);
-
-        $m->insert(['name' => 'Peter']);
-        $m->insert([]);
-
-        $this->assertEquals([
-            'user' => [
-                1 => ['id' => 1, 'name' => 'John', 'login' => 'john@example.com'],
-                2 => ['id' => 2, 'name' => 'Peter', 'login' => 'unknown'],
-                3 => ['id' => 3, 'name' => 'unknown', 'login' => 'unknown'],
-            ],
-        ], $this->getDb());
-    }
-
-    public function testAddFields2(): void
-    {
-        $this->setDb([
-            'user' => [
-                1 => ['name' => 'John', 'last_name' => null, 'login' => null, 'salary' => null, 'tax' => null, 'vat' => null],
-            ],
-        ]);
-
-        $m = new Model($this->db, ['table' => 'user']);
-        $m->addFields(['name'], ['default' => 'anonymous']);
-        $m->addFields([
-            'last_name',
-            'login' => ['default' => 'unknown'],
-            'salary' => [CustomField::class, 'type' => 'atk4_money', 'default' => 100],
-            'tax' => [CustomField::class, 'type' => 'atk4_money', 'default' => 20],
-            'vat' => new CustomField(['type' => 'atk4_money', 'default' => 15]),
-        ]);
-
-        $m->insert([]);
-
-        $this->assertSameExportUnordered([
-            ['id' => 1, 'name' => 'John', 'last_name' => null, 'login' => null, 'salary' => null, 'tax' => null, 'vat' => null],
-            ['id' => 2, 'name' => 'anonymous', 'last_name' => null, 'login' => 'unknown', 'salary' => 100.0, 'tax' => 20.0, 'vat' => 15.0],
-        ], $m->export());
-
-        $m = $m->load(2);
-        $this->assertTrue(is_float($m->get('salary')));
-        $this->assertTrue(is_float($m->get('tax')));
-        $this->assertTrue(is_float($m->get('vat')));
-        $this->assertInstanceOf(CustomField::class, $m->getField('salary'));
-    }
-
     public function testSetPersistence(): void
     {
         $m = new Model($this->db, ['table' => 'user']);

--- a/tests/ReferenceSqlTest.php
+++ b/tests/ReferenceSqlTest.php
@@ -215,10 +215,9 @@ class ReferenceSqlTest extends TestCase
 
         $o = new Model($this->db, ['table' => 'order']);
         $o->addField('amount');
-        $o->hasOne('user_id', ['model' => $u])->addFields([
-            'username' => 'name',
-            ['date', 'type' => 'date'],
-        ]);
+        $o->hasOne('user_id', ['model' => $u])
+            ->addField('username', 'name')
+            ->addField('date', null, ['type' => 'date']);
 
         $this->assertSame('John', $o->load(1)->get('username'));
         $this->assertEquals(new \DateTime('2001-01-02 UTC'), $o->load(1)->get('date'));
@@ -230,10 +229,9 @@ class ReferenceSqlTest extends TestCase
         // few more tests
         $o = new Model($this->db, ['table' => 'order']);
         $o->addField('amount');
-        $o->hasOne('user_id', ['model' => $u])->addFields([
-            'username' => 'name',
-            'thedate' => ['date', 'type' => 'date'],
-        ]);
+        $o->hasOne('user_id', ['model' => $u])
+            ->addField('username', 'name')
+            ->addField('thedate', 'date', ['type' => 'date']);
         $this->assertSame('John', $o->load(1)->get('username'));
         $this->assertEquals(new \DateTime('2001-01-02 UTC'), $o->load(1)->get('thedate'));
 
@@ -308,11 +306,10 @@ class ReferenceSqlTest extends TestCase
         $l->addField('total_vat', ['type' => 'atk4_money']);
         $l->addField('total_gross', ['type' => 'atk4_money']);
 
-        $i->hasMany('line', ['model' => $l])->addFields([
-            'total_net' => ['aggregate' => 'sum'],
-            'total_vat' => ['aggregate' => 'sum', 'type' => 'atk4_money'],
-            'total_gross' => ['aggregate' => 'sum', 'type' => 'atk4_money'],
-        ]);
+        $i->hasMany('line', ['model' => $l])
+            ->addField('total_net', ['aggregate' => 'sum'])
+            ->addField('total_vat', ['aggregate' => 'sum', 'type' => 'atk4_money'])
+            ->addField('total_gross', ['aggregate' => 'sum', 'type' => 'atk4_money']);
         $i = $i->load('1');
 
         // type was set explicitly
@@ -385,16 +382,15 @@ class ReferenceSqlTest extends TestCase
         $i->addField('name');
         $i->addField('code');
 
-        $l->hasMany('Items', ['model' => $i])->addFields([
-            'items_name' => ['aggregate' => 'count', 'field' => 'name', 'type' => 'integer'],
-            'items_code' => ['aggregate' => 'count', 'field' => 'code', 'type' => 'integer'], // counts only not-null values
-            'items_star' => ['aggregate' => 'count', 'type' => 'integer'], // no field set, counts all rows with count(*)
-            'items_c:' => ['concat' => '::', 'field' => 'name'],
-            'items_c-' => ['aggregate' => $i->dsql()->groupConcat($i->expr('[name]'), '-')],
-            'len' => ['aggregate' => $i->expr($buildSumWithIntegerCastSqlFx($buildLengthSqlFx('[name]'))), 'type' => 'integer'], // TODO cast should be implicit when using "aggregate", sandpit http://sqlfiddle.com/#!17/0d2c0/3
-            'len2' => ['expr' => $buildSumWithIntegerCastSqlFx($buildLengthSqlFx('[name]')), 'type' => 'integer'],
-            'chicken5' => ['expr' => $buildSumWithIntegerCastSqlFx('[]'), 'args' => ['5'], 'type' => 'integer'],
-        ]);
+        $l->hasMany('Items', ['model' => $i])
+            ->addField('items_name', ['aggregate' => 'count', 'field' => 'name', 'type' => 'integer'])
+            ->addField('items_code', ['aggregate' => 'count', 'field' => 'code', 'type' => 'integer']) // counts only not-null values
+            ->addField('items_star', ['aggregate' => 'count', 'type' => 'integer']) // no field set, counts all rows with count(*)
+            ->addField('items_c:', ['concat' => '::', 'field' => 'name'])
+            ->addField('items_c-', ['aggregate' => $i->dsql()->groupConcat($i->expr('[name]'), '-')])
+            ->addField('len', ['aggregate' => $i->expr($buildSumWithIntegerCastSqlFx($buildLengthSqlFx('[name]'))), 'type' => 'integer']) // TODO cast should be implicit when using "aggregate", sandpit http://sqlfiddle.com/#!17/0d2c0/3
+            ->addField('len2', ['expr' => $buildSumWithIntegerCastSqlFx($buildLengthSqlFx('[name]')), 'type' => 'integer'])
+            ->addField('chicken5', ['expr' => $buildSumWithIntegerCastSqlFx('[]'), 'args' => ['5'], 'type' => 'integer']);
 
         $ll = $l->load(1);
         $this->assertSame(2, $ll->get('items_name')); // 2 not-null values

--- a/tests/ScopeTest.php
+++ b/tests/ScopeTest.php
@@ -45,7 +45,8 @@ class SUser extends Model
         $this->addField('is_vip', ['type' => 'boolean', 'default' => false]);
 
         $this->hasOne('country_id', ['model' => [SCountry::class]])
-            ->addFields(['country_code' => 'code', 'is_eu'])
+            ->addField('country_code', 'code')
+            ->addField('is_eu')
             ->addTitle();
 
         $this->hasMany('Tickets', ['model' => [STicket::class], 'theirField' => 'user']);


### PR DESCRIPTION
Improve method chaining. All `addField` methods are adding named fields, thus the result can be easily obtained with `Model::getField` method when needed.

also see the discussion below, especially the summary in https://github.com/atk4/data/pull/990#issuecomment-1150251646