### PR TITLE
Assert if reference type is the same by default

### DIFF
--- a/docs/joins.rst
+++ b/docs/joins.rst
@@ -65,7 +65,7 @@ For example it can be used to pull country information based on user.country_id
 but you wouldn't want that adding a new user would create a new country::
 
     $user->addField('username');
-    $user->addField('country_id');
+    $user->addField('country_id', ['type' => 'integer']);
     $jCountry = $user->join('country', ['weak' => true, 'prefix' => 'country_']);
     $jCountry->addField('code');
     $jCountry->addField('name');

--- a/docs/persistence.rst
+++ b/docs/persistence.rst
@@ -628,7 +628,7 @@ some other database (for archive purposes) you can implement it like this::
         $arc = $this->withPersistence($m->getApp()->archive_db);
 
         // add some audit fields
-        $arc->addField('original_id')->set($this->getId());
+        $arc->addField('original_id', ['type' => 'integer'])->set($this->getId());
         $arc->addField('saved_by')->set($this->getApp()->user);
 
         $arc->saveAndUnload();

--- a/docs/references.rst
+++ b/docs/references.rst
@@ -338,7 +338,7 @@ process and the loadAny() will look like this:
 
 By passing options to hasOne() you can also differentiate field name::
 
-    $o->addField('user_id');
+    $o->addField('user_id', ['type' => 'integer']);
     $o->hasOne('User', ['model' => $u, 'ourField' => 'user_id']);
 
     $o->load(1)->ref('User')['name'];

--- a/src/Persistence.php
+++ b/src/Persistence.php
@@ -439,7 +439,7 @@ abstract class Persistence
      * This is the actual field typecasting, which you can override in your
      * persistence to implement necessary typecasting.
      *
-     * @param scalar|null $value
+     * @param scalar $value
      *
      * @return mixed
      */

--- a/src/Persistence/Sql/Join.php
+++ b/src/Persistence/Sql/Join.php
@@ -37,7 +37,7 @@ class Join extends Model\Join
         if (!$this->reverse && !$this->getOwner()->hasField($this->masterField)) {
             $owner = $this->hasJoin() ? $this->getJoin() : $this->getOwner();
 
-            $field = $owner->addField($this->masterField, ['system' => true, 'readOnly' => true]);
+            $field = $owner->addField($this->masterField, ['type' => 'integer', 'system' => true, 'readOnly' => true]);
 
             $this->masterField = $field->shortName;
         }

--- a/src/Reference.php
+++ b/src/Reference.php
@@ -69,6 +69,12 @@ class Reference
     protected ?string $theirField = null;
 
     /**
+     * Database our/their field types must always match, but DBAL types can be different in theory,
+     * set this to false when the DBAL types are intentionally different.
+     */
+    public bool $checkTheirType = true;
+
+    /**
      * Caption of the referenced model. Can be used in UI components, for example.
      * Should be in plain English and ready for proper localization.
      *
@@ -226,6 +232,16 @@ class Reference
         }
 
         $this->addToPersistence($theirModel, $defaults);
+
+        if ($this->checkTheirType) {
+            $ourField = $this->getOurField();
+            $theirField = $theirModel->getField($this->getTheirFieldName($theirModel));
+            if ($theirField->type !== $ourField->type) {
+                throw (new Exception('Reference type mismatch'))
+                    ->addMoreInfo('ourField', $ourField)
+                    ->addMoreInfo('theirField', $theirField);
+            }
+        }
 
         return $theirModel;
     }

--- a/src/Reference/ContainsBase.php
+++ b/src/Reference/ContainsBase.php
@@ -13,6 +13,8 @@ abstract class ContainsBase extends Reference
 {
     use ContainsSeedHackTrait;
 
+    public bool $checkTheirType = false;
+
     /** Field type. */
     public string $type = 'json';
 

--- a/tests/JoinSqlTest.php
+++ b/tests/JoinSqlTest.php
@@ -67,7 +67,7 @@ class JoinSqlTest extends TestCase
             ],
         ]);
 
-        $user->addField('contact_id');
+        $user->addField('contact_id', ['type' => 'integer']);
         $user->addField('name');
         $j = $user->join('contact');
         $this->createMigrator()->createForeignKey($j);
@@ -226,12 +226,12 @@ class JoinSqlTest extends TestCase
 
         $user2 = $user->load(1);
         static::assertSame([
-            'id' => 1, 'name' => 'John', 'contact_id' => '1', 'contact_phone' => '+123',
+            'id' => 1, 'name' => 'John', 'contact_id' => 1, 'contact_phone' => '+123',
         ], $user2->get());
 
         $user2 = $user->load(3);
         static::assertSame([
-            'id' => 3, 'name' => 'Joe', 'contact_id' => '2', 'contact_phone' => '+321',
+            'id' => 3, 'name' => 'Joe', 'contact_id' => 2, 'contact_phone' => '+321',
         ], $user2->get());
 
         $user2 = $user2->unload();
@@ -257,7 +257,7 @@ class JoinSqlTest extends TestCase
         ]);
 
         $user = new Model($this->db, ['table' => 'user']);
-        $user->addField('contact_id');
+        $user->addField('contact_id', ['type' => 'integer']);
         $user->addField('name');
         $j = $user->join('contact');
         $this->createMigrator()->createForeignKey($j);
@@ -351,7 +351,7 @@ class JoinSqlTest extends TestCase
         ]);
 
         $user = new Model($this->db, ['table' => 'user']);
-        $user->addField('contact_id');
+        $user->addField('contact_id', ['type' => 'integer']);
         $user->addField('name');
         $j = $user->join('contact');
         // TODO persist order is broken $this->createMigrator()->createForeignKey($j);
@@ -432,7 +432,7 @@ class JoinSqlTest extends TestCase
         ]);
 
         $user = new Model($this->db, ['table' => 'user']);
-        $user->addField('contact_id');
+        $user->addField('contact_id', ['type' => 'integer']);
         $user->addField('name');
         $jContact = $user->join('contact');
         // TODO persist order is broken $this->createMigrator()->createForeignKey($jContact);
@@ -498,7 +498,7 @@ class JoinSqlTest extends TestCase
         ]);
 
         $user = new Model($this->db, ['table' => 'user']);
-        $user->addField('contact_id');
+        $user->addField('contact_id', ['type' => 'integer']);
         $user->addField('name');
         $j = $user->join('contact');
         // TODO persist order is broken $this->createMigrator()->createForeignKey($j);
@@ -556,13 +556,13 @@ class JoinSqlTest extends TestCase
         // main user model joined to contact table
         $user = new Model($this->db, ['table' => 'user']);
         $user->addField('name');
-        $user->addField('contact_id');
+        $user->addField('contact_id', ['type' => 'integer']);
         $j = $user->join('contact');
         $this->createMigrator()->createForeignKey($j);
 
         $user2 = $user->load(1);
         static::assertSame([
-            'id' => 1, 'name' => 'John', 'contact_id' => '10',
+            'id' => 1, 'name' => 'John', 'contact_id' => 10,
         ], $user2->get());
 
         // hasOne phone model
@@ -574,35 +574,35 @@ class JoinSqlTest extends TestCase
 
         $user2 = $user->load(1);
         static::assertSame([
-            'id' => 1, 'name' => 'John', 'contact_id' => '10', 'phone_id' => 20, 'number' => '+123',
+            'id' => 1, 'name' => 'John', 'contact_id' => 10, 'phone_id' => 20, 'number' => '+123',
         ], $user2->get());
 
         // hasMany token model (uses default ourField, theirField)
         $token = new Model($this->db, ['table' => 'token']);
-        $token->addField('user_id');
+        $token->addField('user_id', ['type' => 'integer']);
         $token->addField('token');
         $refMany = $j->hasMany('Token', ['model' => $token]); // hasMany on JOIN (use default ourField, theirField)
         $this->createMigrator()->createForeignKey($refMany);
 
         $user2 = $user->load(1);
         static::assertSameExportUnordered([
-            ['id' => 30, 'user_id' => '1', 'token' => 'ABC'],
-            ['id' => 31, 'user_id' => '1', 'token' => 'DEF'],
+            ['id' => 30, 'user_id' => 1, 'token' => 'ABC'],
+            ['id' => 31, 'user_id' => 1, 'token' => 'DEF'],
         ], $user2->ref('Token')->export());
 
         $this->markTestIncompleteWhenCreateUniqueIndexIsNotSupportedByPlatform();
 
         // hasMany email model (uses custom ourField, theirField)
         $email = new Model($this->db, ['table' => 'email']);
-        $email->addField('contact_id');
+        $email->addField('contact_id', ['type' => 'integer']);
         $email->addField('address');
         $refMany = $j->hasMany('Email', ['model' => $email, 'ourField' => 'contact_id', 'theirField' => 'contact_id']); // hasMany on JOIN (use custom ourField, theirField)
         $this->createMigrator()->createForeignKey($refMany);
 
         $user2 = $user->load(1);
         static::assertSameExportUnordered([
-            ['id' => 40, 'contact_id' => '10', 'address' => 'john@foo.net'],
-            ['id' => 41, 'contact_id' => '10', 'address' => 'johnny@foo.net'],
+            ['id' => 40, 'contact_id' => 10, 'address' => 'john@foo.net'],
+            ['id' => 41, 'contact_id' => 10, 'address' => 'johnny@foo.net'],
         ], $user2->ref('Email')->export());
     }
 
@@ -704,7 +704,7 @@ class JoinSqlTest extends TestCase
         ]);
 
         $user = new Model($this->db, ['table' => 'user']);
-        $user->addField('contact_id', ['actual' => $contactForeignIdFieldName]);
+        $user->addField('contact_id', ['type' => 'integer', 'actual' => $contactForeignIdFieldName]);
         $user->addField('name', ['actual' => 'first_name']);
         // normal join
         $j = $user->join('contact', ['prefix' => 'j1_']);

--- a/tests/Model/Smbo/Transfer.php
+++ b/tests/Model/Smbo/Transfer.php
@@ -22,7 +22,7 @@ class Transfer extends Payment
             $this->addCondition('transfer_document_id', '!=', null);
         }
 
-        $this->addField('destination_account_id', ['neverPersist' => true]);
+        $this->addField('destination_account_id', ['type' => 'integer', 'neverPersist' => true]);
 
         $this->onHookShort(self::HOOK_BEFORE_SAVE, function () {
             // only for new records and when destination_account_id is set

--- a/tests/ReferenceSqlTest.php
+++ b/tests/ReferenceSqlTest.php
@@ -350,7 +350,7 @@ class ReferenceSqlTest extends TestCase
             $file->addField('name');
             $file->hasOne('parentDirectory', [
                 'model' => $file,
-                'type' => $integerWrappedTypeName, // TODO should be implied from their model
+                'type' => $integerWrappedTypeName,
                 'ourField' => 'parentDirectoryId',
             ]);
             $file->hasMany('childFiles', [

--- a/tests/ReferenceSqlTest.php
+++ b/tests/ReferenceSqlTest.php
@@ -42,7 +42,7 @@ class ReferenceSqlTest extends TestCase
 
         $o = new Model($this->db, ['table' => 'order']);
         $o->addField('amount', ['type' => 'integer']);
-        $o->addField('user_id');
+        $o->addField('user_id', ['type' => 'integer']);
 
         $u->hasMany('Orders', ['model' => $o]);
 
@@ -80,7 +80,7 @@ class ReferenceSqlTest extends TestCase
 
         $o = new Model($this->db, ['table' => 'order']);
         $o->addField('amount');
-        $o->addField('user_id');
+        $o->addField('user_id', ['type' => 'integer']);
 
         $u->hasMany('Orders', ['model' => $o]);
 
@@ -268,7 +268,7 @@ class ReferenceSqlTest extends TestCase
         $i->addField('ref_no');
 
         $l = new Model($this->db, ['table' => 'invoice_line']);
-        $l->addField('invoice_id');
+        $l->addField('invoice_id', ['type' => 'integer']);
         $l->addField('total_net');
         $l->addField('total_vat');
         $l->addField('total_gross');
@@ -433,7 +433,7 @@ class ReferenceSqlTest extends TestCase
         $i->addField('ref_no');
 
         $l = new Model($this->db, ['table' => 'invoice_line']);
-        $l->addField('invoice_id');
+        $l->addField('invoice_id', ['type' => 'integer']);
         $l->addField('total_net', ['type' => 'atk4_money']);
         $l->addField('total_vat', ['type' => 'atk4_money']);
         $l->addField('total_gross', ['type' => 'atk4_money']);
@@ -511,7 +511,7 @@ class ReferenceSqlTest extends TestCase
         $l->addField('name');
 
         $i = new Model($this->db, ['table' => 'item']);
-        $i->addField('list_id');
+        $i->addField('list_id', ['type' => 'integer']);
         $i->addField('name');
         $i->addField('code');
 
@@ -567,7 +567,7 @@ class ReferenceSqlTest extends TestCase
 
         $user = new Model($this->db, ['table' => 'user']);
         $user->addField('name');
-        $user->addField('company_id');
+        $user->addField('company_id', ['type' => 'integer']);
 
         $company = new Model($this->db, ['table' => 'company']);
         $company->addField('name');
@@ -575,7 +575,7 @@ class ReferenceSqlTest extends TestCase
         $user->hasOne('Company', ['model' => $company, 'ourField' => 'company_id', 'theirField' => 'id']);
 
         $order = new Model($this->db, ['table' => 'order']);
-        $order->addField('company_id');
+        $order->addField('company_id', ['type' => 'integer']);
         $order->addField('description');
         $order->addField('amount', ['default' => 20, 'type' => 'float']);
 
@@ -590,14 +590,14 @@ class ReferenceSqlTest extends TestCase
         $userEntity = $user->load(1);
 
         static::assertSameExportUnordered([
-            ['id' => 1, 'company_id' => '1', 'description' => 'Vinny Company Order 1', 'amount' => 50.0],
-            ['id' => 3, 'company_id' => '1', 'description' => 'Vinny Company Order 2', 'amount' => 15.0],
+            ['id' => 1, 'company_id' => 1, 'description' => 'Vinny Company Order 1', 'amount' => 50.0],
+            ['id' => 3, 'company_id' => 1, 'description' => 'Vinny Company Order 2', 'amount' => 15.0],
         ], $userEntity->ref('Company')->ref('Orders')->export());
 
         static::assertSameExportUnordered([
-            ['id' => 1, 'company_id' => '1', 'description' => 'Vinny Company Order 1', 'amount' => 50.0],
-            ['id' => 2, 'company_id' => '2', 'description' => 'Zoe Company Order', 'amount' => 10.0],
-            ['id' => 3, 'company_id' => '1', 'description' => 'Vinny Company Order 2', 'amount' => 15.0],
+            ['id' => 1, 'company_id' => 1, 'description' => 'Vinny Company Order 1', 'amount' => 50.0],
+            ['id' => 2, 'company_id' => 2, 'description' => 'Zoe Company Order', 'amount' => 10.0],
+            ['id' => 3, 'company_id' => 1, 'description' => 'Vinny Company Order 2', 'amount' => 15.0],
         ], $userEntity->getModel()->ref('Company')->ref('Orders')->export());
     }
 

--- a/tests/ReferenceTest.php
+++ b/tests/ReferenceTest.php
@@ -121,4 +121,41 @@ class ReferenceTest extends TestCase
         $user->hasMany('Orders', ['model' => $order, 'caption' => 'My Orders']);
         static::assertSame($user->getReference('Orders')->getTheirFieldName(), 'user_id');
     }
+
+    public function testRefTypeMismatchOneException(): void
+    {
+        $user = new Model($this->db, ['table' => 'user']);
+        $order = new Model($this->db, ['table' => 'order']);
+        $order->addField('placed_by_user_id');
+
+        $order->hasOne('placed_by', ['model' => $user, 'ourField' => 'placed_by_user_id']);
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage('Reference type mismatch');
+        $order->ref('placed_by');
+    }
+
+    public function testRefTypeMismatchManyException(): void
+    {
+        $user = new Model($this->db, ['table' => 'user']);
+        $order = new Model($this->db, ['table' => 'order']);
+        $order->addField('placed_by_user_id');
+
+        $user->hasMany('orders', ['model' => $order, 'theirField' => 'placed_by_user_id']);
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage('Reference type mismatch');
+        $user->ref('orders');
+    }
+
+    public function testRefTypeMismatchWithDisabledCheck(): void
+    {
+        $user = new Model($this->db, ['table' => 'user']);
+        $order = new Model($this->db, ['table' => 'order']);
+        $order->addField('placed_by_user_id');
+
+        $order->hasOne('placed_by', ['model' => $user, 'ourField' => 'placed_by_user_id', 'checkTheirType' => false]);
+
+        static::assertSame('user', $order->ref('placed_by')->table);
+    }
 }

--- a/tests/ReferenceTest.php
+++ b/tests/ReferenceTest.php
@@ -19,7 +19,7 @@ class ReferenceTest extends TestCase
         $user->setId(1);
 
         $order = new Model();
-        $order->addField('id');
+        $order->addField('id', ['type' => 'integer']);
         $order->addField('amount', ['default' => 20]);
         $order->addField('user_id', ['type' => 'integer']);
 
@@ -32,7 +32,7 @@ class ReferenceTest extends TestCase
         $r2 = $user->getModel()->hasMany('BigOrders', ['model' => function () {
             $m = new Model();
             $m->addField('amount', ['default' => 100]);
-            $m->addField('user_id');
+            $m->addField('user_id', ['type' => 'integer']);
 
             return $m;
         }]);
@@ -52,15 +52,15 @@ class ReferenceTest extends TestCase
     public function testModelCaption(): void
     {
         $user = new Model(null, ['table' => 'user']);
-        $user->addField('id');
+        $user->addField('id', ['type' => 'integer']);
         $user->addField('name');
         $user = $user->createEntity();
         $user->setId(1);
 
         $order = new Model();
-        $order->addField('id');
+        $order->addField('id', ['type' => 'integer']);
         $order->addField('amount', ['default' => 20]);
-        $order->addField('user_id');
+        $order->addField('user_id', ['type' => 'integer']);
 
         $user->getModel()->hasMany('Orders', ['model' => $order, 'caption' => 'My Orders']);
 
@@ -83,7 +83,7 @@ class ReferenceTest extends TestCase
     {
         $user = new Model(null, ['table' => 'user']);
         $order = new Model();
-        $order->addField('user_id');
+        $order->addField('user_id', ['type' => 'integer']);
 
         $user->hasMany('Orders', ['model' => $order]);
 
@@ -116,7 +116,7 @@ class ReferenceTest extends TestCase
     {
         $user = new Model($this->db, ['table' => 'db1.user']);
         $order = new Model($this->db, ['table' => 'db2.orders']);
-        $order->addField('user_id');
+        $order->addField('user_id', ['type' => 'integer']);
 
         $user->hasMany('Orders', ['model' => $order, 'caption' => 'My Orders']);
         static::assertSame($user->getReference('Orders')->getTheirFieldName(), 'user_id');

--- a/tests/TypecastingTest.php
+++ b/tests/TypecastingTest.php
@@ -77,7 +77,7 @@ class TypecastingTest extends TestCase
         $dbData = [
             'types' => [
                 1 => [
-                    'id' => '1',
+                    'id' => 1,
                     'string' => 'foo',
                     'date' => '2013-02-20',
                     'datetime' => '2013-02-20 20:00:12.000000',
@@ -89,7 +89,7 @@ class TypecastingTest extends TestCase
                     'json' => '[1,2,3]',
                 ],
                 [
-                    'id' => '2',
+                    'id' => 2,
                     'string' => 'foo',
                     'date' => '2013-02-20',
                     'datetime' => '2013-02-20 20:00:12.000000',


### PR DESCRIPTION
marking as BC-break as `Reference::checkTheirType` needs to be set manually to `false` if the DBAL type mismatch is intentional

in 99% cases, the exception is right and you want to fix your code