### PR TITLE
Fix Model::loadXxx() /w limit/offset set

### DIFF
--- a/src/Model.php
+++ b/src/Model.php
@@ -143,10 +143,10 @@ class Model implements \IteratorAggregate
     /** @var Model\Scope\RootScope */
     private $scope;
 
-    /** @var array Array of limit set. */
-    public $limit = [];
+    /** @var array */
+    public $limit = [null, 0];
 
-    /** @var array Array of set order by. */
+    /** @var array */
     public $order = [];
 
     /** @var array<string, array{'model': Model, 'mapping': array<int|string, string>, 'recursive': bool}> */

--- a/src/Persistence/Sql.php
+++ b/src/Persistence/Sql.php
@@ -307,7 +307,7 @@ class Sql extends Persistence
     protected function setLimitOrder(Model $model, Query $query): void
     {
         // set limit
-        if ($model->limit && ($model->limit[0] || $model->limit[1])) {
+        if ($model->limit[0] !== null || $model->limit[1] !== 0) {
             if ($model->limit[0] === null) {
                 $model->limit[0] = \PHP_INT_MAX;
             }
@@ -315,7 +315,7 @@ class Sql extends Persistence
         }
 
         // set order
-        if ($model->order) {
+        if (count($model->order) > 0) {
             foreach ($model->order as $order) {
                 $isDesc = strtolower($order[1]) === 'desc';
 
@@ -492,7 +492,10 @@ class Sql extends Persistence
             $idRaw = $this->typecastSaveField($model->getField($model->id_field), $id);
             $query->where($model->getField($model->id_field), $idRaw);
         }
-        $query->limit($id === self::ID_LOAD_ANY ? 1 : 2);
+        $query->limit(
+            min($id === self::ID_LOAD_ANY ? 1 : 2, $query->args['limit']['cnt'] ?? \PHP_INT_MAX),
+            $query->args['limit']['shift'] ?? null
+        );
 
         // execute action
         try {

--- a/src/Persistence/Sql.php
+++ b/src/Persistence/Sql.php
@@ -308,10 +308,7 @@ class Sql extends Persistence
     {
         // set limit
         if ($model->limit[0] !== null || $model->limit[1] !== 0) {
-            if ($model->limit[0] === null) {
-                $model->limit[0] = \PHP_INT_MAX;
-            }
-            $query->limit($model->limit[0], $model->limit[1]);
+            $query->limit($model->limit[0] ?? \PHP_INT_MAX, $model->limit[1]);
         }
 
         // set order

--- a/src/Persistence/Sql/Mssql/Query.php
+++ b/src/Persistence/Sql/Mssql/Query.php
@@ -42,6 +42,11 @@ class Query extends BaseQuery
         $cnt = (int) $this->args['limit']['cnt'];
         $shift = (int) $this->args['limit']['shift'];
 
+        if ($cnt === 0) {
+            $cnt = 1;
+            $shift = \PHP_INT_MAX;
+        }
+
         return (!isset($this->args['order']) ? ' order by (select null)' : '')
             . ' offset ' . $shift . ' rows'
             . ' fetch next ' . $cnt . ' rows only';

--- a/tests/LimitOrderTest.php
+++ b/tests/LimitOrderTest.php
@@ -7,6 +7,7 @@ namespace Atk4\Data\Tests;
 use Atk4\Data\Exception;
 use Atk4\Data\Model;
 use Atk4\Data\Schema\TestCase;
+use Doctrine\DBAL\Platforms\SQLServerPlatform;
 
 class LimitOrderTest extends TestCase
 {
@@ -272,23 +273,29 @@ class LimitOrderTest extends TestCase
         $i = (new Model($this->db, ['table' => 'invoice']))->addFields(['total_net']);
         $i->setOrder('total_net');
 
+        $this->assertEquals(10, $i->loadAny()->get('total_net'));
         $i->setLimit(2);
         $this->assertEquals(10, $i->loadAny()->get('total_net'));
+
         $i->setLimit(2, 2);
         $this->assertEquals(20, $i->loadAny()->get('total_net'));
-        $i->setLimit(2, 2);
         $this->assertEquals(20, $i->loadOne()->get('total_net'));
 
         $i->setLimit(1);
+        $this->assertEquals(10, $i->loadAny()->get('total_net'));
         $this->assertEquals(10, $i->loadOne()->get('total_net'));
         $i->setLimit(1, 1);
+        $this->assertEquals(15, $i->loadAny()->get('total_net'));
         $this->assertEquals(15, $i->loadOne()->get('total_net'));
         $i->setLimit(1, 2);
+        $this->assertEquals(20, $i->loadAny()->get('total_net'));
         $this->assertEquals(20, $i->loadOne()->get('total_net'));
         $i->setLimit(1, 3);
+        $this->assertNull($i->tryLoadAny());
         $this->assertNull($i->tryLoadOne());
 
         $i->setLimit(0);
+        $this->assertNull($i->tryLoadAny());
         $this->assertNull($i->tryLoadOne());
     }
 }

--- a/tests/LimitOrderTest.php
+++ b/tests/LimitOrderTest.php
@@ -7,7 +7,6 @@ namespace Atk4\Data\Tests;
 use Atk4\Data\Exception;
 use Atk4\Data\Model;
 use Atk4\Data\Schema\TestCase;
-use Doctrine\DBAL\Platforms\SQLServerPlatform;
 
 class LimitOrderTest extends TestCase
 {

--- a/tests/LimitOrderTest.php
+++ b/tests/LimitOrderTest.php
@@ -258,4 +258,37 @@ class LimitOrderTest extends TestCase
             ['total_net' => 20],
         ], $i->export());
     }
+
+    public function testLimitBug1010(): void
+    {
+        $this->setDb([
+            'invoice' => [
+                ['total_net' => 10],
+                ['total_net' => 20],
+                ['total_net' => 15],
+            ],
+        ]);
+
+        $i = (new Model($this->db, ['table' => 'invoice']))->addFields(['total_net']);
+        $i->setOrder('total_net');
+
+        $i->setLimit(2);
+        $this->assertEquals(10, $i->loadAny()->get('total_net'));
+        $i->setLimit(2, 2);
+        $this->assertEquals(20, $i->loadAny()->get('total_net'));
+        $i->setLimit(2, 2);
+        $this->assertEquals(20, $i->loadOne()->get('total_net'));
+
+        $i->setLimit(1);
+        $this->assertEquals(10, $i->loadOne()->get('total_net'));
+        $i->setLimit(1, 1);
+        $this->assertEquals(15, $i->loadOne()->get('total_net'));
+        $i->setLimit(1, 2);
+        $this->assertEquals(20, $i->loadOne()->get('total_net'));
+        $i->setLimit(1, 3);
+        $this->assertNull($i->tryLoadOne());
+
+        $i->setLimit(0);
+        $this->assertNull($i->tryLoadOne());
+    }
 }


### PR DESCRIPTION
fixes https://github.com/atk4/data/issues/1010

Array persistence does not need fix, as it wraps the Action

most tests should run /w all persistences but a lot of test redesign is needed