### PR TITLE
Remove test skip for MySQL 8.0.32

### DIFF
--- a/tests/Persistence/Sql/WithDb/SelectTest.php
+++ b/tests/Persistence/Sql/WithDb/SelectTest.php
@@ -343,14 +343,6 @@ class SelectTest extends TestCase
             $tableAlias = '名';
         }
 
-        // remove once https://bugs.mysql.com/bug.php?id=109699 is fixed
-        if ($this->getDatabasePlatform() instanceof MySQLPlatform) {
-            $serverVersion = $this->getConnection()->getConnection()->getWrappedConnection()->getServerVersion(); // @phpstan-ignore-line
-            if ($serverVersion === '8.0.32') {
-                static::markTestIncomplete('MySQL Server 8.0.32 optimizer is broken');
-            }
-        }
-
         static::assertSame(
             [$columnAlias => 'žlutý_😀'],
             $this->q(


### PR DESCRIPTION
new MySQL version was released, fix from https://github.com/atk4/data/pull/1086 is no longer needed to fix CI