### PR TITLE
No implicit IN operator for condition with array value

### DIFF
--- a/docs/conditions.md
+++ b/docs/conditions.md
@@ -122,7 +122,7 @@ If you are building multiple conditions against the same field, you can use this
 format:
 
 ```
-$m->addCondition('name', ['John', 'Joe']);
+$m->addCondition('name', 'in', ['John', 'Joe']);
 ```
 
 For all other cases you can implement them with {php:meth}`Model::expr`:
@@ -383,7 +383,7 @@ Creates condition object based on provided arguments. It acts similar to Model::
 
 $key can be Model field name, Field object or Expression object
 $operator can be one of the supported operators >, <, >=, <=, !=, in, not in, like, not like, regexp, not regexp
-$value can be Field object, Expression object, array (interpreted as 'any of the values') or other scalar value
+$value can be Field object, Expression object or any scalar value
 
 If $value is omitted as argument then $operator is considered as $value and '=' is used as operator
 

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -93,7 +93,7 @@ parameters:
             path: 'src/Persistence/Sql/Query.php'
             identifier: variable.undefined
             message: '~^(Undefined variable: \$(operator|value)|Variable \$value might not be defined\.)$~'
-            count: 3
+            count: 2
 
         # TODO these rules are generated, this ignores should be fixed in the code
         # for src/Schema/TestCase.php

--- a/src/Model/Scope/Condition.php
+++ b/src/Model/Scope/Condition.php
@@ -135,12 +135,7 @@ class Condition extends AbstractScope
                 }
             }
 
-            if (!in_array($this->operator, [
-                self::OPERATOR_EQUALS,
-                self::OPERATOR_IN,
-                self::OPERATOR_DOESNOT_EQUAL,
-                self::OPERATOR_NOT_IN,
-            ], true)) {
+            if (!in_array($this->operator, [self::OPERATOR_IN, self::OPERATOR_NOT_IN], true)) {
                 throw (new Exception('Operator is not supported for array condition value'))
                     ->addMoreInfo('operator', $operator)
                     ->addMoreInfo('value', $value);

--- a/src/Persistence/Array_/Action.php
+++ b/src/Persistence/Array_/Action.php
@@ -204,12 +204,6 @@ class Action
                 ->addMoreInfo('class', get_class($v2));
         }
 
-        if (is_array($this->tryConvertTableToValue($v2, true)) && in_array($operator, ['=', '!='], true)) {
-            $operator = $operator === '='
-                ? 'IN'
-                : 'NOT IN';
-        }
-
         $v2Array = in_array(strtoupper($operator), ['IN', 'NOT IN'], true);
 
         $v1 = $this->tryConvertTableToValue($v1, false);

--- a/src/Persistence/Sql/Query.php
+++ b/src/Persistence/Sql/Query.php
@@ -596,18 +596,10 @@ abstract class Query extends Expression
         }
 
         if ($operator === null) {
-            if ($value instanceof Expressionable) {
-                $value = $value->getDsqlExpression($this);
-            }
-
-            if ($value instanceof self && $value->mode === 'select') {
-                $operator = 'in';
-            } else {
-                $operator = '=';
-            }
-        } else {
-            $operator = strtolower($operator);
+            $operator = '=';
         }
+
+        $operator = strtolower($operator);
 
         if (!in_array($operator, $this->supportedOperators, true)) {
             throw (new Exception('Unsupported operator'))

--- a/src/Persistence/Sql/Query.php
+++ b/src/Persistence/Sql/Query.php
@@ -600,9 +600,7 @@ abstract class Query extends Expression
                 $value = $value->getDsqlExpression($this);
             }
 
-            if (is_array($value)) {
-                $operator = 'in';
-            } elseif ($value instanceof self && $value->mode === 'select') {
+            if ($value instanceof self && $value->mode === 'select') {
                 $operator = 'in';
             } else {
                 $operator = '=';

--- a/src/Reference/HasMany.php
+++ b/src/Reference/HasMany.php
@@ -87,6 +87,9 @@ class HasMany extends Reference
 
         return $this->createTheirModel($defaults)->addCondition(
             $this->getTheirFieldName(),
+            $ourModelOrEntity->isEntity()
+                ? '='
+                : 'in',
             $this->getOurFieldValueForRefCondition($ourModelOrEntity)
         );
     }

--- a/src/Reference/HasOneSql.php
+++ b/src/Reference/HasOneSql.php
@@ -151,7 +151,7 @@ class HasOneSql extends HasOne
             $ourFieldExpression = $ourModelOrEntity->action('field', [$this->getOurField()]);
 
             $theirModel->getModel(true)
-                ->addCondition($this->getTheirFieldName($theirModel), $ourFieldExpression);
+                ->addCondition($this->getTheirFieldName($theirModel), 'in', $ourFieldExpression);
         }
 
         return $theirModel;

--- a/tests/ConditionSqlTest.php
+++ b/tests/ConditionSqlTest.php
@@ -363,7 +363,7 @@ class ConditionSqlTest extends TestCase
 
         $m = new Model($this->db, ['table' => 'user']);
         $m->addField('name');
-        $m->addCondition('name', ['John', 'Doe']);
+        $m->addCondition('name', 'in', ['John', 'Doe']);
         self::assertCount(1, $m->export());
 
         $m = new Model($this->db, ['table' => 'user']);
@@ -373,13 +373,34 @@ class ConditionSqlTest extends TestCase
 
         $m = new Model($this->db, ['table' => 'user']);
         $m->addField('name');
-        $m->addCondition('name', []); // always false condition
+        $m->addCondition('name', 'in', []); // always false condition
         self::assertCount(0, $m->export());
 
         $m = new Model($this->db, ['table' => 'user']);
         $m->addField('name');
         $m->addCondition('name', 'not in', []); // always true condition
         self::assertCount(3, $m->export());
+    }
+
+    public function testConditionEqualWithArrayException(): void
+    {
+        $m = new Model($this->db, ['table' => 'user']);
+        $m->addField('name');
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage('Operator is not supported for array condition value');
+        $m->addCondition('name', ['John', 'Doe']);
+    }
+
+    public function testConditionInWithNonArrayException(): void
+    {
+        $m = new Model($this->db, ['table' => 'user']);
+        $m->addField('name');
+        $m->addCondition('name', 'not in', 'John');
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage('Unsupported operator for non-array value');
+        $m->export();
     }
 
     public function testDateCondition(): void

--- a/tests/Persistence/ArrayTest.php
+++ b/tests/Persistence/ArrayTest.php
@@ -477,7 +477,7 @@ class ArrayTest extends TestCase
         ], $m->action('select')->getRows());
 
         $m->scope()->clear();
-        $m->addCondition('code', [11, 12]);
+        $m->addCondition('code', 'IN', [11, 12]);
         self::assertSame([
             $dbDataCountries[1],
             $dbDataCountries[2],
@@ -489,13 +489,6 @@ class ArrayTest extends TestCase
 
         $m->scope()->clear();
         $m->addCondition('code', 'NOT IN', [11, 12, 13, 14, 15, 16, 17]);
-        self::assertSame([
-            $dbDataCountries[8],
-            $dbDataCountries[9],
-        ], $m->action('select')->getRows());
-
-        $m->scope()->clear();
-        $m->addCondition('code', '!=', [11, 12, 13, 14, 15, 16, 17]);
         self::assertSame([
             $dbDataCountries[8],
             $dbDataCountries[9],

--- a/tests/Persistence/Sql/QueryTest.php
+++ b/tests/Persistence/Sql/QueryTest.php
@@ -650,7 +650,7 @@ class QueryTest extends TestCase
             $this->q('[where]')->where('id', 'in', [1, 2])->render()[0]
         );
         self::assertSame(
-            'where "id" in (select * from "user")',
+            'where "id" = (select * from "user")',
             $this->q('[where]')->where('id', $this->q()->table('user'))->render()[0]
         );
 

--- a/tests/Persistence/Sql/QueryTest.php
+++ b/tests/Persistence/Sql/QueryTest.php
@@ -717,6 +717,15 @@ class QueryTest extends TestCase
         $this->q('[where]')->where('a', '!=', new \DateTime());
     }
 
+    public function testWhereNoOperatorWithArrayException(): void
+    {
+        $q = $this->q('[where]')->where('a', [1, 2]);
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage('Unsupported operator for array value');
+        $q->render();
+    }
+
     /**
      * @param mixed $value
      *


### PR DESCRIPTION
Value can be `array` which is not rare for `json` DBAL type, thus we cannot check if value is an array nor infer this from SQL expression.