### PR TITLE
Optimize Model::getIterator()

### DIFF
--- a/src/Field.php
+++ b/src/Field.php
@@ -364,6 +364,10 @@ class Field implements Expressionable
      */
     public function compare($value, $value2): bool
     {
+        if ($value === $value2) { // optimization only
+            return true;
+        }
+
         // TODO, see https://stackoverflow.com/questions/48382457/mysql-json-column-change-array-order-after-saving
         // at least MySQL sorts the JSON keys if stored natively
         return $this->getValueForCompare($value) === $this->getValueForCompare($value2);

--- a/src/Model.php
+++ b/src/Model.php
@@ -422,7 +422,7 @@ class Model implements \IteratorAggregate
         if ($this->_entityId === null) {
             // set entity ID to the first seen ID
             $this->_entityId = $id;
-        } elseif ($this->_entityId !== $id && !$this->compare($this->idField, $this->_entityId)) {
+        } elseif (!$this->compare($this->idField, $this->_entityId)) {
             $this->unload(); // data for different ID were loaded, make sure to discard them
 
             throw (new Exception('Model instance is an entity, ID cannot be changed to a different one'))
@@ -910,7 +910,13 @@ class Model implements \IteratorAggregate
      */
     public function compare(string $name, $value): bool
     {
-        return $this->getField($name)->compare($this->get($name), $value);
+        $value2 = $this->get($name);
+
+        if ($value === $value2) { // optimization only
+            return true;
+        }
+
+        return $this->getField($name)->compare($value, $value2);
     }
 
     /**

--- a/src/Model.php
+++ b/src/Model.php
@@ -1789,7 +1789,7 @@ class Model implements \IteratorAggregate
                 $res = $thisCloned;
             }
 
-            if ($res->idField) {
+            if ($res->getModel()->idField) {
                 yield $res->getId() => $res;
             } else {
                 yield $res;
@@ -1959,10 +1959,6 @@ class Model implements \IteratorAggregate
     public function &__get(string $name)
     {
         $model = $this->getModel(true);
-
-        if ($name === 'idField') { // optimization only
-            return $model->idField;
-        }
 
         if (isset($model->getHintableProps()[$name])) {
             return $this->__hintable_get($name);

--- a/src/Model.php
+++ b/src/Model.php
@@ -607,7 +607,7 @@ class Model implements \IteratorAggregate
         try {
             return $this->_getFromCollection($name, 'fields');
         } catch (\Atk4\Core\Exception $e) {
-            throw (new Exception('Field is not defined in model', 0, $e))
+            throw (new Exception('Field is not defined'))
                 ->addMoreInfo('model', $this)
                 ->addMoreInfo('field', $name);
         }

--- a/src/Model.php
+++ b/src/Model.php
@@ -269,7 +269,7 @@ class Model implements \IteratorAggregate
 
     public function assertIsModel(self $expectedModelInstance = null): void
     {
-        if ($this->isEntity()) {
+        if ($this->_model !== null) {
             throw new Exception('Expected model, but instance is an entity');
         }
 
@@ -282,7 +282,7 @@ class Model implements \IteratorAggregate
 
     public function assertIsEntity(self $expectedModelInstance = null): void
     {
-        if (!$this->isEntity()) {
+        if ($this->_model === null) {
             throw new Exception('Expected entity, but instance is a model');
         }
 
@@ -296,13 +296,15 @@ class Model implements \IteratorAggregate
      */
     public function getModel(bool $allowOnModel = false): self
     {
-        if ($allowOnModel && !$this->isEntity()) {
-            return $this;
+        if ($this->_model !== null) {
+            return $this->_model;
         }
 
-        $this->assertIsEntity();
+        if (!$allowOnModel) {
+            $this->assertIsEntity();
+        }
 
-        return $this->_model;
+        return $this;
     }
 
     public function __clone()

--- a/src/Model.php
+++ b/src/Model.php
@@ -845,12 +845,12 @@ class Model implements \IteratorAggregate
      *
      * @return $this
      */
-    public function setId($value)
+    public function setId($value, bool $allowNull = true)
     {
         $idFieldName = $this->getModel()->idField;
 
         try {
-            if ($value === null) {
+            if ($value === null && $allowNull) {
                 $this->setNull($idFieldName);
             } else {
                 $this->set($idFieldName, $value);
@@ -1231,7 +1231,7 @@ class Model implements \IteratorAggregate
         $dataRef = $data;
 
         if ($this->idField) {
-            $this->setId($data[$this->idField]);
+            $this->setId($data[$this->idField], false);
         }
 
         $res = $this->hook(self::HOOK_AFTER_LOAD);
@@ -1528,7 +1528,7 @@ class Model implements \IteratorAggregate
 
                 $id = $this->getPersistence()->insert($this->getModel(), $data);
                 if ($this->idField) {
-                    $this->setId($id);
+                    $this->setId($id, false);
                 }
 
                 $this->hook(self::HOOK_AFTER_INSERT);
@@ -1760,7 +1760,7 @@ class Model implements \IteratorAggregate
             $dataRef = &$thisCloned->getDataRef();
             $dataRef = $this->getPersistence()->typecastLoadRow($this, $data);
             if ($this->idField) {
-                $thisCloned->setId($data[$this->idField]);
+                $thisCloned->setId($data[$this->idField], false);
             }
 
             // you can return false in afterLoad hook to prevent to yield this data row, example:

--- a/src/Model.php
+++ b/src/Model.php
@@ -422,7 +422,7 @@ class Model implements \IteratorAggregate
         if ($this->_entityId === null) {
             // set entity ID to the first seen ID
             $this->_entityId = $id;
-        } elseif (!$this->compare($this->idField, $this->_entityId)) {
+        } elseif ($this->_entityId !== $id && !$this->compare($this->idField, $this->_entityId)) {
             $this->unload(); // data for different ID were loaded, make sure to discard them
 
             throw (new Exception('Model instance is an entity, ID cannot be changed to a different one'))
@@ -829,8 +829,10 @@ class Model implements \IteratorAggregate
      */
     public function getId()
     {
+        $idFieldName = $this->getModel()->idField;
+
         try {
-            return $this->get($this->idField);
+            return $this->get($idFieldName);
         } catch (Exception $e) {
             $this->assertHasIdField();
 
@@ -845,11 +847,13 @@ class Model implements \IteratorAggregate
      */
     public function setId($value)
     {
+        $idFieldName = $this->getModel()->idField;
+
         try {
             if ($value === null) {
-                $this->setNull($this->idField);
+                $this->setNull($idFieldName);
             } else {
-                $this->set($this->idField, $value);
+                $this->set($idFieldName, $value);
             }
 
             $this->initEntityIdAndAssertUnchanged();
@@ -1162,7 +1166,7 @@ class Model implements \IteratorAggregate
         $dataRef = &$this->getDataRef();
         $dirtyRef = &$this->getDirtyRef();
         $dataRef = [];
-        if ($this->idField && $this->hasField($this->idField)) {
+        if ($this->idField) {
             $this->setId(null);
         }
         $dirtyRef = [];

--- a/src/Model.php
+++ b/src/Model.php
@@ -833,7 +833,7 @@ class Model implements \IteratorAggregate
 
         try {
             return $this->get($idFieldName);
-        } catch (Exception $e) {
+        } catch (\Throwable $e) {
             $this->assertHasIdField();
 
             throw $e;
@@ -859,7 +859,7 @@ class Model implements \IteratorAggregate
             $this->initEntityIdAndAssertUnchanged();
 
             return $this;
-        } catch (Exception $e) {
+        } catch (\Throwable $e) {
             $this->assertHasIdField();
 
             throw $e;

--- a/src/Model.php
+++ b/src/Model.php
@@ -1216,7 +1216,7 @@ class Model implements \IteratorAggregate
         $dataRef = $data;
 
         if ($this->idField) {
-            $this->setId($this->getId());
+            $this->setId($data[$this->idField]);
         }
 
         $res = $this->hook(self::HOOK_AFTER_LOAD);
@@ -1745,7 +1745,7 @@ class Model implements \IteratorAggregate
             $dataRef = &$thisCloned->getDataRef();
             $dataRef = $this->getPersistence()->typecastLoadRow($this, $data);
             if ($this->idField) {
-                $thisCloned->setId($data[$this->idField] ?? null);
+                $thisCloned->setId($data[$this->idField]);
             }
 
             // you can return false in afterLoad hook to prevent to yield this data row, example:

--- a/src/Model.php
+++ b/src/Model.php
@@ -595,8 +595,6 @@ class Model implements \IteratorAggregate
             return $this->getModel()->hasField($name);
         }
 
-        $this->assertIsModel();
-
         return $this->_hasInCollection($name, 'fields');
     }
 
@@ -605,8 +603,6 @@ class Model implements \IteratorAggregate
         if ($this->isEntity()) {
             return $this->getModel()->getField($name);
         }
-
-        $this->assertIsModel();
 
         try {
             return $this->_getFromCollection($name, 'fields');
@@ -674,8 +670,6 @@ class Model implements \IteratorAggregate
         if ($this->isEntity()) {
             return $this->getModel()->getFields($filter);
         }
-
-        $this->assertIsModel();
 
         if ($filter === null) {
             return $this->fields;

--- a/src/Model/UserActionsTrait.php
+++ b/src/Model/UserActionsTrait.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Atk4\Data\Model;
 
 use Atk4\Core\Factory;
+use Atk4\Data\Exception;
 use Atk4\Data\Model;
 
 trait UserActionsTrait
@@ -85,7 +86,13 @@ trait UserActionsTrait
             $this->addUserActionFromModel($name, $this->getModel()->getUserAction($name));
         }
 
-        return $this->_getFromCollection($name, 'userActions');
+        try {
+            return $this->_getFromCollection($name, 'userActions');
+        } catch (\Atk4\Core\Exception $e) {
+            throw (new Exception('User action is not defined'))
+                ->addMoreInfo('model', $this)
+                ->addMoreInfo('userAction', $name);
+        }
     }
 
     /**

--- a/src/Model/UserActionsTrait.php
+++ b/src/Model/UserActionsTrait.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Atk4\Data\Model;
 
+use Atk4\Core\Exception as CoreException;
 use Atk4\Core\Factory;
 use Atk4\Data\Exception;
 use Atk4\Data\Model;
@@ -88,7 +89,7 @@ trait UserActionsTrait
 
         try {
             return $this->_getFromCollection($name, 'userActions');
-        } catch (\Atk4\Core\Exception $e) {
+        } catch (CoreException $e) {
             throw (new Exception('User action is not defined'))
                 ->addMoreInfo('model', $this)
                 ->addMoreInfo('userAction', $name);


### PR DESCRIPTION
Time spent in `Model::getIterator()` is reduced by ~55%.

Together with https://github.com/atk4/core/pull/371 iteration over large dataset it about 5x faster, in other words ~25k entities can be iterated in 1 second.