### PR TITLE
Deduplicate order for MSSQL only and handle different directions

### DIFF
--- a/src/Model.php
+++ b/src/Model.php
@@ -1022,7 +1022,7 @@ class Model implements \IteratorAggregate
      * Set order for model records. Multiple calls are allowed.
      *
      * @param string|array<int, string|array{string, 1?: 'asc'|'desc'}>|array<string, 'asc'|'desc'> $field
-     * @param 'asc'|'desc'                                                                          $direction
+     * @param ($field is array ? never : 'asc'|'desc')                                              $direction
      *
      * @return $this
      */
@@ -1063,7 +1063,6 @@ class Model implements \IteratorAggregate
                 ->addMoreInfo('direction', $direction);
         }
 
-        // finally set order
         $this->order[] = [$field, $direction];
 
         return $this;

--- a/src/Persistence/Sql/Mssql/Query.php
+++ b/src/Persistence/Sql/Mssql/Query.php
@@ -32,6 +32,19 @@ class Query extends BaseQuery
         end catch
         EOF;
 
+    protected function deduplicateRenderOrder(array $sqls): array
+    {
+        $res = [];
+        foreach ($sqls as $sql) {
+            $sqlWithoutDirection = preg_replace('~\s+(?:asc|desc)\s*$~i', '', $sql);
+            if (!isset($res[$sqlWithoutDirection])) {
+                $res[$sqlWithoutDirection] = $sql;
+            }
+        }
+
+        return array_values($res);
+    }
+
     protected function _renderLimit(): ?string
     {
         if (!isset($this->args['limit'])) {

--- a/tests/Model/Smbo/Transfer.php
+++ b/tests/Model/Smbo/Transfer.php
@@ -29,7 +29,8 @@ class Transfer extends Payment
             if ($this->get('destination_account_id') && !$this->getId()) {
                 // in this section we test if "clone" works ok
 
-                $this->otherLegCreation = $m2 = clone $this;
+                $m2 = clone $this;
+                $this->otherLegCreation = $m2;
                 $m2->set('account_id', $m2->get('destination_account_id'));
                 $m2->set('amount', -$m2->get('amount'));
 

--- a/tests/ModelIteratorTest.php
+++ b/tests/ModelIteratorTest.php
@@ -19,7 +19,7 @@ class ModelIteratorTest extends TestCase
 
         $this->expectException(Exception::class);
         $this->expectExceptionMessage('If first argument is array, second argument must not be used');
-        $m->setOrder(['name', 'salary'], 'desc');
+        $m->setOrder(['name', 'salary'], 'desc'); // @phpstan-ignore-line
     }
 
     public function testNoPersistenceTryLoadException(): void

--- a/tests/Persistence/Sql/QueryTest.php
+++ b/tests/Persistence/Sql/QueryTest.php
@@ -862,11 +862,11 @@ class QueryTest extends TestCase
         );
     }
 
-    public function testOrderException1(): void
+    public function testOrderException(): void
     {
-        // if first argument is array, second argument must not be used
         $this->expectException(Exception::class);
-        $this->q('[order]')->order(['name', 'surname'], 'desc');
+        $this->expectExceptionMessage('If first argument is array, second argument must not be used');
+        $this->q('[order]')->order(['name', 'surname'], 'desc'); // @phpstan-ignore-line
     }
 
     public function testGroup(): void

--- a/tests/Persistence/Sql/WithDb/SelectTest.php
+++ b/tests/Persistence/Sql/WithDb/SelectTest.php
@@ -455,6 +455,8 @@ class SelectTest extends TestCase
     {
         $query = $this->q('employee')->field('name')
             ->order('id')
+            ->order('name', 'desc')
+            ->order('name', 'ASC')
             ->order('name')
             ->order('surname')
             ->order('name');


### PR DESCRIPTION
improve #1141

for MSSQL it is required, for other DB vendors, better to log full order