### PR TITLE
Remove WITH/CTE column mapping for model

### DIFF
--- a/docs/advanced.rst
+++ b/docs/advanced.rst
@@ -460,14 +460,14 @@ Using WITH cursors
 Many SQL database engines support defining WITH cursors to use in select, update
 and even delete statements.
 
-.. php:method:: addWith(string $name, Model $model, bool $recursive = false)
+.. php:method:: addCteModel(string $name, Model $model, bool $recursive = false)
 
     Agile toolkit data models also support these cursors. Usage is like this::
 
     $invoices = new Invoice();
 
     $contacts = new Contact();
-    $contacts->addWith('inv', $invoices);
+    $contacts->addCteModel('inv', $invoices);
     $contacts->join('inv.cid');
 
 .. code-block:: sql

--- a/docs/advanced.rst
+++ b/docs/advanced.rst
@@ -460,26 +460,26 @@ Using WITH cursors
 Many SQL database engines support defining WITH cursors to use in select, update
 and even delete statements.
 
-.. php:method:: addWith(Model $model, string $alias, array $fields, bool $recursive = false)
+.. php:method:: addWith(string $name, Model $model, bool $recursive = false)
 
     Agile toolkit data models also support these cursors. Usage is like this::
 
     $invoices = new Invoice();
 
     $contacts = new Contact();
-    $contacts->addWith($invoices, 'inv', ['contact_id' => 'cid', 'ref_no', 'total_net' => 'invoiced'], false);
+    $contacts->addWith('inv', $invoices);
     $contacts->join('inv.cid');
 
 .. code-block:: sql
 
     with
-        `inv` (`cid`, `ref_no`, `total_net`) as (select `contact_id`, `ref_no`, `total_net` from `invoice`)
+        `inv` as (select `contact_id`, `ref_no`, `total_net` from `invoice`)
     select
         *
     from `contact`
-        join `inv` on `inv`.`cid`=`contact`.`id`
+        join `inv` on `inv`.`contact_id`=`contact`.`id`
 
-.. note:: Supported starting from MySQL 8.x. MariaDB supported it earlier.
+.. note:: Supported since MySQL 8.x, MariaDB supported it earlier.
 
 Creating Many to Many relationship
 ==================================

--- a/docs/persistence/sql/queries.rst
+++ b/docs/persistence/sql/queries.rst
@@ -570,10 +570,6 @@ Use WITH cursors
 
     Did you know: you can use these cursors when joining your query to other tables. Just join cursor instead.
 
-.. php:method:: withRecursive(Query $cursor, string $alias, ?array $fields = null)
-
-    Same as :php:meth:`with()`, but always sets it as recursive.
-
     Keep in mind that if any of cursors added in your query will be recursive, then all cursors will
     be set recursive. That's how SQL want it to be.
 

--- a/src/Model.php
+++ b/src/Model.php
@@ -144,7 +144,7 @@ class Model implements \IteratorAggregate
     /** @var array */
     public $order = [];
 
-    /** @var array<string, array{'model': Model, 'mapping': array<int|string, string>, 'recursive': bool}> */
+    /** @var array<string, array{'model': Model, 'recursive': bool}> */
     public $with = [];
 
     /**
@@ -1055,20 +1055,17 @@ class Model implements \IteratorAggregate
     /**
      * Adds WITH cursor.
      *
-     * @param Model $model
-     *
      * @return $this
      */
-    public function addWith(self $model, string $alias, array $mapping = [], bool $recursive = false)
+    public function addWith(string $name, self $model, bool $recursive = false)
     {
-        if ($alias === $this->table || $alias === $this->table_alias || isset($this->with[$alias])) {
-            throw (new Exception('With cursor already set with given alias'))
-                ->addMoreInfo('alias', $alias);
+        if ($name === $this->table || $name === $this->table_alias || isset($this->with[$name])) {
+            throw (new Exception('WITH cursor with given name already exist'))
+                ->addMoreInfo('name', $name);
         }
 
-        $this->with[$alias] = [
+        $this->with[$name] = [
             'model' => $model,
-            'mapping' => $mapping,
             'recursive' => $recursive,
         ];
 

--- a/src/Model.php
+++ b/src/Model.php
@@ -1060,7 +1060,7 @@ class Model implements \IteratorAggregate
     public function addCteModel(string $name, self $model, bool $recursive = false)
     {
         if ($name === $this->table || $name === $this->table_alias || isset($this->cteModels[$name])) {
-            throw (new Exception('WITH cursor with given name already exist'))
+            throw (new Exception('CTE model with given name already exist'))
                 ->addMoreInfo('name', $name);
         }
 

--- a/src/Model.php
+++ b/src/Model.php
@@ -145,7 +145,7 @@ class Model implements \IteratorAggregate
     public $order = [];
 
     /** @var array<string, array{'model': Model, 'recursive': bool}> */
-    public $with = [];
+    public $cteModels = [];
 
     /**
      * Currently loaded record data. This record is associative array
@@ -1053,18 +1053,18 @@ class Model implements \IteratorAggregate
     }
 
     /**
-     * Adds WITH cursor.
+     * Adds WITH/CTE model.
      *
      * @return $this
      */
-    public function addWith(string $name, self $model, bool $recursive = false)
+    public function addCteModel(string $name, self $model, bool $recursive = false)
     {
-        if ($name === $this->table || $name === $this->table_alias || isset($this->with[$name])) {
+        if ($name === $this->table || $name === $this->table_alias || isset($this->cteModels[$name])) {
             throw (new Exception('WITH cursor with given name already exist'))
                 ->addMoreInfo('name', $name);
         }
 
-        $this->with[$name] = [
+        $this->cteModels[$name] = [
             'model' => $model,
             'recursive' => $recursive,
         ];

--- a/src/Model/Join.php
+++ b/src/Model/Join.php
@@ -141,11 +141,11 @@ abstract class Join
     public function getForeignModel(): Model
     {
         // TODO this should be removed in the future
-        if (!isset($this->getOwner()->with[$this->foreign_table])) {
+        if (!isset($this->getOwner()->cteModels[$this->foreign_table])) {
             return $this->createFakeForeignModel();
         }
 
-        return $this->getOwner()->with[$this->foreign_table]['model'];
+        return $this->getOwner()->cteModels[$this->foreign_table]['model'];
     }
 
     /**

--- a/src/Persistence/Sql.php
+++ b/src/Persistence/Sql.php
@@ -214,17 +214,9 @@ class Sql extends Persistence
         return $query;
     }
 
-    /**
-     * Initializes WITH cursors.
-     */
     public function initWithCursors(Model $model, Query $query): void
     {
-        $with = $model->with;
-        if (count($with) === 0) {
-            return;
-        }
-
-        foreach ($with as $withAlias => ['model' => $withModel, 'recursive' => $withRecursive]) {
+        foreach ($model->cteModels as $withAlias => ['model' => $withModel, 'recursive' => $withRecursive]) {
             $subQuery = $withModel->action('select');
             $query->with($subQuery, $withAlias, null, $withRecursive);
         }

--- a/src/Persistence/Sql.php
+++ b/src/Persistence/Sql.php
@@ -224,23 +224,9 @@ class Sql extends Persistence
             return;
         }
 
-        foreach ($with as $alias => ['model' => $withModel, 'mapping' => $withMapping, 'recursive' => $withRecursive]) {
-            // prepare field names
-            $fieldsFrom = $fieldsTo = [];
-            foreach ($withMapping as $from => $to) {
-                $fieldsFrom[] = is_int($from) ? $to : $from;
-                $fieldsTo[] = $to;
-            }
-
-            // prepare sub-query
-            if ($fieldsFrom) {
-                $withModel->setOnlyFields($fieldsFrom); // TODO this mutates model state
-            }
-            // 2nd parameter here strictly define which fields should be selected
-            // as result system fields will not be added if they are not requested
-            $subQuery = $withModel->action('select', [$fieldsFrom]);
-
-            $query->with($subQuery, $alias, $fieldsTo ?: null, $withRecursive);
+        foreach ($with as $withAlias => ['model' => $withModel, 'recursive' => $withRecursive]) {
+            $subQuery = $withModel->action('select');
+            $query->with($subQuery, $withAlias, null, $withRecursive);
         }
     }
 

--- a/src/Persistence/Sql/Query.php
+++ b/src/Persistence/Sql/Query.php
@@ -283,30 +283,14 @@ class Query extends Expression
         return $this;
     }
 
-    /**
-     * Recursive WITH query.
-     *
-     * @param Query  $cursor Specifies cursor query or array [alias => query] for adding multiple
-     * @param string $alias  Specify alias for this cursor
-     * @param array  $fields Optional array of field names used in cursor
-     *
-     * @return $this
-     */
-    public function withRecursive(self $cursor, string $alias, array $fields = null)
-    {
-        return $this->with($cursor, $alias, $fields, true);
-    }
-
     protected function _render_with(): ?string
     {
-        // will be joined for output
-        $ret = [];
-
         if (empty($this->args['with'])) {
             return '';
         }
 
-        // process each defined cursor
+        $ret = [];
+
         $isRecursive = false;
         foreach ($this->args['with'] as $alias => ['cursor' => $cursor, 'fields' => $fields, 'recursive' => $recursive]) {
             // cursor alias cannot be expression, so simply escape it

--- a/tests/ModelWithCteTest.php
+++ b/tests/ModelWithCteTest.php
@@ -66,16 +66,28 @@ class ModelWithCteTest extends TestCase
         $m2 = new Model();
 
         $this->expectException(Exception::class);
+        $this->expectExceptionMessage('CTE model with given name already exist');
         $m1->addCteModel('t', $m2);
     }
 
     public function testUniqueNameException2(): void
+    {
+        $m1 = new Model(null, ['table_alias' => 't']);
+        $m2 = new Model();
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage('CTE model with given name already exist');
+        $m1->addCteModel('t', $m2);
+    }
+
+    public function testUniqueNameException3(): void
     {
         $m1 = new Model();
         $m2 = new Model();
         $m1->addCteModel('t', $m2);
 
         $this->expectException(Exception::class);
+        $this->expectExceptionMessage('CTE model with given name already exist');
         $m1->addCteModel('t', $m2);
     }
 }

--- a/tests/WithTest.php
+++ b/tests/WithTest.php
@@ -38,14 +38,14 @@ class WithTest extends TestCase
 
         // setup test model
         $m = clone $m_user;
-        $m->addWith($m_invoice, 'i', ['user_id', 'net' => 'invoiced']); // add cursor
+        $m->addWith('i', $m_invoice); // add cursor
         $j_invoice = $m->join('i.user_id'); // join cursor
-        $j_invoice->addField('invoiced', ['type' => 'integer']); // add field from joined cursor
+        $j_invoice->addField('invoiced', ['type' => 'integer', 'actual' => 'net']); // add field from joined cursor
 
         // tests
         $this->assertSameSql(
-            'with "i" ("user_id", "invoiced") as (select "user_id", "net" from "invoice" where "net" > :a)' . "\n"
-                . 'select "user"."id", "user"."name", "user"."salary", "_i"."invoiced" from "user" inner join "i" "_i" on "_i"."user_id" = "user"."id"',
+            'with "i" as (select "id", "net", "user_id" from "invoice" where "net" > :a)' . "\n"
+                . 'select "user"."id", "user"."name", "user"."salary", "_i"."net" "invoiced" from "user" inner join "i" "_i" on "_i"."user_id" = "user"."id"',
             $m->action('select')->render()[0]
         );
 
@@ -63,12 +63,22 @@ class WithTest extends TestCase
         ], $m->export());
     }
 
-    public function testUniqueAliasException(): void
+    public function testUniqueNameException1(): void
+    {
+        $m1 = new Model(null, ['table' => 't']);
+        $m2 = new Model();
+
+        $this->expectException(Exception::class);
+        $m1->addWith('t', $m2);
+    }
+
+    public function testUniqueNameException2(): void
     {
         $m1 = new Model();
         $m2 = new Model();
-        $m1->addWith($m2, 't');
+        $m1->addWith('t', $m2);
+
         $this->expectException(Exception::class);
-        $m1->addWith($m2, 't');
+        $m1->addWith('t', $m2);
     }
 }


### PR DESCRIPTION
Mapping duplicated the functionality of `Field::$actual`, so we drop the WITH mapping from model completely.

Mapping was also used for filtering wanted columns, we drop it as it mutated the source model state and DB query optimizer should be smart enough to prune the unneded columns. Later, we should optimize them away automatically. Alternatively, you can set `Model::$onlyFields` for the added CTE model manually.

Also, the method was renamed from `Model::addWith` to `Model::addCteModel` and name/alias is now accepted as the 1st param.