### PR TITLE
Remove Field::toString() method

### DIFF
--- a/docs/persistence/sql/expressions.rst
+++ b/docs/persistence/sql/expressions.rst
@@ -235,22 +235,10 @@ Finally, you can pass connection class into :php:meth:`executeQuery` directly.
 Magic an Debug Methods
 ======================
 
-.. php:method:: __toString()
-
-    You may use :php:class:`Expression` or :php:class:`Query` as a string. It
-    will be automatically executed when being cast by executing :php:meth:`getOne`.
-    Because the `__toString() <http://php.net/manual/en/language.oop5.magic.php#object.tostring>`_
-    is not allowed to throw exceptions we encourage you not to use this format.
-
 .. php:method:: __debugInfo()
 
     This method is used to prepare a sensible information about your query
     when you are executing ``var_dump($expr)``. The output will be HTML-safe.
-
-.. php:method:: debug()
-
-    Calling this method will set :php:attr:`debug` into ``true`` and the further
-    execution to :php:meth:`render` will also attempt to echo query.
 
 .. php:method:: getDebugQuery()
 

--- a/src/Field.php
+++ b/src/Field.php
@@ -283,16 +283,6 @@ class Field implements Expressionable
     }
 
     /**
-     * Casts field value to string.
-     *
-     * @param mixed $value
-     */
-    public function toString($value): string
-    {
-        return (string) $this->typecastSaveField($value, true);
-    }
-
-    /**
      * Returns field value.
      *
      * @return mixed

--- a/src/Persistence.php
+++ b/src/Persistence.php
@@ -143,7 +143,7 @@ abstract class Persistence
         if (!$data) {
             $noId = $id === self::ID_LOAD_ONE || $id === self::ID_LOAD_ANY;
 
-            throw (new Exception($noId ? 'No record was found' : 'Record with specified ID was not found', 404))
+            throw (new Exception($noId ? 'No record was found' : 'Record with specified ID was not found'))
                 ->addMoreInfo('model', $model)
                 ->addMoreInfo('id', $noId ? null : $id)
                 ->addMoreInfo('scope', $model->scope()->toWords());

--- a/tests/FieldTest.php
+++ b/tests/FieldTest.php
@@ -750,6 +750,7 @@ class FieldTest extends TestCase
         // only return subset of onlyFields
         static::assertSame(['visible', 'not_editable'], array_keys($model->getFields('visible')));
 
+        $this->expectException(Exception::class);
         $this->expectExceptionMessage('not supported');
         $model->getFields('foo');
     }

--- a/tests/FieldTest.php
+++ b/tests/FieldTest.php
@@ -716,37 +716,6 @@ class FieldTest extends TestCase
         $m->set('foo', 'ABC');
     }
 
-    public function testToString(): void
-    {
-        $m = new Model();
-
-        $m->addField('string', ['type' => 'string']);
-        $m->addField('text', ['type' => 'text']);
-        $m->addField('integer', ['type' => 'integer']);
-        $m->addField('money', ['type' => 'atk4_money']);
-        $m->addField('float', ['type' => 'float']);
-        $m->addField('boolean', ['type' => 'boolean']);
-        $m->addField('date', ['type' => 'date']);
-        $m->addField('datetime', ['type' => 'datetime']);
-        $m->addField('time', ['type' => 'time']);
-        $m->addField('json', ['type' => 'json']);
-        $m->addField('object', ['type' => 'object']);
-        $m = $m->createEntity();
-
-        static::assertSame('Two Lines', $m->getField('string')->toString("Two\r\nLines  "));
-        static::assertSame("Two\nLines", $m->getField('text')->toString("Two\r\nLines  "));
-        static::assertSame('123', $m->getField('integer')->toString(123));
-        static::assertSame('123.45', $m->getField('money')->toString(123.45));
-        static::assertSame('123.456789', $m->getField('float')->toString(123.456789));
-        static::assertSame('1', $m->getField('boolean')->toString(true));
-        static::assertSame('0', $m->getField('boolean')->toString(false));
-        static::assertSame('2019-01-20', $m->getField('date')->toString(new \DateTime('2019-01-20T12:23:34 UTC')));
-        static::assertSame('2019-01-20 12:23:34.000000', $m->getField('datetime')->toString(new \DateTime('2019-01-20 12:23:34 UTC')));
-        static::assertSame('12:23:34.000000', $m->getField('time')->toString(new \DateTime('2019-01-20 12:23:34 UTC')));
-        static::assertSame('{"foo":"bar","int":123,"rows":["a","b"]}', $m->getField('json')->toString(['foo' => 'bar', 'int' => 123, 'rows' => ['a', 'b']]));
-        static::assertSame('O:8:"stdClass":3:{s:3:"foo";s:3:"bar";s:3:"int";i:123;s:4:"rows";a:2:{i:0;s:1:"a";i:1;s:1:"b";}}', $m->getField('object')->toString((object) ['foo' => 'bar', 'int' => 123, 'rows' => ['a', 'b']]));
-    }
-
     public function testAddFieldDirectly(): void
     {
         $model = new Model();
@@ -783,39 +752,6 @@ class FieldTest extends TestCase
 
         $this->expectExceptionMessage('not supported');
         $model->getFields('foo');
-    }
-
-    public function testDateTimeFieldsToString(): void
-    {
-        $model = new Model();
-        $model->addField('date', ['type' => 'date']);
-        $model->addField('time', ['type' => 'time']);
-        $model->addField('datetime', ['type' => 'datetime']);
-        $model = $model->createEntity();
-
-        static::assertSame('', $model->getField('date')->toString($model->get('date')));
-        static::assertSame('', $model->getField('time')->toString($model->get('time')));
-        static::assertSame('', $model->getField('datetime')->toString($model->get('datetime')));
-
-        // datetime without microseconds
-        $dt = new \DateTime('2020-01-21 21:09:42 UTC');
-        $model->set('date', $dt);
-        $model->set('time', $dt);
-        $model->set('datetime', $dt);
-
-        static::assertSame($dt->format('Y-m-d'), $model->getField('date')->toString($model->get('date')));
-        static::assertSame($dt->format('H:i:s.u'), $model->getField('time')->toString($model->get('time')));
-        static::assertSame($dt->format('Y-m-d H:i:s.u'), $model->getField('datetime')->toString($model->get('datetime')));
-
-        // datetime with microseconds
-        $dt = new \DateTime('2020-01-21 21:09:42.895623 UTC');
-        $model->set('date', $dt);
-        $model->set('time', $dt);
-        $model->set('datetime', $dt);
-
-        static::assertSame($dt->format('Y-m-d'), $model->getField('date')->toString($model->get('date')));
-        static::assertSame($dt->format('H:i:s.u'), $model->getField('time')->toString($model->get('time')));
-        static::assertSame($dt->format('Y-m-d H:i:s.u'), $model->getField('datetime')->toString($model->get('datetime')));
     }
 
     public function testSetNull(): void

--- a/tests/Persistence/ArrayTest.php
+++ b/tests/Persistence/ArrayTest.php
@@ -881,7 +881,8 @@ class ArrayTest extends TestCase
         $m = new Model($p);
         $m->addField('name');
 
-        $this->expectExceptionCode(404);
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage('No record was found');
         $m->loadAny();
     }
 


### PR DESCRIPTION
if you need to typecast a value, use persistence typecast function

for UI render, use ui persistence

also no `404` exception code when record is not found, later, a special exception class can be thrown