### PR TITLE
Update docs about dirty fields and after save hook

### DIFF
--- a/docs/typecasting.md
+++ b/docs/typecasting.md
@@ -28,8 +28,7 @@ $m->save();
 ```
 
 Typecasting is necessary to save the values inside the database and restore
-them back just as they were before. When modifying a record, typecasting will
-only be invoked on the fields which were dirty.
+them back just as they were before.
 
 The purpose of a flexible typecasting system is to allow you to store your date
 in a compatible format or even fine-tune it to match your database settings

--- a/src/Model.php
+++ b/src/Model.php
@@ -150,15 +150,16 @@ class Model implements \IteratorAggregate
 
     /**
      * After loading an active record from DataSet it will be stored in
-     * $data property and you can access it using get(). If you use
+     * $data property, and you can access it using get(). If you use
      * set() to change any of the data, the original value will be copied
      * here.
      *
      * If the value you set equal to the original value, then the key
      * in this array will be removed.
      *
-     * The $dirty data will be reset after you save() the data but it is
-     * still available to all before/after save handlers.
+     * Behaviour in Model::save():
+     * The $dirty data is available in all before save hook spots.
+     * After the actual save operation, $dirty is reset to an empty array.
      *
      * @var array<string, mixed>
      */

--- a/src/Model.php
+++ b/src/Model.php
@@ -87,8 +87,6 @@ class Model implements \IteratorAggregate
     protected const ID_LOAD_ONE = self::class . '@idLoadOne-h7axmDNBB3qVXjVv';
     protected const ID_LOAD_ANY = self::class . '@idLoadAny-h7axmDNBB3qVXjVv';
 
-    // {{{ Properties of the class
-
     /** @var static|null not-null if and only if this instance is an entity */
     private ?self $_model = null;
 
@@ -149,8 +147,8 @@ class Model implements \IteratorAggregate
     private array $data = [];
 
     /**
-     * After loading an active record from DataSet it will be stored in
-     * $data property, and you can access it using get(). If you use
+     * After loading an entity the data will be stored in
+     * $data property and you can access them using get(). If you use
      * set() to change any of the data, the original value will be copied
      * here.
      *
@@ -226,8 +224,6 @@ class Model implements \IteratorAggregate
 
     /** Only for Reference class */
     public ?Reference $ownerReference = null;
-
-    // }}}
 
     // {{{ Basic Functionality, field definition, set() and get()
 
@@ -943,7 +939,7 @@ class Model implements \IteratorAggregate
 
     // }}}
 
-    // {{{ DataSet logic
+    // {{{ Model logic
 
     /**
      * Get the scope object of the Model.
@@ -1942,10 +1938,6 @@ class Model implements \IteratorAggregate
         return $res;
     }
 
-    // }}}
-
-    // {{{ Expressions
-
     /**
      * Add expression field.
      *
@@ -1980,8 +1972,6 @@ class Model implements \IteratorAggregate
 
         return $field;
     }
-
-    // }}}
 
     public function __isset(string $name): bool
     {

--- a/src/Model.php
+++ b/src/Model.php
@@ -157,10 +157,6 @@ class Model implements \IteratorAggregate
      * If the value you set equal to the original value, then the key
      * in this array will be removed.
      *
-     * Behaviour in Model::save():
-     * The $dirty data is available in all before save hook spots.
-     * After the actual save operation, $dirty is reset to an empty array.
-     *
      * @var array<string, mixed>
      */
     private array $dirty = [];


### PR DESCRIPTION
related with https://github.com/atk4/data/issues/1130

The old PHPDoc implied that $dirty data was available in Model::HOOK_AFTER_SAVE spot. This is not the case.