### PR TITLE
Forbid ContainsXxx unmanaged data modification

### DIFF
--- a/src/Reference/ContainsMany.php
+++ b/src/Reference/ContainsMany.php
@@ -30,13 +30,11 @@ class ContainsMany extends ContainsOne
     {
         $ourModel = $this->getOurModel($ourModel);
 
-        // get model
         $theirModel = $this->createTheirModel(array_merge($defaults, [
             'containedInEntity' => $ourModel->isEntity() ? $ourModel : null,
             'table' => $this->table_alias,
         ]));
 
-        // set some hooks for ref_model
         foreach ([Model::HOOK_AFTER_SAVE, Model::HOOK_AFTER_DELETE] as $spot) {
             $this->onHookToTheirModel($theirModel, $spot, function (Model $theirModel) {
                 $ourModel = $this->getOurModel($theirModel->containedInEntity);

--- a/src/Reference/ContainsOne.php
+++ b/src/Reference/ContainsOne.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Atk4\Data\Reference;
 
+use Atk4\Data\Exception;
+use Atk4\Data\Field;
 use Atk4\Data\Model;
 use Atk4\Data\Persistence;
 use Atk4\Data\Reference;
@@ -61,6 +63,23 @@ class ContainsOne extends Reference
                 ], $this->ui),
             ]);
         }
+
+        // TODO https://github.com/atk4/data/issues/881
+        // prevent unmanaged ContainsXxx data modification (/wo proper normalize, hooks, ...)
+        $this->onHookToOurModel($ourModel, Model::HOOK_NORMALIZE, function (Model $ourModel, Field $field, $value) {
+            $ourRef = $field->getReference();
+            if ($ourRef === null || $field->shortName !== $this->getOurFieldName() || $value === null) {
+                return;
+            }
+
+            foreach (array_slice(debug_backtrace(\DEBUG_BACKTRACE_IGNORE_ARGS), 1) as $frame) {
+                if (($frame['class'] ?? null) === static::class) {
+                    return null; // allow load/save from ContainsOne hooks
+                }
+            }
+
+            throw new Exception('ContainsXxx does not support unmanaged data modification');
+        });
     }
 
     protected function getDefaultPersistence(Model $theirModel): Persistence

--- a/src/Reference/ContainsOne.php
+++ b/src/Reference/ContainsOne.php
@@ -76,7 +76,7 @@ class ContainsOne extends Reference
 
             foreach (array_slice(debug_backtrace(\DEBUG_BACKTRACE_IGNORE_ARGS), 1) as $frame) {
                 if (($frame['class'] ?? null) === static::class) {
-                    return null; // allow load/save from ContainsOne hooks
+                    return; // allow load/save from ContainsOne hooks
                 }
             }
 

--- a/src/Reference/ContainsOne.php
+++ b/src/Reference/ContainsOne.php
@@ -69,6 +69,8 @@ class ContainsOne extends Reference
         $this->onHookToOurModel($ourModel, Model::HOOK_NORMALIZE, function (Model $ourModel, Field $field, $value) {
             $ourRef = $field->getReference();
             if ($ourRef === null || $field->shortName !== $this->getOurFieldName() || $value === null) {
+                // this code relies on Field::$referenceLink set
+                // also, allowing null value to be set will not fire any HOOK_BEFORE_DELETE/HOOK_AFTER_DELETE hook
                 return;
             }
 

--- a/tests/ContainsManyTest.php
+++ b/tests/ContainsManyTest.php
@@ -291,4 +291,66 @@ class ContainsManyTest extends TestCase
             $exp_lines
         );
     }
+
+    public function testContainsManyPr881(): void
+    {
+        $i = new Invoice($this->db);
+        $i = $i->loadBy($i->fieldName()->ref_no, 'A1');
+
+        $this->assertSame(Line::class, get_class($i->getModel()->lines));
+
+        // now let's add some lines
+        $l = $i->lines;
+        $this->assertNotNull($l);
+        $rows = [
+            1 => [
+                $l->fieldName()->id => 1,
+                $l->fieldName()->vat_rate_id => 1,
+                $l->fieldName()->price => 10,
+                $l->fieldName()->qty => 2,
+                $l->fieldName()->discounts => null,
+                $l->fieldName()->add_date => new \DateTime('2019-01-01'),
+            ],
+            2 => [
+                $l->fieldName()->id => 2,
+                $l->fieldName()->vat_rate_id => 2,
+                $l->fieldName()->price => 15,
+                $l->fieldName()->qty => 5,
+                $l->fieldName()->discounts => null,
+                $l->fieldName()->add_date => new \DateTime('2019-01-01'),
+            ],
+        ];
+
+        foreach ($rows as $row) {
+            $l->insert($row);
+        }
+
+        // reload invoice just in case
+        $this->assertSameExportUnordered($rows, $i->lines->export());
+        $i->reload();
+        $this->assertSameExportUnordered($rows, $i->lines->export());
+
+        // test https://github.com/atk4/data/issues/881
+        // $i aka "Client"
+        $ac = $i->lines; // aka "Account"
+
+        $dumpBtFx = static function ($m) {
+            var_dump($m->table);
+            debug_print_backtrace(\DEBUG_BACKTRACE_IGNORE_ARGS);
+            echo "\n";
+        };
+
+        $i->onHook(\Atk4\Data\Model::HOOK_BEFORE_SAVE, $dumpBtFx);
+        $ac->onHook(\Atk4\Data\Model::HOOK_BEFORE_SAVE, $dumpBtFx);
+        $i->onHook(\Atk4\Data\Model::HOOK_BEFORE_DELETE, $dumpBtFx);
+        $ac->onHook(\Atk4\Data\Model::HOOK_BEFORE_DELETE, $dumpBtFx);
+
+        // array_pop($ac) - type error, $ac is not an array, hasMany traversal result is an conditioned Model
+        $ac->loadAny()->delete();
+        $i->save();
+
+        $i->set('lines', $ac); // why this does not fail?
+
+        $i->delete(); // this should delete the contained models first and trigger all delete hooks on them, a bug
+    }
 }

--- a/tests/ContainsOneTest.php
+++ b/tests/ContainsOneTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Atk4\Data\Tests;
 
+use Atk4\Data\Exception;
 use Atk4\Data\Schema\TestCase;
 use Atk4\Data\Tests\ContainsOne\Address;
 use Atk4\Data\Tests\ContainsOne\Country;
@@ -205,5 +206,15 @@ class ContainsOneTest extends TestCase
         // and it references to same old Address model without post_index field - no errors
         $a = $i->addr;
         $this->assertEquals($row, $a->get());
+    }
+
+    public function testUnmanagedDataModificationException(): void
+    {
+        $i = new Invoice($this->db);
+        $i = $i->loadBy($i->fieldName()->ref_no, 'A1');
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage('ContainsXxx does not support unmanaged data modification');
+        $i->set($i->fieldName()->addr, [0]);
     }
 }


### PR DESCRIPTION
closes https://github.com/atk4/data/issues/881

we forbid the hidden feature to prevent unwanted behaviour (no hooks, normalization, ...)

when the direct unmanaged data modification is really wanted, simply add a field using `$m->addField()` instead of `$m->containsOne()` (or `$m->containsMany()`)