### PR TITLE
Fix `Scope::$shortName` cannot be unset to null

### DIFF
--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -365,7 +365,7 @@ class ControllerUniqueFields
     }
     use \Atk4\Core\TrackableTrait;
 
-    protected $fields = null;
+    protected ?array $fields = null;
 
     protected function init(): void
     {

--- a/src/Model/Scope.php
+++ b/src/Model/Scope.php
@@ -64,7 +64,7 @@ class Scope extends AbstractScope
         if ($this->issetOwner()) {
             $this->unsetOwner();
         }
-        $this->shortName = null; // @phpstan-ignore-line
+        // $this->shortName = null; // uncomment once https://github.com/php/php-src/issues/9389 is resolved
     }
 
     /**


### PR DESCRIPTION
related with https://github.com/atk4/core/pull/400 and https://github.com/php/php-src/issues/9389