### PR TITLE
Remove "<>", "is", "is not", "not" operators support

### DIFF
--- a/docs/advanced.rst
+++ b/docs/advanced.rst
@@ -497,7 +497,8 @@ Here is what I need to do:
 Create new Model::
 
     class Model_InvoicePayment extends \Atk4\Data\Model {
-        public $table='invoice_payment';
+        public $table = 'invoice_payment';
+
         function init(): void
         {
             parent::init();

--- a/docs/conditions.rst
+++ b/docs/conditions.rst
@@ -369,7 +369,7 @@ If $value is omitted as argument then $operator is considered as $value and '=' 
 
 Negates the condition, e.g::
 
-	// results in 'name is not John'
+	// results in "name != 'John'"
 	$condition = (new Condition('name', 'John'))->negate();
 
 .. php:method:: toWords(Model $model = null);

--- a/docs/conditions.rst
+++ b/docs/conditions.rst
@@ -23,7 +23,7 @@ narrow down set of "loadable" records by introducing a condition::
 
     $m = new Model_User($db, 'user');
     $m->addCondition('gender', 'F');
-    $m = $m->load(1);    // exception, user with ID=1 is M
+    $m = $m->load(1); // exception, user with ID=1 is M
 
 Conditions serve important role and must be used to intelligently restrict
 logically accessible data for a model before you attempt the loading.

--- a/docs/persistence/sql/queries.rst
+++ b/docs/persistence/sql/queries.rst
@@ -315,11 +315,10 @@ Both methods use identical call interface. They support one, two or three
 argument calls.
 
 Pass string (field name), :php:class:`Expression` or even :php:class:`Query` as
-first argument. If you are using string, you may end it with operation, such as
-"age>" or "parent_id is not" DSQL will recognize <, >, =, !=, is, is not.
+first argument.
 
-If you haven't specified parameter as a part of $field, specify it through a
-second parameter - $operation. If unspecified, will default to '='.
+Operator can be specified through a second parameter - $operation. If unspecified,
+will default to '='.
 
 Last argument is value. You can specify number, string, array, expression or
 even null (specifying null is not the same as omitting this argument).
@@ -331,10 +330,9 @@ Starting with the basic examples::
     $q->where('id', 1);
     $q->where('id', '=', 1); // same as above
 
-    $q->where('id>', 1);
-    $q->where('id', '>', 1); // same as above
+    $q->where('id', '>', 1);
 
-    $q->where('id', 'is', null);
+    $q->where('id', '=', null); // will render to "IS NULL" SQL
     $q->where('id', null);   // same as above
 
     $q->where('now()', 1);   // will not use backticks

--- a/docs/persistence/sql/queries.rst
+++ b/docs/persistence/sql/queries.rst
@@ -316,7 +316,7 @@ argument calls.
 
 Pass string (field name), :php:class:`Expression` or even :php:class:`Query` as
 first argument. If you are using string, you may end it with operation, such as
-"age>" or "parent_id is not" DSQL will recognize <, >, =, !=, <>, is, is not.
+"age>" or "parent_id is not" DSQL will recognize <, >, =, !=, is, is not.
 
 If you haven't specified parameter as a part of $field, specify it through a
 second parameter - $operation. If unspecified, will default to '='.

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -135,7 +135,7 @@ inside console::
 
     $m = new \Atk4\Data\Model($db, 'contact_info');
     $m->addFields(['address_1', 'address_2']);
-    $m->addCondition('address_1', 'not', null);
+    $m->addCondition('address_1', '!=', null);
     $m = $m->loadAny();
     $m->get();
     $m->executeCountQuery(); // same as ((int) $m->action('count')->getOne())
@@ -151,7 +151,7 @@ Next, exit and create file `src/Model_ContactInfo.php`::
             parent::init();
 
             $this->addFields(['address_1', 'address_2']);
-            $this->addCondition('address_1', 'not', null);
+            $this->addCondition('address_1', '!=', null);
         }
     }
 

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -399,7 +399,7 @@ For some persistence classes, you should use constructor directly::
 There are several Persistence classes that deal with different data sources.
 Lets load up our console and try out a different persistence::
 
-    $a=['user' => [], 'contact_info' => []];
+    $a = ['user' => [], 'contact_info' => []];
     $ar = new \Atk4\Data\Persistence\Array_($a);
     $m = new Model_User($ar);
     $m->set('username', 'test');

--- a/docs/references.rst
+++ b/docs/references.rst
@@ -537,7 +537,8 @@ or :php:meth:`Model::refLink()`. This can help you in creating a recursive model
 that relate to itself. Here is example::
 
     class Model_Item3 extends \Atk4\Data\Model {
-        public $table='item';
+        public $table = 'item';
+
         function init(): void {
             parent::init();
 

--- a/src/Model/Scope/AbstractScope.php
+++ b/src/Model/Scope/AbstractScope.php
@@ -56,7 +56,7 @@ abstract class AbstractScope
 
     /**
      * Negate the scope object
-     * e.g from 'is' to 'is not'.
+     * e.g from '=' to '!='.
      *
      * @return static
      */

--- a/src/Persistence/Array_/Action.php
+++ b/src/Persistence/Array_/Action.php
@@ -179,7 +179,6 @@ class Action
 
             break;
             case '!=':
-            case '<>':
                 $result = !$this->evaluateIf($v1, '=', $v2);
 
             break;

--- a/src/Persistence/Sql/Oracle/Query.php
+++ b/src/Persistence/Sql/Oracle/Query.php
@@ -53,7 +53,7 @@ class Query extends BaseQuery
                 $value = $this->expr('LOWER([])', [$value]);
             }
 
-            if (in_array($cond, ['=', '!=', '<>'], true)) {
+            if (in_array($cond, ['=', '!='], true)) {
                 $row = [$this->expr('dbms_lob.compare([], [])', [$field, $value]), $cond, 0];
             } else {
                 throw (new Exception('Unsupported CLOB/BLOB field operator'))

--- a/src/Persistence/Sql/Query.php
+++ b/src/Persistence/Sql/Query.php
@@ -630,17 +630,17 @@ class Query extends Expression
                 return $field . ' is null';
             } elseif ($cond === '!=') {
                 return $field . ' is not null';
-            } else {
-                throw (new Exception('Unsupported operator for null value'))
-                    ->addMoreInfo('operator', $cond);
             }
+
+            throw (new Exception('Unsupported operator for null value'))
+                ->addMoreInfo('operator', $cond);
         }
 
         // special conditions (IN | NOT IN) if value is array
         if (is_array($value)) {
             if (in_array($cond, ['in', 'not in'], true)) {
                 // special treatment of empty array condition
-                if (empty($value)) {
+                if (count($value) === 0) {
                     if ($cond === 'in') {
                         return '1 = 0'; // never true
                     }
@@ -651,10 +651,10 @@ class Query extends Expression
                 $value = '(' . implode(', ', array_map(function ($v) { return $this->consume($v); }, $value)) . ')';
 
                 return $field . ' ' . $cond . ' ' . $value;
-            } else {
-                throw (new Exception('Unsupported operator for array value'))
-                    ->addMoreInfo('operator', $cond);
             }
+
+            throw (new Exception('Unsupported operator for array value'))
+                ->addMoreInfo('operator', $cond);
         } elseif (!$value instanceof Expressionable && in_array($cond, ['in', 'not in'], true)) {
             throw (new Exception('Unsupported operator for non-array value'))
                 ->addMoreInfo('operator', $cond);

--- a/src/Persistence/Sql/Query.php
+++ b/src/Persistence/Sql/Query.php
@@ -468,14 +468,13 @@ class Query extends Expression
      *  $q->where('id', 1);
      *
      * By default condition implies equality. You can specify a different comparison
-     * operator by either including it along with the field or using 3-argument
+     * operator by using 3-argument
      * format:
-     *  $q->where('id>', '1');
      *  $q->where('id', '>', 1);
      *
      * You may use Expression as any part of the query.
-     *  $q->where($q->expr('a=b'));
-     *  $q->where('date>', $q->expr('now()'));
+     *  $q->where($q->expr('a = b'));
+     *  $q->where('date', '>', $q->expr('now()'));
      *  $q->where($q->expr('length(password)'), '>', 5);
      *
      * If you specify Query as an argument, it will be automatically

--- a/tests/Persistence/Sql/QueryTest.php
+++ b/tests/Persistence/Sql/QueryTest.php
@@ -750,40 +750,73 @@ class QueryTest extends TestCase
     public function testWhereIncompatibleFieldWithCondition(): void
     {
         $this->expectException(Exception::class);
-        $this->q('[where]')->where('id=', 1)->render();
+        $this->q('[where]')->where('id=', 1);
     }
 
-    /**
-     * Verify that passing garbage to where throw exception.
-     *
-     * @covers ::order
-     */
     public function testWhereIncompatibleObject1(): void
-    {
-        $this->expectException(Exception::class);
-        $this->q('[where]')->where('a', new \DateTime())->render();
-    }
-
-    /**
-     * Verify that passing garbage to where throw exception.
-     *
-     * @covers ::order
-     */
-    public function testWhereIncompatibleObject2(): void
     {
         $this->expectException(Exception::class);
         $this->q('[where]')->where('a', new \DateTime());
     }
 
-    /**
-     * Verify that passing garbage to where throw exception.
-     *
-     * @covers ::order
-     */
+    public function testWhereIncompatibleObject2(): void
+    {
+        $this->expectException(Exception::class);
+        $this->q('[where]')->where('a', '=', new \DateTime());
+    }
+
     public function testWhereIncompatibleObject3(): void
     {
         $this->expectException(Exception::class);
-        $this->q('[where]')->where('a', '<>', new \DateTime());
+        $this->q('[where]')->where('a', '!=', new \DateTime());
+    }
+
+    public function testWhereUnsupportedOperator1Exception(): void
+    {
+        $this->expectException(Exception::class);
+        $this->q('[where]')->where('x', '<>', 2)->render();
+    }
+
+    public function testWhereUnsupportedOperator2Exception(): void
+    {
+        $this->expectException(Exception::class);
+        $this->q('[where]')->where('x', 'operator', 2)->render();
+    }
+
+    public function testWhereUnsupportedOperator3Exception(): void
+    {
+        $this->expectException(Exception::class);
+        $this->q('[where]')->where('x', 'is', true)->render();
+    }
+
+    public function testWhereUnsupportedOperator4Exception(): void
+    {
+        $this->expectException(Exception::class);
+        $this->q('[where]')->where('x', 'is', null)->render();
+    }
+
+    public function testWhereUnsupportedOperator5Exception(): void
+    {
+        $this->expectException(Exception::class);
+        $this->q('[where]')->where('x', 'is not', null)->render();
+    }
+
+    public function testWhereUnsupportedOperator6Exception(): void
+    {
+        $this->expectException(Exception::class);
+        $this->q('[where]')->where('x', 'not', null)->render();
+    }
+
+    public function testWhereUnsupportedOperator7Exception(): void
+    {
+        $this->expectException(Exception::class);
+        $this->q('[where]')->where('x', 'not', 2)->render();
+    }
+
+    public function testWhereUnsupportedOperator8Exception(): void
+    {
+        $this->expectException(Exception::class);
+        $this->q('[where]')->where('x', 'not', [1, 2])->render();
     }
 
     /**
@@ -805,16 +838,8 @@ class QueryTest extends TestCase
             $this->q('[where]')->where('id', 'not in', [1, 2])->render()[0]
         );
         $this->assertSame(
-            'where "id" not in (:a, :b)',
-            $this->q('[where]')->where('id', 'not', [1, 2])->render()[0]
-        );
-        $this->assertSame(
             'where "id" in (:a, :b)',
             $this->q('[where]')->where('id', '=', [1, 2])->render()[0]
-        );
-        $this->assertSame(
-            'where "id" not in (:a, :b)',
-            $this->q('[where]')->where('id', '<>', [1, 2])->render()[0]
         );
         $this->assertSame(
             'where "id" not in (:a, :b)',
@@ -827,7 +852,7 @@ class QueryTest extends TestCase
         );
         $this->assertSame(
             'where 1 = 1',
-            $this->q('[where]')->where('id', '<>', [])->render()[0]
+            $this->q('[where]')->where('id', '!=', [])->render()[0]
         );
         // pass array as CSV
         $this->assertSame(
@@ -838,31 +863,11 @@ class QueryTest extends TestCase
             'where "id" not in (:a, :b)',
             $this->q('[where]')->where('id', 'not in', '1,    2')->render()[0]
         );
-        $this->assertSame(
-            'where "id" not in (:a, :b)',
-            $this->q('[where]')->where('id', 'not', '1,2')->render()[0]
-        );
 
-        // is | is not
-        $this->assertSame(
-            'where "id" is null',
-            $this->q('[where]')->where('id', 'is', null)->render()[0]
-        );
-        $this->assertSame(
-            'where "id" is not null',
-            $this->q('[where]')->where('id', 'is not', null)->render()[0]
-        );
-        $this->assertSame(
-            'where "id" is not null',
-            $this->q('[where]')->where('id', 'not', null)->render()[0]
-        );
+        // is null | is not null
         $this->assertSame(
             'where "id" is null',
             $this->q('[where]')->where('id', '=', null)->render()[0]
-        );
-        $this->assertSame(
-            'where "id" is not null',
-            $this->q('[where]')->where('id', '<>', null)->render()[0]
         );
         $this->assertSame(
             'where "id" is not null',

--- a/tests/ReferenceSqlTest.php
+++ b/tests/ReferenceSqlTest.php
@@ -647,8 +647,8 @@ class ReferenceSqlTest extends TestCase
 
         // change order user by changing ref field value
         $o = $o->load(1);
-        $o->set('my_user', 'Foo'); // user_id=2
-        $o->set('user_id', 3);     // user_id=3 (this will take precedence)
+        $o->set('my_user', 'Foo'); // user_id = 2
+        $o->set('user_id', 3);     // user_id = 3 (this will take precedence)
         $this->assertEquals(3, $o->get('user_id'));
         $o->save();
         $this->assertEquals(3, $o->get('user_id')); // user_id changed to Goofy ID


### PR DESCRIPTION
remove `<>` operator support in favor of `!=`

and assert an operator is supported during SQL query render

also remove support of `is`, `is not`, `not` operators in favor of `=` and `!=`

also remove `=` support for array values, use `in` operator instead