### PR TITLE
Improve datetime types typecasting

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -3,9 +3,7 @@ name: Build Release
 on:
   push:
     branches:
-      - '**\.build'
       - 'release/*'
-      - '!**\.gen'
 
 jobs:
   autocommit:
@@ -14,19 +12,16 @@ jobs:
     container:
       image: ghcr.io/mvorisek/image-php:latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           ref: ${{ github.ref }}
 
       - name: Install PHP dependencies
         run: composer update --ansi --prefer-dist --no-interaction --no-progress --optimize-autoloader
 
-      - name: Composer unset version
-        run: composer config version --unset
-
       - name: Update composer.json
         run: >-
-          php -r '
+          composer config --unset version && php -r '
           $f = __DIR__ . "/composer.json";
           $data = json_decode(file_get_contents($f), true);
           foreach ($data as $k => $v) {
@@ -39,18 +34,14 @@ jobs:
           file_put_contents($f, $str);
           '
 
-      - name: Composer validate config
-        run: composer validate --strict --no-check-lock && composer normalize --dry-run --no-check-lock
-
       - name: Commit
         run: |
           git config --global user.name "$(git show -s --format='%an')"
           git config --global user.email "$(git show -s --format='%ae')"
-          git add -A && git diff --staged && git commit -m "Build Release"
+          git add . -N && (git diff --exit-code || git commit -a -m "Branch for stable release")
 
       - name: Push
         uses: ad-m/github-push-action@master
         with:
-          branch: ${{ github.ref }}.gen
-          force: true
+          branch: ${{ github.ref }}
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test-unit.yml
+++ b/.github/workflows/test-unit.yml
@@ -24,7 +24,7 @@ jobs:
             type: 'StaticAnalysis'
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Configure PHP
         run: |
@@ -66,6 +66,8 @@ jobs:
         if: matrix.type == 'CodingStyle'
         run: |
           vendor/bin/php-cs-fixer fix --dry-run --using-cache=no --diff --verbose
+          composer config --unset version && composer config --unset require-release
+          composer validate --strict --no-check-lock && composer normalize --dry-run --no-check-lock
 
       - name: Run Static Analysis (only for StaticAnalysis)
         if: matrix.type == 'StaticAnalysis'
@@ -116,7 +118,7 @@ jobs:
           ORACLE_PASSWORD: atk4_pass
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Configure PHP
         run: |

--- a/composer.json
+++ b/composer.json
@@ -54,11 +54,11 @@
         "phpstan/phpstan-deprecation-rules": "^1.0",
         "phpunit/phpunit": "^9.5.5"
     },
-    "suggest": {
-        "jdorn/sql-formatter": "*"
-    },
     "conflict": {
         "jdorn/sql-formatter": "<1.2.9"
+    },
+    "suggest": {
+        "jdorn/sql-formatter": "*"
     },
     "minimum-stability": "dev",
     "prefer-stable": true,

--- a/docs/fields.rst
+++ b/docs/fields.rst
@@ -67,7 +67,7 @@ Agile Data defines some basic types to make sure that values:
 A good example would be a `date` type::
 
     $model->addField('birth', ['type' => 'date']);
-    $model->set('birth', DateTime::createFromFormat('m/d/Y', '1/10/2014'));
+    $model->set('birth', new DateTime('2014-01-10'));
 
     $model->save();
 

--- a/docs/persistence.rst
+++ b/docs/persistence.rst
@@ -349,10 +349,8 @@ Dates and Time
 
 .. todo:: this section might need cleanup
 
-There are 4 date formats supported:
+There are 3 datetime formats supported:
 
--  ts (or timestamp): Stores in database using UTC. Defaults into unix
-   timestamp (int) in PHP.
 -  date: Converts into YYYY-MM-DD using UTC timezone for SQL. Defaults
    to DateTime() class in PHP, but supports string input (parsed as date
    in a current timezone) or unix timestamp.

--- a/docs/typecasting.rst
+++ b/docs/typecasting.rst
@@ -37,16 +37,7 @@ You must remember that type-casting is a two-way operation. If you are
 introducing your own types, you will need to make sure they can be saved and
 loaded correctly.
 
-Some formats such as `date`, `time` and `datetime` may have additional options
-to it::
-
-    $m->addField('registered', [
-        'type' => 'date',
-        'persist_format' => 'd/m/Y',
-        'persist_timezone' => 'IST',
-    ]);
-
-Here is another example with booleans::
+Some types such as `boolean` may support additional options like::
 
     $m->addField('is_married', [
         'type' => 'boolean',

--- a/src/Model/FieldPropertiesTrait.php
+++ b/src/Model/FieldPropertiesTrait.php
@@ -106,22 +106,4 @@ trait FieldPropertiesTrait
      * @var bool|string
      */
     public $required = false;
-
-    /**
-     * Persisting format for type = 'date', 'datetime', 'time' fields.
-     *
-     * For example, for date it can be 'Y-m-d', for datetime - 'Y-m-d H:i:s.u' etc.
-     *
-     * @var string
-     */
-    public $persist_format;
-
-    /**
-     * Persisting timezone for type = 'date', 'datetime', 'time' fields.
-     *
-     * For example, 'IST', 'UTC', 'Europe/Riga' etc.
-     *
-     * @var string
-     */
-    public $persist_timezone = 'UTC';
 }

--- a/src/Persistence.php
+++ b/src/Persistence.php
@@ -439,19 +439,18 @@ abstract class Persistence
                 $format = preg_replace('~(?<=H:i:s)(?![. ]*u)~', '.u', $format);
             }
 
-            if ($field->type === 'datetime') {
-                $value = \DateTime::createFromFormat('!' . $format, $value, new \DateTimeZone('UTC'));
-                if ($value !== false) {
+            $valueOrig = $value;
+            $value = \DateTime::createFromFormat('!' . $format, $value, new \DateTimeZone('UTC'));
+            if ($value !== false) {
+                if ($field->type === 'datetime') {
                     $value->setTimezone(new \DateTimeZone(date_default_timezone_get()));
                 }
-            } else {
-                $value = \DateTime::createFromFormat('!' . $format, $value);
             }
 
             if ($value === false) {
                 throw (new Exception('Incorrectly formatted date/time'))
                     ->addMoreInfo('format', $format)
-                    ->addMoreInfo('value', $value)
+                    ->addMoreInfo('value', $valueOrig)
                     ->addMoreInfo('field', $field);
             }
 

--- a/src/Persistence.php
+++ b/src/Persistence.php
@@ -439,7 +439,7 @@ abstract class Persistence
                 $format = $field->persist_format;
             } else {
                 // ! symbol in date format is essential here to remove time part of DateTime - don't remove, this is not a bug
-                $formats = ['date' => '+!Y-m-d', 'datetime' => '+!Y-m-d H:i:s', 'time' => '+!H:i:s'];
+                $formats = ['date' => '!Y-m-d', 'datetime' => '!Y-m-d H:i:s', 'time' => '!H:i:s'];
                 $format = $formats[$field->type];
                 if (str_contains($value, '.')) { // time possibly with microseconds, otherwise invalid format
                     $format = preg_replace('~(?<=H:i:s)(?![. ]*u)~', '.u', $format);

--- a/src/Persistence.php
+++ b/src/Persistence.php
@@ -441,17 +441,15 @@ abstract class Persistence
 
             $valueOrig = $value;
             $value = \DateTime::createFromFormat('!' . $format, $value, new \DateTimeZone('UTC'));
-            if ($value !== false) {
-                if ($field->type === 'datetime') {
-                    $value->setTimezone(new \DateTimeZone(date_default_timezone_get()));
-                }
-            }
-
             if ($value === false) {
-                throw (new Exception('Incorrectly formatted date/time'))
+                throw (new Exception('Incorrectly formatted datetime'))
                     ->addMoreInfo('format', $format)
                     ->addMoreInfo('value', $valueOrig)
                     ->addMoreInfo('field', $field);
+            }
+
+            if ($field->type === 'datetime') {
+                $value->setTimezone(new \DateTimeZone(date_default_timezone_get()));
             }
 
             return $value;

--- a/tests/ModelNestedArrayTest.php
+++ b/tests/ModelNestedArrayTest.php
@@ -107,8 +107,8 @@ class ModelNestedArrayTest extends TestCase
         $m = $this->createTestModel();
 
         $this->assertSameExportUnordered([
-            1 => ['name' => 'John', 'birthday' => new \DateTime('1980-2-1')],
-            ['name' => 'Sue', 'birthday' => new \DateTime('2005-4-3')],
+            1 => ['name' => 'John', 'birthday' => new \DateTime('1980-2-1 UTC')],
+            ['name' => 'Sue', 'birthday' => new \DateTime('2005-4-3 UTC')],
         ], $m->export());
 
         $this->assertSame([], $this->hookLog);
@@ -146,12 +146,12 @@ class ModelNestedArrayTest extends TestCase
         ], $this->hookLog);
 
         $this->assertSame(4, $m->table->loadBy('name', 'Karl')->getId());
-        $this->assertSameExportUnordered([[new \DateTime('2000-6-1')]], [[$entity->getId()]]);
+        $this->assertSameExportUnordered([[new \DateTime('2000-6-1 UTC')]], [[$entity->getId()]]);
 
         $this->assertSameExportUnordered([
-            1 => ['name' => 'John', 'birthday' => new \DateTime('1980-2-1')],
-            ['name' => 'Sue', 'birthday' => new \DateTime('2005-4-3')],
-            4 => ['name' => 'Karl', 'birthday' => new \DateTime('2000-6-1')],
+            1 => ['name' => 'John', 'birthday' => new \DateTime('1980-2-1 UTC')],
+            ['name' => 'Sue', 'birthday' => new \DateTime('2005-4-3 UTC')],
+            4 => ['name' => 'Karl', 'birthday' => new \DateTime('2000-6-1 UTC')],
         ], $m->export());
     }
 
@@ -195,8 +195,8 @@ class ModelNestedArrayTest extends TestCase
         ], $this->hookLog);
 
         $this->assertSameExportUnordered([
-            1 => ['name' => 'John', 'birthday' => new \DateTime('1980-2-1')],
-            ['name' => 'Susan', 'birthday' => new \DateTime('2005-4-3')],
+            1 => ['name' => 'John', 'birthday' => new \DateTime('1980-2-1 UTC')],
+            ['name' => 'Susan', 'birthday' => new \DateTime('2005-4-3 UTC')],
         ], $m->export());
     }
 
@@ -227,7 +227,7 @@ class ModelNestedArrayTest extends TestCase
         ], $this->hookLog);
 
         $this->assertSameExportUnordered([
-            1 => ['name' => 'John', 'birthday' => new \DateTime('1980-2-1')],
+            1 => ['name' => 'John', 'birthday' => new \DateTime('1980-2-1 UTC')],
         ], $m->export());
     }
 }

--- a/tests/ModelNestedSqlTest.php
+++ b/tests/ModelNestedSqlTest.php
@@ -140,8 +140,8 @@ class ModelNestedSqlTest extends TestCase
         $m = $this->createTestModel();
 
         $this->assertSameExportUnordered([
-            ['name' => 'John', 'birthday' => new \DateTime('1980-2-1')],
-            ['name' => 'Sue', 'birthday' => new \DateTime('2005-4-3')],
+            ['name' => 'John', 'birthday' => new \DateTime('1980-2-1 UTC')],
+            ['name' => 'Sue', 'birthday' => new \DateTime('2005-4-3 UTC')],
         ], $m->export());
 
         $this->assertSame([
@@ -186,12 +186,12 @@ class ModelNestedSqlTest extends TestCase
         ], $this->hookLog);
 
         $this->assertSame(4, $m->table->loadBy('name', 'Karl')->getId());
-        $this->assertSameExportUnordered([[new \DateTime('2000-6-1')]], [[$entity->getId()]]);
+        $this->assertSameExportUnordered([[new \DateTime('2000-6-1 UTC')]], [[$entity->getId()]]);
 
         $this->assertSameExportUnordered([
-            ['name' => 'John', 'birthday' => new \DateTime('1980-2-1')],
-            ['name' => 'Sue', 'birthday' => new \DateTime('2005-4-3')],
-            ['name' => 'Karl', 'birthday' => new \DateTime('2000-6-1')],
+            ['name' => 'John', 'birthday' => new \DateTime('1980-2-1 UTC')],
+            ['name' => 'Sue', 'birthday' => new \DateTime('2005-4-3 UTC')],
+            ['name' => 'Karl', 'birthday' => new \DateTime('2000-6-1 UTC')],
         ], $m->export());
     }
 
@@ -240,8 +240,8 @@ class ModelNestedSqlTest extends TestCase
         ], $this->hookLog);
 
         $this->assertSameExportUnordered([
-            ['name' => 'John', 'birthday' => new \DateTime('1980-2-1')],
-            ['name' => 'Susan', 'birthday' => new \DateTime('2005-4-3')],
+            ['name' => 'John', 'birthday' => new \DateTime('1980-2-1 UTC')],
+            ['name' => 'Susan', 'birthday' => new \DateTime('2005-4-3 UTC')],
         ], $m->export());
     }
 
@@ -277,7 +277,7 @@ class ModelNestedSqlTest extends TestCase
         ], $this->hookLog);
 
         $this->assertSameExportUnordered([
-            ['name' => 'John', 'birthday' => new \DateTime('1980-2-1')],
+            ['name' => 'John', 'birthday' => new \DateTime('1980-2-1 UTC')],
         ], $m->export());
     }
 }

--- a/tests/ReferenceSqlTest.php
+++ b/tests/ReferenceSqlTest.php
@@ -187,7 +187,7 @@ class ReferenceSqlTest extends TestCase
         $o->hasOne('user_id', ['model' => $u])->addFields(['username' => 'name', ['date', 'type' => 'date']]);
 
         $this->assertSame('John', $o->load(1)->get('username'));
-        $this->assertEquals(new \DateTime('2001-01-02'), $o->load(1)->get('date'));
+        $this->assertEquals(new \DateTime('2001-01-02 UTC'), $o->load(1)->get('date'));
 
         $this->assertSame('Peter', $o->load(2)->get('username'));
         $this->assertSame('John', $o->load(3)->get('username'));
@@ -197,11 +197,11 @@ class ReferenceSqlTest extends TestCase
         $o = (new Model($this->db, ['table' => 'order']))->addFields(['amount']);
         $o->hasOne('user_id', ['model' => $u])->addFields(['username' => 'name', 'thedate' => ['date', 'type' => 'date']]);
         $this->assertSame('John', $o->load(1)->get('username'));
-        $this->assertEquals(new \DateTime('2001-01-02'), $o->load(1)->get('thedate'));
+        $this->assertEquals(new \DateTime('2001-01-02 UTC'), $o->load(1)->get('thedate'));
 
         $o = (new Model($this->db, ['table' => 'order']))->addFields(['amount']);
         $o->hasOne('user_id', ['model' => $u])->addFields(['date'], ['type' => 'date']);
-        $this->assertEquals(new \DateTime('2001-01-02'), $o->load(1)->get('date'));
+        $this->assertEquals(new \DateTime('2001-01-02 UTC'), $o->load(1)->get('date'));
     }
 
     public function testRelatedExpression(): void

--- a/tests/TypecastingTest.php
+++ b/tests/TypecastingTest.php
@@ -377,43 +377,6 @@ class TypecastingTest extends TestCase
         $this->assertTrue($m2->isLoaded());
     }
 
-    public function testTypecastTimezone(): void
-    {
-        $m = new Model($this->db, ['table' => 'event']);
-        $dt = $m->addField('dt', ['type' => 'datetime', 'persist_timezone' => 'EEST']);
-        $d = $m->addField('d', ['type' => 'date', 'persist_timezone' => 'EEST']);
-        $t = $m->addField('t', ['type' => 'time', 'persist_timezone' => 'EEST']);
-
-        date_default_timezone_set('UTC');
-        $s = new \DateTime('Monday, 15-Aug-05 22:52:01 UTC');
-        $this->assertSame('2005-08-16 00:52:01.000000', $this->db->typecastSaveField($dt, $s));
-        $this->assertSame('2005-08-15', $this->db->typecastSaveField($d, $s));
-        $this->assertSame('22:52:01.000000', $this->db->typecastSaveField($t, $s));
-        $this->assertEquals(new \DateTime('Monday, 15-Aug-05 22:52:01 UTC'), $this->db->typecastLoadField($dt, '2005-08-16 00:52:01'));
-        $this->assertEquals(new \DateTime('Monday, 15-Aug-05'), $this->db->typecastLoadField($d, '2005-08-15'));
-        $this->assertEquals(new \DateTime('1970-01-01 22:52:01'), $this->db->typecastLoadField($t, '22:52:01'));
-
-        date_default_timezone_set('Asia/Tokyo');
-
-        $s = new \DateTime('Monday, 15-Aug-05 22:52:01 UTC');
-        $this->assertSame('2005-08-16 00:52:01.000000', $this->db->typecastSaveField($dt, $s));
-        $this->assertSame('2005-08-15', $this->db->typecastSaveField($d, $s));
-        $this->assertSame('22:52:01.000000', $this->db->typecastSaveField($t, $s));
-        $this->assertEquals(new \DateTime('Monday, 15-Aug-05 22:52:01 UTC'), $this->db->typecastLoadField($dt, '2005-08-16 00:52:01'));
-        $this->assertEquals(new \DateTime('Monday, 15-Aug-05'), $this->db->typecastLoadField($d, '2005-08-15'));
-        $this->assertEquals(new \DateTime('1970-01-01 22:52:01'), $this->db->typecastLoadField($t, '22:52:01'));
-
-        date_default_timezone_set('America/Los_Angeles');
-
-        $s = new \DateTime('Monday, 15-Aug-05 22:52:01'); // uses servers default timezone
-        $this->assertSame('2005-08-16 07:52:01.000000', $this->db->typecastSaveField($dt, $s));
-        $this->assertSame('2005-08-15', $this->db->typecastSaveField($d, $s));
-        $this->assertSame('22:52:01.000000', $this->db->typecastSaveField($t, $s));
-        $this->assertEquals(new \DateTime('Monday, 15-Aug-05 22:52:01 America/Los_Angeles'), $this->db->typecastLoadField($dt, '2005-08-16 07:52:01'));
-        $this->assertEquals(new \DateTime('Monday, 15-Aug-05'), $this->db->typecastLoadField($d, '2005-08-15'));
-        $this->assertEquals(new \DateTime('1970-01-01 22:52:01'), $this->db->typecastLoadField($t, '22:52:01'));
-    }
-
     public function testTimestamp(): void
     {
         $sql_time = '2016-10-25 11:44:08';

--- a/tests/TypecastingTest.php
+++ b/tests/TypecastingTest.php
@@ -65,9 +65,9 @@ class TypecastingTest extends TestCase
         $this->assertSame('foo', $mm->get('string'));
         $this->assertTrue($mm->get('boolean'));
         $this->assertSame(8.20, $mm->get('money'));
-        $this->assertEquals(new \DateTime('2013-02-20'), $mm->get('date'));
+        $this->assertEquals(new \DateTime('2013-02-20 UTC'), $mm->get('date'));
         $this->assertEquals(new \DateTime('2013-02-20 20:00:12 UTC'), $mm->get('datetime'));
-        $this->assertEquals(new \DateTime('1970-01-01 12:00:50'), $mm->get('time'));
+        $this->assertEquals(new \DateTime('1970-01-01 12:00:50 UTC'), $mm->get('time'));
         $this->assertSame(2940, $mm->get('integer'));
         $this->assertSame([1, 2, 3], $mm->get('json'));
         $this->assertSame(8.20234376757473, $mm->get('float'));


### PR DESCRIPTION
also drop `Field::persist_format` and `Field::persist_timezone` properties (`datetime` is always stored (and converted to) in UTC)

if a custom persist format/timezone is wanted, implement a custom persistence or add a custom/named DBAL type