### PR TITLE
Make Reference::$model property protected

### DIFF
--- a/src/Reference.php
+++ b/src/Reference.php
@@ -10,9 +10,7 @@ use Atk4\Core\InitializerTrait;
 use Atk4\Core\TrackableTrait;
 
 /**
- * Reference implements a link between one model and another. The basic components for
- * a reference is ability to generate the destination model, which is returned through
- * getModel() and that's pretty much it.
+ * Reference implements a link between our model and their model..
  *
  * It's possible to extend the basic reference with more meaningful references.
  *
@@ -29,7 +27,7 @@ class Reference
     }
 
     /**
-     * Use this alias for related entity by default. This can help you
+     * Use this alias for their model by default. This can help you
      * if you create sub-queries or joins to separate this from main
      * table. The tableAlias will be uniquely generated.
      *
@@ -47,10 +45,8 @@ class Reference
     public $link;
 
     /**
-     * Definition of the destination their model, that can be either an object, a
-     * callback or a string. This can be defined during initialization and
-     * then used inside getModel() to fully populate and associate with
-     * persistence.
+     * Seed of their model. If it is a Model instance, self::createTheirModel() must
+     * always clone it to return a new instance.
      *
      * @var Model|\Closure(object, static, array<string, mixed>): Model|array<mixed>
      */
@@ -222,14 +218,9 @@ class Reference
     }
 
     /**
-     * Create destination model that is linked through this reference. Will apply
-     * necessary conditions.
-     *
-     * IMPORTANT: the returned model must be a fresh clone or freshly built from a seed
-     *
      * @param array<string, mixed> $defaults
      */
-    public function createTheirModel(array $defaults = []): Model
+    protected function createTheirModelBeforeInit(array $defaults): Model
     {
         $defaults['tableAlias'] ??= $this->tableAlias;
 
@@ -251,8 +242,11 @@ class Reference
             $theirModel = Factory::factory($theirModelSeed, $defaults);
         }
 
-        $this->addToPersistence($theirModel, $defaults);
+        return $theirModel;
+    }
 
+    protected function createTheirModelAfterInit(Model $theirModel): void
+    {
         if ($this->checkTheirType) {
             $ourField = $this->getOurField();
             $theirField = $theirModel->getField($this->getTheirFieldName($theirModel));
@@ -264,6 +258,21 @@ class Reference
                     ->addMoreInfo('theirFieldType', $theirField->type);
             }
         }
+    }
+
+    /**
+     * Create their model that is linked through this reference. Will apply
+     * necessary conditions.
+     *
+     * IMPORTANT: the returned model must be a fresh clone or freshly built from a seed
+     *
+     * @param array<string, mixed> $defaults
+     */
+    final public function createTheirModel(array $defaults = []): Model
+    {
+        $theirModel = $this->createTheirModelBeforeInit($defaults);
+        $this->addToPersistence($theirModel, $defaults);
+        $this->createTheirModelAfterInit($theirModel);
 
         return $theirModel;
     }
@@ -287,7 +296,7 @@ class Reference
     /**
      * @param array<string, mixed> $defaults
      */
-    protected function addToPersistence(Model $theirModel, array $defaults = []): void
+    protected function addToPersistence(Model $theirModel, array $defaults): void
     {
         if (!$theirModel->issetPersistence()) {
             $persistence = $this->getDefaultPersistence($theirModel);

--- a/src/Reference.php
+++ b/src/Reference.php
@@ -293,22 +293,15 @@ class Reference
         }
     }
 
-    /**
-     * @param array<string, mixed> $defaults
-     */
-    protected function addToPersistence(Model $theirModel, array $defaults): void
+    protected function addToPersistence(Model $theirModel): void
     {
         if (!$theirModel->issetPersistence()) {
             $persistence = $this->getDefaultPersistence($theirModel);
             if ($persistence !== false) {
-                $theirModel->setDefaults($defaults);
                 $theirModel->setPersistence($persistence);
             }
-        } elseif ($defaults !== []) {
-            // TODO this seems dangerous
         }
 
-        // set model caption
         if ($this->caption !== null) {
             $theirModel->caption = $this->caption;
         }

--- a/src/Reference.php
+++ b/src/Reference.php
@@ -50,7 +50,7 @@ class Reference
      *
      * @var Model|\Closure(object, static, array<string, mixed>): Model|array<mixed>
      */
-    public $model;
+    protected $model;
 
     /**
      * This is an optional property which can be used by your implementation

--- a/src/Reference.php
+++ b/src/Reference.php
@@ -247,6 +247,10 @@ class Reference
 
     protected function createTheirModelAfterInit(Model $theirModel): void
     {
+        if ($this->caption !== null) {
+            $theirModel->caption = $this->caption;
+        }
+
         if ($this->checkTheirType) {
             $ourField = $this->getOurField();
             $theirField = $theirModel->getField($this->getTheirFieldName($theirModel));
@@ -300,10 +304,6 @@ class Reference
             if ($persistence !== false) {
                 $theirModel->setPersistence($persistence);
             }
-        }
-
-        if ($this->caption !== null) {
-            $theirModel->caption = $this->caption;
         }
     }
 

--- a/src/Schema/Migrator.php
+++ b/src/Schema/Migrator.php
@@ -317,14 +317,10 @@ class Migrator
     {
         $reference = $field->getReference();
         if ($reference instanceof HasOne) {
-            $referenceField = $reference->getTheirFieldName($reference->createTheirModel());
+            $theirModel = $reference->createTheirModel();
+            $referenceField = $reference->getTheirFieldName($theirModel);
 
-            $modelSeed = is_array($reference->model)
-                ? $reference->model
-                : clone $reference->model;
-            $referenceModel = Model::fromSeed($modelSeed, [new Persistence\Sql($this->getConnection())]);
-
-            return $referenceModel->getField($referenceField);
+            return $theirModel->getField($referenceField);
         }
 
         return null;

--- a/tests/Type/LocalObjectTypeTest.php
+++ b/tests/Type/LocalObjectTypeTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Atk4\Data\Tests;
+namespace Atk4\Data\Tests\Type;
 
 use Atk4\Data\Exception;
 use Atk4\Data\Model;
@@ -11,7 +11,7 @@ use Atk4\Data\Type\LocalObjectHandle;
 use Atk4\Data\Type\LocalObjectType;
 use Doctrine\DBAL\Types as DbalTypes;
 
-class LocalObjectTest extends TestCase
+class LocalObjectTypeTest extends TestCase
 {
     /**
      * @return \WeakMap<object, LocalObjectHandle>
@@ -51,7 +51,7 @@ class LocalObjectTest extends TestCase
         parent::tearDown();
     }
 
-    public function testTypeBasic(): void
+    public function testBasic(): void
     {
         $t1 = new LocalObjectType();
         $t2 = new LocalObjectType();
@@ -93,7 +93,7 @@ class LocalObjectTest extends TestCase
         self::assertNotSame($v4, $v3);
     }
 
-    public function testTypeCloneException(): void
+    public function testCloneException(): void
     {
         $t = new LocalObjectType();
 
@@ -101,7 +101,7 @@ class LocalObjectTest extends TestCase
         clone $t;
     }
 
-    public function testTypeDifferentInstanceException(): void
+    public function testDifferentInstanceException(): void
     {
         $t1 = new LocalObjectType();
         $t2 = new LocalObjectType();
@@ -116,7 +116,7 @@ class LocalObjectTest extends TestCase
         $t2->convertToPHPValue($v, $platform);
     }
 
-    public function testTypeReleasedException(): void
+    public function testReleasedException(): void
     {
         $t = new LocalObjectType();
         $platform = $this->getDatabasePlatform();
@@ -185,8 +185,8 @@ class LocalObjectTest extends TestCase
         self::assertLessThan(250, strlen($v1));
         self::assertLessThan(250, strlen($v2));
 
-        self::assertSame('Atk4\Data\Tests\LocalObjectDummyClassWithLongNameAWithLongNameBWithLongNameCWith...eFWithLongNameGWithLongNameHWithLongNameIWithLongNameJWithLongNameKWithLongNameL', explode('-', $v1)[0]);
-        self::assertSame('Atk4\Data\Tests\LocalObjectDummyClassWithLongNameAWithLongNameBWithLongNameCWith...NameGWithLongNameHWithLongNameIWithLongNameJWithLongNameKWithLongNameL@anonymous', explode('-', $v2)[0]);
+        self::assertSame('Atk4\Data\Tests\Type\LocalObjectDummyClassWithLongNameAWithLongNameBWithLongName...eFWithLongNameGWithLongNameHWithLongNameIWithLongNameJWithLongNameKWithLongNameL', explode('-', $v1)[0]);
+        self::assertSame('Atk4\Data\Tests\Type\LocalObjectDummyClassWithLongNameAWithLongNameBWithLongName...NameGWithLongNameHWithLongNameIWithLongNameJWithLongNameKWithLongNameL@anonymous', explode('-', $v2)[0]);
     }
 }
 

--- a/tests/Util/DeepCopyTest.php
+++ b/tests/Util/DeepCopyTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Atk4\Data\Tests\Util;
 
 use Atk4\Data\Model;
+use Atk4\Data\Reference;
 use Atk4\Data\Schema\TestCase;
 use Atk4\Data\Util\DeepCopy;
 use Atk4\Data\Util\DeepCopyException;
@@ -343,17 +344,19 @@ class DeepCopyTest extends TestCase
     {
         $quote = $this->createTestQuote();
 
-        $quote->getModel()->getReference('client_id')->model = [get_class(new class() extends DcClient {
-            #[\Override]
-            protected function init(): void
-            {
-                parent::init();
+        \Closure::bind(function () use ($quote) {
+            $quote->getModel()->getReference('client_id')->model = [get_class(new class() extends DcClient {
+                #[\Override]
+                protected function init(): void
+                {
+                    parent::init();
 
-                $this->onHook(DeepCopy::HOOK_AFTER_COPY, static function (Model $entity) {
-                    throw new \Exception('test ex');
-                });
-            }
-        })];
+                    $this->onHook(DeepCopy::HOOK_AFTER_COPY, static function (Model $entity) {
+                        throw new \Exception('test ex');
+                    });
+                }
+            })];
+        }, null, Reference::class)();
 
         $dc = new DeepCopy();
 


### PR DESCRIPTION
to enforce `Reference::createTheirModel()` usage

impact should be minimal as using `Reference::$model` directly is mostly wrong