### PR TITLE
Throw an exception when array with null is passed to IN condition

### DIFF
--- a/src/Field.php
+++ b/src/Field.php
@@ -388,9 +388,9 @@ class Field implements Expressionable
         if ($value instanceof Persistence\Array_\Action) { // needed to pass hintable tests
             $v = $value;
         } elseif (is_array($value)) {
-            $v = array_map(static fn ($value) => $typecastField->typecastSaveField($value), $value);
+            $v = array_map(static fn ($value) => $value === null ? null : $typecastField->typecastSaveField($value), $value);
         } else {
-            $v = $typecastField->typecastSaveField($value);
+            $v = $value === null ? null : $typecastField->typecastSaveField($value);
         }
 
         return [$this, $operator, $v];

--- a/src/Persistence/Sql/Query.php
+++ b/src/Persistence/Sql/Query.php
@@ -591,6 +591,13 @@ abstract class Query extends Expression
                     return '1 = 1'; // always true
                 }
 
+                foreach ($value as $v) {
+                    if ($v === null) {
+                        throw (new Exception('Null value in IN operator is not supported'))
+                            ->addMoreInfo('operator', $cond);
+                    }
+                }
+
                 $values = array_map(fn ($v) => $this->consume($v, self::ESCAPE_PARAM), $value);
 
                 return $this->_renderConditionInOperator($cond === 'not in', $field, $values);

--- a/tests/Persistence/Sql/QueryTest.php
+++ b/tests/Persistence/Sql/QueryTest.php
@@ -762,6 +762,15 @@ class QueryTest extends TestCase
         );
     }
 
+    public function testWhereInWithNullException(): void
+    {
+        $q = $this->q('[where]')->where('x', 'in', ['a', null, 'b']);
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage('Null value in IN operator is not supported');
+        $q->render();
+    }
+
     /**
      * Having basically is the same as where, so we can relax and thoroughly test where() instead.
      */

--- a/tests/Persistence/Sql/WithDb/SelectTest.php
+++ b/tests/Persistence/Sql/WithDb/SelectTest.php
@@ -390,6 +390,12 @@ class SelectTest extends TestCase
         yield [['2 + 2.5'], '=', ['[] + []', [1.5, 3.0]]];
         yield [['[] + []', [-1.5, 6.0]], '=', ['[] + []', [1.5, 3.0]]];
         yield [['2 + 2.5'], '=', ['[]', ['4.5']], true];
+
+        yield [['null'], '=', ['null']];
+        yield [['[]', [null]], '=', ['[]', [null]]];
+        yield [['null'], '=', ['[]', [null]]];
+        yield [['0'], '!=', ['null']];
+        yield [['[]', [0]], '!=', ['[]', [null]]];
     }
 
     public function testGroupConcat(): void

--- a/tests/Persistence/Sql/WithDb/SelectTest.php
+++ b/tests/Persistence/Sql/WithDb/SelectTest.php
@@ -390,12 +390,6 @@ class SelectTest extends TestCase
         yield [['2 + 2.5'], '=', ['[] + []', [1.5, 3.0]]];
         yield [['[] + []', [-1.5, 6.0]], '=', ['[] + []', [1.5, 3.0]]];
         yield [['2 + 2.5'], '=', ['[]', ['4.5']], true];
-
-        yield [['null'], '=', ['null']];
-        yield [['[]', [null]], '=', ['[]', [null]]];
-        yield [['null'], '=', ['[]', [null]]];
-        yield [['0'], '!=', ['null']];
-        yield [['[]', [0]], '!=', ['[]', [null]]];
     }
 
     public function testGroupConcat(): void


### PR DESCRIPTION
We convert `x = null` condition to `x is null` if set using managed API, but `x in('a', null)` seems to obscure to me to be supported so better to reject that completely.