### PR TITLE
Always use savepoints when nesting transactions

### DIFF
--- a/src/Model.php
+++ b/src/Model.php
@@ -1640,16 +1640,16 @@ class Model implements \IteratorAggregate
     {
         $entity = $this->createEntity();
 
-        $hasArrayValue = false;
+        $hasRefs = false;
         foreach ($row as $v) {
             if (is_array($v)) {
-                $hasArrayValue = true;
+                $hasRefs = true;
 
                 break;
             }
         }
 
-        if (!$hasArrayValue) {
+        if (!$hasRefs) {
             $entity->_insert($row);
         } else {
             $this->atomic(static function () use ($entity, $row) {

--- a/src/Persistence/Sql/Connection.php
+++ b/src/Persistence/Sql/Connection.php
@@ -201,6 +201,8 @@ abstract class Connection
             $dbalConnection = $connectionClass::connectFromDbalDriverConnection($dbalDriverConnection);
         }
 
+        $dbalConnection->setNestTransactionsWithSavepoints(true); // remove once DBAL 3.x support is dropped
+
         $connection = new $connectionClass($defaults);
         $connection->_connection = $dbalConnection;
 

--- a/src/Schema/TestSqlPersistence.php
+++ b/src/Schema/TestSqlPersistence.php
@@ -36,6 +36,12 @@ final class TestSqlPersistence extends Persistence\Sql
                     new class() implements SQLLogger {
                         public function startQuery($sql, array $params = null, array $types = null): void
                         {
+                            // log transaction savepoint operations only once
+                            // https://github.com/doctrine/dbal/blob/3.6.7/src/Connection.php#L1365
+                            if (preg_match('~^(?:SAVEPOINT|RELEASE SAVEPOINT|ROLLBACK TO SAVEPOINT|SAVE TRANSACTION|ROLLBACK TRANSACTION) DOCTRINE2_SAVEPOINT_\d+;?$~', $sql)) {
+                                return;
+                            }
+
                             // fix https://github.com/doctrine/dbal/issues/5525
                             if ($params !== null && $params !== [] && array_is_list($params)) {
                                 $params = array_combine(range(1, count($params)), $params);

--- a/tests/Schema/TestCaseTest.php
+++ b/tests/Schema/TestCaseTest.php
@@ -56,6 +56,9 @@ class TestCaseTest extends TestCase
                 "START TRANSACTION";
 
 
+                "SAVEPOINT";
+
+
                 insert into `t` (`name`, `int`, `float`, `null`)
                 values
                   (
@@ -86,9 +89,9 @@ class TestCaseTest extends TestCase
                   and `id` = 1
                 EOF
             . $makeLimitSqlFx(2)
+            . ";\n\n"
+            . ($this->getDatabasePlatform()->supportsReleaseSavepoints() ? "\n\"RELEASE SAVEPOINT\";\n\n" : '')
             . <<<'EOF'
-                ;
-
 
                 "COMMIT";
 

--- a/tests/TransactionTest.php
+++ b/tests/TransactionTest.php
@@ -82,6 +82,49 @@ class TransactionTest extends TestCase
         ], $this->getDb()['item']);
     }
 
+    public function testAtomicWithRollbackToSavepoint(): void
+    {
+        $this->setDb([
+            'item' => [
+                ['name' => 'John'],
+                ['name' => 'Sue'],
+                ['name' => 'Smith'],
+            ],
+        ]);
+
+        $m = new Model($this->db, ['table' => 'item']);
+        $m->addField('name');
+        $m->setOrder('id');
+
+        $this->getConnection()->getConnection()->setNestTransactionsWithSavepoints(true);
+
+        $this->db->atomic(function () use ($m) {
+            foreach ($m as $entity) {
+                $rollback = $entity->get('name') === 'Sue';
+
+                try {
+                    $this->db->atomic(static function () use ($entity, $rollback) {
+                        $entity->set('name', $entity->get('name') . ' 2');
+                        $entity->save();
+
+                        if ($rollback) {
+                            throw new \Exception('Rollback to savepoint');
+                        }
+                    });
+                } catch (\Exception $e) {
+                    self::assertSame('Rollback to savepoint', $e->getMessage());
+                    self::assertTrue($rollback);
+                }
+            }
+        });
+
+        self::assertSame([
+            1 => ['id' => 1, 'name' => 'John 2'],
+            ['id' => 2, 'name' => 'Sue'],
+            ['id' => 3, 'name' => 'Smith 2'],
+        ], $this->getDb()['item']);
+    }
+
     public function testBeforeSaveHook(): void
     {
         $this->setDb([

--- a/tests/TransactionTest.php
+++ b/tests/TransactionTest.php
@@ -96,8 +96,6 @@ class TransactionTest extends TestCase
         $m->addField('name');
         $m->setOrder('id');
 
-        $this->getConnection()->getConnection()->setNestTransactionsWithSavepoints(true);
-
         $this->db->atomic(function () use ($m) {
             foreach ($m as $entity) {
                 $rollback = $entity->get('name') === 'Sue';


### PR DESCRIPTION
the only supported mode in upcoming DBAL 4.x

no BC break when the transaction is not rolled back or rolled completely