### PR TITLE
Drop $fxArgs from Connection::atomic() method

### DIFF
--- a/src/Model.php
+++ b/src/Model.php
@@ -1892,9 +1892,11 @@ class Model implements \IteratorAggregate
      * the code inside callback will fail, then all of the transaction
      * will be also rolled back.
      *
-     * @param \Closure(): mixed $fx
+     * @template T
      *
-     * @return mixed
+     * @param \Closure(): T $fx
+     *
+     * @return T
      */
     public function atomic(\Closure $fx)
     {

--- a/src/Model/EntityFieldPair.php
+++ b/src/Model/EntityFieldPair.php
@@ -22,7 +22,7 @@ class EntityFieldPair
     private $fieldName;
 
     /**
-     * @phpstan-param TModel $entity
+     * @param TModel $entity
      */
     public function __construct(Model $entity, string $fieldName)
     {
@@ -33,7 +33,7 @@ class EntityFieldPair
     }
 
     /**
-     * @phpstan-return TModel
+     * @return TModel
      */
     public function getModel(): Model
     {
@@ -41,7 +41,7 @@ class EntityFieldPair
     }
 
     /**
-     * @phpstan-return TModel
+     * @return TModel
      */
     public function getEntity(): Model
     {

--- a/src/Model/Join.php
+++ b/src/Model/Join.php
@@ -618,8 +618,7 @@ abstract class Join
         $this->assertReferenceIdNotNull($foreignId);
         $saveBuffer = $this->getAndUnsetReindexedSaveBuffer($entity);
         $foreignModel->atomic(function () use ($foreignModel, $foreignId, $saveBuffer) {
-            $foreignModel = (clone $foreignModel)->addCondition($this->foreignField, $foreignId);
-            foreach ($foreignModel as $foreignEntity) {
+            foreach ($foreignModel->createIteratorBy($this->foreignField, $foreignId) as $foreignEntity) {
                 $foreignEntity->setMulti($saveBuffer);
                 $foreignEntity->save();
             }
@@ -636,8 +635,7 @@ abstract class Join
         $foreignId = $this->getForeignIdFromEntity($entity);
         $this->assertReferenceIdNotNull($foreignId);
         $foreignModel->atomic(function () use ($foreignModel, $foreignId) {
-            $foreignModel = (clone $foreignModel)->addCondition($this->foreignField, $foreignId);
-            foreach ($foreignModel as $foreignEntity) {
+            foreach ($foreignModel->createIteratorBy($this->foreignField, $foreignId) as $foreignEntity) {
                 $foreignEntity->delete();
             }
         });

--- a/src/Persistence.php
+++ b/src/Persistence.php
@@ -103,9 +103,11 @@ abstract class Persistence
      * persistencies will support atomic operations, so by default we just
      * don't do anything.
      *
-     * @param \Closure(): mixed $fx
+     * @template T
      *
-     * @return mixed
+     * @param \Closure(): T $fx
+     *
+     * @return T
      */
     public function atomic(\Closure $fx)
     {

--- a/src/Persistence/Sql/Connection.php
+++ b/src/Persistence/Sql/Connection.php
@@ -333,9 +333,11 @@ abstract class Connection
      * the code inside callback will fail, then all of the transaction
      * will be also rolled back.
      *
-     * @param \Closure(): mixed $fx
+     * @template T
      *
-     * @return mixed
+     * @param \Closure(): T $fx
+     *
+     * @return T
      */
     public function atomic(\Closure $fx)
     {

--- a/src/Persistence/Sql/Connection.php
+++ b/src/Persistence/Sql/Connection.php
@@ -333,16 +333,15 @@ abstract class Connection
      * the code inside callback will fail, then all of the transaction
      * will be also rolled back.
      *
-     * @param \Closure(mixed, mixed, mixed, mixed, mixed, mixed, mixed, mixed, mixed, mixed): mixed $fx
-     * @param mixed                                                                                 ...$fxArgs
+     * @param \Closure(): mixed $fx
      *
      * @return mixed
      */
-    public function atomic(\Closure $fx, ...$fxArgs)
+    public function atomic(\Closure $fx)
     {
         $this->beginTransaction();
         try {
-            $res = $fx(...$fxArgs);
+            $res = $fx();
             $this->commit();
 
             return $res;

--- a/src/Persistence/Sql/Connection.php
+++ b/src/Persistence/Sql/Connection.php
@@ -317,7 +317,7 @@ abstract class Connection
     /**
      * Execute Expression by using this connection and return affected rows.
      *
-     * @phpstan-return int<0, max>
+     * @return int<0, max>
      */
     public function executeStatement(Expression $expr): int
     {

--- a/src/Persistence/Sql/DbalDriverMiddleware.php
+++ b/src/Persistence/Sql/DbalDriverMiddleware.php
@@ -58,7 +58,7 @@ class DbalDriverMiddleware extends AbstractDriverMiddleware
     }
 
     /**
-     * @phpstan-return AbstractSchemaManager<AbstractPlatform>
+     * @return AbstractSchemaManager<AbstractPlatform>
      */
     public function getSchemaManager(DbalConnection $connection, AbstractPlatform $platform): AbstractSchemaManager
     {

--- a/src/Persistence/Sql/Expression.php
+++ b/src/Persistence/Sql/Expression.php
@@ -548,9 +548,7 @@ abstract class Expression implements Expressionable, \ArrayAccess
     /**
      * @param DbalConnection|Connection $connection
      *
-     * @return DbalResult|int<0, max>
-     *
-     * @phpstan-return ($fromExecuteStatement is true ? int<0, max> : DbalResult)
+     * @return ($fromExecuteStatement is true ? int<0, max> : DbalResult)
      */
     protected function _execute(?object $connection, bool $fromExecuteStatement)
     {
@@ -651,7 +649,7 @@ abstract class Expression implements Expressionable, \ArrayAccess
     /**
      * @param DbalConnection|Connection $connection
      *
-     * @phpstan-return int<0, max>
+     * @return int<0, max>
      */
     public function executeStatement(object $connection = null): int
     {

--- a/src/Schema/Migrator.php
+++ b/src/Schema/Migrator.php
@@ -90,9 +90,9 @@ class Migrator
      *
      * @template T of AbstractAsset
      *
-     * @phpstan-param T $abstractAsset
+     * @param T $abstractAsset
      *
-     * @phpstan-return T
+     * @return T
      */
     protected function fixAbstractAssetName(AbstractAsset $abstractAsset, string $name): AbstractAsset
     {


### PR DESCRIPTION
if args are needed, wrap the original fx in another anonymous fx