### PR TITLE
Allow Model::isset/getPersistence() calls on model only

### DIFF
--- a/docs/advanced.rst
+++ b/docs/advanced.rst
@@ -81,7 +81,7 @@ hook. Place the following inside Transaction::init()::
     $this->onHookShort(Model::HOOK_AFTER_LOAD, function () {
         if (get_class($this) != $this->getClassName()) {
             $cl = $this->getClassName();
-            $m = new $cl($this->getPersistence());
+            $m = new $cl($this->getModel()->getPersistence());
             $m = $m->load($this->getId());
 
             $this->breakHook($m);

--- a/docs/sql.rst
+++ b/docs/sql.rst
@@ -169,7 +169,7 @@ This method allows you to execute code within a 'START TRANSACTION / COMMIT' blo
     {
         public function applyPayment(Payment $p)
         {
-            $this->getPersistence()->atomic(function () use ($p) {
+            $this->getModel()->getPersistence()->atomic(function () use ($p) {
                 $this->set('paid', true);
                 $this->save();
 

--- a/src/Model.php
+++ b/src/Model.php
@@ -1800,8 +1800,6 @@ class Model implements \IteratorAggregate
      */
     public function getRawIterator(): \Traversable
     {
-        $this->assertIsModel();
-
         return $this->getPersistence()->prepareIterator($this);
     }
 

--- a/src/Model.php
+++ b/src/Model.php
@@ -271,20 +271,20 @@ class Model implements \IteratorAggregate
     public function assertIsModel(self $expectedModelInstance = null): void
     {
         if ($this->_model !== null) {
-            throw new Exception('Expected model, but instance is an entity');
+            throw new \TypeError('Expected model, but instance is an entity');
         }
 
         if ($expectedModelInstance !== null && $expectedModelInstance !== $this) {
             $expectedModelInstance->assertIsModel();
 
-            throw new Exception('Model instance does not match');
+            throw new \TypeError('Model instance does not match');
         }
     }
 
     public function assertIsEntity(self $expectedModelInstance = null): void
     {
         if ($this->_model === null) {
-            throw new Exception('Expected entity, but instance is a model');
+            throw new \TypeError('Expected entity, but instance is a model');
         }
 
         if ($expectedModelInstance !== null) {
@@ -1493,7 +1493,7 @@ class Model implements \IteratorAggregate
     public function save(array $data = [])
     {
         if ($this->readOnly) {
-            throw new Exception('Model is read-only and cannot be saved');
+            throw new Exception('Model is read-only');
         }
 
         $this->getModel()->assertHasPersistence();
@@ -1824,7 +1824,7 @@ class Model implements \IteratorAggregate
         }
 
         if ($this->readOnly) {
-            throw new Exception('Model is read-only and cannot be deleted');
+            throw new Exception('Model is read-only');
         }
 
         $this->getModel()->assertHasPersistence();

--- a/src/Model.php
+++ b/src/Model.php
@@ -420,7 +420,7 @@ class Model implements \IteratorAggregate
         if ($this->_entityId === null) {
             // set entity ID to the first seen ID
             $this->_entityId = $id;
-        } elseif (!$this->compare($this->idField, $this->_entityId)) {
+        } elseif ($this->_entityId !== $id && !$this->compare($this->idField, $this->_entityId)) {
             $this->unload(); // data for different ID were loaded, make sure to discard them
 
             throw (new Exception('Model instance is an entity, ID cannot be changed to a different one'))

--- a/src/Model.php
+++ b/src/Model.php
@@ -336,7 +336,7 @@ class Model implements \IteratorAggregate
                 }
             }
 
-            foreach ([
+            $modelOnlyProperties = array_diff_key($modelOnlyProperties, array_flip([
                 '_model',
                 '_entityId',
                 'data',
@@ -350,9 +350,7 @@ class Model implements \IteratorAggregate
                 'userActions', // should be removed once user actions are non-entity
 
                 'containedInEntity',
-            ] as $name) {
-                unset($modelOnlyProperties[$name]);
-            }
+            ]));
 
             self::$_modelOnlyProperties = $modelOnlyProperties;
         }

--- a/src/Persistence/Array_.php
+++ b/src/Persistence/Array_.php
@@ -102,6 +102,8 @@ class Array_ extends Persistence
      */
     public function getRawDataByTable(Model $model, string $table): array
     {
+        $model->assertIsModel();
+
         if (!is_object($model->table)) {
             $this->seedData($model);
         }

--- a/src/Persistence/Sql.php
+++ b/src/Persistence/Sql.php
@@ -134,18 +134,12 @@ class Sql extends Persistence
     protected function initPersistence(Model $model): void
     {
         $model->addMethod('expr', static function (Model $m, ...$args) {
-            $m->assertIsModel();
-
             return $m->getPersistence()->expr($m, ...$args);
         });
         $model->addMethod('dsql', static function (Model $m, ...$args) {
-            $m->assertIsModel();
-
             return $m->getPersistence()->dsql($m, ...$args); // @phpstan-ignore-line
         });
         $model->addMethod('exprNow', static function (Model $m, ...$args) {
-            $m->assertIsModel();
-
             return $m->getPersistence()->exprNow($m, ...$args);
         });
     }

--- a/src/Reference.php
+++ b/src/Reference.php
@@ -279,8 +279,8 @@ class Reference
         // this is useful for ContainsOne/Many implementation in case when you have
         // SQL_Model->containsOne()->hasOne() structure to get back to SQL persistence
         // from Array persistence used in ContainsOne model
-        if ($ourModel->containedInEntity && $ourModel->containedInEntity->issetPersistence()) {
-            return $ourModel->containedInEntity->getPersistence();
+        if ($ourModel->containedInEntity && $ourModel->containedInEntity->getModel()->issetPersistence()) {
+            return $ourModel->containedInEntity->getModel()->getPersistence();
         }
 
         return $ourModel->issetPersistence() ? $ourModel->getPersistence() : false;

--- a/src/Reference/ContainsMany.php
+++ b/src/Reference/ContainsMany.php
@@ -28,13 +28,13 @@ class ContainsMany extends ContainsBase
         ]));
 
         foreach ([Model::HOOK_AFTER_SAVE, Model::HOOK_AFTER_DELETE] as $spot) {
-            $this->onHookToTheirModel($theirModel, $spot, function (Model $theirModel) {
-                $ourModel = $this->getOurModel($theirModel->containedInEntity);
+            $this->onHookToTheirModel($theirModel, $spot, function (Model $theirEntity) {
+                $ourModel = $this->getOurModel($theirEntity->containedInEntity);
                 $ourModel->assertIsEntity();
 
                 /** @var Persistence\Array_ */
-                $persistence = $theirModel->getPersistence();
-                $rows = $persistence->getRawDataByTable($theirModel, $this->tableAlias); // @phpstan-ignore-line
+                $persistence = $theirEntity->getModel()->getPersistence();
+                $rows = $persistence->getRawDataByTable($theirEntity->getModel(), $this->tableAlias); // @phpstan-ignore-line
                 $ourModel->save([$this->getOurFieldName() => $rows !== [] ? $rows : null]);
             });
         }

--- a/src/Reference/ContainsOne.php
+++ b/src/Reference/ContainsOne.php
@@ -28,13 +28,13 @@ class ContainsOne extends ContainsBase
         ]));
 
         foreach ([Model::HOOK_AFTER_SAVE, Model::HOOK_AFTER_DELETE] as $spot) {
-            $this->onHookToTheirModel($theirModel, $spot, function (Model $theirModel) {
-                $ourModel = $this->getOurModel($theirModel->containedInEntity);
+            $this->onHookToTheirModel($theirModel, $spot, function (Model $theirEntity) {
+                $ourModel = $this->getOurModel($theirEntity->containedInEntity);
                 $ourModel->assertIsEntity();
 
                 /** @var Persistence\Array_ */
-                $persistence = $theirModel->getPersistence();
-                $row = $persistence->getRawDataByTable($theirModel, $this->tableAlias); // @phpstan-ignore-line
+                $persistence = $theirEntity->getModel()->getPersistence();
+                $row = $persistence->getRawDataByTable($theirEntity->getModel(), $this->tableAlias); // @phpstan-ignore-line
                 $row = $row ? array_shift($row) : null; // get first and only one record from array persistence
                 $ourModel->save([$this->getOurFieldName() => $row]);
             });

--- a/src/Util/DeepCopy.php
+++ b/src/Util/DeepCopy.php
@@ -86,7 +86,7 @@ class DeepCopy
         $this->destination = $destination;
 
         if (!$this->destination->issetPersistence()) {
-            $this->destination->setPersistence($this->source->getPersistence());
+            $this->destination->setPersistence($this->source->getModel()->getPersistence());
         }
 
         return $this;

--- a/tests/ConditionSqlTest.php
+++ b/tests/ConditionSqlTest.php
@@ -49,7 +49,8 @@ class ConditionSqlTest extends TestCase
         $scope = $m->scope();
         static::assertSame($scope, $m->createEntity()->getModel()->scope());
 
-        $this->expectException(Exception::class);
+        $this->expectException(\TypeError::class);
+        $this->expectExceptionMessage('Expected model, but instance is an entity');
         $m->createEntity()->scope();
     }
 

--- a/tests/ConditionSqlTest.php
+++ b/tests/ConditionSqlTest.php
@@ -74,7 +74,7 @@ class ConditionSqlTest extends TestCase
         }, null, Model::class)();
 
         $this->expectException(Exception::class);
-        $this->expectExceptionMessageMatches('~entity.+different~');
+        $this->expectExceptionMessage('Model instance is an entity, ID cannot be changed to a different one');
         $m->reload();
     }
 

--- a/tests/IteratorTest.php
+++ b/tests/IteratorTest.php
@@ -73,7 +73,8 @@ class IteratorTest extends TestCase
     {
         $m = new Model();
 
-        $this->expectException(Exception::class);
+        $this->expectException(\TypeError::class);
+        $this->expectExceptionMessage('Expected entity, but instance is a model');
         $m->save();
     }
 

--- a/tests/Model/Smbo/Account.php
+++ b/tests/Model/Smbo/Account.php
@@ -25,7 +25,7 @@ class Account extends Model
      */
     public function transfer(self $a, float $amount): Transfer
     {
-        $t = new Transfer($this->getPersistence(), ['detached' => true]);
+        $t = new Transfer($this->getModel()->getPersistence(), ['detached' => true]);
         $t = $t->createEntity();
         $t->set('account_id', $this->getId());
 

--- a/tests/RandomTest.php
+++ b/tests/RandomTest.php
@@ -385,7 +385,8 @@ class RandomTest extends TestCase
         $mm = $m->load(2);
         static::assertSame('2', $mm->getTitle()); // loaded returns id value
 
-        $this->expectException(Exception::class);
+        $this->expectException(\TypeError::class);
+        $this->expectExceptionMessage('Expected model, but instance is an entity');
         $mm->getTitles();
     }
 

--- a/tests/SubTypesTest.php
+++ b/tests/SubTypesTest.php
@@ -91,7 +91,7 @@ class StGenericTransaction extends Model
         $this->onHookShort(Model::HOOK_AFTER_LOAD, function () {
             if (static::class !== $this->getClassName()) {
                 $cl = $this->getClassName();
-                $cl = new $cl($this->getPersistence());
+                $cl = new $cl($this->getModel()->getPersistence());
                 $cl = $cl->load($this->getId());
 
                 $this->breakHook($cl);


### PR DESCRIPTION
Currently Model is tightly coupled with one persistence.

persistence getters on entity are not wanted and `$this->_persistence` in `$entity->getPersistence()` was fetched using `__get`