### PR TITLE
Use 1:1 model class name as model caption fallback

### DIFF
--- a/src/Model.php
+++ b/src/Model.php
@@ -863,7 +863,7 @@ class Model implements \IteratorAggregate
      */
     public function getModelCaption(): string
     {
-        return $this->caption ?? $this->readableCaption(get_debug_type($this));
+        return $this->caption ?? get_debug_type($this);
     }
 
     /**

--- a/tests/RandomTest.php
+++ b/tests/RandomTest.php
@@ -334,12 +334,12 @@ class RandomTest extends TestCase
 
     public function testModelCaption(): void
     {
-        // caption is not set, so generate it from class name Model
+        // caption is not set, fallback to class name
         $m = new Model($this->db, ['table' => 'user']);
-        static::assertSame('Atk 4 Data Model', $m->getModelCaption());
+        static::assertSame('Atk4\Data\Model', $m->getModelCaption());
 
         $m = new class($this->db, ['table' => 'user']) extends Model {};
-        static::assertSame('Atk 4 Data Model Anonymous', $m->getModelCaption());
+        static::assertSame('Atk4\Data\Model@anonymous', $m->getModelCaption());
 
         // caption is set
         $m->caption = 'test';


### PR DESCRIPTION
I do not want to use model table name as a fallback as it is often prefixed.

When model class name is used as a fallback, I belive it is better to return it 1:1 (incl. `\`) as it is then must more obvious where the data is comming from. Namespace is almost always present, so if `\` is not desired to be displayed to the end user, simply set model caption manually. If you already do, this change has no impact on your code.