### PR TITLE
Add Model::executeCountQuery() method

### DIFF
--- a/README.md
+++ b/README.md
@@ -609,8 +609,7 @@ Now you can explore. Try typing:
 > $m->loadBy('email', 'example@example.com')
 > $m->get()
 > $m->export(['email', 'name'])
-> $m->action('count')
-> $m->action('count')->getOne()
+> $m->executeCountQuery()
 ```
 
 ## Agile Core and DSQL

--- a/docs/persistence.rst
+++ b/docs/persistence.rst
@@ -417,7 +417,7 @@ Create copy of existing record
 
         // Now you have 2 records:
         // one with ID = 123 and another with ID = {next db generated id}
-        echo $m->action('count')->getOne();
+        echo $m->executeCountQuery();
 
 Duplicate then save under a new ID
 ----------------------------------
@@ -759,7 +759,7 @@ rows of data.
 Action can be executed at any time and that will return an expected result::
 
     $m = Model_Invoice();
-    $val = $m->action('count')->getOne();
+    $val = (int) $m->action('count')->getOne(); // same as $val = $m->executeCountQuery()
 
 Most actions are sufficiently smart to understand what type of result you are
 expecting, so you can have the following code::
@@ -803,7 +803,7 @@ There are ability to execute aggregation functions::
 
 and finally you can also use count::
 
-    echo $m->action('count')->getOne();
+    echo $m->executeCountQuery(); // same as echo $m->action('count')->getOne()
 
 
 SQL Actions on Linked Records

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -138,7 +138,7 @@ inside console::
     $m->addCondition('address_1', 'not', null);
     $m = $m->loadAny();
     $m->get();
-    $m->action('count')->getOne();
+    $m->executeCountQuery(); // same as ((int) $m->action('count')->getOne())
 
 Next, exit and create file `src/Model_ContactInfo.php`::
 
@@ -454,7 +454,7 @@ corresponding to all Systems that belong to user john. You can use the following
 to see number of records in DataSet or export DataSet::
 
     $s->isLoaded();
-    $s->action('count')->getOne();
+    $s->executeCountQuery();
     $s->export();
     $s->action('count')->getDebugQuery();
 
@@ -471,7 +471,7 @@ the Clients that are contained in all of the Systems that belong to user john.
 You can examine the this model further::
 
     $c->isLoaded();
-    $c->action('count')->getOne();
+    $c->executeCountQuery();
     $c->export();
     $c->action('count')->getDebugQuery();
 
@@ -529,7 +529,7 @@ basic aggregation without grouping. This type of aggregation provides some
 specific value from a data-set. SQL persistence implements some of the operations::
 
     $m = new Model_Invoice($db);
-    $m->action('count')->getOne();
+    $m->executeCountQuery();
     $m->action('fx', ['sum', 'total'])->getOne();
     $m->action('fx', ['max', 'shipping'])->getOne();
 

--- a/docs/sql.rst
+++ b/docs/sql.rst
@@ -247,6 +247,8 @@ Returns query for `count(*)`::
 
     $action = $model->action('count');
     $cnt = $action->getOne();
+    // for materialized count use:
+    $cnt = $model->executeCountQuery();
 
 You can also specify alias::
 

--- a/src/Model.php
+++ b/src/Model.php
@@ -1930,7 +1930,12 @@ class Model implements \IteratorAggregate
     {
         $this->assertIsModel();
 
-        return (int) $this->action('count')->getOne();
+        $res = $this->action('count')->getOne();
+        if (is_string($res)) {
+            $res = (int) $res;
+        }
+
+        return $res;
     }
 
     // }}}

--- a/src/Model.php
+++ b/src/Model.php
@@ -1926,6 +1926,13 @@ class Model implements \IteratorAggregate
         return $this->persistence->action($this, $mode, $args);
     }
 
+    public function executeCountQuery(): int
+    {
+        $this->assertIsModel();
+
+        return (int) $this->action('count')->getOne();
+    }
+
     // }}}
 
     // {{{ Expressions

--- a/src/Model.php
+++ b/src/Model.php
@@ -1931,7 +1931,7 @@ class Model implements \IteratorAggregate
         $this->assertIsModel();
 
         $res = $this->action('count')->getOne();
-        if (is_string($res)) {
+        if (is_string($res) && $res === (string) (int) $res) {
             $res = (int) $res;
         }
 

--- a/src/Persistence/Sql/Query.php
+++ b/src/Persistence/Sql/Query.php
@@ -116,7 +116,7 @@ class Query extends Expression
             if (
                 $add_alias === false
                 || (is_string($field) && $alias === $field)
-                || is_numeric($alias)
+                || is_int($alias)
             ) {
                 $alias = null;
             }
@@ -225,7 +225,7 @@ class Query extends Expression
             if (
                 $add_alias === false
                 || (is_string($table) && $alias === $table)
-                || is_numeric($alias)
+                || is_int($alias)
             ) {
                 $alias = null;
             }

--- a/tests/ConditionSqlTest.php
+++ b/tests/ConditionSqlTest.php
@@ -383,13 +383,13 @@ class ConditionSqlTest extends TestCase
             ['name', 'Peter'],
         ));
 
-        $this->assertSame('2', $u->action('count')->getOne());
+        $this->assertSame(2, $u->executeCountQuery());
 
         $u->addCondition(Model\Scope::createOr(
             ['name', 'Peter'],
             ['name', 'Joe'],
         ));
-        $this->assertSame('1', $u->action('count')->getOne());
+        $this->assertSame(1, $u->executeCountQuery());
     }
 
     /**

--- a/tests/ModelWithoutIdTest.php
+++ b/tests/ModelWithoutIdTest.php
@@ -86,7 +86,7 @@ class ModelWithoutIdTest extends TestCase
         }
 
         $this->m->insert(['name' => 'Joe']);
-        $this->assertSame('3', $this->m->action('count')->getOne());
+        $this->assertSame(3, $this->m->executeCountQuery());
     }
 
     /**
@@ -101,7 +101,7 @@ class ModelWithoutIdTest extends TestCase
         $m = $this->m->tryLoadAny();
         $m->saveAndUnload();
 
-        $this->assertSame('3', $this->m->action('count')->getOne());
+        $this->assertSame(3, $this->m->executeCountQuery());
     }
 
     /**
@@ -116,7 +116,7 @@ class ModelWithoutIdTest extends TestCase
         $m = $this->m->tryLoadAny();
         $m->save();
 
-        $this->assertSame('3', $this->m->action('count')->getOne());
+        $this->assertSame(3, $this->m->executeCountQuery());
     }
 
     /**

--- a/tests/Persistence/ArrayTest.php
+++ b/tests/Persistence/ArrayTest.php
@@ -244,6 +244,7 @@ class ArrayTest extends TestCase
         $m->addField('surname');
 
         $this->assertSame(2, $m->action('count')->getOne());
+        $this->assertSame(2, $m->executeCountQuery());
     }
 
     /**

--- a/tests/Persistence/ArrayTest.php
+++ b/tests/Persistence/ArrayTest.php
@@ -260,8 +260,6 @@ class ArrayTest extends TestCase
         $m->addField('name');
         $m->addField('surname');
 
-        $this->assertSame(2, $m->action('count')->getOne());
-
         // use alias as array key if it is set
         $q = $m->action('field', ['name', 'alias' => 'first_name']);
         $this->assertSame([
@@ -644,40 +642,40 @@ class ArrayTest extends TestCase
             ['id' => 1, 'f1' => 'A'],
             ['id' => 2, 'f1' => 'B'],
         ]);
-        $this->assertSame(2, $m->action('count')->getOne());
+        $this->assertSame(2, $m->executeCountQuery());
 
         $m->import([
             ['f1' => 'C'],
             ['f1' => 'D'],
         ]);
-        $this->assertSame(4, $m->action('count')->getOne());
+        $this->assertSame(4, $m->executeCountQuery());
 
         $m->import([
             ['id' => 6, 'f1' => 'E'],
             ['id' => 7, 'f1' => 'F'],
         ]);
-        $this->assertSame(6, $m->action('count')->getOne());
+        $this->assertSame(6, $m->executeCountQuery());
 
         $m->delete(6);
-        $this->assertSame(5, $m->action('count')->getOne());
+        $this->assertSame(5, $m->executeCountQuery());
 
         $m->import([
             ['f1' => 'G'],
             ['f1' => 'H'],
         ]);
-        $this->assertSame(7, $m->action('count')->getOne());
+        $this->assertSame(7, $m->executeCountQuery());
 
         $m->import([
             ['id' => 99, 'f1' => 'I'],
             ['id' => 20, 'f1' => 'J'],
         ]);
-        $this->assertSame(9, $m->action('count')->getOne());
+        $this->assertSame(9, $m->executeCountQuery());
 
         $m->import([
             ['f1' => 'K'],
             ['f1' => 'L'],
         ]);
-        $this->assertSame(11, $m->action('count')->getOne());
+        $this->assertSame(11, $m->executeCountQuery());
 
         $m->delete(100);
         $m->createEntity()->set('f1', 'M')->save();
@@ -712,10 +710,10 @@ class ArrayTest extends TestCase
         $m = new Model($p);
         $m->addField('f1');
 
-        $this->assertSame(4, $m->action('count')->getOne());
+        $this->assertSame(4, $m->executeCountQuery());
 
         $m->setLimit(3);
-        $this->assertSame(3, $m->action('count')->getOne());
+        $this->assertSame(3, $m->executeCountQuery());
         $this->assertSame([
             ['id' => 1, 'f1' => 'A'],
             ['id' => 2, 'f1' => 'D'],
@@ -723,7 +721,7 @@ class ArrayTest extends TestCase
         ], array_values($m->export()));
 
         $m->setLimit(2, 1);
-        $this->assertSame(2, $m->action('count')->getOne());
+        $this->assertSame(2, $m->executeCountQuery());
         $this->assertSame([
             ['id' => 2, 'f1' => 'D'],
             ['id' => 3, 'f1' => 'E'],
@@ -732,7 +730,7 @@ class ArrayTest extends TestCase
         // well, this is strange, that you can actually change limit on-the-fly and then previous
         // limit is not taken into account, but most likely you will never set it multiple times
         $m->setLimit(3);
-        $this->assertSame(3, $m->action('count')->getOne());
+        $this->assertSame(3, $m->executeCountQuery());
     }
 
     /**
@@ -750,19 +748,19 @@ class ArrayTest extends TestCase
         $m->addField('name');
         $m->addField('surname');
 
-        $this->assertSame(4, $m->action('count')->getOne());
+        $this->assertSame(4, $m->executeCountQuery());
         $this->assertSame(['data' => $dbData], $this->getInternalPersistenceData($p));
 
         $m->addCondition('name', 'Sarah');
-        $this->assertSame(3, $m->action('count')->getOne());
+        $this->assertSame(3, $m->executeCountQuery());
 
         $m->addCondition('surname', 'Smith');
-        $this->assertSame(1, $m->action('count')->getOne());
+        $this->assertSame(1, $m->executeCountQuery());
         $this->assertSame([4 => ['id' => 4, 'name' => 'Sarah', 'surname' => 'Smith']], $m->export());
         $this->assertSame([4 => ['id' => 4, 'name' => 'Sarah', 'surname' => 'Smith']], $m->action('select')->getRows());
 
         $m->addCondition('surname', 'Siiiith');
-        $this->assertSame(0, $m->action('count')->getOne());
+        $this->assertSame(0, $m->executeCountQuery());
     }
 
     public function testUnsupportedAction(): void
@@ -864,10 +862,10 @@ class ArrayTest extends TestCase
         $user->hasOne('country_id', ['model' => $country]);
 
         $cc = $country->load(1);
-        $this->assertSame(2, $cc->ref('Users')->action('count')->getOne());
+        $this->assertSame(2, $cc->ref('Users')->executeCountQuery());
 
         $cc = $country->load(2);
-        $this->assertSame(1, $cc->ref('Users')->action('count')->getOne());
+        $this->assertSame(1, $cc->ref('Users')->executeCountQuery());
     }
 
     public function testLoadAnyThrowsExceptionOnRecordNotFound(): void

--- a/tests/Persistence/Sql/WithDb/SelectTest.php
+++ b/tests/Persistence/Sql/WithDb/SelectTest.php
@@ -326,46 +326,46 @@ class SelectTest extends TestCase
             ['id' => 1, 'f1' => 'A'],
             ['id' => 2, 'f1' => 'B'],
         ]);
-        $this->assertSame('2', $m->action('count')->getOne());
+        $this->assertSame(2, $m->executeCountQuery());
         $this->assertSame(2, $getLastAiFx());
 
         $m->import([
             ['f1' => 'C'],
             ['f1' => 'D'],
         ]);
-        $this->assertSame('4', $m->action('count')->getOne());
+        $this->assertSame(4, $m->executeCountQuery());
         $this->assertSame(4, $getLastAiFx());
 
         $m->import([
             ['id' => 6, 'f1' => 'E'],
             ['id' => 7, 'f1' => 'F'],
         ]);
-        $this->assertSame('6', $m->action('count')->getOne());
+        $this->assertSame(6, $m->executeCountQuery());
         $this->assertSame(7, $getLastAiFx());
 
         $m->delete(6);
-        $this->assertSame('5', $m->action('count')->getOne());
+        $this->assertSame(5, $m->executeCountQuery());
         $this->assertSame(7, $getLastAiFx());
 
         $m->import([
             ['f1' => 'G'],
             ['f1' => 'H'],
         ]);
-        $this->assertSame('7', $m->action('count')->getOne());
+        $this->assertSame(7, $m->executeCountQuery());
         $this->assertSame(9, $getLastAiFx());
 
         $m->import([
             ['id' => 99, 'f1' => 'I'],
             ['id' => 20, 'f1' => 'J'],
         ]);
-        $this->assertSame('9', $m->action('count')->getOne());
+        $this->assertSame(9, $m->executeCountQuery());
         $this->assertSame(99, $getLastAiFx());
 
         $m->import([
             ['f1' => 'K'],
             ['f1' => 'L'],
         ]);
-        $this->assertSame('11', $m->action('count')->getOne());
+        $this->assertSame(11, $m->executeCountQuery());
         $this->assertSame(101, $getLastAiFx());
 
         $m->delete(100);

--- a/tests/Persistence/SqlTest.php
+++ b/tests/Persistence/SqlTest.php
@@ -177,7 +177,7 @@ class SqlTest extends TestCase
 
         $this->assertSame('1', $m->action('exists')->getOne());
 
-        $this->assertSame('2', $m->action('count')->getOne());
+        $this->assertSame(2, $m->executeCountQuery());
     }
 
     public function testPersistenceDelete(): void

--- a/tests/RandomTest.php
+++ b/tests/RandomTest.php
@@ -88,7 +88,7 @@ class RandomTest extends TestCase
 
         $m = new Model_Rate($this->db);
 
-        $this->assertSame('2', $m->action('count')->getOne());
+        $this->assertSame(2, $m->executeCountQuery());
     }
 
     public function testTitleImport(): void
@@ -234,7 +234,7 @@ class RandomTest extends TestCase
             $m->load(2)->get()
         );
 
-        $this->assertSame('1', $m->load(2)->ref('Child', ['table_alias' => 'pp'])->action('count')->getOne());
+        $this->assertSame(1, $m->load(2)->ref('Child', ['table_alias' => 'pp'])->executeCountQuery());
         $this->assertSame('John', $m->load(2)->ref('parent_item_id', ['table_alias' => 'pp'])->get('name'));
     }
 

--- a/tests/Schema/ModelTest.php
+++ b/tests/Schema/ModelTest.php
@@ -158,7 +158,7 @@ class ModelTest extends TestCase
             for ($i = 0; $i <= 0x10FFFF; $i = $i * 1.001 + 1) {
                 $iInt = (int) $i;
                 if ($iInt < 0xD800 || $iInt > 0xDFFF) {
-                    $baseChars[crc32($length . '_' . $i)] = mb_chr($iInt);
+                    $baseChars[crc32($length . '_' . $iInt)] = mb_chr($iInt);
                 }
             }
         }

--- a/tests/ScopeTest.php
+++ b/tests/ScopeTest.php
@@ -204,7 +204,7 @@ class ScopeTest extends TestCase
 
         $user->addCondition('country_id/code', 'LV');
 
-        $this->assertSame('1', $user->action('count')->getOne());
+        $this->assertSame(1, $user->executeCountQuery());
 
         foreach ($user as $u) {
             $this->assertEquals('LV', $u->get('country_code'));
@@ -215,7 +215,7 @@ class ScopeTest extends TestCase
         // users that have no ticket
         $user->addCondition('Tickets/#', 0);
 
-        $this->assertSame('1', $user->action('count')->getOne());
+        $this->assertSame(1, $user->executeCountQuery());
 
         foreach ($user as $u) {
             $this->assertTrue(in_array($u->get('name'), ['Alain', 'Aerton', 'Rubens'], true));
@@ -253,7 +253,7 @@ class ScopeTest extends TestCase
         // countries with users that have any tickets
         $country->addCondition('Users/Tickets/#', '>', 0);
 
-        $this->assertSame('3', $country->action('count')->getOne());
+        $this->assertSame(3, $country->executeCountQuery());
 
         foreach ($country as $c) {
             $this->assertTrue(in_array($c->get('code'), ['LV', 'CA', 'BR'], true));
@@ -264,7 +264,7 @@ class ScopeTest extends TestCase
         // countries with users that have no tickets
         $country->addCondition('Users/Tickets/#', 0);
 
-        $this->assertSame('1', $country->action('count')->getOne());
+        $this->assertSame(1, $country->executeCountQuery());
 
         foreach ($country as $c) {
             $this->assertTrue(in_array($c->get('code'), ['FR'], true));
@@ -286,7 +286,7 @@ class ScopeTest extends TestCase
             $user->addCondition('Tickets/user/country_id/Users/country_id/Users/name', '!=', null); // should be always true
         }
 
-        $this->assertSame('2', $user->action('count')->getOne());
+        $this->assertSame(2, $user->executeCountQuery());
         foreach ($user as $u) {
             $this->assertTrue(in_array($u->get('name'), ['Aerton', 'Rubens'], true));
         }

--- a/tests/Util/DeepCopyTest.php
+++ b/tests/Util/DeepCopyTest.php
@@ -243,9 +243,9 @@ class DeepCopyTest extends TestCase
         $this->assertEquals(3, $client3->getId());
 
         // We should have one of each records for this new client
-        $this->assertSame('1', $client3->ref('Invoices')->action('count')->getOne());
-        $this->assertSame('1', $client3->ref('Quotes')->action('count')->getOne());
-        $this->assertSame('1', $client3->ref('Payments')->action('count')->getOne());
+        $this->assertSame(1, $client3->ref('Invoices')->executeCountQuery());
+        $this->assertSame(1, $client3->ref('Quotes')->executeCountQuery());
+        $this->assertSame(1, $client3->ref('Payments')->executeCountQuery());
 
         if ($this->getDatabasePlatform() instanceof SQLServerPlatform) {
             $this->markTestIncomplete('TODO MSSQL: Cannot perform an aggregate function on an expression containing an aggregate or a subquery');


### PR DESCRIPTION
after a long discussion, I propose `Model::executeCountQuery` name

I do not want to name it `Model::getCount`, as such name might imply it is stored and/or no query is sent to the DB

it is not only shorter than `$m->action('count')->getOne()` but the value is also casted properly to an `integer`