### PR TITLE
`Model::tryLoad` returns null when not found

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -37,13 +37,13 @@
         "php": ">=7.4 <8.2",
         "atk4/core": "dev-develop",
         "doctrine/dbal": "^3.3",
-        "mvorisek/atk4-hintable": "~1.7.1"
+        "mvorisek/atk4-hintable": "~1.8.0"
     },
     "require-release": {
         "php": ">=7.4 <8.2",
         "atk4/core": "~3.2.0",
         "doctrine/dbal": "^3.3",
-        "mvorisek/atk4-hintable": "~1.7.1"
+        "mvorisek/atk4-hintable": "~1.8.0"
     },
     "require-dev": {
         "ergebnis/composer-normalize": "^2.13",

--- a/composer.json
+++ b/composer.json
@@ -50,7 +50,7 @@
         "friendsofphp/php-cs-fixer": "^3.0",
         "johnkary/phpunit-speedtrap": "^3.3",
         "phpstan/extension-installer": "^1.1",
-        "phpstan/phpstan": "^1.0",
+        "phpstan/phpstan": "^1.6",
         "phpstan/phpstan-deprecation-rules": "^1.0",
         "phpunit/phpunit": "^9.5.5"
     },

--- a/docs/advanced.rst
+++ b/docs/advanced.rst
@@ -166,7 +166,7 @@ which I want to define like this::
 
         $this->getOwner()->addField('updated_dts', ['type' => 'datetime']);
 
-        $this->getOwner()->onHook(Model::HOOK_BEFORE_UPDATE, function($m, $data) {
+        $this->getOwner()->onHook(Model::HOOK_BEFORE_UPDATE, function ($m, $data) {
             if(isset($this->getApp()->user) && $this->getApp()->user->isLoaded()) {
                 $data['updated_by'] = $this->getApp()->user->getId();
             }
@@ -440,7 +440,7 @@ inside your model are unique::
                     $mm->addCondition($mm->id_field != $this->id);
                     $mm = $mm->tryLoadBy($field, $m->get($field));
 
-                    if ($mm->isLoaded()) {
+                    if ($mm !== null) {
                         throw (new \Atk4\Core\Exception('Duplicate record exists'))
                             ->addMoreInfo('field', $field)
                             ->addMoreInfo('value', $m->get($field));
@@ -514,7 +514,7 @@ Next we need to define reference. Inside Model_Invoice add::
 
     $this->hasMany('InvoicePayment');
 
-    $this->hasMany('Payment', ['model' => function($m) {
+    $this->hasMany('Payment', ['model' => function ($m) {
         $p = new Model_Payment($m->persistence);
         $j = $p->join('invoice_payment.payment_id');
         $j->addField('amount_closed');
@@ -570,24 +570,23 @@ payment towards a most suitable invoice::
 
         while($this->get('amount_due') > 0) {
 
-            // See if any invoices match by 'reference';
-            $invoices = $invoices->tryLoadBy('reference', $this->get('reference'));
+            // see if any invoices match by 'reference'
+            $invoice = $invoices->tryLoadBy('reference', $this->get('reference'));
 
-            if (!$invoices->isLoaded()) {
+            if ($invoice === null) {
 
                 // otherwise load any unpaid invoice
-                $invoices = $invoices->tryLoadAny();
+                $invoice = $invoices->tryLoadAny();
 
-                if(!$invoices->isLoaded()) {
-
-                    // couldn't load any invoice.
+                if ($invoice === null) {
+                    // couldn't load any invoice
                     return;
                 }
             }
 
             // How much we can allocate to this invoice
-            $alloc = min($this->get('amount_due'), $invoices->get('amount_due'))
-            $this->ref('InvoicePayment')->insert(['amount_closed' => $alloc, 'invoice_id' => $invoices->getId()]);
+            $alloc = min($this->get('amount_due'), $invoice->get('amount_due'))
+            $this->ref('InvoicePayment')->insert(['amount_closed' => $alloc, 'invoice_id' => $invoice->getId()]);
 
             // Reload ourselves to refresh amount_due
             $this->reload();
@@ -744,7 +743,7 @@ section. Add this into your Invoice Model::
 Next both payment and lines need to be added after invoice is actually created,
 so::
 
-    $this->onHookShort(Model::HOOK_AFTER_SAVE, function($is_update) {
+    $this->onHookShort(Model::HOOK_AFTER_SAVE, function ($is_update) {
         if($this->_isset('payment')) {
             $this->ref('Payment')->insert($this->get('payment'));
         }
@@ -800,7 +799,7 @@ field only to offer payments made by the same client. Inside Model_Invoice add::
 
     $this->hasOne('client_id', 'Client');
 
-    $this->hasOne('payment_invoice_id', ['model' => function($m) {
+    $this->hasOne('payment_invoice_id', ['model' => function ($m) {
         return $m->ref('client_id')->ref('Payment');
     }]);
 
@@ -809,13 +808,13 @@ field only to offer payments made by the same client. Inside Model_Invoice add::
     $m = new Model_Invoice($db);
     $m->set('client_id', 123);
 
-    $m->set('payment_invoice_id', $m->ref('payment_invoice_id')->tryLoadOne()->getId());
+    $m->set('payment_invoice_id', $m->ref('payment_invoice_id')->loadOne()->getId());
 
 In this case the payment_invoice_id will be set to ID of any payment by client
 123. There also may be some better uses::
 
     foreach ($cl->ref('Invoice') as $m) {
-        $m->set('payment_invoice_id', $m->ref('payment_invoice_id')->tryLoadOne()->getId());
+        $m->set('payment_invoice_id', $m->ref('payment_invoice_id')->loadOne()->getId());
         $m->save();
     }
 
@@ -826,7 +825,7 @@ Agile Data allow you to define multiple references between same entities, but
 sometimes that can be quite useful. Consider adding this inside your Model_Contact::
 
     $this->hasMany('Invoice', 'Model_Invoice');
-    $this->hasMany('OverdueInvoice', ['model' => function($m) {
+    $this->hasMany('OverdueInvoice', ['model' => function ($m) {
         return $m->ref('Invoice')->addCondition('due', '<', date('Y-m-d'))
     }]);
 

--- a/docs/hooks.rst
+++ b/docs/hooks.rst
@@ -52,7 +52,7 @@ Example with beforeSave
 The next code snippet demonstrates a basic usage of a `beforeSave` hook.
 This one will update field values just before record is saved::
 
-    $m->onHook(Model::HOOK_BEFORE_SAVE, function($m) {
+    $m->onHook(Model::HOOK_BEFORE_SAVE, function ($m) {
         $m->set('name', strtoupper($m->get('name')));
         $m->set('surname', strtoupper($m->get('surname')));
     });
@@ -136,7 +136,7 @@ of save.
 
 You may actually drop validation exception inside save, insert or update hooks::
 
-    $m->onHook(Model::HOOK_BEFORE_SAVE, function($m) {
+    $m->onHook(Model::HOOK_BEFORE_SAVE, function ($m) {
         if ($m->get('name') === 'Yagi') {
             throw new \Atk4\Data\ValidationException(['name' => "We don't serve like you"]);
         }
@@ -193,7 +193,7 @@ and your update() may not actually update anything. This does not normally
 generate an error, however if you want to actually make sure that update() was
 effective, you can implement this through a hook::
 
-    $m->onHook(Persistence\Sql::HOOK_AFTER_UPDATE_QUERY, function($m, $update, $c) {
+    $m->onHook(Persistence\Sql::HOOK_AFTER_UPDATE_QUERY, function ($m, $update, $c) {
         if ($c === 0) {
             throw (new \Atk4\Core\Exception('Update didn\'t affect any records'))
                 ->addMoreInfo('query', $update->getDebugQuery())
@@ -210,7 +210,7 @@ In some cases you want to prevent default actions from executing.
 Suppose you want to check 'memcache' before actually loading the record from
 the database. Here is how you can implement this functionality::
 
-    $m->onHook(Model::HOOK_BEFORE_LOAD, function($m, $id) {
+    $m->onHook(Model::HOOK_BEFORE_LOAD, function ($m, $id) {
         $data = $m->getApp()->cacheFetch($m->table, $id);
         if ($data) {
             $dataRef = &$m->getDataRef();
@@ -237,7 +237,7 @@ This can be used in various situations.
 
 Save information into auditLog about failure:
 
-    $m->onHook(Model::HOOK_ROLLBACK, function($m) {
+    $m->onHook(Model::HOOK_ROLLBACK, function ($m) {
         $m->auditLog->registerFailure();
     });
 
@@ -245,7 +245,7 @@ Upgrade schema:
 
     use Atk4\Data\Persistence\Sql\Exception as SqlException;
 
-    $m->onHook(Model::HOOK_ROLLBACK, function($m, $exception) {
+    $m->onHook(Model::HOOK_ROLLBACK, function ($m, $exception) {
         if ($exception instanceof SqlException) {
             $m->schema->upgrade();
             $m->breakHook(false); // exception will not be thrown

--- a/docs/model.rst
+++ b/docs/model.rst
@@ -180,7 +180,7 @@ To invoke code from `init()` methods of ALL models (for example soft-delete logi
 you use Persistence's "afterAdd" hook. This will not affect ALL models but just models
 which are associated with said persistence::
 
-   $db->onHook(Persistence::HOOK_AFTER_ADD, function($p, $m) use($acl) {
+   $db->onHook(Persistence::HOOK_AFTER_ADD, function ($p, $m) use ($acl) {
 
       $fields = $m->getFields();
 

--- a/docs/overview.rst
+++ b/docs/overview.rst
@@ -166,7 +166,7 @@ If your persistence does not support expressions (e.g. you are using Redis or
 MongoDB), you would need to define the field differently::
 
     $model->addField('gross');
-    $model->onHook(Model::HOOK_BEFORE_SAVE, function($m) {
+    $model->onHook(Model::HOOK_BEFORE_SAVE, function ($m) {
         $m->set('gross', $m->get('net') + $m->get('vat'));
     });
 
@@ -186,7 +186,7 @@ you want it to work with NoSQL, then your solution might be::
 
         // persistence does not support expressions
         $model->addField('gross');
-        $model->onHook(Model::HOOK_BEFORE_SAVE, function($m) {
+        $model->onHook(Model::HOOK_BEFORE_SAVE, function ($m) {
             $m->set('gross', $m->get('net') + $m->get('vat'));
         });
 

--- a/docs/references.rst
+++ b/docs/references.rst
@@ -106,7 +106,7 @@ There are several ways how to link models with hasMany::
 
     $m->hasMany('Orders', ['model' => [Model_Order::class]]); // using seed
 
-    $m->hasMany('Order', ['model' => function($m, $r) {   // using callback
+    $m->hasMany('Order', ['model' => function ($m, $r) {   // using callback
         return new Model_Order();
     }]);
 
@@ -433,7 +433,7 @@ User-defined Reference
 Sometimes you would want to have a different type of relation between models,
 so with `addRef` you can define whatever reference you want::
 
-    $m->addRef('Archive', ['model' => function($m) {
+    $m->addRef('Archive', ['model' => function ($m) {
         return $m->newInstance(null, ['table' => $m->table . '_archive']);
     }]);
 
@@ -447,7 +447,7 @@ Note that you can create one-to-many or many-to-one relations, by using your
 custom logic.
 No condition will be applied by default so it's all up to you::
 
-    $m->addRef('Archive', ['model' => function($m) {
+    $m->addRef('Archive', ['model' => function ($m) {
         $archive = $m->newInstance(null, ['table' => $m->table . '_archive']);
 
         $m->addField('original_id', ['type' => 'integer']);

--- a/docs/types.rst
+++ b/docs/types.rst
@@ -92,7 +92,7 @@ ATK Data prior to 1.5 supports the following types:
 
 In ATK Data the number of supported types has been extended with:
 
- - percent (34.2%) ([':php:class:`Number`', 'format' => function($v) { return $v * 100; }, 'postfix' => '%'])
+ - percent (34.2%) ([':php:class:`Number`', 'format' => function ($v) { return $v * 100; }, 'postfix' => '%'])
  - rating (3 out of 5) ([':php:class:`Number`', 'max' => 5, 'precision' => 0])
  - uuid (xxxxxxxx-xxxx-...) ([':php:class:`Number`', 'base' => 16, 'mask' => '########-##..'])
  - hex (number with base 16) ([':php:class:`Number`', 'base' => 16])

--- a/src/Model.php
+++ b/src/Model.php
@@ -91,9 +91,9 @@ class Model implements \IteratorAggregate
     public const HOOK_ONLY_FIELDS = self::class . '@onlyFields';
 
     /** @const string */
-    protected const ID_LOAD_ONE = self::class . '@idLoadOne';
+    protected const ID_LOAD_ONE = self::class . '@idLoadOne-h7axmDNBB3qVXjVv';
     /** @const string */
-    protected const ID_LOAD_ANY = self::class . '@idLoadAny';
+    protected const ID_LOAD_ANY = self::class . '@idLoadAny-h7axmDNBB3qVXjVv';
 
     // {{{ Properties of the class
 

--- a/src/Model.php
+++ b/src/Model.php
@@ -1234,9 +1234,9 @@ class Model implements \IteratorAggregate
     /**
      * @param mixed $id
      *
-     * @return $this
+     * @return ($fromTryLoad is true ? $this|null : $this)
      */
-    private function _loadThis(bool $isTryLoad, $id)
+    private function _loadThis(bool $fromTryLoad, $id)
     {
         $this->assertIsEntity();
         if ($this->isLoaded()) {
@@ -1250,21 +1250,27 @@ class Model implements \IteratorAggregate
             return $this;
         }
         $dataRef = &$this->getDataRef();
-        $dataRef = $this->persistence->{$isTryLoad ? 'tryLoad' : 'load'}($this->getModel(), $this->remapIdLoadToPersistence($id));
-        if ($isTryLoad && $dataRef === null) {
-            $dataRef = [];
-            $this->unload();
-        } else {
-            if ($this->id_field) {
-                $this->setId($this->getId());
+        $dataRef = $this->persistence->{$fromTryLoad ? 'tryLoad' : 'load'}($this->getModel(), $this->remapIdLoadToPersistence($id));
+
+        if ($dataRef === null) {
+            // $fromTryLoad is true here
+
+            return null;
+        }
+
+        if ($this->id_field) {
+            $this->setId($this->getId());
+        }
+
+        $ret = $this->hook(self::HOOK_AFTER_LOAD);
+        if ($ret === false) {
+            if ($fromTryLoad) {
+                return null;
             }
 
-            $ret = $this->hook(self::HOOK_AFTER_LOAD);
-            if ($ret === false) {
-                $this->unload();
-            } elseif (is_object($ret)) {
-                return $ret; // @phpstan-ignore-line
-            }
+            $this->unload();
+        } elseif (is_object($ret)) {
+            return $ret; // @phpstan-ignore-line
         }
 
         return $this;

--- a/src/Model.php
+++ b/src/Model.php
@@ -1253,7 +1253,7 @@ class Model implements \IteratorAggregate
         $dataRef = $this->persistence->{$fromTryLoad ? 'tryLoad' : 'load'}($this->getModel(), $this->remapIdLoadToPersistence($id));
 
         if ($dataRef === null) {
-            // $fromTryLoad is true here
+            // $fromTryLoad is always true here
 
             return null;
         }

--- a/src/Reference/ContainsOne.php
+++ b/src/Reference/ContainsOne.php
@@ -94,7 +94,12 @@ class ContainsOne extends Reference
             });
         }
 
+        $theirModelOrig = $theirModel;
         $theirModel = $theirModel->tryLoadOne();
+
+        if ($theirModel === null) { // TODO or implement tryRef?
+            $theirModel = $theirModelOrig->createEntity();
+        }
 
         return $theirModel;
     }

--- a/src/Reference/ContainsOne.php
+++ b/src/Reference/ContainsOne.php
@@ -94,11 +94,13 @@ class ContainsOne extends Reference
             });
         }
 
-        $theirModelOrig = $theirModel;
-        $theirModel = $theirModel->tryLoadOne();
+        if ($ourModel->isEntity()) {
+            $theirModelOrig = $theirModel;
+            $theirModel = $theirModel->tryLoadOne();
 
-        if ($theirModel === null) { // TODO or implement tryRef?
-            $theirModel = $theirModelOrig->createEntity();
+            if ($theirModel === null) { // TODO or implement tryRef?
+                $theirModel = $theirModelOrig->createEntity();
+            }
         }
 
         return $theirModel;

--- a/src/Reference/HasOne.php
+++ b/src/Reference/HasOne.php
@@ -91,10 +91,15 @@ class HasOne extends Reference
             $ourValue = $this->getOurFieldValue($ourModel);
             $this->assertReferenceValueNotNull($ourValue);
 
+            $theirModelOrig = $theirModel;
             if ($this->their_field) {
                 $theirModel = $theirModel->tryLoadBy($this->their_field, $ourValue);
             } else {
                 $theirModel = $theirModel->tryLoad($ourValue);
+            }
+
+            if ($theirModel === null) { // TODO or implement tryRef?
+                $theirModel = $theirModelOrig->createEntity();
             }
         }
 

--- a/src/Util/DeepCopy.php
+++ b/src/Util/DeepCopy.php
@@ -43,7 +43,7 @@ class DeepCopy
 
     /**
      * @var array contains array similar to references but containing list of callback methods to transform fields/values:
-     *            e.g. ['Invoices' => ['Lines' => function($data) {
+     *            e.g. ['Invoices' => ['Lines' => function ($data) {
      *            $data['exchanged_amount'] = $data['amount'] * getExRate($data['date'], $data['currency']);
      *            return $data;
      *            }]]
@@ -112,12 +112,12 @@ class DeepCopy
      * May also contain arrays for related entries.
      *
      * ->transformData(
-     *      [function($data) { // for Client entity
+     *      [function ($data) { // for Client entity
      *          $data['name'] => $data['last_name'] . ' ' . $data['first_name'];
      *          unset($data['first_name'], $data['last_name']);
      *          return $data;
      *      }],
-     *      'Invoices' => ['Lines' => function($data) { // for nested Client->Invoices->Lines hasMany entity
+     *      'Invoices' => ['Lines' => function ($data) { // for nested Client->Invoices->Lines hasMany entity
      *          $data['exchanged_amount'] = $data['amount'] * getExRate($data['date'], $data['currency']);
      *          return $data;
      *      }]

--- a/tests/ConditionSqlTest.php
+++ b/tests/ConditionSqlTest.php
@@ -33,7 +33,7 @@ class ConditionSqlTest extends TestCase
         $mm2 = $mm->tryLoad(1);
         $this->assertSame('John', $mm2->get('name'));
         $mm2 = $mm->tryLoad(2);
-        $this->assertNull($mm2->get('name'));
+        $this->assertNull($mm2);
 
         if ($this->getDatabasePlatform() instanceof SqlitePlatform) {
             $this->assertSame(
@@ -43,9 +43,9 @@ class ConditionSqlTest extends TestCase
         }
 
         $mm = clone $m;
-        $mm->withId(2); // = addCondition(id, 2)
+        $mm->withId(2); // = addCondition('id', 2)
         $mm2 = $mm->tryLoad(1);
-        $this->assertNull($mm2->get('name'));
+        $this->assertNull($mm2);
         $mm2 = $mm->tryLoad(2);
         $this->assertSame('Sue', $mm2->get('name'));
     }

--- a/tests/ConditionSqlTest.php
+++ b/tests/ConditionSqlTest.php
@@ -130,19 +130,19 @@ class ConditionSqlTest extends TestCase
         $mm2 = $mm->tryLoad(1);
         $this->assertSame('John', $mm2->get('name'));
         $mm2 = $mm->tryLoad(2);
-        $this->assertNull($mm2->get('name'));
+        $this->assertNull($mm2);
 
         $mm = clone $m;
         $mm->addCondition('gender', '!=', 'M');
         $mm2 = $mm->tryLoad(1);
-        $this->assertNull($mm2->get('name'));
+        $this->assertNull($mm2);
         $mm2 = $mm->tryLoad(2);
         $this->assertSame('Sue', $mm2->get('name'));
 
         $mm = clone $m;
         $mm->addCondition('id', '>', 1);
         $mm2 = $mm->tryLoad(1);
-        $this->assertNull($mm2->get('name'));
+        $this->assertNull($mm2);
         $mm2 = $mm->tryLoad(2);
         $this->assertSame('Sue', $mm2->get('name'));
 
@@ -151,7 +151,7 @@ class ConditionSqlTest extends TestCase
         $mm2 = $mm->tryLoad(1);
         $this->assertSame('John', $mm2->get('name'));
         $mm2 = $mm->tryLoad(2);
-        $this->assertNull($mm2->get('name'));
+        $this->assertNull($mm2);
     }
 
     public function testExpressions1(): void
@@ -174,14 +174,14 @@ class ConditionSqlTest extends TestCase
         $mm = clone $m;
         $mm->addCondition($mm->expr('[] > 1', [$mm->getField('id')]));
         $mm2 = $mm->tryLoad(1);
-        $this->assertNull($mm2->get('name'));
+        $this->assertNull($mm2);
         $mm2 = $mm->tryLoad(2);
         $this->assertSame('Sue', $mm2->get('name'));
 
         $mm = clone $m;
         $mm->addCondition($mm->expr('[id] > 1'));
         $mm2 = $mm->tryLoad(1);
-        $this->assertNull($mm2->get('name'));
+        $this->assertNull($mm2);
         $mm2 = $mm->tryLoad(2);
         $this->assertSame('Sue', $mm2->get('name'));
     }
@@ -206,14 +206,14 @@ class ConditionSqlTest extends TestCase
         $mm = clone $m;
         $mm->addCondition($mm->expr('[name] = [surname]'));
         $mm2 = $mm->tryLoad(1);
-        $this->assertNull($mm2->get('name'));
+        $this->assertNull($mm2);
         $mm2 = $mm->tryLoad(2);
         $this->assertSame('Sue', $mm2->get('name'));
 
         $mm = clone $m;
         $mm->addCondition($m->getField('name'), $m->getField('surname'));
         $mm2 = $mm->tryLoad(1);
-        $this->assertNull($mm2->get('name'));
+        $this->assertNull($mm2);
         $mm2 = $mm->tryLoad(2);
         $this->assertSame('Sue', $mm2->get('name'));
 
@@ -222,14 +222,14 @@ class ConditionSqlTest extends TestCase
         $mm2 = $mm->tryLoad(1);
         $this->assertSame('John', $mm2->get('name'));
         $mm2 = $mm->tryLoad(2);
-        $this->assertNull($mm2->get('name'));
+        $this->assertNull($mm2);
 
         $mm = clone $m;
         $mm->addCondition($m->getField('name'), '!=', $m->getField('surname'));
         $mm2 = $mm->tryLoad(1);
         $this->assertSame('John', $mm2->get('name'));
         $mm2 = $mm->tryLoad(2);
-        $this->assertNull($mm2->get('name'));
+        $this->assertNull($mm2);
     }
 
     public function testExpressionJoin(): void
@@ -264,12 +264,12 @@ class ConditionSqlTest extends TestCase
         $mm = clone $m;
         $mm->addCondition($mm->expr('[name] = [surname]'));
         $mm2 = $mm->tryLoad(1);
-        $this->assertFalse($mm2->isLoaded());
+        $this->assertNull($mm2);
         $mm2 = $mm->tryLoad(2);
         $this->assertSame('Sue', $mm2->get('name'));
         $this->assertSame('+321 sues', $mm2->get('contact_phone'));
         $mm2 = $mm->tryLoad(3);
-        $this->assertFalse($mm2->isLoaded());
+        $this->assertNull($mm2);
 
         $mm = clone $m;
         $mm->addCondition($mm->expr('\'+123 smiths\' = [contact_phone]'));
@@ -277,8 +277,7 @@ class ConditionSqlTest extends TestCase
         $this->assertSame('John', $mm2->get('name'));
         $this->assertSame('+123 smiths', $mm2->get('contact_phone'));
         $mm2 = $mm->tryLoad(2);
-        $this->assertNull($mm2->get('name'));
-        $this->assertNull($mm2->get('contact_phone'));
+        $this->assertNull($mm2);
         $mm2 = $mm->tryLoad(3);
         $this->assertSame('Peter', $mm2->get('name'));
         $this->assertSame('+123 smiths', $mm2->get('contact_phone'));

--- a/tests/ContainsManyTest.php
+++ b/tests/ContainsManyTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Atk4\Data\Tests;
 
-use Atk4\Data\Exception;
 use Atk4\Data\Schema\TestCase;
 use Atk4\Data\Tests\ContainsMany\Invoice;
 use Atk4\Data\Tests\ContainsMany\VatRate;
@@ -171,18 +170,6 @@ class ContainsManyTest extends TestCase
         $i->reload(); // we need to reload invoice for changes in lines to be recalculated
         $this->assertSame(10 * 2 * (1 + 21 / 100) + 40 * 1 * (1 + 21 / 100) + 50 * 3 * (1 + 15 / 100), $i->total_gross); // = 245.1
     }
-
-    /**
-     * Model should be loaded before traversing to containsMany relation.
-     */
-    /* Imants: it looks that this is not actually required - disabling
-    public function testEx1(): void
-    {
-        $i = new Invoice($this->db);
-        $this->expectException(Exception::class);
-        $i->lines;
-    }
-    */
 
     /**
      * Nested containsMany tests.

--- a/tests/ContainsManyTest.php
+++ b/tests/ContainsManyTest.php
@@ -6,6 +6,7 @@ namespace Atk4\Data\Tests;
 
 use Atk4\Data\Schema\TestCase;
 use Atk4\Data\Tests\ContainsMany\Invoice;
+use Atk4\Data\Tests\ContainsMany\Line;
 use Atk4\Data\Tests\ContainsMany\VatRate;
 
 /**
@@ -74,16 +75,16 @@ class ContainsManyTest extends TestCase
         $this->assertSame('My Invoice Lines', $i->lines->getModelCaption());
     }
 
-    /**
-     * Test containsMany.
-     */
     public function testContainsMany(): void
     {
         $i = new Invoice($this->db);
         $i = $i->loadBy($i->fieldName()->ref_no, 'A1');
 
+        $this->assertSame(Line::class, get_class($i->getModel()->lines));
+
         // now let's add some lines
         $l = $i->lines;
+        $this->assertNotNull($l);
         $rows = [
             1 => [
                 $l->fieldName()->id => 1,

--- a/tests/ContainsOneTest.php
+++ b/tests/ContainsOneTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Atk4\Data\Tests;
 
-use Atk4\Data\Exception;
 use Atk4\Data\Schema\TestCase;
 use Atk4\Data\Tests\ContainsOne\Country;
 use Atk4\Data\Tests\ContainsOne\Invoice;
@@ -65,6 +64,7 @@ class ContainsOneTest extends TestCase
      */
     public function testModelCaption(): void
     {
+        $this->markTestSkipped('ContainsOne need to be fixed, non-entity must be returned when traversing non-entity');
         $a = (new Invoice($this->db))->addr;
 
         // test caption of containsOne reference
@@ -82,8 +82,9 @@ class ContainsOneTest extends TestCase
         $i = $i->loadBy($i->fieldName()->ref_no, 'A1');
 
         // check do we have address set
-        $a = $i->addr;
-        $this->assertFalse($a->isLoaded());
+        $this->markTestSkipped('ContainsOne need to be fixed, non-entity must be returned when traversing non-entity');
+        $this->assertNull($i->addr);
+        $a = $i->getModel()->addr->createEntity();
 
         // now store some address
         $a->setMulti($row = [
@@ -170,7 +171,9 @@ class ContainsOneTest extends TestCase
         $i = $i->loadBy($i->fieldName()->ref_no, 'A1');
 
         // with address
-        $a = $i->addr;
+        $this->markTestSkipped('ContainsOne need to be fixed, non-entity must be returned when traversing non-entity');
+        $this->assertNull($i->addr);
+        $a = $i->getModel()->addr->createEntity();
         $a->setMulti($row = [
             $a->fieldName()->id => 1,
             $a->fieldName()->country_id => 1,
@@ -199,17 +202,4 @@ class ContainsOneTest extends TestCase
         $a = $i->addr;
         $this->assertEquals($row, $a->get());
     }
-
-    /*
-     * Model should be loaded before traversing to containsOne relation.
-     * Imants: it looks that this is not actually required - disabling.
-     */
-    /*
-    public function testEx1(): void
-    {
-        $i = new Invoice($this->db);
-        $this->expectException(Exception::class);
-        $i->addr;
-    }
-    */
 }

--- a/tests/ContainsOneTest.php
+++ b/tests/ContainsOneTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Atk4\Data\Tests;
 
 use Atk4\Data\Schema\TestCase;
+use Atk4\Data\Tests\ContainsOne\Address;
 use Atk4\Data\Tests\ContainsOne\Country;
 use Atk4\Data\Tests\ContainsOne\Invoice;
 
@@ -64,8 +65,8 @@ class ContainsOneTest extends TestCase
      */
     public function testModelCaption(): void
     {
-        $this->markTestSkipped('ContainsOne need to be fixed, non-entity must be returned when traversing non-entity');
-        $a = (new Invoice($this->db))->addr;
+        $i = new Invoice($this->db);
+        $a = $i->ref($i->fieldName()->addr);
 
         // test caption of containsOne reference
         $this->assertSame('Secret Code', $a->getField($a->fieldName()->door_code)->getCaption());
@@ -73,18 +74,16 @@ class ContainsOneTest extends TestCase
         $this->assertSame('Secret Code', $a->door_code->getModelCaption());
     }
 
-    /**
-     * Test containsOne.
-     */
     public function testContainsOne(): void
     {
         $i = new Invoice($this->db);
         $i = $i->loadBy($i->fieldName()->ref_no, 'A1');
 
+        $this->assertSame(Address::class, get_class($i->getModel()->addr));
+
         // check do we have address set
-        $this->markTestSkipped('ContainsOne need to be fixed, non-entity must be returned when traversing non-entity');
         $this->assertNull($i->addr);
-        $a = $i->getModel()->addr->createEntity();
+        $a = $i->ref($i->fieldName()->addr);
 
         // now store some address
         $a->setMulti($row = [
@@ -107,7 +106,7 @@ class ContainsOneTest extends TestCase
         $this->assertSame('bar', $i->addr->address);
 
         // now add nested containsOne - DoorCode
-        $c = $i->addr->door_code;
+        $c = $i->addr->ref($i->addr->fieldName()->door_code);
         $c->setMulti($row = [
             $c->fieldName()->id => 1,
             $c->fieldName()->code => 'ABC',
@@ -154,12 +153,12 @@ class ContainsOneTest extends TestCase
         // so far so good. now let's try to delete door_code
         $i->addr->door_code->delete();
         $this->assertNull($i->addr->get($i->addr->fieldName()->door_code));
-        $this->assertFalse($i->addr->door_code->isLoaded());
+        $this->assertNull($i->addr->door_code);
 
         // and now delete address
         $i->addr->delete();
         $this->assertNull($i->get($i->fieldName()->addr));
-        $this->assertFalse($i->addr->isLoaded());
+        $this->assertNull($i->addr);
     }
 
     /**
@@ -171,9 +170,8 @@ class ContainsOneTest extends TestCase
         $i = $i->loadBy($i->fieldName()->ref_no, 'A1');
 
         // with address
-        $this->markTestSkipped('ContainsOne need to be fixed, non-entity must be returned when traversing non-entity');
         $this->assertNull($i->addr);
-        $a = $i->getModel()->addr->createEntity();
+        $a = $i->ref($i->fieldName()->addr);
         $a->setMulti($row = [
             $a->fieldName()->id => 1,
             $a->fieldName()->country_id => 1,

--- a/tests/ContainsOneTest.php
+++ b/tests/ContainsOneTest.php
@@ -7,6 +7,7 @@ namespace Atk4\Data\Tests;
 use Atk4\Data\Schema\TestCase;
 use Atk4\Data\Tests\ContainsOne\Address;
 use Atk4\Data\Tests\ContainsOne\Country;
+use Atk4\Data\Tests\ContainsOne\DoorCode;
 use Atk4\Data\Tests\ContainsOne\Invoice;
 
 /**
@@ -108,6 +109,7 @@ class ContainsOneTest extends TestCase
         $this->assertSame('bar', $i->addr->address);
 
         // now add nested containsOne - DoorCode
+        /** @var DoorCode */
         $c = $i->addr->ref($i->addr->fieldName()->door_code);
         $c->setMulti($row = [
             $c->fieldName()->id => 1,

--- a/tests/ContainsOneTest.php
+++ b/tests/ContainsOneTest.php
@@ -66,6 +66,7 @@ class ContainsOneTest extends TestCase
     public function testModelCaption(): void
     {
         $i = new Invoice($this->db);
+        /** @var Address */
         $a = $i->ref($i->fieldName()->addr);
 
         // test caption of containsOne reference
@@ -83,6 +84,7 @@ class ContainsOneTest extends TestCase
 
         // check do we have address set
         $this->assertNull($i->addr);
+        /** @var Address */
         $a = $i->ref($i->fieldName()->addr);
 
         // now store some address
@@ -171,6 +173,7 @@ class ContainsOneTest extends TestCase
 
         // with address
         $this->assertNull($i->addr);
+        /** @var Address */
         $a = $i->ref($i->fieldName()->addr);
         $a->setMulti($row = [
             $a->fieldName()->id => 1,

--- a/tests/ExpressionSqlTest.php
+++ b/tests/ExpressionSqlTest.php
@@ -151,7 +151,7 @@ class ExpressionSqlTest extends TestCase
         );
 
         $mm = $m->tryLoad(1);
-        $this->assertNull($mm->get('name'));
+        $this->assertNull($mm);
         $mm = $m->tryLoad(2);
         $this->assertSame('Sue', $mm->get('name'));
     }

--- a/tests/IteratorTest.php
+++ b/tests/IteratorTest.php
@@ -156,14 +156,14 @@ class IteratorTest extends TestCase
             $data[] = $row;
         }
 
-        $this->assertEquals([
-            ['total_net' => 10, 'id' => 1],
+        $this->assertSame([
+            ['total_net' => '10', 'id' => '1'],
 
-            ['total_net' => 10, 'id' => 1],
-            ['total_net' => 15, 'id' => 3],
-            ['total_net' => 20, 'id' => 2],
+            ['total_net' => '10', 'id' => '1'],
+            ['total_net' => '15', 'id' => '3'],
+            ['total_net' => '20', 'id' => '2'],
 
-            ['total_net' => 10, 'id' => 1], // affected by limit now
+            ['total_net' => '10', 'id' => '1'], // affected by limit now
         ], $data);
     }
 

--- a/tests/JoinArrayTest.php
+++ b/tests/JoinArrayTest.php
@@ -245,10 +245,12 @@ class JoinArrayTest extends TestCase
             'id' => 3, 'contact_id' => 2, 'name' => 'Joe', 'contact_phone' => '+321',
         ], $m_u2->get());
 
-        $m_u2 = $m_u->tryLoad(4);
+        $m_u2 = $m_u2->unload();
         $this->assertSame([
             'id' => null, 'contact_id' => null, 'name' => null, 'contact_phone' => null,
         ], $m_u2->get());
+
+        $this->assertNull($m_u->tryLoad(4));
     }
 
     public function testJoinUpdate(): void
@@ -304,7 +306,7 @@ class JoinArrayTest extends TestCase
             ],
         ], $this->getInternalPersistenceData($db));
 
-        $m_u2 = $m_u->tryLoad(4);
+        $m_u2 = $m_u->createEntity();
         $m_u2->set('name', 'YYY');
         $m_u2->set('contact_phone', '+777');
         $m_u2->save();

--- a/tests/JoinArrayTest.php
+++ b/tests/JoinArrayTest.php
@@ -236,18 +236,18 @@ class JoinArrayTest extends TestCase
         $j->addField('contact_phone');
 
         $m_u2 = $m_u->load(1);
-        $this->assertEquals([
-            'name' => 'John', 'contact_id' => 1, 'contact_phone' => '+123', 'id' => 1,
+        $this->assertSame([
+            'id' => 1, 'contact_id' => 1, 'name' => 'John', 'contact_phone' => '+123',
         ], $m_u2->get());
 
         $m_u2 = $m_u->load(3);
-        $this->assertEquals([
-            'name' => 'Joe', 'contact_id' => 2, 'contact_phone' => '+321', 'id' => 3,
+        $this->assertSame([
+            'id' => 3, 'contact_id' => 2, 'name' => 'Joe', 'contact_phone' => '+321',
         ], $m_u2->get());
 
         $m_u2 = $m_u->tryLoad(4);
-        $this->assertEquals([
-            'name' => null, 'contact_id' => null, 'contact_phone' => null, 'id' => null,
+        $this->assertSame([
+            'id' => null, 'contact_id' => null, 'name' => null, 'contact_phone' => null,
         ], $m_u2->get());
     }
 

--- a/tests/JoinSqlTest.php
+++ b/tests/JoinSqlTest.php
@@ -197,18 +197,18 @@ class JoinSqlTest extends TestCase
         $j->addField('contact_phone');
 
         $m_u2 = $m_u->load(1);
-        $this->assertEquals([
-            'name' => 'John', 'contact_id' => 1, 'contact_phone' => '+123', 'id' => 1,
+        $this->assertSame([
+            'id' => 1, 'name' => 'John', 'contact_id' => '1', 'contact_phone' => '+123',
         ], $m_u2->get());
 
         $m_u2 = $m_u->load(3);
-        $this->assertEquals([
-            'name' => 'Joe', 'contact_id' => 2, 'contact_phone' => '+321', 'id' => 3,
+        $this->assertSame([
+            'id' => 3, 'name' => 'Joe', 'contact_id' => '2', 'contact_phone' => '+321',
         ], $m_u2->get());
 
         $m_u2 = $m_u->tryLoad(4);
-        $this->assertEquals([
-            'name' => null, 'contact_id' => null, 'contact_phone' => null, 'id' => null,
+        $this->assertSame([
+            'id' => null, 'name' => null, 'contact_id' => null, 'contact_phone' => null,
         ], $m_u2->get());
     }
 

--- a/tests/JoinSqlTest.php
+++ b/tests/JoinSqlTest.php
@@ -206,10 +206,12 @@ class JoinSqlTest extends TestCase
             'id' => 3, 'name' => 'Joe', 'contact_id' => '2', 'contact_phone' => '+321',
         ], $m_u2->get());
 
-        $m_u2 = $m_u->tryLoad(4);
+        $m_u2 = $m_u2->unload();
         $this->assertSame([
             'id' => null, 'name' => null, 'contact_id' => null, 'contact_phone' => null,
         ], $m_u2->get());
+
+        $this->assertNull($m_u->tryLoad(4));
     }
 
     public function testJoinUpdate(): void
@@ -283,7 +285,7 @@ class JoinSqlTest extends TestCase
             ],
         ], $this->getDb());
 
-        $m_u2 = $m_u->tryLoad(4);
+        $m_u2 = $m_u->createEntity();
         $m_u2->set('name', 'YYY');
         $m_u2->set('contact_phone', '+777');
         $m_u2->save();
@@ -409,7 +411,7 @@ class JoinSqlTest extends TestCase
         $m_u2->set('country_name', 'USA');
         $m_u2->save();
 
-        $m_u2 = $m_u->tryLoad(40);
+        $m_u2 = $m_u2->unload();
         $this->assertFalse($m_u2->isLoaded());
 
         $this->assertSame($m_u2->getModel()->getField('country_id')->getJoin(), $m_u2->getModel()->getField('contact_phone')->getJoin());

--- a/tests/Persistence/ArrayTest.php
+++ b/tests/Persistence/ArrayTest.php
@@ -885,7 +885,7 @@ class ArrayTest extends TestCase
         $m->addField('name');
         $m->addField('surname');
         $m = $m->tryLoadAny();
-        $this->assertFalse($m->isLoaded());
+        $this->assertNull($m);
     }
 
     public function testTryLoadAnyReturnsFirstRecord(): void

--- a/tests/Persistence/CsvTest.php
+++ b/tests/Persistence/CsvTest.php
@@ -144,7 +144,7 @@ class CsvTest extends TestCase
         $this->assertSame('Jones', $mm->get('surname'));
 
         $mm = $m->tryLoadAny();
-        $this->assertFalse($mm->isLoaded());
+        $this->assertNull($mm);
     }
 
     public function testLoadByIdNotSupportedException(): void

--- a/tests/Persistence/SqlTest.php
+++ b/tests/Persistence/SqlTest.php
@@ -53,7 +53,7 @@ class SqlTest extends TestCase
 
         $mm = (clone $m)->addCondition($m->id_field, 1);
         $this->assertSame('John', $mm->load(1)->get('name'));
-        $this->assertNull($mm->tryLoad(2)->get('name'));
+        $this->assertNull($mm->tryLoad(2));
         $this->assertSame('John', $mm->tryLoadOne()->get('name'));
         $this->assertSame('John', $mm->loadOne()->get('name'));
         $this->assertSame('John', $mm->tryLoadAny()->get('name'));
@@ -61,7 +61,7 @@ class SqlTest extends TestCase
 
         $mm = (clone $m)->addCondition('surname', 'Jones');
         $this->assertSame('Sarah', $mm->load(2)->get('name'));
-        $this->assertNull($mm->tryLoad(1)->get('name'));
+        $this->assertNull($mm->tryLoad(1));
         $this->assertSame('Sarah', $mm->tryLoadOne()->get('name'));
         $this->assertSame('Sarah', $mm->loadOne()->get('name'));
         $this->assertSame('Sarah', $mm->tryLoadAny()->get('name'));
@@ -207,7 +207,7 @@ class SqlTest extends TestCase
         $m2->save();
 
         $m2 = $m->tryLoad($ids[0]);
-        $this->assertFalse($m2->isLoaded());
+        $this->assertNull($m2);
 
         $m2 = $m->load($ids[1]);
         $this->assertSame('Smith', $m2->get('surname'));

--- a/tests/Persistence/StaticTest.php
+++ b/tests/Persistence/StaticTest.php
@@ -99,8 +99,7 @@ class StaticTest extends TestCase
         $m = new Model($p);
 
         $m = $m->tryLoadAny();
-
-        $this->assertFalse($m->isLoaded());
+        $this->assertNull($m);
     }
 
     public function testCustomField(): void

--- a/tests/ReferenceSqlTest.php
+++ b/tests/ReferenceSqlTest.php
@@ -43,17 +43,17 @@ class ReferenceSqlTest extends TestCase
         $ooo = $oo->tryLoad(1);
         $this->assertEquals(20, $ooo->get('amount'));
         $ooo = $oo->tryLoad(2);
-        $this->assertNull($ooo->get('amount'));
+        $this->assertNull($ooo);
         $ooo = $oo->tryLoad(3);
         $this->assertEquals(5, $ooo->get('amount'));
 
         $oo = $u->load(2)->ref('Orders');
         $ooo = $oo->tryLoad(1);
-        $this->assertNull($ooo->get('amount'));
+        $this->assertNull($ooo);
         $ooo = $oo->tryLoad(2);
         $this->assertEquals(15, $ooo->get('amount'));
         $ooo = $oo->tryLoad(3);
-        $this->assertNull($ooo->get('amount'));
+        $this->assertNull($ooo);
 
         $oo = $u->addCondition('id', '>', '1')->ref('Orders');
 


### PR DESCRIPTION
the return type was already documented as `null`, but the implementation returned unloaded entity

NOTE: `hintable` newly returns `null` when traversing entity 1:1 and the referenced record is not found - see https://github.com/mvorisek/atk4-hintable-mirror/commit/6a1863283b47afe20bb43f942544a8a7fd615460