### PR TITLE
Fix HasOneSql imported field update support

### DIFF
--- a/src/Field.php
+++ b/src/Field.php
@@ -141,7 +141,7 @@ class Field implements Expressionable
                 switch ($this->type) {
                     case null:
                     case 'string':
-                        $value = trim(preg_replace('~\r?\n|\r~', ' ', $value)); // remove all line-ends and trim
+                        $value = trim(preg_replace('~\r?\n|\r|\s~', ' ', $value)); // remove all line-ends and trim
 
                         break;
                     case 'text':

--- a/src/Model.php
+++ b/src/Model.php
@@ -1666,7 +1666,7 @@ class Model implements \IteratorAggregate
         $hasArrayValue = false;
         foreach ($row as $v) {
             if (is_array($v)) {
-                $hasArrayValue = false;
+                $hasArrayValue = true;
 
                 break;
             }

--- a/src/Model.php
+++ b/src/Model.php
@@ -466,10 +466,6 @@ class Model implements \IteratorAggregate
 
         $this->onHookShort(self::HOOK_BEFORE_LOAD, $fx, [], 10);
         $this->onHookShort(self::HOOK_AFTER_LOAD, $fx, [], -10);
-        $this->onHookShort(self::HOOK_BEFORE_INSERT, $fx, [], 10);
-        $this->onHookShort(self::HOOK_AFTER_INSERT, $fx, [], -10);
-        $this->onHookShort(self::HOOK_BEFORE_UPDATE, $fx, [], 10);
-        $this->onHookShort(self::HOOK_AFTER_UPDATE, $fx, [], -10);
         $this->onHookShort(self::HOOK_BEFORE_DELETE, $fx, [], 10);
         $this->onHookShort(self::HOOK_AFTER_DELETE, $fx, [], -10);
         $this->onHookShort(self::HOOK_BEFORE_SAVE, $fx, [], 10);

--- a/src/Persistence/Sql.php
+++ b/src/Persistence/Sql.php
@@ -586,7 +586,7 @@ class Sql extends Persistence
         $model->hook(self::HOOK_AFTER_UPDATE_QUERY, [$update, $c]);
 
         // if any rows were updated in database, and we had expressions, reload
-        if ($model->reloadAfterSave && $c > 0) {
+        if ($model->reloadAfterSave) {
             $d = $model->getDirtyRef();
             $model->reload();
             \Closure::bind(function () use ($model) {

--- a/src/Persistence/Sql/Connection.php
+++ b/src/Persistence/Sql/Connection.php
@@ -24,11 +24,8 @@ abstract class Connection
 {
     use DiContainerTrait;
 
-    /** @var string Query classname */
-    protected $queryClass = Query::class;
-
-    /** @var string Expression classname */
-    protected $expressionClass = Expression::class;
+    protected string $queryClass = Query::class;
+    protected string $expressionClass = Expression::class;
 
     /** @var DbalConnection */
     private $_connection;

--- a/src/Persistence/Sql/Connection.php
+++ b/src/Persistence/Sql/Connection.php
@@ -24,8 +24,8 @@ abstract class Connection
 {
     use DiContainerTrait;
 
-    protected string $queryClass = Query::class;
     protected string $expressionClass = Expression::class;
+    protected string $queryClass = Query::class;
 
     /** @var DbalConnection */
     private $_connection;
@@ -273,31 +273,31 @@ abstract class Connection
     }
 
     /**
-     * Returns new Query object with connection already set.
-     *
-     * @param string|array $properties
-     */
-    public function dsql($properties = []): Query
-    {
-        $c = $this->queryClass;
-        $q = new $c($properties);
-        $q->connection = $this;
-
-        return $q;
-    }
-
-    /**
-     * Returns Expression object with connection already set.
+     * Returns new Expression with connection already set.
      *
      * @param string|array $properties
      */
     public function expr($properties = [], array $arguments = []): Expression
     {
-        $c = $this->expressionClass;
-        $e = new $c($properties, $arguments);
+        $class = $this->expressionClass;
+        $e = new $class($properties, $arguments);
         $e->connection = $this;
 
         return $e;
+    }
+
+    /**
+     * Returns new Query with connection already set.
+     *
+     * @param string|array $properties
+     */
+    public function dsql($properties = []): Query
+    {
+        $class = $this->queryClass;
+        $q = new $class($properties);
+        $q->connection = $this;
+
+        return $q;
     }
 
     /**

--- a/src/Persistence/Sql/Expression.php
+++ b/src/Persistence/Sql/Expression.php
@@ -44,10 +44,10 @@ class Expression implements Expressionable, \ArrayAccess
      *
      * @var array<array<mixed>>
      */
-    public $args = ['custom' => []];
+    public array $args = ['custom' => []];
 
     /** @var string As per PDO, escapeParam() will convert value into :a, :b, :c .. :aa .. etc. */
-    protected $paramBase = 'a';
+    protected string $paramBase = 'a';
 
     /**
      * Identifier (table, column, ...) escaping symbol. By SQL Standard it's double
@@ -55,10 +55,8 @@ class Expression implements Expressionable, \ArrayAccess
      */
     protected string $identifierEscapeChar = '"';
 
-    /** @var string|null */
-    private $renderParamBase;
-    /** @var array|null */
-    private $renderParams;
+    private ?string $renderParamBase = null;
+    private ?array $renderParams = null;
 
     /** @var Connection|null */
     public $connection;

--- a/src/Persistence/Sql/Expression.php
+++ b/src/Persistence/Sql/Expression.php
@@ -52,10 +52,8 @@ class Expression implements Expressionable, \ArrayAccess
     /**
      * Identifier (table, column, ...) escaping symbol. By SQL Standard it's double
      * quote, but MySQL uses backtick.
-     *
-     * @var string
      */
-    protected $identifierEscapeChar = '"';
+    protected string $identifierEscapeChar = '"';
 
     /** @var string|null */
     private $renderParamBase;
@@ -65,8 +63,8 @@ class Expression implements Expressionable, \ArrayAccess
     /** @var Connection|null */
     public $connection;
 
-    /** @var bool Wrap the expression in parentheses when consumed by another expression or not. */
-    public $wrapInParentheses = false;
+    /** Wrap the expression in parentheses when consumed by another expression or not. */
+    public bool $wrapInParentheses = false;
 
     /**
      * Specifying options to constructors will override default
@@ -228,7 +226,7 @@ class Expression implements Expressionable, \ArrayAccess
         }
 
         // wrap in parentheses if expression requires so
-        if ($expr->wrapInParentheses === true) {
+        if ($expr->wrapInParentheses) {
             $sql = '(' . $sql . ')';
         }
 

--- a/src/Persistence/Sql/Mssql/Connection.php
+++ b/src/Persistence/Sql/Mssql/Connection.php
@@ -8,6 +8,6 @@ use Atk4\Data\Persistence\Sql\Connection as BaseConnection;
 
 class Connection extends BaseConnection
 {
-    protected $queryClass = Query::class;
-    protected $expressionClass = Expression::class;
+    protected string $queryClass = Query::class;
+    protected string $expressionClass = Expression::class;
 }

--- a/src/Persistence/Sql/Mssql/Connection.php
+++ b/src/Persistence/Sql/Mssql/Connection.php
@@ -8,6 +8,6 @@ use Atk4\Data\Persistence\Sql\Connection as BaseConnection;
 
 class Connection extends BaseConnection
 {
-    protected string $queryClass = Query::class;
     protected string $expressionClass = Expression::class;
+    protected string $queryClass = Query::class;
 }

--- a/src/Persistence/Sql/Mssql/Expression.php
+++ b/src/Persistence/Sql/Mssql/Expression.php
@@ -10,5 +10,5 @@ class Expression extends BaseExpression
 {
     use ExpressionTrait;
 
-    protected $identifierEscapeChar = ']';
+    protected string $identifierEscapeChar = ']';
 }

--- a/src/Persistence/Sql/Mssql/Query.php
+++ b/src/Persistence/Sql/Mssql/Query.php
@@ -10,9 +10,9 @@ class Query extends BaseQuery
 {
     use ExpressionTrait;
 
-    protected $identifierEscapeChar = ']';
+    protected string $identifierEscapeChar = ']';
 
-    protected $expressionClass = Expression::class;
+    protected string $expressionClass = Expression::class;
 
     protected $template_insert = <<<'EOF'
         begin try

--- a/src/Persistence/Sql/Mysql/Connection.php
+++ b/src/Persistence/Sql/Mysql/Connection.php
@@ -8,6 +8,6 @@ use Atk4\Data\Persistence\Sql\Connection as BaseConnection;
 
 class Connection extends BaseConnection
 {
-    protected $queryClass = Query::class;
-    protected $expressionClass = Expression::class;
+    protected string $queryClass = Query::class;
+    protected string $expressionClass = Expression::class;
 }

--- a/src/Persistence/Sql/Mysql/Connection.php
+++ b/src/Persistence/Sql/Mysql/Connection.php
@@ -8,6 +8,6 @@ use Atk4\Data\Persistence\Sql\Connection as BaseConnection;
 
 class Connection extends BaseConnection
 {
-    protected string $queryClass = Query::class;
     protected string $expressionClass = Expression::class;
+    protected string $queryClass = Query::class;
 }

--- a/src/Persistence/Sql/Mysql/Expression.php
+++ b/src/Persistence/Sql/Mysql/Expression.php
@@ -10,5 +10,5 @@ class Expression extends BaseExpression
 {
     use ExpressionTrait;
 
-    protected $identifierEscapeChar = '`';
+    protected string $identifierEscapeChar = '`';
 }

--- a/src/Persistence/Sql/Mysql/Query.php
+++ b/src/Persistence/Sql/Mysql/Query.php
@@ -14,7 +14,7 @@ class Query extends BaseQuery
 
     protected string $expressionClass = Expression::class;
 
-    protected $supportedOperators = ['=', '!=', '<', '>', '<=', '>=', 'like', 'not like', 'in', 'not in', 'regexp', 'not regexp'];
+    protected array $supportedOperators = ['=', '!=', '<', '>', '<=', '>=', 'like', 'not like', 'in', 'not in', 'regexp', 'not regexp'];
 
     protected $template_update = 'update [table][join] set [set] [where]';
 

--- a/src/Persistence/Sql/Mysql/Query.php
+++ b/src/Persistence/Sql/Mysql/Query.php
@@ -10,9 +10,9 @@ class Query extends BaseQuery
 {
     use ExpressionTrait;
 
-    protected $identifierEscapeChar = '`';
+    protected string $identifierEscapeChar = '`';
 
-    protected $expressionClass = Expression::class;
+    protected string $expressionClass = Expression::class;
 
     protected $supportedOperators = ['=', '!=', '<', '>', '<=', '>=', 'like', 'not like', 'in', 'not in', 'regexp', 'not regexp'];
 

--- a/src/Persistence/Sql/Oracle/Connection.php
+++ b/src/Persistence/Sql/Oracle/Connection.php
@@ -10,7 +10,7 @@ use Doctrine\DBAL\Event\Listeners\OracleSessionInit;
 
 class Connection extends BaseConnection
 {
-    protected $queryClass = Query::class;
+    protected string $queryClass = Query::class;
 
     protected static function createDbalEventManager(): EventManager
     {

--- a/src/Persistence/Sql/Oracle/Query.php
+++ b/src/Persistence/Sql/Oracle/Query.php
@@ -14,7 +14,7 @@ class Query extends BaseQuery
 
     protected $paramBase = 'xxaaaa';
 
-    protected $expressionClass = Expression::class;
+    protected string $expressionClass = Expression::class;
 
     public function render(): array
     {

--- a/src/Persistence/Sql/Oracle/Query.php
+++ b/src/Persistence/Sql/Oracle/Query.php
@@ -12,7 +12,7 @@ class Query extends BaseQuery
 {
     use ExpressionTrait;
 
-    protected $paramBase = 'xxaaaa';
+    protected string $paramBase = 'xxaaaa';
 
     protected string $expressionClass = Expression::class;
 

--- a/src/Persistence/Sql/Postgresql/Connection.php
+++ b/src/Persistence/Sql/Postgresql/Connection.php
@@ -8,5 +8,5 @@ use Atk4\Data\Persistence\Sql\Connection as BaseConnection;
 
 class Connection extends BaseConnection
 {
-    protected $queryClass = Query::class;
+    protected string $queryClass = Query::class;
 }

--- a/src/Persistence/Sql/Query.php
+++ b/src/Persistence/Sql/Query.php
@@ -24,7 +24,7 @@ class Query extends Expression
     public bool $wrapInParentheses = true;
 
     /** @var array<string> */
-    protected $supportedOperators = ['=', '!=', '<', '>', '<=', '>=', 'like', 'not like', 'in', 'not in'];
+    protected array $supportedOperators = ['=', '!=', '<', '>', '<=', '>=', 'like', 'not like', 'in', 'not in'];
 
     /** @var string */
     protected $template_select = '[with]select[option] [field] [from] [table][join][where][group][having][order][limit]';

--- a/src/Persistence/Sql/Query.php
+++ b/src/Persistence/Sql/Query.php
@@ -13,19 +13,15 @@ class Query extends Expression
      * Query will use one of the predefined templates. The $mode will contain
      * name of template used. Basically it's part of Query property name -
      * Query::template_[$mode].
-     *
-     * @var string
      */
-    public $mode = 'select';
+    public string $mode = 'select';
 
     /** @var string|Expression If no fields are defined, this field is used. */
     public $defaultField = '*';
 
-    /** @var string Expression classname */
-    protected $expressionClass = Expression::class;
+    protected string $expressionClass = Expression::class;
 
-    /** @var bool */
-    public $wrapInParentheses = true;
+    public bool $wrapInParentheses = true;
 
     /** @var array<string> */
     protected $supportedOperators = ['=', '!=', '<', '>', '<=', '>=', 'like', 'not like', 'in', 'not in'];

--- a/src/Persistence/Sql/Sqlite/Connection.php
+++ b/src/Persistence/Sql/Sqlite/Connection.php
@@ -12,6 +12,7 @@ use Doctrine\DBAL\Events;
 
 class Connection extends BaseConnection
 {
+    protected string $expressionClass = Expression::class;
     protected string $queryClass = Query::class;
 
     protected static function createDbalEventManager(): EventManager

--- a/src/Persistence/Sql/Sqlite/Connection.php
+++ b/src/Persistence/Sql/Sqlite/Connection.php
@@ -12,7 +12,7 @@ use Doctrine\DBAL\Events;
 
 class Connection extends BaseConnection
 {
-    protected $queryClass = Query::class;
+    protected string $queryClass = Query::class;
 
     protected static function createDbalEventManager(): EventManager
     {

--- a/src/Persistence/Sql/Sqlite/Expression.php
+++ b/src/Persistence/Sql/Sqlite/Expression.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Atk4\Data\Persistence\Sql\Sqlite;
+
+use Atk4\Data\Persistence\Sql\Expression as BaseExpression;
+
+class Expression extends BaseExpression
+{
+    protected string $identifierEscapeChar = '`';
+}

--- a/src/Persistence/Sql/Sqlite/Query.php
+++ b/src/Persistence/Sql/Sqlite/Query.php
@@ -8,6 +8,10 @@ use Atk4\Data\Persistence\Sql\Query as BaseQuery;
 
 class Query extends BaseQuery
 {
+    protected string $identifierEscapeChar = '`';
+
+    protected string $expressionClass = Expression::class;
+
     protected $template_truncate = 'delete [from] [table_noalias]';
 
     public function groupConcat($field, string $delimiter = ',')

--- a/src/Reference/HasOne.php
+++ b/src/Reference/HasOne.php
@@ -82,11 +82,6 @@ class HasOne extends Reference
         $ourModel = $this->getOurModel($ourModel);
         $theirModel = $this->createTheirModel($defaults);
 
-        // add hook to set our_field = null when record of referenced model is deleted
-        $this->onHookToTheirModel($theirModel, Model::HOOK_AFTER_DELETE, function (Model $theirModel) use ($ourModel) {
-            $ourModel->setNull($this->getOurFieldName());
-        });
-
         if ($ourModel->isEntity()) {
             $ourValue = $this->getOurFieldValue($ourModel);
 
@@ -125,6 +120,11 @@ class HasOne extends Reference
                 }
 
                 $theirModel->reload();
+            });
+
+            // add hook to set our field = null when record of referenced model is deleted
+            $this->onHookToTheirModel($theirModel, Model::HOOK_AFTER_DELETE, function (Model $theirModel) use ($ourModel) {
+                $ourModel->setNull($this->getOurFieldName());
             });
         }
 

--- a/src/Reference/HasOneSql.php
+++ b/src/Reference/HasOneSql.php
@@ -34,11 +34,6 @@ class HasOneSql extends HasOne
         ]));
 
         $this->onHookToOurModel($ourModel, Model::HOOK_BEFORE_SAVE, function (Model $ourModel) use ($fieldName, $theirFieldIsTitle, $theirFieldName) {
-            // fix UI persistence normalization of empty string to null
-            if ($ourModel->isDirty($fieldName) && $ourModel->get($fieldName) === '' && $ourModel->getField($fieldName)->nullable) {
-                $ourModel->set($fieldName, null);
-            }
-
             if ($ourModel->isDirty($fieldName)) {
                 $theirModel = $this->createTheirModel();
                 if ($theirFieldIsTitle) {

--- a/src/Reference/HasOneSql.php
+++ b/src/Reference/HasOneSql.php
@@ -85,7 +85,7 @@ class HasOneSql extends HasOne
         $defaults['ui'] ??= $refModelField->ui;
 
         $fieldExpression = $this->_addField($fieldName, false, $theirFieldName, array_merge_recursive([
-            'ui' => ['editable' => false], // fix https://github.com/atk4/data/issues/929
+            'ui' => ['editable' => false],
         ], $defaults));
 
         return $fieldExpression;

--- a/tests/BusinessModelTest.php
+++ b/tests/BusinessModelTest.php
@@ -48,6 +48,7 @@ class BusinessModelTest extends TestCase
     {
         $m = new Model();
         $m = $m->createEntity();
+
         $this->expectException(Exception::class);
         $m->set('name', 5);
     }
@@ -180,6 +181,7 @@ class BusinessModelTest extends TestCase
     {
         $m = new Model();
         $m = $m->createEntity();
+
         $this->expectException(\Error::class);
         $m->set(0, 'foo'); // @phpstan-ignore-line
     }
@@ -188,6 +190,7 @@ class BusinessModelTest extends TestCase
     {
         $m = new Model();
         $m = $m->createEntity();
+
         $this->expectException(Exception::class);
         $m->set('3', 'foo');
     }
@@ -196,6 +199,7 @@ class BusinessModelTest extends TestCase
     {
         $m = new Model();
         $m = $m->createEntity();
+
         $this->expectException(Exception::class);
         $m->set('3b', 'foo');
     }
@@ -204,6 +208,7 @@ class BusinessModelTest extends TestCase
     {
         $m = new Model();
         $m = $m->createEntity();
+
         $this->expectException(Exception::class);
         $m->set('', 'foo');
     }

--- a/tests/ConditionSqlTest.php
+++ b/tests/ConditionSqlTest.php
@@ -6,7 +6,6 @@ namespace Atk4\Data\Tests;
 
 use Atk4\Data\Model;
 use Atk4\Data\Schema\TestCase;
-use Doctrine\DBAL\Platforms\SqlitePlatform;
 
 class ConditionSqlTest extends TestCase
 {
@@ -33,13 +32,6 @@ class ConditionSqlTest extends TestCase
         $this->assertSame('John', $mm2->get('name'));
         $mm2 = $mm->tryLoad(2);
         $this->assertNull($mm2);
-
-        if ($this->getDatabasePlatform() instanceof SqlitePlatform) {
-            $this->assertSame(
-                'select "id", "name", "gender" from "user" where "gender" = :a',
-                $mm->action('select')->render()[0]
-            );
-        }
 
         $mm = clone $m;
         $mm->addCondition('id', 2);

--- a/tests/ConditionSqlTest.php
+++ b/tests/ConditionSqlTest.php
@@ -46,6 +46,7 @@ class ConditionSqlTest extends TestCase
         $m = new Model($this->db, ['table' => 'user']);
         $scope = $m->scope();
         $this->assertSame($scope, $m->createEntity()->getModel()->scope());
+
         $this->expectException(\Atk4\Data\Exception::class);
         $m->createEntity()->scope();
     }
@@ -67,6 +68,7 @@ class ConditionSqlTest extends TestCase
         \Closure::bind(function () use ($m) {
             $m->_entityId = 2;
         }, null, Model::class)();
+
         $this->expectException(\Atk4\Data\Exception::class);
         $this->expectExceptionMessageMatches('~entity.+different~');
         $m->reload();

--- a/tests/ExpressionSqlTest.php
+++ b/tests/ExpressionSqlTest.php
@@ -33,7 +33,7 @@ class ExpressionSqlTest extends TestCase
 
         if ($this->getDatabasePlatform() instanceof SqlitePlatform) {
             $this->assertSame(
-                'select "id", "total_net", "total_vat", ("total_net" + "total_vat") "total_gross" from "invoice"',
+                'select `id`, `total_net`, `total_vat`, (`total_net` + `total_vat`) `total_gross` from `invoice`',
                 $i->action('select')->render()[0]
             );
         }
@@ -50,7 +50,7 @@ class ExpressionSqlTest extends TestCase
 
         if ($this->getDatabasePlatform() instanceof SqlitePlatform) {
             $this->assertEquals(
-                'select "id", "total_net", "total_vat", ("total_net" + "total_vat") "total_gross", (("total_net" + "total_vat") * 2) "double_total_gross" from "invoice"',
+                'select `id`, `total_net`, `total_vat`, (`total_net` + `total_vat`) `total_gross`, ((`total_net` + `total_vat`) * 2) `double_total_gross` from `invoice`',
                 $i->action('select')->render()[0]
             );
         }
@@ -75,7 +75,7 @@ class ExpressionSqlTest extends TestCase
 
         if ($this->getDatabasePlatform() instanceof SqlitePlatform) {
             $this->assertSame(
-                'select "id", "total_net", "total_vat", ("total_net" + "total_vat") "total_gross" from "invoice"',
+                'select `id`, `total_net`, `total_vat`, (`total_net` + `total_vat`) `total_gross` from `invoice`',
                 $i->action('select')->render()[0]
             );
         }
@@ -103,7 +103,7 @@ class ExpressionSqlTest extends TestCase
 
         if ($this->getDatabasePlatform() instanceof SqlitePlatform) {
             $this->assertSame(
-                'select "id", "total_net", "total_vat", (select sum("total_net") from "invoice") "sum_net" from "invoice"',
+                'select `id`, `total_net`, `total_vat`, (select sum(`total_net`) from `invoice`) `sum_net` from `invoice`',
                 $i->action('select')->render()[0]
             );
         }
@@ -142,9 +142,9 @@ class ExpressionSqlTest extends TestCase
 
         $m->addCondition($m->expr('[full_name] != [cached_name]'));
 
-        $concatSql = preg_replace('~\[(\w+)\]~', '"$1"', $concatExpr);
+        $concatSql = preg_replace('~\[(\w+)\]~', '`$1`', $concatExpr);
         $this->assertSameSql(
-            'select "id", "name", "surname", "cached_name", (' . $concatSql . ') "full_name" from "user" where ((' . $concatSql . ') != "cached_name")',
+            'select `id`, `name`, `surname`, `cached_name`, (' . $concatSql . ') `full_name` from `user` where ((' . $concatSql . ') != `cached_name`)',
             $m->action('select')->render()[0]
         );
 

--- a/tests/Field/PasswordFieldTest.php
+++ b/tests/Field/PasswordFieldTest.php
@@ -75,9 +75,13 @@ class PasswordFieldTest extends TestCase
     public function testInvalidPasswordCntrlChar(): void
     {
         $field = new PasswordField();
+        $pwd = 'myPassword' . "\t" . 'x';
+        $hash = $field->hashPassword($pwd);
+        $this->assertTrue($field->hashPasswordIsHashed($hash));
+        $this->assertTrue($field->hashPasswordVerify($hash, str_replace("\t", ' ', $pwd)));
 
         $this->expectException(Exception::class);
-        $field->hashPassword('myPassword' . "\t" . 'x');
+        $field->hashPassword('myPassword' . "\x07" . 'x');
     }
 
     public function testSetUnhashedException(): void

--- a/tests/FieldTest.php
+++ b/tests/FieldTest.php
@@ -110,6 +110,7 @@ class FieldTest extends TestCase
         $m = new Model($this->db, ['table' => 'user']);
         $m->addField('name', ['nullable' => false]);
         $m->addField('surname');
+
         $this->expectException(Exception::class);
         $m->insert(['surname' => 'qq']);
     }
@@ -125,6 +126,7 @@ class FieldTest extends TestCase
         $m = new Model($this->db, ['table' => 'user']);
         $m->addField('name', ['required' => true]);
         $m->addField('surname');
+
         $this->expectException(Exception::class);
         $m->insert(['surname' => 'qq', 'name' => '']);
     }
@@ -141,6 +143,7 @@ class FieldTest extends TestCase
         $m->addField('name', ['nullable' => false]);
         $m->addField('surname');
         $m = $m->load(1);
+
         $this->expectException(Exception::class);
         $m->save(['name' => null]);
     }
@@ -195,6 +198,7 @@ class FieldTest extends TestCase
         $m = new Model();
         $m->addField('foo', ['readOnly' => true]);
         $m = $m->createEntity();
+
         $this->expectException(Exception::class);
         $m->set('foo', 'bar');
     }
@@ -213,6 +217,7 @@ class FieldTest extends TestCase
         $m = new Model();
         $m->addField('foo', ['enum' => ['foo', 'bar']]);
         $m = $m->createEntity();
+
         $this->expectException(Exception::class);
         $m->set('foo', 'xx');
     }
@@ -248,6 +253,7 @@ class FieldTest extends TestCase
         $m = new Model();
         $m->addField('foo', ['enum' => [1, 'bar']]);
         $m = $m->createEntity();
+
         $this->expectException(Exception::class);
         $m->set('foo', true);
     }
@@ -270,6 +276,7 @@ class FieldTest extends TestCase
         $m = new Model();
         $m->addField('foo', ['values' => ['foo', 'bar']]);
         $m = $m->createEntity();
+
         $this->expectException(Exception::class);
         $m->set('foo', 4);
     }
@@ -292,6 +299,7 @@ class FieldTest extends TestCase
         $m = new Model();
         $m->addField('foo', ['values' => [1 => 'bar']]);
         $m = $m->createEntity();
+
         $this->expectException(Exception::class);
         $m->set('foo', 'bar');
     }
@@ -410,6 +418,7 @@ class FieldTest extends TestCase
         $m = new Model();
         $m->addField('foo');
         $m = $m->createEntity();
+
         $this->expectException(Exception::class);
         $m->set('baz', 'bar');
     }
@@ -553,6 +562,7 @@ class FieldTest extends TestCase
         $m = new Model();
         $m->addField('foo', ['type' => 'string']);
         $m = $m->createEntity();
+
         $this->expectException(ValidationException::class);
         $m->set('foo', []);
     }
@@ -562,6 +572,7 @@ class FieldTest extends TestCase
         $m = new Model();
         $m->addField('foo', ['type' => 'text']);
         $m = $m->createEntity();
+
         $this->expectException(ValidationException::class);
         $m->set('foo', []);
     }
@@ -571,6 +582,7 @@ class FieldTest extends TestCase
         $m = new Model();
         $m->addField('foo', ['type' => 'integer']);
         $m = $m->createEntity();
+
         $this->expectException(ValidationException::class);
         $m->set('foo', []);
     }
@@ -580,6 +592,7 @@ class FieldTest extends TestCase
         $m = new Model();
         $m->addField('foo', ['type' => 'atk4_money']);
         $m = $m->createEntity();
+
         $this->expectException(ValidationException::class);
         $m->set('foo', []);
     }
@@ -589,6 +602,7 @@ class FieldTest extends TestCase
         $m = new Model();
         $m->addField('foo', ['type' => 'float']);
         $m = $m->createEntity();
+
         $this->expectException(ValidationException::class);
         $m->set('foo', []);
     }
@@ -598,6 +612,7 @@ class FieldTest extends TestCase
         $m = new Model();
         $m->addField('foo', ['type' => 'date']);
         $m = $m->createEntity();
+
         $this->expectException(ValidationException::class);
         $m->set('foo', []);
     }
@@ -607,6 +622,7 @@ class FieldTest extends TestCase
         $m = new Model();
         $m->addField('foo', ['type' => 'datetime']);
         $m = $m->createEntity();
+
         $this->expectException(ValidationException::class);
         $m->set('foo', []);
     }
@@ -616,6 +632,7 @@ class FieldTest extends TestCase
         $m = new Model();
         $m->addField('foo', ['type' => 'time']);
         $m = $m->createEntity();
+
         $this->expectException(ValidationException::class);
         $m->set('foo', []);
     }
@@ -625,6 +642,7 @@ class FieldTest extends TestCase
         $m = new Model();
         $m->addField('foo', ['type' => 'integer']);
         $m = $m->createEntity();
+
         $this->expectException(ValidationException::class);
         $m->set('foo', '123---456');
     }
@@ -634,6 +652,7 @@ class FieldTest extends TestCase
         $m = new Model();
         $m->addField('foo', ['type' => 'atk4_money']);
         $m = $m->createEntity();
+
         $this->expectException(ValidationException::class);
         $m->set('foo', '123---456');
     }
@@ -643,6 +662,7 @@ class FieldTest extends TestCase
         $m = new Model();
         $m->addField('foo', ['type' => 'float']);
         $m = $m->createEntity();
+
         $this->expectException(ValidationException::class);
         $m->set('foo', '123---456');
     }
@@ -652,6 +672,7 @@ class FieldTest extends TestCase
         $m = new Model();
         $m->addField('foo', ['type' => 'json']);
         $m = $m->createEntity();
+
         $this->expectException(ValidationException::class);
         $m->set('foo', 'ABC');
     }
@@ -661,6 +682,7 @@ class FieldTest extends TestCase
         $m = new Model();
         $m->addField('foo', ['type' => 'object']);
         $m = $m->createEntity();
+
         $this->expectException(ValidationException::class);
         $m->set('foo', 'ABC');
     }
@@ -670,6 +692,7 @@ class FieldTest extends TestCase
         $m = new Model();
         $m->addField('foo', ['type' => 'boolean']);
         $m = $m->createEntity();
+
         $this->expectException(ValidationException::class);
         $m->set('foo', 'ABC');
     }
@@ -707,8 +730,9 @@ class FieldTest extends TestCase
 
     public function testAddFieldDirectly(): void
     {
-        $this->expectException(Exception::class);
         $model = new Model();
+
+        $this->expectException(Exception::class);
         $model->add(new Field(), ['test']);
     }
 
@@ -805,7 +829,6 @@ class FieldTest extends TestCase
         $this->assertNull($m->get('b'));
         $this->assertNull($m->get('c'));
 
-        // invalid value for set() - normalization must fail
         $this->expectException(Exception::class);
         $m->set('c', null);
     }

--- a/tests/IteratorTest.php
+++ b/tests/IteratorTest.php
@@ -17,6 +17,7 @@ class IteratorTest extends TestCase
     {
         $m = new Model();
         $m->addFields(['name', 'salary']);
+
         $this->expectException(Exception::class);
         $m->setOrder(['name', 'salary'], 'desc');
     }
@@ -27,6 +28,7 @@ class IteratorTest extends TestCase
     public function testException2(): void
     {
         $m = new Model();
+
         $this->expectException(Exception::class);
         $m = $m->tryLoad(1);
     }
@@ -37,6 +39,7 @@ class IteratorTest extends TestCase
     public function testException3(): void
     {
         $m = new Model();
+
         $this->expectException(Exception::class);
         $m = $m->tryLoadAny();
     }
@@ -47,6 +50,7 @@ class IteratorTest extends TestCase
     public function testException4(): void
     {
         $m = new Model();
+
         $this->expectException(Exception::class);
         $m = $m->load(1);
     }
@@ -57,6 +61,7 @@ class IteratorTest extends TestCase
     public function testException5(): void
     {
         $m = new Model();
+
         $this->expectException(Exception::class);
         $m = $m->loadAny();
     }
@@ -67,6 +72,7 @@ class IteratorTest extends TestCase
     public function testException6(): void
     {
         $m = new Model();
+
         $this->expectException(Exception::class);
         $m->save();
     }
@@ -77,6 +83,7 @@ class IteratorTest extends TestCase
     public function testException7(): void
     {
         $m = new Model();
+
         $this->expectException(Exception::class);
         $m->action('count');
     }

--- a/tests/JoinArrayTest.php
+++ b/tests/JoinArrayTest.php
@@ -383,6 +383,7 @@ class JoinArrayTest extends TestCase
         $user->addField('name');
         $j = $user->join('contact');
         $j->addField('contact_phone');
+
         $this->expectException(Exception::class);
         $user = $user->load(2);
     }

--- a/tests/LimitOrderTest.php
+++ b/tests/LimitOrderTest.php
@@ -209,6 +209,7 @@ class LimitOrderTest extends TestCase
 
         $i = (new Model($this->db, ['table' => 'invoice']))->addFields(['net']);
         $i->setOrder(new \DateTime()); // @phpstan-ignore-line
+
         $this->expectException(Exception::class);
         $i->export(); // executes query and throws exception because of DateTime object
     }

--- a/tests/LookupSqlTest.php
+++ b/tests/LookupSqlTest.php
@@ -298,6 +298,10 @@ class LookupSqlTest extends TestCase
 
         $u = new LUser($this->db);
 
+        $this->assertTrue($u->getField('country_id')->isEditable());
+        $this->assertFalse($u->getField('country')->isEditable());
+        $this->assertFalse($u->getField('country_code')->isEditable());
+
         $u->import([
             ['name' => 'Alain', 'country_code' => 'CA'],
             ['name' => 'Imants', 'country_code' => 'LV'],

--- a/tests/ModelAggregateTest.php
+++ b/tests/ModelAggregateTest.php
@@ -277,7 +277,7 @@ class ModelAggregateTest extends TestCase
         $aggregate->setOrder('client_id', 'asc');
 
         $this->assertSameSql(
-            'select "client", "client_id", sum("amount") "amount" from (select "id", "client_id", "name", "amount", (select "name" from "client" "_c_2bfe9d72a4aa" where "id" = "invoice"."client_id") "client" from "invoice") "_tm" group by "client_id", "client" order by "client_id"',
+            'select `client`, `client_id`, sum(`amount`) `amount` from (select `id`, `client_id`, `name`, `amount`, (select `name` from `client` `_c_2bfe9d72a4aa` where `id` = `invoice`.`client_id`) `client` from `invoice`) `_tm` group by `client_id`, `client` order by `client_id`',
             $aggregate->action('select')->render()[0]
         );
 
@@ -285,7 +285,7 @@ class ModelAggregateTest extends TestCase
         $aggregate->removeField('client');
         $aggregate->groupByFields = array_diff($aggregate->groupByFields, ['client']);
         $this->assertSameSql(
-            'select "client_id", sum("amount") "amount" from (select "id", "client_id", "name", "amount", (select "name" from "client" "_c_2bfe9d72a4aa" where "id" = "invoice"."client_id") "client" from "invoice") "_tm" group by "client_id" order by "client_id"',
+            'select `client_id`, sum(`amount`) `amount` from (select `id`, `client_id`, `name`, `amount`, (select `name` from `client` `_c_2bfe9d72a4aa` where `id` = `invoice`.`client_id`) `client` from `invoice`) `_tm` group by `client_id` order by `client_id`',
             $aggregate->action('select')->render()[0]
         );
     }
@@ -335,7 +335,7 @@ class ModelAggregateTest extends TestCase
         self::fixAllNonAggregatedFieldsInGroupBy($aggregate);
 
         $this->assertSameSql(
-            'select count(*) from ((select 1 from (select "id", "client_id", "name", "amount", (select "name" from "client" "_c_2bfe9d72a4aa" where "id" = "invoice"."client_id") "client" from "invoice") "_tm" group by "client_id", "client")) "_tc"',
+            'select count(*) from ((select 1 from (select `id`, `client_id`, `name`, `amount`, (select `name` from `client` `_c_2bfe9d72a4aa` where `id` = `invoice`.`client_id`) `client` from `invoice`) `_tm` group by `client_id`, `client`)) `_tc`',
             $aggregate->action('count')->render()[0]
         );
     }
@@ -349,7 +349,7 @@ class ModelAggregateTest extends TestCase
         ]);
 
         $this->assertSameSql(
-            'select sum("amount") "xyz" from (select "id", "client_id", "name", "amount", (select "name" from "client" "_c_2bfe9d72a4aa" where "id" = "invoice"."client_id") "client" from "invoice") "_tm" group by "abc"',
+            'select sum(`amount`) `xyz` from (select `id`, `client_id`, `name`, `amount`, (select `name` from `client` `_c_2bfe9d72a4aa` where `id` = `invoice`.`client_id`) `client` from `invoice`) `_tm` group by `abc`',
             $aggregate->action('select')->render()[0]
         );
     }

--- a/tests/ModelWithCteTest.php
+++ b/tests/ModelWithCteTest.php
@@ -41,8 +41,8 @@ class ModelWithCteTest extends TestCase
         $jInvoice->addField('invoiced', ['type' => 'integer', 'actual' => 'net']); // add field from joined cursor
 
         $this->assertSameSql(
-            'with "i" as (select "id", "net", "user_id" from "invoice" where "net" > :a)' . "\n"
-                . 'select "user"."id", "user"."name", "user"."salary", "_i"."net" "invoiced" from "user" inner join "i" "_i" on "_i"."user_id" = "user"."id"',
+            'with `i` as (select `id`, `net`, `user_id` from `invoice` where `net` > :a)' . "\n"
+                . 'select `user`.`id`, `user`.`name`, `user`.`salary`, `_i`.`net` `invoiced` from `user` inner join `i` `_i` on `_i`.`user_id` = `user`.`id`',
             $m->action('select')->render()[0]
         );
 

--- a/tests/ModelWithoutIdTest.php
+++ b/tests/ModelWithoutIdTest.php
@@ -54,6 +54,7 @@ class ModelWithoutIdTest extends TestCase
     public function testGetIdException(): void
     {
         $m = $this->m->loadAny();
+
         $this->expectException(Exception::class);
         $this->expectErrorMessage('ID field is not defined');
         $m->getId();
@@ -62,6 +63,7 @@ class ModelWithoutIdTest extends TestCase
     public function testSetIdException(): void
     {
         $m = $this->m->createEntity();
+
         $this->expectException(Exception::class);
         $this->expectErrorMessage('ID field is not defined');
         $m->setId(1);

--- a/tests/Persistence/ArrayTest.php
+++ b/tests/Persistence/ArrayTest.php
@@ -607,6 +607,7 @@ class ArrayTest extends TestCase
         $p = new Persistence\Array_([
             ['id' => 3, 'f1' => 'A'],
         ]);
+
         $this->expectException(Exception::class);
         $m = new Model($p);
     }
@@ -741,6 +742,7 @@ class ArrayTest extends TestCase
         $p = new Persistence\Array_([1 => ['name' => 'John']]);
         $m = new Model($p);
         $m->addField('name');
+
         $this->expectException(Exception::class);
         $m->action('foo');
     }
@@ -760,6 +762,7 @@ class ArrayTest extends TestCase
         $p = new Persistence\Array_([1 => ['name' => 'John']]);
         $m = new Model($p);
         $m->addField('name');
+
         $this->expectException(Exception::class);
         $m->addCondition('name');
     }
@@ -769,6 +772,7 @@ class ArrayTest extends TestCase
         $p = new Persistence\Array_([1 => ['name' => 'John']]);
         $m = new Model($p);
         $m->addField('name');
+
         $this->expectException(Exception::class);
         $m->addCondition(new Model(), 'like', '%o%');
     }

--- a/tests/Persistence/CsvTest.php
+++ b/tests/Persistence/CsvTest.php
@@ -158,6 +158,7 @@ class CsvTest extends TestCase
 
         $p = $this->makeCsvPersistence($this->file);
         $m = new Model($p);
+
         $this->expectException(Exception::class);
         $m = $m->tryLoad(1);
     }

--- a/tests/Persistence/Sql/ExceptionTest.php
+++ b/tests/Persistence/Sql/ExceptionTest.php
@@ -20,6 +20,7 @@ class ExceptionTest extends TestCase
     public function testException2(): void
     {
         $e = new Expression('hello, [world]');
+
         $this->expectException(SqlException::class);
         $e->render();
     }

--- a/tests/Persistence/Sql/ExpressionTest.php
+++ b/tests/Persistence/Sql/ExpressionTest.php
@@ -9,7 +9,6 @@ use Atk4\Data\Persistence\Sql\Exception;
 use Atk4\Data\Persistence\Sql\Expression;
 use Atk4\Data\Persistence\Sql\Expressionable;
 use Atk4\Data\Persistence\Sql\Mysql;
-use Atk4\Data\Persistence\Sql\Query;
 use Atk4\Data\Persistence\Sql\Sqlite;
 
 class ExpressionTest extends TestCase

--- a/tests/Persistence/Sql/ExpressionTest.php
+++ b/tests/Persistence/Sql/ExpressionTest.php
@@ -286,10 +286,6 @@ class ExpressionTest extends TestCase
             123,
             $this->callProtected($this->e(), 'consume', 123, $constants['ESCAPE_NONE'])
         );
-        $this->assertSame(
-            '(select *)',
-            $this->callProtected($this->e(), 'consume', new Query())
-        );
 
         $myField = new class() implements Expressionable {
             public function getDsqlExpression(Expression $expr): Expression

--- a/tests/Persistence/Sql/QueryTest.php
+++ b/tests/Persistence/Sql/QueryTest.php
@@ -100,11 +100,6 @@ class QueryTest extends TestCase
             'all.values',
             $this->callProtected($this->q(['defaultField' => 'all.values']), '_render_field')
         );
-        // defaultField as Expression object - not escaped
-        $this->assertSame(
-            'values()',
-            $this->callProtected($this->q(['defaultField' => new Expression('values()')]), '_render_field')
-        );
     }
 
     public function testFieldExpression(): void

--- a/tests/Persistence/Sql/WithDb/SelectTest.php
+++ b/tests/Persistence/Sql/WithDb/SelectTest.php
@@ -254,7 +254,7 @@ class SelectTest extends TestCase
             ], $q->render());
         } else {
             $this->assertSame([
-                'select "age", group_concat("name", :a) from "people" group by "age"',
+                'select `age`, group_concat(`name`, :a) from `people` group by `age`',
                 [':a' => ','],
             ], $q->render());
         }
@@ -289,7 +289,7 @@ class SelectTest extends TestCase
             ], $q->render());
         } else {
             $this->assertSame([
-                'select exists (select * from "contacts" where "first_name" = :a)',
+                'select exists (select * from `contacts` where `first_name` = :a)',
                 [':a' => 'John'],
             ], $q->render());
         }
@@ -316,7 +316,7 @@ class SelectTest extends TestCase
 
             $this->assertSame($expectedErrorCode, $e->getCode());
             $this->assertSameSql(
-                preg_replace('~\s+~', '', 'select "non_existing_field" from "non_existing_table"'),
+                preg_replace('~\s+~', '', 'select `non_existing_field` from `non_existing_table`'),
                 preg_replace('~\s+~', '', $e->getDebugQuery())
             );
 

--- a/tests/Persistence/Sql/WithDb/SelectTest.php
+++ b/tests/Persistence/Sql/WithDb/SelectTest.php
@@ -141,7 +141,6 @@ class SelectTest extends TestCase
 
     public function testOtherQueries(): void
     {
-        // truncate table
         $this->q('employee')->mode('truncate')->executeStatement();
         $this->assertSame(
             '0',
@@ -210,10 +209,19 @@ class SelectTest extends TestCase
 
     public function testEmptyGetOne(): void
     {
-        // truncate table
         $this->q('employee')->mode('truncate')->executeStatement();
+        $q = $this->q('employee')->field('name');
+
         $this->expectException(Exception::class);
-        $this->q('employee')->field('name')->getOne();
+        $q->getOne();
+    }
+
+    public function testSelectUnexistingColumnException(): void
+    {
+        $q = $this->q('employee')->field('Sqlite must use backticks for identifier escape');
+
+        $this->expectException(Exception::class);
+        $q->executeStatement();
     }
 
     public function testWhereExpression(): void
@@ -297,10 +305,11 @@ class SelectTest extends TestCase
 
     public function testExecuteException(): void
     {
-        $this->expectException(ExecuteException::class);
+        $q = $this->q('non_existing_table')->field('non_existing_field');
 
+        $this->expectException(ExecuteException::class);
         try {
-            $this->q('non_existing_table')->field('non_existing_field')->getOne();
+            $q->getOne();
         } catch (ExecuteException $e) {
             if ($this->getDatabasePlatform() instanceof MySQLPlatform) {
                 $expectedErrorCode = 1146; // SQLSTATE[42S02]: Base table or view not found: 1146 Table 'non_existing_table' doesn't exist

--- a/tests/Persistence/Sql/WithDb/TransactionTest.php
+++ b/tests/Persistence/Sql/WithDb/TransactionTest.php
@@ -53,9 +53,10 @@ class TransactionTest extends TestCase
 
     public function testCommitException2(): void
     {
-        // try to commit when not in transaction anymore
         $this->getConnection()->beginTransaction();
         $this->getConnection()->commit();
+
+        // try to commit when not in transaction anymore
         $this->expectException(Exception::class);
         $this->getConnection()->commit();
     }
@@ -69,9 +70,10 @@ class TransactionTest extends TestCase
 
     public function testRollbackException2(): void
     {
-        // try to rollback when not in transaction anymore
         $this->getConnection()->beginTransaction();
         $this->getConnection()->rollBack();
+
+        // try to rollback when not in transaction anymore
         $this->expectException(Exception::class);
         $this->getConnection()->rollBack();
     }

--- a/tests/Persistence/SqlTest.php
+++ b/tests/Persistence/SqlTest.php
@@ -69,6 +69,7 @@ class SqlTest extends TestCase
 
         $m->loadAny();
         $m->tryLoadAny();
+
         $this->expectException(Exception::class);
         $this->expectExceptionMessage('Ambiguous conditions, more than one record can be loaded');
         $m->tryLoadOne();

--- a/tests/RandomTest.php
+++ b/tests/RandomTest.php
@@ -321,7 +321,6 @@ class RandomTest extends TestCase
 
         try {
             $this->expectException(Exception::class);
-
             $m->save();
         } catch (\Exception $e) {
             $this->assertEquals($dbData, $this->getDb());
@@ -532,6 +531,7 @@ class RandomTest extends TestCase
     public function testDuplicateWithIdArgumentException(): void
     {
         $m = new Model_Rate();
+
         $this->expectException(Exception::class);
         $m->duplicate(2)->save();
     }

--- a/tests/RandomTest.php
+++ b/tests/RandomTest.php
@@ -587,10 +587,10 @@ class RandomTest extends TestCase
         $this->assertSame($render, $selectAction->render());
         $this->assertSame($render, $doc->action('select')->render());
 
-        $userTableQuoted = '"' . str_replace('.', '"."', $userSchema) . '"."user"';
-        $docTableQuoted = '"' . str_replace('.', '"."', $docSchema) . '"."doc"';
+        $userTableQuoted = '`' . str_replace('.', '`.`', $userSchema) . '`.`user`';
+        $docTableQuoted = '`' . str_replace('.', '`.`', $docSchema) . '`.`doc`';
         $this->assertSameSql(
-            'select "id", "name", "user_id", (select "name" from ' . $userTableQuoted . ' "_u_e8701ad48ba0" where "id" = ' . $docTableQuoted . '."user_id") "user" from ' . $docTableQuoted . ' where (select "name" from ' . $userTableQuoted . ' "_u_e8701ad48ba0" where "id" = ' . $docTableQuoted . '."user_id") = :a',
+            'select `id`, `name`, `user_id`, (select `name` from ' . $userTableQuoted . ' `_u_e8701ad48ba0` where `id` = ' . $docTableQuoted . '.`user_id`) `user` from ' . $docTableQuoted . ' where (select `name` from ' . $userTableQuoted . ' `_u_e8701ad48ba0` where `id` = ' . $docTableQuoted . '.`user_id`) = :a',
             $render[0]
         );
 

--- a/tests/ReadOnlyModeTest.php
+++ b/tests/ReadOnlyModeTest.php
@@ -62,6 +62,7 @@ class ReadOnlyModeTest extends TestCase
     {
         $m = $this->m->load(1);
         $m->set('name', 'X');
+
         $this->expectException(Exception::class);
         $m->save();
     }
@@ -81,6 +82,7 @@ class ReadOnlyModeTest extends TestCase
     public function testSave1(): void
     {
         $m = $this->m->tryLoadAny();
+
         $this->expectException(Exception::class);
         $m->saveAndUnload();
     }

--- a/tests/ReferenceSqlTest.php
+++ b/tests/ReferenceSqlTest.php
@@ -59,7 +59,7 @@ class ReferenceSqlTest extends TestCase
         $oo = $u->addCondition('id', '>', '1')->ref('Orders');
 
         $this->assertSameSql(
-            'select "id", "amount", "user_id" from "order" "_O_7442e29d7d53" where "user_id" in (select "id" from "user" where "id" > :a)',
+            'select `id`, `amount`, `user_id` from `order` `_O_7442e29d7d53` where `user_id` in (select `id` from `user` where `id` > :a)',
             $oo->action('select')->render()[0]
         );
     }
@@ -75,7 +75,7 @@ class ReferenceSqlTest extends TestCase
         $u->hasMany('Orders', ['model' => $o]);
 
         $this->assertSameSql(
-            'select "id", "amount", "user_id" from "order" "_O_7442e29d7d53" where "user_id" = "user"."id"',
+            'select `id`, `amount`, `user_id` from `order` `_O_7442e29d7d53` where `user_id` = `user`.`id`',
             $u->refLink('Orders')->action('select')->render()[0]
         );
     }
@@ -124,7 +124,7 @@ class ReferenceSqlTest extends TestCase
         $u->hasMany('cur', ['model' => $c, 'our_field' => 'currency_code', 'their_field' => 'code']);
 
         $this->assertSameSql(
-            'select "id", "code", "name" from "currency" "_c_b5fddf1ef601" where "code" = "user"."currency_code"',
+            'select `id`, `code`, `name` from `currency` `_c_b5fddf1ef601` where `code` = `user`.`currency_code`',
             $u->refLink('cur')->action('select')->render()[0]
         );
     }
@@ -163,7 +163,7 @@ class ReferenceSqlTest extends TestCase
         $o->addCondition('amount', '<', 9);
 
         $this->assertSameSql(
-            'select "id", "name" from "user" "_u_e8701ad48ba0" where "id" in (select "user_id" from "order" where ("amount" > :a and "amount" < :b))',
+            'select `id`, `name` from `user` `_u_e8701ad48ba0` where `id` in (select `user_id` from `order` where (`amount` > :a and `amount` < :b))',
             $o->ref('user_id')->action('select')->render()[0]
         );
     }
@@ -237,7 +237,7 @@ class ReferenceSqlTest extends TestCase
         $i->addExpression('total_net', ['expr' => $i->refLink('line')->action('fx', ['sum', 'total_net'])]);
 
         $this->assertSameSql(
-            'select "id", "ref_no", (select sum("total_net") from "invoice_line" "_l_6438c669e0d0" where "invoice_id" = "invoice"."id") "total_net" from "invoice"',
+            'select `id`, `ref_no`, (select sum(`total_net`) from `invoice_line` `_l_6438c669e0d0` where `invoice_id` = `invoice`.`id`) `total_net` from `invoice`',
             $i->action('select')->render()[0]
         );
     }

--- a/tests/ReferenceSqlTest.php
+++ b/tests/ReferenceSqlTest.php
@@ -608,8 +608,6 @@ class ReferenceSqlTest extends TestCase
         $this->assertNull($o->get('user_id'));
         $o->save();
         $this->assertEquals(2, $o->get('user_id'));
-        $o->reload();
-        $this->assertEquals(2, $o->get('user_id'));
 
         $this->dropCreatedDb();
         $this->setDb($dbData);
@@ -627,8 +625,6 @@ class ReferenceSqlTest extends TestCase
         $o->set('user', 'Foo');
         $this->assertNull($o->get('user_id'));
         $o->save();
-        $this->assertEquals(2, $o->get('user_id'));
-        $o->reload();
         $this->assertEquals(2, $o->get('user_id'));
 
         $this->dropCreatedDb();
@@ -648,8 +644,6 @@ class ReferenceSqlTest extends TestCase
         $this->assertNull($o->get('user_id'));
         $o->save();
         $this->assertEquals(2, $o->get('user_id'));
-        $o->reload();
-        $this->assertEquals(2, $o->get('user_id'));
 
         $this->dropCreatedDb();
         $this->setDb($dbData);
@@ -668,8 +662,6 @@ class ReferenceSqlTest extends TestCase
         $o->set('user_id', 2);
         $this->assertEquals(2, $o->get('user_id'));
         $o->save();
-        $this->assertEquals(2, $o->get('user_id'));
-        $o->reload();
         $this->assertEquals(2, $o->get('user_id'));
 
         $this->dropCreatedDb();

--- a/tests/ReferenceSqlTest.php
+++ b/tests/ReferenceSqlTest.php
@@ -601,12 +601,15 @@ class ReferenceSqlTest extends TestCase
 
         // change order user by changing title_field value
         $o = $o->load(1);
-        $o->set('user', 'Peter');
         $this->assertEquals(1, $o->get('user_id'));
+        $o->set('user_id', null);
         $o->save();
-        $this->assertEquals(2, $o->get('user_id')); // user_id changed to Peters ID
+        $o->set('user', 'Peter');
+        $this->assertNull($o->get('user_id'));
+        $o->save();
+        $this->assertEquals(2, $o->get('user_id'));
         $o->reload();
-        $this->assertEquals(2, $o->get('user_id')); // and it's really saved like that
+        $this->assertEquals(2, $o->get('user_id'));
 
         $this->dropCreatedDb();
         $this->setDb($dbData);
@@ -618,12 +621,15 @@ class ReferenceSqlTest extends TestCase
 
         // change order user by changing title_field value
         $o = $o->load(1);
-        $o->set('user', 'Foo');
         $this->assertEquals(1, $o->get('user_id'));
+        $o->set('user_id', null);
         $o->save();
-        $this->assertEquals(2, $o->get('user_id')); // user_id changed to Peters ID
+        $o->set('user', 'Foo');
+        $this->assertNull($o->get('user_id'));
+        $o->save();
+        $this->assertEquals(2, $o->get('user_id'));
         $o->reload();
-        $this->assertEquals(2, $o->get('user_id')); // and it's really saved like that
+        $this->assertEquals(2, $o->get('user_id'));
 
         $this->dropCreatedDb();
         $this->setDb($dbData);
@@ -635,12 +641,15 @@ class ReferenceSqlTest extends TestCase
 
         // change order user by changing reference field value
         $o = $o->load(1);
-        $o->set('my_user', 'Foo');
         $this->assertEquals(1, $o->get('user_id'));
+        $o->set('user_id', null);
         $o->save();
-        $this->assertEquals(2, $o->get('user_id')); // user_id changed to Peters ID
+        $o->set('my_user', 'Foo');
+        $this->assertNull($o->get('user_id'));
+        $o->save();
+        $this->assertEquals(2, $o->get('user_id'));
         $o->reload();
-        $this->assertEquals(2, $o->get('user_id')); // and it's really saved like that
+        $this->assertEquals(2, $o->get('user_id'));
 
         $this->dropCreatedDb();
         $this->setDb($dbData);
@@ -650,15 +659,33 @@ class ReferenceSqlTest extends TestCase
         $o = (new Model($this->db, ['table' => 'order']));
         $o->hasOne('my_user', ['model' => $u, 'our_field' => 'user_id'])->addTitle();
 
-        // change order user by changing ref field value
+        // change order user by changing ref field and title_field value - same
         $o = $o->load(1);
-        $o->set('my_user', 'Foo'); // user_id = 2
-        $o->set('user_id', 3);     // user_id = 3 (this will take precedence)
-        $this->assertEquals(3, $o->get('user_id'));
+        $this->assertEquals(1, $o->get('user_id'));
+        $o->set('user_id', null);
         $o->save();
-        $this->assertEquals(3, $o->get('user_id')); // user_id changed to Goofy ID
+        $o->set('my_user', 'Foo'); // user_id = 2
+        $o->set('user_id', 2);
+        $this->assertEquals(2, $o->get('user_id'));
+        $o->save();
+        $this->assertEquals(2, $o->get('user_id'));
         $o->reload();
-        $this->assertEquals(3, $o->get('user_id')); // and it's really saved like that
+        $this->assertEquals(2, $o->get('user_id'));
+
+        $this->dropCreatedDb();
+        $this->setDb($dbData);
+
+        // change order user by changing ref field and title_field value - mismatched
+        $o = $o->getModel()->load(1);
+        $this->assertEquals(1, $o->get('user_id'));
+        $o->set('user_id', null);
+        $o->save();
+        $o->set('my_user', 'Foo'); // user_id = 2
+        $o->set('user_id', 3);
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage('Imported field was changed to an unexpected value');
+        $o->save();
     }
 
     /**

--- a/tests/Schema/TestCaseTest.php
+++ b/tests/Schema/TestCaseTest.php
@@ -47,7 +47,7 @@ class TestCaseTest extends TestCase
                 "START TRANSACTION";
 
 
-                insert into "t" ("name", "int", "float", "null")
+                insert into `t` (`name`, `int`, `float`, `null`)
                 values
                   ('Ewa', 1, '1.0', NULL);
 
@@ -56,15 +56,15 @@ class TestCaseTest extends TestCase
 
 
                 select
-                  "id",
-                  "name",
-                  "int",
-                  "float",
-                  "null"
+                  `id`,
+                  `name`,
+                  `int`,
+                  `float`,
+                  `null`
                 from
-                  "t"
+                  `t`
                 where
-                  "int" > -1
+                  `int` > -1
                 limit
                   0,
                   1;

--- a/tests/ScopeTest.php
+++ b/tests/ScopeTest.php
@@ -10,6 +10,7 @@ use Atk4\Data\Model\Scope;
 use Atk4\Data\Model\Scope\Condition;
 use Atk4\Data\Persistence\Sql\Expression;
 use Atk4\Data\Schema\TestCase;
+use Doctrine\DBAL\Platforms\MySQLPlatform;
 use Doctrine\DBAL\Platforms\SqlitePlatform;
 
 class SCountry extends Model
@@ -137,10 +138,10 @@ class ScopeTest extends TestCase
 
         $this->assertEquals('Country ID is equal to 2 (\'Latvia\')', $condition->toWords($user));
 
-        if ($this->getDatabasePlatform() instanceof SqlitePlatform) {
+        if ($this->getDatabasePlatform() instanceof SqlitePlatform || $this->getDatabasePlatform() instanceof MySQLPlatform) {
             $condition = new Condition('name', $user->expr('[surname]'));
 
-            $this->assertEquals('Name is equal to expression \'"surname"\'', $condition->toWords($user));
+            $this->assertSame('Name is equal to expression \'`surname`\'', $condition->toWords($user));
         }
 
         $condition = new Condition('country_id', null);

--- a/tests/TypecastingTest.php
+++ b/tests/TypecastingTest.php
@@ -411,6 +411,7 @@ class TypecastingTest extends TestCase
 
         $m = new Model($this->db, ['table' => 'types']);
         $m->addField('ts', ['actual' => 'date', 'type' => 'datetime']);
+
         $this->expectException(Exception::class);
         $m = $m->loadOne();
     }

--- a/tests/ValidationTest.php
+++ b/tests/ValidationTest.php
@@ -74,6 +74,7 @@ class ValidationTest extends TestCase
     {
         $m = $this->m->createEntity();
         $m->set('name', 'Python');
+
         $this->expectException(ValidationException::class);
         $this->expectExceptionMessage('Snakes');
         $m->save();
@@ -84,6 +85,7 @@ class ValidationTest extends TestCase
         $m = $this->m->createEntity();
         $m->set('name', 'Python');
         $m->set('domain', 'example.com');
+
         $this->expectException(ValidationException::class);
         $this->expectExceptionMessage('Multiple');
         $m->save();


### PR DESCRIPTION
fixes https://github.com/atk4/data/issues/929
closes https://github.com/atk4/data/pull/933
fixes https://github.com/atk4/filestore/issues/26

https://github.com/atk4/data/blob/6657685ec9684286415b4d84d6fcc1ba4f0da1b7/src/Reference/HasOneSql.php#L35-L50

hook code is simply wrong.

In https://github.com/atk4/data/commit/5d49235b39cb5dca6e50fff781737eebe7de09d7 the code was intended to be fixed for changed values for different than `our_field` field. This caused data corruptions like https://github.com/atk4/filestore/issues/26. The data corruption was hotfixed in https://github.com/atk4/data/pull/1037 but looking into this issue deeper, the hook should simply not be there. We cannot infer `our_field` values based on "imported"/"joined" fields, as these fields might not be unique and might represent totaly different relation.

The proposed fix maintains the feature for the setting the `our_field` value for a new record with our field equal to null, under this state, we can determine the foreign/their record based on the imported/joined field without the possibility to mismatch the our field. The relation to foreign/their record can still imply duplicates, but this is a decision by the developer.

Making the field read only after the record is saved will fix also https://github.com/atk4/data/issues/929.

The update issue is obvious in https://github.com/atk4/data/blob/3.1.0/tests/ReferenceSqlTest.php#L562 test. How on Earth can "first name" solely uniquely locate a foreign user record?