### PR TITLE
Remove Field::getTypeObject() method

### DIFF
--- a/docs/model.rst
+++ b/docs/model.rst
@@ -284,7 +284,7 @@ calculated by your callback method right after individual record is loaded by th
     }, 'type' => 'float']);
 
 .. important:: always use argument `$m` instead of `$this` inside your callbacks. If model is to be
-   `clone`d, the code relying on `$this` would reference original model, but the code using
+   cloned, the code relying on `$this` would reference original model, but the code using
    `$m` will properly address the model which triggered the callback.
 
 This can also be useful for calculating relative times::

--- a/docs/persistence/sql/expressions.rst
+++ b/docs/persistence/sql/expressions.rst
@@ -69,7 +69,7 @@ Parameters
 
 Because some values are un-safe to use in the query and can contain dangerous
 values they are kept outside of the SQL query string and are using
-`PDO's bindParam <http://php.net/manual/en/pdostatement.bindparam.php>`_
+`PDO's bindValue <https://www.php.net/manual/en/pdostatement.bindvalue.php>`_
 instead. DSQL can consist of multiple objects and each object may have
 some parameters. During `rendering`_ those parameters are joined together to
 produce one complete query.

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -147,7 +147,7 @@ following categories:
 Persistence
 ^^^^^^^^^^^
 
-When you create instance of a model (`new Model`) you need to specify
+When you create instance of a model (`new Model()`) you need to specify
 :php:class:`Persistence` as a parameter. If you don't you can still use
 the model, but it won't be able to :php:meth:`Model::load()` or
 :php:meth:`Model::save()` data.

--- a/src/Field.php
+++ b/src/Field.php
@@ -56,18 +56,22 @@ class Field implements Expressionable
     {
         $this->_setDefaults($properties, $passively);
 
-        $this->getTypeObject(); // assert type exists
+        $this->getType(); // assert type exists
 
         return $this;
     }
 
-    public function getTypeObject(): Type
+    public function getType(): string
     {
-        if ($this->type === 'array') { // remove in 2022-mar
+        $res = $this->type ?? 'string';
+
+        if ($res === 'array') { // remove in v4.1
             throw new Exception('Atk4 "array" type is no longer supported, originally, it serialized value to JSON, to keep this behaviour, use "json" type');
         }
 
-        return Type::getType($this->type ?? 'string');
+        Type::getType($res); // assert type exists
+
+        return $res;
     }
 
     /**
@@ -133,7 +137,7 @@ class Field implements Expressionable
      */
     public function normalize($value)
     {
-        $this->getTypeObject(); // assert type exists
+        $this->getType(); // assert type exists
 
         try {
             if ($this->issetOwner() && $this->getOwner()->hook(Model::HOOK_NORMALIZE, [$this, $value]) === false) {

--- a/src/Field.php
+++ b/src/Field.php
@@ -60,22 +60,16 @@ class Field implements Expressionable
     {
         $this->_setDefaults($properties, $passively);
 
-        $this->getType(); // assert type exists
+        // assert type exists
+        if (isset($properties['type'])) {
+            if ($this->type === 'array') { // remove in v4.1
+                throw new Exception('Atk4 "array" type is no longer supported, originally, it serialized value to JSON, to keep this behaviour, use "json" type');
+            }
 
-        return $this;
-    }
-
-    public function getType(): string
-    {
-        $res = $this->type ?? 'string';
-
-        if ($res === 'array') { // remove in v4.1
-            throw new Exception('Atk4 "array" type is no longer supported, originally, it serialized value to JSON, to keep this behaviour, use "json" type');
+            Type::getType($this->type);
         }
 
-        Type::getType($res); // assert type exists
-
-        return $res;
+        return $this;
     }
 
     /**
@@ -141,8 +135,6 @@ class Field implements Expressionable
      */
     public function normalize($value)
     {
-        $this->getType(); // assert type exists
-
         try {
             if ($this->issetOwner() && $this->getOwner()->hook(Model::HOOK_NORMALIZE, [$this, $value]) === false) {
                 return $value;

--- a/src/Field.php
+++ b/src/Field.php
@@ -35,6 +35,10 @@ class Field implements Expressionable
     public function __construct(array $defaults = [])
     {
         $this->setDefaults($defaults);
+
+        if (!(new \ReflectionProperty($this, 'type'))->isInitialized($this)) {
+            $this->type = 'string';
+        }
     }
 
     /**

--- a/src/Field.php
+++ b/src/Field.php
@@ -142,7 +142,6 @@ class Field implements Expressionable
 
             if (is_string($value)) {
                 switch ($this->type) {
-                    case null:
                     case 'string':
                         $value = trim(preg_replace('~\r?\n|\r|\s~', ' ', $value)); // remove all line-ends and trim
 
@@ -178,18 +177,13 @@ class Field implements Expressionable
                 }
             } elseif ($value !== null) {
                 switch ($this->type) {
-                    case null:
                     case 'string':
                     case 'text':
                     case 'integer':
                     case 'float':
                     case 'atk4_money':
                         if (is_bool($value)) {
-                            if ($this->type === 'boolean') {
-                                $value = $value ? '1' : '0';
-                            } else {
-                                throw new Exception('Must not be boolean type');
-                            }
+                            throw new Exception('Must not be boolean type');
                         } elseif (is_int($value)) {
                             $value = (string) $value;
                         } elseif (is_float($value)) {
@@ -217,7 +211,6 @@ class Field implements Expressionable
             }
 
             switch ($this->type) {
-                case null:
                 case 'string':
                 case 'text':
                     if ($this->required && !$value) {

--- a/src/Model/FieldPropertiesTrait.php
+++ b/src/Model/FieldPropertiesTrait.php
@@ -14,7 +14,7 @@ trait FieldPropertiesTrait
     public bool $neverSave = false;
 
     /** DBAL type registered in \Doctrine\DBAL\Types\Type. */
-    public ?string $type = null;
+    public string $type;
     /** Nullable field can be null, otherwise the value must be set, even if it is an empty value. */
     public bool $nullable = true;
     /** Required field must have non-empty value. A null value is considered empty too. */

--- a/src/Persistence.php
+++ b/src/Persistence.php
@@ -11,6 +11,7 @@ use Atk4\Core\Factory;
 use Atk4\Core\HookTrait;
 use Atk4\Core\NameTrait;
 use Doctrine\DBAL\Platforms;
+use Doctrine\DBAL\Types\Type;
 
 abstract class Persistence
 {
@@ -408,7 +409,7 @@ abstract class Persistence
 
         // native DBAL DT types have no microseconds support
         if (in_array($field->type, ['datetime', 'date', 'time'], true)
-            && str_starts_with(get_class($field->getTypeObject()), 'Doctrine\DBAL\Types\\')) {
+            && str_starts_with(get_class(Type::getType($field->getType())), 'Doctrine\DBAL\Types\\')) {
             if ($value === '') {
                 return null;
             } elseif (!$value instanceof \DateTimeInterface) {
@@ -426,7 +427,7 @@ abstract class Persistence
             return $value;
         }
 
-        $res = $field->getTypeObject()->convertToDatabaseValue($value, $this->getDatabasePlatform());
+        $res = Type::getType($field->getType())->convertToDatabaseValue($value, $this->getDatabasePlatform());
         if (is_resource($res) && get_resource_type($res) === 'stream') {
             $res = stream_get_contents($res);
         }
@@ -451,7 +452,7 @@ abstract class Persistence
 
         // native DBAL DT types have no microseconds support
         if (in_array($field->type, ['datetime', 'date', 'time'], true)
-            && str_starts_with(get_class($field->getTypeObject()), 'Doctrine\DBAL\Types\\')) {
+            && str_starts_with(get_class(Type::getType($field->getType())), 'Doctrine\DBAL\Types\\')) {
             $format = ['date' => 'Y-m-d', 'datetime' => 'Y-m-d H:i:s', 'time' => 'H:i:s'][$field->type];
             if (str_contains($value, '.')) { // time possibly with microseconds, otherwise invalid format
                 $format = preg_replace('~(?<=H:i:s)(?![. ]*u)~', '.u', $format);
@@ -473,7 +474,7 @@ abstract class Persistence
             return $value;
         }
 
-        $res = $field->getTypeObject()->convertToPHPValue($value, $this->getDatabasePlatform());
+        $res = Type::getType($field->getType())->convertToPHPValue($value, $this->getDatabasePlatform());
         if (is_resource($res) && get_resource_type($res) === 'stream') {
             $res = stream_get_contents($res);
         }

--- a/src/Persistence.php
+++ b/src/Persistence.php
@@ -409,7 +409,7 @@ abstract class Persistence
 
         // native DBAL DT types have no microseconds support
         if (in_array($field->type, ['datetime', 'date', 'time'], true)
-            && str_starts_with(get_class(Type::getType($field->getType())), 'Doctrine\DBAL\Types\\')) {
+            && str_starts_with(get_class(Type::getType($field->type)), 'Doctrine\DBAL\Types\\')) {
             if ($value === '') {
                 return null;
             } elseif (!$value instanceof \DateTimeInterface) {
@@ -427,7 +427,7 @@ abstract class Persistence
             return $value;
         }
 
-        $res = Type::getType($field->getType())->convertToDatabaseValue($value, $this->getDatabasePlatform());
+        $res = Type::getType($field->type)->convertToDatabaseValue($value, $this->getDatabasePlatform());
         if (is_resource($res) && get_resource_type($res) === 'stream') {
             $res = stream_get_contents($res);
         }
@@ -452,7 +452,7 @@ abstract class Persistence
 
         // native DBAL DT types have no microseconds support
         if (in_array($field->type, ['datetime', 'date', 'time'], true)
-            && str_starts_with(get_class(Type::getType($field->getType())), 'Doctrine\DBAL\Types\\')) {
+            && str_starts_with(get_class(Type::getType($field->type)), 'Doctrine\DBAL\Types\\')) {
             $format = ['date' => 'Y-m-d', 'datetime' => 'Y-m-d H:i:s', 'time' => 'H:i:s'][$field->type];
             if (str_contains($value, '.')) { // time possibly with microseconds, otherwise invalid format
                 $format = preg_replace('~(?<=H:i:s)(?![. ]*u)~', '.u', $format);
@@ -474,7 +474,7 @@ abstract class Persistence
             return $value;
         }
 
-        $res = Type::getType($field->getType())->convertToPHPValue($value, $this->getDatabasePlatform());
+        $res = Type::getType($field->type)->convertToPHPValue($value, $this->getDatabasePlatform());
         if (is_resource($res) && get_resource_type($res) === 'stream') {
             $res = stream_get_contents($res);
         }

--- a/src/Persistence/Array_.php
+++ b/src/Persistence/Array_.php
@@ -181,13 +181,6 @@ class Array_ extends Persistence
             $model->table = 'data';
         }
 
-        if ($model->idField) {
-            $f = $model->getField($model->idField);
-            if ($f->type === null) {
-                $f->type = 'integer';
-            }
-        }
-
         if (!is_object($model->table)) {
             $this->seedData($model);
         }

--- a/src/Persistence/Sql.php
+++ b/src/Persistence/Sql.php
@@ -629,7 +629,7 @@ class Sql extends Persistence
     {
         $value = parent::typecastSaveField($field, $value);
 
-        if ($value !== null && $this->binaryTypeIsEncodeNeeded($field->getTypeObject())) {
+        if ($value !== null && $this->binaryTypeIsEncodeNeeded($field->getType())) {
             $value = $this->binaryTypeValueEncode($value);
         }
 
@@ -640,7 +640,7 @@ class Sql extends Persistence
     {
         $value = parent::typecastLoadField($field, $value);
 
-        if ($value !== null && $this->binaryTypeIsDecodeNeeded($field->getTypeObject(), $value)) {
+        if ($value !== null && $this->binaryTypeIsDecodeNeeded($field->getType(), $value)) {
             $value = $this->binaryTypeValueDecode($value);
         }
 

--- a/src/Persistence/Sql.php
+++ b/src/Persistence/Sql.php
@@ -629,7 +629,7 @@ class Sql extends Persistence
     {
         $value = parent::typecastSaveField($field, $value);
 
-        if ($value !== null && $this->binaryTypeIsEncodeNeeded($field->getType())) {
+        if ($value !== null && $this->binaryTypeIsEncodeNeeded($field->type)) {
             $value = $this->binaryTypeValueEncode($value);
         }
 
@@ -640,7 +640,7 @@ class Sql extends Persistence
     {
         $value = parent::typecastLoadField($field, $value);
 
-        if ($value !== null && $this->binaryTypeIsDecodeNeeded($field->getType(), $value)) {
+        if ($value !== null && $this->binaryTypeIsDecodeNeeded($field->type, $value)) {
             $value = $this->binaryTypeValueDecode($value);
         }
 

--- a/src/Persistence/Sql/BinaryTypeCompatibilityTypecastTrait.php
+++ b/src/Persistence/Sql/BinaryTypeCompatibilityTypecastTrait.php
@@ -49,7 +49,7 @@ trait BinaryTypeCompatibilityTypecastTrait
         return $res;
     }
 
-    private function binaryTypeIsEncodeNeeded(Type $type): bool
+    private function binaryTypeIsEncodeNeeded(string $type): bool
     {
         // binary values for PostgreSQL and MSSQL databases are stored natively, but we need
         // to encode first to hold the binary type info for PDO parameter type binding
@@ -59,7 +59,7 @@ trait BinaryTypeCompatibilityTypecastTrait
             || $platform instanceof SQLServerPlatform
             || $platform instanceof OraclePlatform
         ) {
-            if (in_array($type->getName(), ['binary', 'blob'], true)) {
+            if (in_array($type, ['binary', 'blob'], true)) {
                 return true;
             }
         }
@@ -70,7 +70,7 @@ trait BinaryTypeCompatibilityTypecastTrait
     /**
      * @param scalar $value
      */
-    private function binaryTypeIsDecodeNeeded(Type $type, $value): bool
+    private function binaryTypeIsDecodeNeeded(string $type, $value): bool
     {
         if ($this->binaryTypeIsEncodeNeeded($type)) {
             // always decode for Oracle platform to assert the value is always encoded,

--- a/src/Persistence/Sql/Oracle/Query.php
+++ b/src/Persistence/Sql/Oracle/Query.php
@@ -48,8 +48,8 @@ class Query extends BaseQuery
         }
 
         if (count($row) >= 2 && $field instanceof Field
-            && in_array($field->getType(), ['text', 'blob'], true)) {
-            if ($field->getType() === 'text') {
+            && in_array($field->type, ['text', 'blob'], true)) {
+            if ($field->type === 'text') {
                 $field = $this->expr('LOWER([])', [$field]);
                 $value = $this->expr('LOWER([])', [$value]);
             }

--- a/src/Persistence/Sql/Oracle/Query.php
+++ b/src/Persistence/Sql/Oracle/Query.php
@@ -48,8 +48,8 @@ class Query extends BaseQuery
         }
 
         if (count($row) >= 2 && $field instanceof Field
-            && in_array($field->getTypeObject()->getName(), ['text', 'blob'], true)) {
-            if ($field->getTypeObject()->getName() === 'text') {
+            && in_array($field->getType(), ['text', 'blob'], true)) {
+            if ($field->getType() === 'text') {
                 $field = $this->expr('LOWER([])', [$field]);
                 $value = $this->expr('LOWER([])', [$value]);
             }

--- a/src/Reference/HasOne.php
+++ b/src/Reference/HasOne.php
@@ -25,7 +25,8 @@ class HasOne extends Reference
             $this->ourField = $this->link;
         }
 
-        if ($this->type === null) { // different default value than in Model\FieldPropertiesTrait
+        // for references use "integer" as a default type
+        if (!(new \ReflectionProperty($this, 'type'))->isInitialized($this)) {
             $this->type = 'integer';
         }
 
@@ -40,7 +41,7 @@ class HasOne extends Reference
             foreach ($fieldPropsRefl as $fieldPropRefl) {
                 $v = $this->{$fieldPropRefl->getName()};
                 $vDefault = \PHP_MAJOR_VERSION < 8
-                    ? $fieldPropRefl->getDeclaringClass()->getDefaultProperties()[$fieldPropRefl->getName()]
+                    ? ($fieldPropRefl->getDeclaringClass()->getDefaultProperties()[$fieldPropRefl->getName()] ?? null)
                     : (null ?? $fieldPropRefl->getDefaultValue()); // @phpstan-ignore-line for PHP 7.x
                 if ($v !== $vDefault) {
                     $fieldSeed[$fieldPropRefl->getName()] = $v;

--- a/src/Schema/Migrator.php
+++ b/src/Schema/Migrator.php
@@ -228,31 +228,31 @@ class Migrator
      */
     public function field(string $fieldName, array $options = []): self
     {
-        if (($options['type'] ?? null) === null) {
-            $options['type'] = 'string';
-        } elseif ($options['type'] === 'time' && $this->getDatabasePlatform() instanceof OraclePlatform) {
-            $options['type'] = 'string';
+        $type = $options['type'] ?? 'string';
+        unset($options['type']);
+        if ($type === 'time' && $this->getDatabasePlatform() instanceof OraclePlatform) {
+            $type = 'string';
         }
 
         $refType = $options['ref_type'] ?? self::REF_TYPE_NONE;
         unset($options['ref_type']);
 
-        $column = $this->table->addColumn($this->getDatabasePlatform()->quoteSingleIdentifier($fieldName), $options['type']);
+        $column = $this->table->addColumn($this->getDatabasePlatform()->quoteSingleIdentifier($fieldName), $type);
 
         if (($options['nullable'] ?? true) && $refType !== self::REF_TYPE_PRIMARY) {
             $column->setNotnull(false);
         }
 
-        if ($column->getType()->getName() === 'integer' && $refType !== self::REF_TYPE_NONE) {
+        if ($type === 'integer' && $refType !== self::REF_TYPE_NONE) {
             $column->setUnsigned(true);
         }
 
         // TODO remove, hack for createForeignKey so ID columns are unsigned
-        if ($column->getType()->getName() === 'integer' && str_ends_with($fieldName, '_id')) {
+        if ($type === 'integer' && str_ends_with($fieldName, '_id')) {
             $column->setUnsigned(true);
         }
 
-        if (in_array($column->getType()->getName(), ['string', 'text'], true)) {
+        if (in_array($type, ['string', 'text'], true)) {
             if ($this->getDatabasePlatform() instanceof SqlitePlatform) {
                 $column->setPlatformOption('collation', 'NOCASE');
             }

--- a/src/Schema/Migrator.php
+++ b/src/Schema/Migrator.php
@@ -303,7 +303,7 @@ class Migrator
             }
 
             $options = [
-                'type' => $refype !== self::REF_TYPE_NONE && $persistField->type === null ? 'integer' : $persistField->type,
+                'type' => $persistField->type,
                 'ref_type' => $refype,
                 'nullable' => ($field->nullable && !$field->required) || ($persistField->nullable && !$persistField->required),
             ];

--- a/tests/ReferenceSqlTest.php
+++ b/tests/ReferenceSqlTest.php
@@ -319,7 +319,7 @@ class ReferenceSqlTest extends TestCase
         static::assertSame('atk4_money', $i->getField('total_vat')->type);
 
         // type was not set and is not inherited
-        static::assertNull($i->getField('total_net')->type);
+        static::assertSame('string', $i->getField('total_net')->type);
 
         static::assertSame(40.0, (float) $i->get('total_net'));
         static::assertSame(9.2, $i->get('total_vat'));


### PR DESCRIPTION
needed for https://github.com/atk4/data/pull/1069

`string` name can no longer be obtained from `Type`

also make `Field::type` property not null (always `string`)

in the future, type might be required to be defined explicitly, for now, we still fallback to `string` implicitly