### PR TITLE
Adjusted scope validation

### DIFF
--- a/src/Model.php
+++ b/src/Model.php
@@ -1510,7 +1510,7 @@ class Model implements \IteratorAggregate
 
     protected function validateEntityScope(): void
     {
-        if (!$this->getModel()->scope()->isEmpty()) {
+        if ($this->reloadAfterSave && !$this->getModel()->scope()->isEmpty()) {
             $this->getPersistence()->load($this->getModel(), $this->getId());
         }
     }


### PR DESCRIPTION
The introduced scope validation is fine, but too strict:

We have often situations where through a Save command, the entity will leave the scope of the model. This is and should be handled with saveAndUnload. With the latest https://github.com/atk4/data/pull/1044 even $model->saveAndUnload will not permit for example the SoftDelete code example to mark an entity as 'is_deleted' => true. Because it drops out of the model and will result in a record not found.

I generally agree, but only for save, and not for situations where saveAndUnload is used , that means ->reloadAfterSave is false. Otherwise it is a lot of messing around if you let the user change values which make entities leave the model scope. 