### PR TITLE
Rename Model::getRef() to getReference()

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ class JobReport extends Job {
         $timesheet = new Timesheet($this->getPersistence());
 
         // timesheet relates to client, import client.hourly_rate as expression
-        $timesheet->getRef('client_id')->addField('hourly_rate');
+        $timesheet->getReference('client_id')->addField('hourly_rate');
 
         // calculate timesheet cost expression
         $timesheet->addExpression('cost', ['expr' => '[hours] * [hourly_rate]']);

--- a/docs/advanced.rst
+++ b/docs/advanced.rst
@@ -783,12 +783,12 @@ different for the extended class::
 
 Alternatively you can replace model in the init() method of Model_Invoice::
 
-    $this->getRef('client_id')->model = 'Model_Client';
+    $this->getReference('client_id')->model = 'Model_Client';
 
 You can also use array here if you wish to pass additional information into
 related model::
 
-    $this->getRef('client_id')->model = ['Model_Client', 'no_audit' => true];
+    $this->getReference('client_id')->model = ['Model_Client', 'no_audit' => true];
 
 Combined with our "Audit" handler above, this should allow you to relate
 with deleted clients.
@@ -833,7 +833,7 @@ sometimes that can be quite useful. Consider adding this inside your Model_Conta
 This way if you extend your class into 'Model_Client' and modify the 'Invoice'
 reference to use different model::
 
-    $this->getRef('Invoice')->model = 'Model_Invoice_Sale';
+    $this->getReference('Invoice')->model = 'Model_Invoice_Sale';
 
 The 'OverdueInvoice' reference will be also properly adjusted.
 

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -502,8 +502,8 @@ the new object is created and added into Model of class :php:class:`Reference\Ha
 or :php:class:`Reference\\HasOne` (or :php:class:`Reference\\HasOneSql` in case you
 use SQL database). The object itself is quite simple and you can fetch it from
 the model if you keep the return value of hasOne() / hasMany() or call
-:php:meth:`Model::getRef()` with the same identifier later on.
-You can also use :php:meth:`Model::hasRef()` to check if reference exists in model.
+:php:meth:`Model::getReference()` with the same identifier later on.
+You can also use :php:meth:`Model::hasReference()` to check if reference exists in model.
 
 Calling :php:meth:`Model::ref()` will proxy into the ref() method of reference
 object which will in turn figure out what to do.
@@ -537,8 +537,8 @@ Aggregation actions can be used in Expressions with hasMany references and they
 can be brought into the original model as fields::
 
     $m = new Model_Client($db);
-    $m->getRef('Invoice')->addField('max_delivery', ['aggregate' => 'max', 'field' => 'shipping']);
-    $m->getRef('Payment')->addField('total_paid', ['aggregate' => 'sum', 'field' => 'amount']);
+    $m->getReference('Invoice')->addField('max_delivery', ['aggregate' => 'max', 'field' => 'shipping']);
+    $m->getReference('Payment')->addField('total_paid', ['aggregate' => 'sum', 'field' => 'amount']);
     $m->export(['name', 'max_delivery', 'total_paid']);
 
 The above code is more concise and can be used together with reference declaration,
@@ -572,7 +572,7 @@ Field referencing allows you to fetch a specific field from related model::
 This is useful with hasMany references::
 
     $m = new Model_User($db);
-    $m->getRef('country_id')->addField('country', 'name');
+    $m->getReference('country_id')->addField('country', 'name');
     $m = $m->loadAny();
     $m->get();  // look for 'country' field
 
@@ -614,8 +614,8 @@ will continue to work even without SQL (although might be more performance-expen
 however if you're stuck with SQL you can use free-form pattern-based expressions::
 
     $m = new Model_Client($db);
-    $m->getRef('Invoice')->addField('total_purchase', ['aggregate' => 'sum', 'field' => 'total']);
-    $m->getRef('Payment')->addField('total_paid', ['aggregate' => 'sum', 'field' => 'amount']);
+    $m->getReference('Invoice')->addField('total_purchase', ['aggregate' => 'sum', 'field' => 'total']);
+    $m->getReference('Payment')->addField('total_paid', ['aggregate' => 'sum', 'field' => 'amount']);
 
     $m->addExpression('balance', ['expr' => '[total_purchase] + [total_paid]']);
     $m->export(['name', 'balance']);

--- a/docs/references.rst
+++ b/docs/references.rst
@@ -428,12 +428,12 @@ explicitly::
 User-defined Reference
 ======================
 
-.. php:method:: addRef($link, $callback)
+.. php:method:: addReference($link, $callback)
 
 Sometimes you would want to have a different type of relation between models,
-so with `addRef` you can define whatever reference you want::
+so with `addReference` you can define whatever reference you want::
 
-    $m->addRef('Archive', ['model' => function ($m) {
+    $m->addReference('Archive', ['model' => function ($m) {
         return $m->newInstance(null, ['table' => $m->table . '_archive']);
     }]);
 
@@ -447,7 +447,7 @@ Note that you can create one-to-many or many-to-one relations, by using your
 custom logic.
 No condition will be applied by default so it's all up to you::
 
-    $m->addRef('Archive', ['model' => function ($m) {
+    $m->addReference('Archive', ['model' => function ($m) {
         $archive = $m->newInstance(null, ['table' => $m->table . '_archive']);
 
         $m->addField('original_id', ['type' => 'integer']);
@@ -461,16 +461,16 @@ No condition will be applied by default so it's all up to you::
 Reference Discovery
 ===================
 
-You can call :php:meth:`Model::getRefs()` to fetch all the references of a model::
+You can call :php:meth:`Model::getReferences()` to fetch all the references of a model::
 
-    $refs = $model->getRefs();
-    $ref = $refs['owner_id'];
+    $references = $model->getReferences();
+    $reference = $references['owner_id'];
 
-or if you know the reference you'd like to fetch, you can use :php:meth:`Model::getRef()`::
+or if you know the reference you'd like to fetch, you can use :php:meth:`Model::getReference()`::
 
-    $ref = $model->getRef('owner_id');
+    $reference = $model->getReference('owner_id');
 
-While :php:meth:`Model::ref()` returns a related model, :php:meth:`Model::getRef()`
+While :php:meth:`Model::ref()` returns a related model, :php:meth:`Model::getReference()`
 gives you the reference object itself so that you could perform some changes on it,
 such as import more fields with :php:meth:`Model::addField()`.
 
@@ -479,11 +479,11 @@ model and you can do fancy things with it.
 
     $refModel = $model->refModel('owner_id');
 
-You can also use :php:meth:`Model::hasRef()` to check if particular reference
+You can also use :php:meth:`Model::hasReference()` to check if particular reference
 exists in model::
 
-    if ($model->hasRef('owner_id')) {
-        $ref = $model->getRef('owner_id');
+    if ($model->hasReference('owner_id')) {
+        $reference = $model->getReference('owner_id');
     }
 
 Deep traversal
@@ -649,7 +649,7 @@ References are implemented through several classes:
 
 .. php:class:: Reference\HasOne
 
-    Defines generic reference, that is typically created by :php:meth:`Model::addRef`
+    Defines generic reference, that is typically created by :php:meth:`Model::addReference`
 
 .. php:attr:: tableAlias
 

--- a/docs/typecasting.rst
+++ b/docs/typecasting.rst
@@ -1,5 +1,5 @@
 
-.. _ref: typecasting
+.. _Typecasting:
 
 ===========
 Typecasting

--- a/src/Field.php
+++ b/src/Field.php
@@ -392,7 +392,7 @@ class Field implements Expressionable
 
     public function getReference(): Reference
     {
-        return $this->getOwner()->getRef($this->referenceLink);
+        return $this->getOwner()->getReference($this->referenceLink);
     }
 
     public function getPersistenceName(): string

--- a/src/Model.php
+++ b/src/Model.php
@@ -1641,7 +1641,7 @@ class Model implements \IteratorAggregate
             }
 
             // and reference must exist with same name
-            if (!$this->hasRef($key)) {
+            if (!$this->hasReference($key)) {
                 continue;
             }
 

--- a/src/Model/ReferencesTrait.php
+++ b/src/Model/ReferencesTrait.php
@@ -13,8 +13,8 @@ use Atk4\Data\Reference;
  */
 trait ReferencesTrait
 {
-    /** @var array The seed used by addRef() method. */
-    protected $_defaultSeedAddRef = [Reference::class];
+    /** @var array The seed used by addReference() method. */
+    protected $_defaultSeedAddReference = [Reference::class];
 
     /** @var array The seed used by hasOne() method. */
     protected $_defaultSeedHasOne = [Reference\HasOne::class];
@@ -29,9 +29,9 @@ trait ReferencesTrait
     protected $_defaultSeedContainsMany = [Reference\ContainsMany::class];
 
     /**
-     * @param array<string, mixed> $defaults Properties which we will pass to Reference object constructor
+     * @param array<string, mixed> $defaults
      */
-    protected function _addRef(array $seed, string $link, array $defaults = []): Reference
+    protected function _addReference(array $seed, string $link, array $defaults = []): Reference
     {
         $this->assertIsModel();
 
@@ -53,9 +53,9 @@ trait ReferencesTrait
     /**
      * Add generic relation. Provide your own call-back that will return the model.
      */
-    public function addRef(string $link, array $defaults): Reference
+    public function addReference(string $link, array $defaults): Reference
     {
-        return $this->_addRef($this->_defaultSeedAddRef, $link, $defaults);
+        return $this->_addReference($this->_defaultSeedAddReference, $link, $defaults);
     }
 
     /**
@@ -65,7 +65,7 @@ trait ReferencesTrait
      */
     public function hasOne(string $link, array $defaults = []) // : Reference
     {
-        return $this->_addRef($this->_defaultSeedHasOne, $link, $defaults); // @phpstan-ignore-line
+        return $this->_addReference($this->_defaultSeedHasOne, $link, $defaults); // @phpstan-ignore-line
     }
 
     /**
@@ -75,7 +75,7 @@ trait ReferencesTrait
      */
     public function hasMany(string $link, array $defaults = []) // : Reference
     {
-        return $this->_addRef($this->_defaultSeedHasMany, $link, $defaults); // @phpstan-ignore-line
+        return $this->_addReference($this->_defaultSeedHasMany, $link, $defaults); // @phpstan-ignore-line
     }
 
     /**
@@ -85,7 +85,7 @@ trait ReferencesTrait
      */
     public function containsOne(string $link, array $defaults = []) // : Reference
     {
-        return $this->_addRef($this->_defaultSeedContainsOne, $link, $defaults); // @phpstan-ignore-line
+        return $this->_addReference($this->_defaultSeedContainsOne, $link, $defaults); // @phpstan-ignore-line
     }
 
     /**
@@ -95,15 +95,15 @@ trait ReferencesTrait
      */
     public function containsMany(string $link, array $defaults = []) // : Reference
     {
-        return $this->_addRef($this->_defaultSeedContainsMany, $link, $defaults); // @phpstan-ignore-line
+        return $this->_addReference($this->_defaultSeedContainsMany, $link, $defaults); // @phpstan-ignore-line
     }
 
-    public function hasRef(string $link): bool
+    public function hasReference(string $link): bool
     {
         return $this->getModel(true)->hasElement('#ref-' . $link);
     }
 
-    public function getRef(string $link): Reference
+    public function getReference(string $link): Reference
     {
         $this->assertIsModel();
 
@@ -113,7 +113,7 @@ trait ReferencesTrait
     /**
      * @return array<string, Reference>
      */
-    public function getRefs(): array
+    public function getReferences(): array
     {
         $this->assertIsModel();
 
@@ -121,7 +121,7 @@ trait ReferencesTrait
         foreach ($this->elements as $k => $v) {
             if (str_starts_with($k, '#ref-')) {
                 $link = substr($k, strlen('#ref-'));
-                $res[$link] = $this->getRef($link);
+                $res[$link] = $this->getReference($link);
             } elseif ($v instanceof Reference) {
                 throw new \Error('Unexpected Reference index');
             }
@@ -135,7 +135,7 @@ trait ReferencesTrait
      */
     public function ref(string $link, array $defaults = []): Model
     {
-        return $this->getModel(true)->getRef($link)->ref($this, $defaults);
+        return $this->getModel(true)->getReference($link)->ref($this, $defaults);
     }
 
     /**
@@ -143,7 +143,7 @@ trait ReferencesTrait
      */
     public function refModel(string $link, array $defaults = []): Model
     {
-        return $this->getModel(true)->getRef($link)->refModel($this, $defaults);
+        return $this->getModel(true)->getReference($link)->refModel($this, $defaults);
     }
 
     /**
@@ -151,6 +151,6 @@ trait ReferencesTrait
      */
     public function refLink(string $link, array $defaults = []): Model
     {
-        return $this->getModel(true)->getRef($link)->refLink($this, $defaults);
+        return $this->getModel(true)->getReference($link)->refLink($this, $defaults);
     }
 }

--- a/src/Reference/ContainsBase.php
+++ b/src/Reference/ContainsBase.php
@@ -52,7 +52,7 @@ abstract class ContainsBase extends Reference
                 'type' => $this->type,
                 'referenceLink' => $this->link,
                 'system' => $this->system,
-                'caption' => $this->caption, // it's ref models caption, but we can use it here for field too
+                'caption' => $this->caption, // it's reference models caption, but we can use it here for field too
                 'ui' => array_merge([
                     'visible' => false, // not visible in UI Table, Grid and Crud
                     'editable' => true, // but should be editable in UI Form

--- a/src/Reference/HasMany.php
+++ b/src/Reference/HasMany.php
@@ -72,7 +72,7 @@ class HasMany extends Reference
         $ourModelCloned = clone $this->getOurModel(null);
         $ourModelCloned->persistenceData['use_table_prefixes'] = true;
 
-        return $ourModelCloned->getRef($this->link)->getOurField();
+        return $ourModelCloned->getReference($this->link)->getOurField();
     }
 
     /**

--- a/src/Reference/HasOne.php
+++ b/src/Reference/HasOne.php
@@ -68,7 +68,7 @@ class HasOne extends Reference
         $ourModelCloned = clone $this->getOurModel(null);
         $ourModelCloned->persistenceData['use_table_prefixes'] = true;
 
-        return $ourModelCloned->getRef($this->link)->getOurField();
+        return $ourModelCloned->getReference($this->link)->getOurField();
     }
 
     /**

--- a/src/Util/DeepCopy.php
+++ b/src/Util/DeepCopy.php
@@ -218,7 +218,7 @@ class DeepCopy
             foreach ($this->extractKeys($references) as $refKey => $refVal) {
                 $this->debug('Considering ' . $refKey);
 
-                if ($source->hasRef($refKey) && $source->getModel(true)->getRef($refKey) instanceof HasOne) {
+                if ($source->hasReference($refKey) && $source->getModel(true)->getReference($refKey) instanceof HasOne) {
                     $this->debug('Proceeding with ' . $refKey);
 
                     // load destination model through $source
@@ -272,7 +272,7 @@ class DeepCopy
             // Next look for hasMany relationships and copy those too
 
             foreach ($this->extractKeys($references) as $refKey => $refVal) {
-                if ($source->hasRef($refKey) && $source->getModel(true)->getRef($refKey) instanceof HasMany) {
+                if ($source->hasReference($refKey) && $source->getModel(true)->getReference($refKey) instanceof HasMany) {
                     // No mapping, will always copy
                     foreach ($source->ref($refKey) as $refModel) {
                         $this->_copy(

--- a/tests/FolderTest.php
+++ b/tests/FolderTest.php
@@ -45,7 +45,7 @@ class FolderTest extends TestCase
         ]);
 
         $f = new Folder($this->db);
-        $this->createMigrator()->createForeignKey($f->getRef('SubFolder'));
+        $this->createMigrator()->createForeignKey($f->getReference('SubFolder'));
         $f = $f->load(4);
 
         $this->assertSame([

--- a/tests/LookupSqlTest.php
+++ b/tests/LookupSqlTest.php
@@ -67,7 +67,7 @@ class LUser extends Model
         $this->addField('name');
         $this->addField('is_vip', ['type' => 'boolean', 'default' => false]);
 
-        $ref = $this->hasOne('country_id', ['model' => [LCountry::class]])
+        $this->hasOne('country_id', ['model' => [LCountry::class]])
             ->addFields(['country_code' => 'code', 'is_eu'])
             ->addTitle();
 
@@ -149,9 +149,9 @@ class LookupSqlTest extends TestCase
         $this->createMigrator($user)->create();
         $friend = new LFriend($this->db);
         $this->createMigrator($friend)->create();
-        $this->createMigrator()->createForeignKey($user->getRef('country_id'));
-        $this->createMigrator()->createForeignKey($friend->getRef('user_id'));
-        $this->createMigrator()->createForeignKey($friend->getRef('friend_id'));
+        $this->createMigrator()->createForeignKey($user->getReference('country_id'));
+        $this->createMigrator()->createForeignKey($friend->getReference('user_id'));
+        $this->createMigrator()->createForeignKey($friend->getReference('friend_id'));
     }
 
     public function testImportCountriesBasic(): void

--- a/tests/ModelAggregateTest.php
+++ b/tests/ModelAggregateTest.php
@@ -46,7 +46,7 @@ class ModelAggregateTest extends TestCase
     protected function createInvoice(): Model\Invoice
     {
         $invoice = new Model\Invoice($this->db);
-        $invoice->getRef('client_id')->addTitle();
+        $invoice->getReference('client_id')->addTitle();
 
         return $invoice;
     }

--- a/tests/Persistence/Sql/QueryTest.php
+++ b/tests/Persistence/Sql/QueryTest.php
@@ -22,7 +22,6 @@ class QueryTest extends TestCase
 
     public function testConstruct(): void
     {
-        // passing properties in constructor
         $this->assertSame(
             '"q"',
             $this->callProtected($this->q(), 'escapeIdentifier', 'q')

--- a/tests/RandomTest.php
+++ b/tests/RandomTest.php
@@ -597,7 +597,7 @@ class RandomTest extends TestCase
         if ($runWithDb) {
             $this->createMigrator($user)->create();
             $this->createMigrator($doc)->create();
-            $this->createMigrator()->createForeignKey($doc->getRef('user_id'));
+            $this->createMigrator()->createForeignKey($doc->getReference('user_id'));
 
             $user->createEntity()
                 ->set('name', 'Sarah')

--- a/tests/ReferenceSqlTest.php
+++ b/tests/ReferenceSqlTest.php
@@ -107,7 +107,7 @@ class ReferenceSqlTest extends TestCase
         $this->markTestIncompleteWhenCreateUniqueIndexIsNotSupportedByPlatform();
 
         $u->hasOne('cur', ['model' => $c, 'our_field' => 'currency', 'their_field' => 'currency']);
-        $this->createMigrator()->createForeignKey($u->getRef('cur'));
+        $this->createMigrator()->createForeignKey($u->getReference('cur'));
 
         $cc = $u->load(1)->ref('cur');
         $this->assertSame('Euro', $cc->get('name'));
@@ -436,7 +436,7 @@ class ReferenceSqlTest extends TestCase
     public function testUnloadedEntityTraversingHasOneEx(): void
     {
         $user = $this->setupDbForTraversing();
-        $user->getRef('Company')->setDefaults(['our_field' => 'id']);
+        $user->getReference('Company')->setDefaults(['our_field' => 'id']);
         $userEntity = $user->createEntity();
 
         $this->expectException(Exception::class);
@@ -523,7 +523,7 @@ class ReferenceSqlTest extends TestCase
         $p->addField('name');
         $p->delete(2);
         $p->hasOne('Stadium', ['model' => $s, 'our_field' => 'id', 'their_field' => 'player_id']);
-        $this->createMigrator()->createForeignKey($p->getRef('Stadium'));
+        $this->createMigrator()->createForeignKey($p->getReference('Stadium'));
 
         $s = $p->ref('Stadium')->createEntity()->save(['name' => 'Nou camp nou', 'player_id' => 4]);
         $p = $p->createEntity()->save(['name' => 'Ivan']);
@@ -559,7 +559,7 @@ class ReferenceSqlTest extends TestCase
         $o->hasOne('user_id', ['model' => $u]);
         $this->assertSame($o->getField('user_id')->isVisible(), true);
 
-        $o->getRef('user_id')->addTitle();
+        $o->getReference('user_id')->addTitle();
         $this->assertTrue($o->hasField('user'));
         $this->assertSame($o->getField('user')->isVisible(), true);
         $this->assertSame($o->getField('user_id')->isVisible(), false);
@@ -568,7 +568,7 @@ class ReferenceSqlTest extends TestCase
         $o = (new Model($this->db, ['table' => 'order']))->addFields(['amount']);
         $o->hasOne('user_id', ['model' => $u]);
         $o->getField('user_id')->ui['visible'] = true;
-        $o->getRef('user_id')->addTitle();
+        $o->getReference('user_id')->addTitle();
 
         $this->assertSame($o->getField('user_id')->isVisible(), true);
     }
@@ -633,7 +633,7 @@ class ReferenceSqlTest extends TestCase
         $o = (new Model($this->db, ['table' => 'order']));
         $o->hasOne('my_user', ['model' => $u, 'our_field' => 'user_id'])->addTitle();
 
-        // change order user by changing ref field value
+        // change order user by changing reference field value
         $o = $o->load(1);
         $o->set('my_user', 'Foo');
         $this->assertEquals(1, $o->get('user_id'));

--- a/tests/ReferenceTest.php
+++ b/tests/ReferenceTest.php
@@ -42,11 +42,11 @@ class ReferenceTest extends TestCase
         $this->assertSame([
             'Orders' => $r1,
             'BigOrders' => $r2,
-        ], $user->getModel()->getRefs());
-        $this->assertSame($r1, $user->getModel()->getRef('Orders'));
-        $this->assertSame($r2, $user->getModel()->getRef('BigOrders'));
-        $this->assertTrue($user->getModel()->hasRef('BigOrders'));
-        $this->assertFalse($user->getModel()->hasRef('SmallOrders'));
+        ], $user->getModel()->getReferences());
+        $this->assertSame($r1, $user->getModel()->getReference('Orders'));
+        $this->assertSame($r2, $user->getModel()->getReference('BigOrders'));
+        $this->assertTrue($user->getModel()->hasReference('BigOrders'));
+        $this->assertFalse($user->getModel()->hasReference('SmallOrders'));
     }
 
     public function testModelCaption(): void
@@ -102,10 +102,10 @@ class ReferenceTest extends TestCase
         $user->hasOne('user_id', ['model' => $user]);
     }
 
-    public function testCustomRef(): void
+    public function testCustomReference(): void
     {
         $m = new Model($this->db, ['table' => 'user']);
-        $m->addRef('archive', ['model' => function ($m) {
+        $m->addReference('archive', ['model' => function ($m) {
             return new $m(null, ['table' => $m->table . '_archive']);
         }]);
 
@@ -119,6 +119,6 @@ class ReferenceTest extends TestCase
         $order->addField('user_id');
 
         $user->hasMany('Orders', ['model' => $order, 'caption' => 'My Orders']);
-        $this->assertSame($user->getRef('Orders')->getTheirFieldName(), 'user_id');
+        $this->assertSame($user->getReference('Orders')->getTheirFieldName(), 'user_id');
     }
 }

--- a/tests/Schema/MigratorFkTest.php
+++ b/tests/Schema/MigratorFkTest.php
@@ -45,9 +45,9 @@ class MigratorFkTest extends TestCase
         $this->createMigrator($invoice)->create();
         $this->createMigrator($country)->create();
 
-        $this->createMigrator()->createForeignKey($client->getRef('country_id'));
-        $this->createMigrator()->createForeignKey($client->getRef('created_by_client_id'));
-        $this->createMigrator()->createForeignKey($invoice->getRef('client_id'));
+        $this->createMigrator()->createForeignKey($client->getReference('country_id'));
+        $this->createMigrator()->createForeignKey($client->getReference('created_by_client_id'));
+        $this->createMigrator()->createForeignKey($invoice->getReference('client_id'));
 
         // make sure FK client-country was not removed during FK invoice-client setup
         $this->assertSame([


### PR DESCRIPTION
it should be named Relation instead of Reference, but we unify the naming for now with `Field::getReference()`

`Model->ref()` stays, that is for traversing