### PR TITLE
Fix unique index creation for MSSQL & Oracle

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -17,9 +17,9 @@ parameters:
 
         # fix https://github.com/phpstan/phpstan-deprecation-rules/issues/52 and https://github.com/phpstan/phpstan/issues/6444
         -
-            message: '~^Call to method (getVarcharTypeDeclarationSQL|getClobTypeDeclarationSQL|getCreateTableSQL|getCurrentDatabaseExpression|initializeDoctrineTypeMappings)\(\) of deprecated class Doctrine\\DBAL\\Platforms\\(PostgreSQLPlatform|SQLServerPlatform|AbstractPlatform):\nUse.+instead\.$~'
+            message: '~^Call to method (getVarcharTypeDeclarationSQL|getClobTypeDeclarationSQL|getCreateIndexSQL|getCreateTableSQL|getCurrentDatabaseExpression|initializeDoctrineTypeMappings)\(\) of deprecated class Doctrine\\DBAL\\Platforms\\(PostgreSQLPlatform|SQLServerPlatform|AbstractPlatform):\nUse.+instead\.$~'
             path: '*'
-            count: 5
+            count: 6
         # https://github.com/phpstan/phpstan-deprecation-rules/issues/75
         -
             message: '~^Call to deprecated method getVarcharTypeDeclarationSQL\(\) of class AnonymousClass\w+:\nUse \{@link getStringTypeDeclarationSQL\(\)\} instead\.$~'


### PR DESCRIPTION
fix MSSQL https://github.com/doctrine/dbal/issues/5507 - FK cannot be created if the foreign unique index was created with `WHERE xxx IS NOT NULL`

fix Oracle https://github.com/doctrine/dbal/issues/5508 - foreign unique index is not enough to create FK, unique table constraint needs to be present