### PR TITLE
Drop entity parameter from {HasOneSql, HasMany}::refLink() method

### DIFF
--- a/docs/persistence.md
+++ b/docs/persistence.md
@@ -298,7 +298,7 @@ protected function init(): void
     $this->getOwner()->hasOne(
         $f . '_currency_id',
         [
-            $this->currency_model ?? new Currency(),
+            'model' => $this->currency_model ?? new Currency(),
             'system' => true,
         ]
     );

--- a/src/Field.php
+++ b/src/Field.php
@@ -38,7 +38,7 @@ class Field implements Expressionable
     {
         $this->setDefaults($defaults);
 
-        if (!(new \ReflectionProperty($this, 'type'))->isInitialized($this)) {
+        if (($this->type ?? null) === null) {
             $this->type = 'string';
         }
     }

--- a/src/Model.php
+++ b/src/Model.php
@@ -123,8 +123,7 @@ class Model implements \IteratorAggregate
     /** @var string|null */
     public $tableAlias;
 
-    /** @var Persistence|null */
-    private $_persistence;
+    private ?Persistence $_persistence = null;
 
     /** @var array<string, mixed>|null Persistence store some custom information in here that may be useful for them. */
     public ?array $persistenceData = null;

--- a/src/Model.php
+++ b/src/Model.php
@@ -533,6 +533,12 @@ class Model implements \IteratorAggregate
     {
         $this->assertIsModel();
 
+        if ($this->hasField($name)) {
+            throw (new Exception('Field with such name already exists'))
+                ->addMoreInfo('name', $name)
+                ->addMoreInfo('seed', $seed);
+        }
+
         if (is_object($seed)) {
             $field = $seed;
         } else {

--- a/src/Model/ReferencesTrait.php
+++ b/src/Model/ReferencesTrait.php
@@ -155,14 +155,14 @@ trait ReferencesTrait
     }
 
     /**
-     * Traverse reference and create their model but keep condition not materialized (for subquery actions).
+     * Traverse reference and create their model but keep reference condition not materialized (for subquery actions).
      *
      * @param array<string, mixed> $defaults
      */
     public function refLink(string $link, array $defaults = []): Model
     {
-        $reference = $this->getModel(true)->getReference($link);
+        $reference = $this->getReference($link);
 
-        return $reference->refLink($this, $defaults);
+        return $reference->refLink($defaults);
     }
 }

--- a/src/Model/Scope/Condition.php
+++ b/src/Model/Scope/Condition.php
@@ -287,12 +287,14 @@ class Condition extends AbstractScope
     #[\Override]
     public function toWords(Model $model = null): string
     {
-        if ($model === null) {
+        if ($model !== null) {
+            $model->assertIsModel();
+        } else {
             $model = $this->getModel();
-        }
 
-        if ($model === null) {
-            throw new Exception('Condition must be associated with Model to convert to words');
+            if ($model === null) {
+                throw new Exception('Condition must be associated with model to convert to words');
+            }
         }
 
         $field = $this->fieldToWords($model);
@@ -405,9 +407,7 @@ class Condition extends AbstractScope
         $title = null;
         if ($field instanceof Field && $field->hasReference()) {
             // make sure we set the value in the Model
-            $entity = $model->isEntity()
-                ? clone $model
-                : $model->createEntity();
+            $entity = $model->createEntity();
             $entity->set($field->shortName, $value);
 
             // then take the title

--- a/src/Model/UserActionsTrait.php
+++ b/src/Model/UserActionsTrait.php
@@ -27,6 +27,12 @@ trait UserActionsTrait
     {
         $this->assertIsModel();
 
+        if ($this->hasUserAction($name)) {
+            throw (new Exception('User action with such name already exists'))
+                ->addMoreInfo('name', $name)
+                ->addMoreInfo('seed', $seed);
+        }
+
         if ($seed instanceof \Closure) {
             $seed = ['callback' => $seed];
         }

--- a/src/Reference.php
+++ b/src/Reference.php
@@ -109,12 +109,12 @@ class Reference
     public function getOurFieldName(): string
     {
         return $this->ourField
-            ?? $this->getOurModel(null)->idField;
+            ?? $this->getOurModel()->idField;
     }
 
     final protected function getOurField(): Field
     {
-        return $this->getOurModel(null)->getField($this->getOurFieldName());
+        return $this->getOurModel()->getField($this->getOurFieldName());
     }
 
     /**
@@ -141,7 +141,7 @@ class Reference
     {
         $name = $this->shortName; // use static function to allow this object to be GCed
 
-        return $this->getOurModel(null)->onHookDynamic(
+        return $this->getOurModel()->onHookDynamic(
             $spot,
             static function (Model $modelOrEntity) use ($name): self {
                 /** @var self */
@@ -164,7 +164,7 @@ class Reference
     {
         $theirModel->assertIsModel();
 
-        $ourModel = $this->getOurModel(null);
+        $ourModel = $this->getOurModel();
         $name = $this->shortName; // use static function to allow this object to be GCed
 
         return $theirModel->onHookDynamic(
@@ -203,14 +203,10 @@ class Reference
             ->assertIsModel($ourModelOrEntity->getModel(true));
     }
 
-    public function getOurModel(?Model $ourModelOrEntity): Model
+    public function getOurModel(): Model
     {
-        $ourModel = $ourModelOrEntity !== null
-            ? $ourModelOrEntity->getModel(true)
-            : $this->getOwner();
-
-        $this->getOwner()
-            ->assertIsModel($ourModel);
+        $ourModel = $this->getOwner();
+        $ourModel->assertIsModel();
 
         return $ourModel;
     }
@@ -218,7 +214,7 @@ class Reference
     protected function initTableAlias(): void
     {
         if (!$this->tableAlias) {
-            $ourModel = $this->getOurModel(null);
+            $ourModel = $this->getOurModel();
 
             $aliasFull = $this->link;
             $alias = preg_replace('~_(' . preg_quote($ourModel->idField !== false ? $ourModel->idField : '', '~') . '|id)$~', '', $aliasFull);
@@ -238,7 +234,7 @@ class Reference
      */
     protected function getDefaultPersistence(Model $theirModel)
     {
-        $ourModel = $this->getOurModel(null);
+        $ourModel = $this->getOurModel();
 
         // this is useful for ContainsOne/Many implementation in case when you have
         // SQL_Model->containsOne()->hasOne() structure to get back to SQL persistence
@@ -261,7 +257,7 @@ class Reference
 
         // if model is Closure, then call the closure and it should return a model
         if ($this->model instanceof \Closure) {
-            $m = ($this->model)($this->getOurModel(null), $this, $defaults);
+            $m = ($this->model)($this->getOurModel(), $this, $defaults);
         } else {
             $m = $this->model;
         }

--- a/src/Reference/ContainsBase.php
+++ b/src/Reference/ContainsBase.php
@@ -31,7 +31,7 @@ abstract class ContainsBase extends Reference
     {
         parent::init();
 
-        if (!$this->ourField) {
+        if ($this->ourField === null) {
             $this->ourField = $this->link;
         }
 

--- a/src/Reference/ContainsBase.php
+++ b/src/Reference/ContainsBase.php
@@ -35,7 +35,7 @@ abstract class ContainsBase extends Reference
             $this->ourField = $this->link;
         }
 
-        $ourModel = $this->getOurModel(null);
+        $ourModel = $this->getOurModel();
 
         $ourField = $this->getOurFieldName();
         if (!$ourModel->hasField($ourField)) {

--- a/src/Reference/ContainsMany.php
+++ b/src/Reference/ContainsMany.php
@@ -32,8 +32,7 @@ class ContainsMany extends ContainsBase
                 $this->assertOurModelOrEntity($ourEntity);
                 $ourEntity->assertIsEntity();
 
-                /** @var Persistence\Array_ */
-                $persistence = $theirEntity->getModel()->getPersistence();
+                $persistence = Persistence\Array_::assertInstanceOf($theirEntity->getModel()->getPersistence());
                 $rows = $persistence->getRawDataByTable($theirEntity->getModel(), $this->tableAlias); // @phpstan-ignore-line
                 $ourEntity->save([$this->getOurFieldName() => $rows !== [] ? $rows : null]);
             });

--- a/src/Reference/ContainsOne.php
+++ b/src/Reference/ContainsOne.php
@@ -32,8 +32,7 @@ class ContainsOne extends ContainsBase
                 $this->assertOurModelOrEntity($ourEntity);
                 $ourEntity->assertIsEntity();
 
-                /** @var Persistence\Array_ */
-                $persistence = $theirEntity->getModel()->getPersistence();
+                $persistence = Persistence\Array_::assertInstanceOf($theirEntity->getModel()->getPersistence());
                 $row = $persistence->getRawDataByTable($theirEntity->getModel(), $this->tableAlias); // @phpstan-ignore-line
                 $row = $row ? array_shift($row) : null; // get first and only one record from array persistence
                 $ourEntity->save([$this->getOurFieldName() => $row]);

--- a/src/Reference/HasMany.php
+++ b/src/Reference/HasMany.php
@@ -24,7 +24,7 @@ class HasMany extends Reference
     #[\Override]
     public function getTheirFieldName(Model $theirModel = null): string
     {
-        if ($this->theirField) {
+        if ($this->theirField !== null) {
             return $this->theirField;
         }
 
@@ -50,7 +50,7 @@ class HasMany extends Reference
         $this->assertOurModelOrEntity($ourModelOrEntity);
 
         if ($ourModelOrEntity->isEntity()) {
-            $res = $this->ourField
+            $res = $this->ourField !== null
                 ? $ourModelOrEntity->get($this->ourField)
                 : $ourModelOrEntity->getId();
             $this->assertReferenceValueNotNull($res);
@@ -96,9 +96,11 @@ class HasMany extends Reference
      *
      * @param array<string, mixed> $defaults
      */
-    public function refLink(?Model $ourModel, array $defaults = []): Model
+    public function refLink(?Model $ourModelOrEntity, array $defaults = []): Model
     {
-        $this->getOurModel($ourModel); // or should $this->assertOurModelOrEntity($ourModelOrEntity); be here? What is exactly the difference between ref and refLink?
+        if ($ourModelOrEntity !== null) { // TODO drop this parameter, refLink for entity is useless
+            $this->assertOurModelOrEntity($ourModelOrEntity);
+        }
 
         $theirModelLinked = $this->createTheirModel($defaults)->addCondition(
             $this->getTheirFieldName(),

--- a/src/Reference/HasMany.php
+++ b/src/Reference/HasMany.php
@@ -33,8 +33,8 @@ class HasMany extends Reference
         $ourModel = $this->getOurModel();
         $theirFieldName = preg_replace('~^.+\.~s', '', $this->getModelTableString($ourModel)) . '_' . $ourModel->idField;
         if (!($theirModel ?? $this->createTheirModel())->hasField($theirFieldName)) {
-            throw (new Exception('Their model does not contain fallback field'))
-                ->addMoreInfo('their_fallback_field', $theirFieldName);
+            throw (new Exception('Their model does not contain implicit field'))
+                ->addMoreInfo('theirImplicitField', $theirFieldName);
         }
 
         return $theirFieldName;

--- a/src/Reference/HasMany.php
+++ b/src/Reference/HasMany.php
@@ -96,12 +96,8 @@ class HasMany extends Reference
      *
      * @param array<string, mixed> $defaults
      */
-    public function refLink(?Model $ourModelOrEntity, array $defaults = []): Model
+    public function refLink(array $defaults = []): Model
     {
-        if ($ourModelOrEntity !== null) { // TODO drop this parameter, refLink for entity is useless
-            $this->assertOurModelOrEntity($ourModelOrEntity);
-        }
-
         $theirModelLinked = $this->createTheirModel($defaults)->addCondition(
             $this->getTheirFieldName(),
             $this->referenceOurValue()
@@ -136,7 +132,7 @@ class HasMany extends Reference
 
         if (isset($defaults['expr'])) {
             $fx = function () use ($defaults, $alias) {
-                $theirModelLinked = $this->refLink(null);
+                $theirModelLinked = $this->refLink();
 
                 return $theirModelLinked->action('field', [$theirModelLinked->expr(
                     $defaults['expr'],
@@ -146,15 +142,15 @@ class HasMany extends Reference
             unset($defaults['args']);
         } elseif (is_object($defaults['aggregate'])) {
             $fx = function () use ($defaults, $alias) {
-                return $this->refLink(null)->action('field', [$defaults['aggregate'], 'alias' => $alias]);
+                return $this->refLink()->action('field', [$defaults['aggregate'], 'alias' => $alias]);
             };
         } elseif ($defaults['aggregate'] === 'count' && !isset($defaults['field'])) {
             $fx = function () use ($alias) {
-                return $this->refLink(null)->action('count', ['alias' => $alias]);
+                return $this->refLink()->action('count', ['alias' => $alias]);
             };
         } elseif (in_array($defaults['aggregate'], ['sum', 'avg', 'min', 'max', 'count'], true)) {
             $fx = function () use ($defaults, $field) {
-                return $this->refLink(null)->action('fx0', [$defaults['aggregate'], $field]);
+                return $this->refLink()->action('fx0', [$defaults['aggregate'], $field]);
             };
         } else {
             $fx = function () use ($defaults, $field) {
@@ -163,7 +159,7 @@ class HasMany extends Reference
                     $args['concatSeparator'] = $defaults['concatSeparator'];
                 }
 
-                return $this->refLink(null)->action('fx', $args);
+                return $this->refLink()->action('fx', $args);
             };
         }
 

--- a/src/Reference/HasMany.php
+++ b/src/Reference/HasMany.php
@@ -30,7 +30,7 @@ class HasMany extends Reference
 
         // this is pure guess, verify if such field exist, otherwise throw
         // TODO probably remove completely in the future
-        $ourModel = $this->getOurModel(null);
+        $ourModel = $this->getOurModel();
         $theirFieldName = preg_replace('~^.+\.~s', '', $this->getModelTableString($ourModel)) . '_' . $ourModel->idField;
         if (!($theirModel ?? $this->createTheirModel())->hasField($theirFieldName)) {
             throw (new Exception('Their model does not contain fallback field'))
@@ -71,7 +71,7 @@ class HasMany extends Reference
     {
         // TODO horrible hack to render the field with a table prefix,
         // find a solution how to wrap the field inside custom Field (without owner?)
-        $ourModelCloned = clone $this->getOurModel(null);
+        $ourModelCloned = clone $this->getOurModel();
         $ourModelCloned->persistenceData['use_table_prefixes'] = true;
 
         return $ourModelCloned->getReference($this->link)->getOurField();
@@ -163,7 +163,7 @@ class HasMany extends Reference
             };
         }
 
-        return $this->getOurModel(null)->addExpression($fieldName, array_merge($defaults, ['expr' => $fx]));
+        return $this->getOurModel()->addExpression($fieldName, array_merge($defaults, ['expr' => $fx]));
     }
 
     /**

--- a/src/Reference/HasOne.php
+++ b/src/Reference/HasOne.php
@@ -18,12 +18,12 @@ class HasOne extends Reference
     {
         parent::init();
 
-        if (!$this->ourField) {
+        if ($this->ourField === null) {
             $this->ourField = $this->link;
         }
 
         // for references use "integer" as a default type
-        if (!(new \ReflectionProperty($this, 'type'))->isInitialized($this)) {
+        if (($this->type ?? null) === null) {
             $this->type = 'integer';
         }
 
@@ -84,7 +84,7 @@ class HasOne extends Reference
 
         if ($ourModelOrEntity->isEntity()) {
             $this->onHookToTheirModel($theirModel, Model::HOOK_AFTER_SAVE, function (Model $theirEntity) use ($ourModelOrEntity) {
-                $theirValue = $this->theirField
+                $theirValue = $this->theirField !== null
                     ? $theirEntity->get($this->theirField)
                     : $theirEntity->getId();
 

--- a/src/Reference/HasOne.php
+++ b/src/Reference/HasOne.php
@@ -32,7 +32,7 @@ class HasOne extends Reference
         $fieldPropsRefl = (new \ReflectionClass(Model\FieldPropertiesTrait::class))->getProperties();
         $fieldPropsRefl[] = (new \ReflectionClass(Model\JoinLinkTrait::class))->getProperty('joinName');
 
-        $ourModel = $this->getOurModel(null);
+        $ourModel = $this->getOurModel();
         if (!$ourModel->hasField($this->ourField)) {
             $fieldSeed = [];
             foreach ($fieldPropsRefl as $fieldPropRefl) {
@@ -63,7 +63,7 @@ class HasOne extends Reference
     {
         // TODO horrible hack to render the field with a table prefix,
         // find a solution how to wrap the field inside custom Field (without owner?)
-        $ourModelCloned = clone $this->getOurModel(null);
+        $ourModelCloned = clone $this->getOurModel();
         $ourModelCloned->persistenceData['use_table_prefixes'] = true;
 
         return $ourModelCloned->getReference($this->link)->getOurField();

--- a/src/Reference/HasOneSql.php
+++ b/src/Reference/HasOneSql.php
@@ -78,7 +78,7 @@ class HasOneSql extends HasOne
 
         $ourModel = $this->getOurModel(null);
 
-        // if caption/type is not defined in $defaults -> get it directly from the linked model field $theirFieldName
+        // if caption/type is not defined in $defaults then infer it from their field
         $refModel = $ourModel->getReference($this->link)->createTheirModel();
         $refModelField = $refModel->getField($theirFieldName);
         $defaults['type'] ??= $refModelField->type;
@@ -122,20 +122,6 @@ class HasOneSql extends HasOne
         return $this;
     }
 
-    /**
-     * Creates model that can be used for generating sub-query actions.
-     *
-     * @param array<string, mixed> $defaults
-     */
-    public function refLink(Model $ourModel, array $defaults = []): Model
-    {
-        $theirModel = $this->createTheirModel($defaults);
-
-        $theirModel->addCondition($this->getTheirFieldName($theirModel), $this->referenceOurValue());
-
-        return $theirModel;
-    }
-
     #[\Override]
     public function ref(Model $ourModelOrEntity, array $defaults = []): Model
     {
@@ -152,6 +138,20 @@ class HasOneSql extends HasOne
             $theirModel->getModel(true)
                 ->addCondition($this->getTheirFieldName($theirModel), $ourFieldExpression);
         }
+
+        return $theirModel;
+    }
+
+    /**
+     * Creates model that can be used for generating sub-query actions.
+     *
+     * @param array<string, mixed> $defaults
+     */
+    public function refLink(Model $ourModelOrEntity, array $defaults = []): Model
+    {
+        $theirModel = $this->createTheirModel($defaults);
+
+        $theirModel->addCondition($this->getTheirFieldName($theirModel), $this->referenceOurValue());
 
         return $theirModel;
     }

--- a/src/Reference/HasOneSql.php
+++ b/src/Reference/HasOneSql.php
@@ -147,7 +147,7 @@ class HasOneSql extends HasOne
      *
      * @param array<string, mixed> $defaults
      */
-    public function refLink(Model $ourModelOrEntity, array $defaults = []): Model
+    public function refLink(array $defaults = []): Model
     {
         $theirModel = $this->createTheirModel($defaults);
 

--- a/src/Reference/HasOneSql.php
+++ b/src/Reference/HasOneSql.php
@@ -16,7 +16,7 @@ class HasOneSql extends HasOne
      */
     private function _addField(string $fieldName, bool $theirFieldIsTitle, ?string $theirFieldName, array $defaults): SqlExpressionField
     {
-        $ourModel = $this->getOurModel(null);
+        $ourModel = $this->getOurModel();
 
         $fieldExpression = $ourModel->addExpression($fieldName, array_merge([
             'expr' => function (Model $ourModel) use ($theirFieldIsTitle, $theirFieldName) {
@@ -76,7 +76,7 @@ class HasOneSql extends HasOne
             $theirFieldName = $fieldName;
         }
 
-        $ourModel = $this->getOurModel(null);
+        $ourModel = $this->getOurModel();
 
         // if caption/type is not defined in $defaults then infer it from their field
         $refModel = $ourModel->getReference($this->link)->createTheirModel();
@@ -167,7 +167,7 @@ class HasOneSql extends HasOne
      */
     public function addTitle(array $defaults = []): SqlExpressionField
     {
-        $ourModel = $this->getOurModel(null);
+        $ourModel = $this->getOurModel();
 
         $fieldName = $defaults['field'] ?? preg_replace('~_(' . preg_quote($ourModel->idField, '~') . '|id)$~', '', $this->link);
 

--- a/tests/ContainsOne/Address.php
+++ b/tests/ContainsOne/Address.php
@@ -20,7 +20,7 @@ class Address extends Model
     {
         parent::init();
 
-        $this->hasOne($this->fieldName()->country_id, ['model' => [Country::class], 'type' => 'integer']);
+        $this->hasOne($this->fieldName()->country_id, ['model' => [Country::class]]);
 
         $this->addField($this->fieldName()->address);
         $this->addField($this->fieldName()->built_date, ['type' => 'datetime']);

--- a/tests/FieldTest.php
+++ b/tests/FieldTest.php
@@ -767,11 +767,22 @@ class FieldTest extends TestCase
         $m->set('foo', 'ABC');
     }
 
-    public function testAddFieldDirectly(): void
+    public function testAddFieldDuplicateNameException(): void
+    {
+        $m = new Model();
+        $m->addField('foo');
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage('Field with such name already exists');
+        $m->addField('foo');
+    }
+
+    public function testAddFieldDirectlyException(): void
     {
         $model = new Model();
 
         $this->expectException(Exception::class);
+        $this->expectExceptionMessage('Field can be added using addField() method only');
         $model->add(new Field());
     }
 

--- a/tests/JoinArrayTest.php
+++ b/tests/JoinArrayTest.php
@@ -57,20 +57,33 @@ class JoinArrayTest extends TestCase
         self::assertSame('test_id', $this->getProtected($j, 'masterField'));
         self::assertSame('id', $this->getProtected($j, 'foreignField'));
 
-        $this->expectException(Exception::class); // TODO not implemented yet, see https://github.com/atk4/data/issues/803
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage('Joining tables on non-id fields is not implemented yet');
         $j = $m->join('contact4.foo_id', ['masterField' => 'test_id', 'reverse' => true]);
         // self::assertTrue($j->reverse);
         // self::assertSame('test_id', $this->getProtected($j, 'masterField'));
         // self::assertSame('foo_id', $this->getProtected($j, 'foreignField'));
     }
 
-    public function testJoinException(): void
+    public function testDirectionException(): void
     {
         $db = new Persistence\Array_(['user' => [], 'contact' => []]);
         $m = new Model($db, ['table' => 'user']);
 
         $this->expectException(Exception::class);
+        $this->expectExceptionMessage('Joining tables on non-id fields is not implemented yet');
         $m->join('contact.foo_id', ['masterField' => 'test_id']);
+    }
+
+    public function testAddJoinDuplicateNameException(): void
+    {
+        $db = new Persistence\Array_();
+        $m = new Model($db);
+        $m->join('foo');
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage('Join with such name already exists');
+        $m->join('foo');
     }
 
     public function testJoinSaving1(): void
@@ -212,15 +225,16 @@ class JoinArrayTest extends TestCase
         ], $this->getInternalPersistenceData($db));
     }
 
-    /* Joining tables on non-id fields is not implemented yet
     public function testJoinSaving4(): void
     {
         $db = new Persistence\Array_(['user' => [], 'contact' => []]);
         $user = new Model($db, ['table' => 'user']);
         $user->addField('name');
         $user->addField('code');
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage('Joining tables on non-id fields is not implemented yet');
         $j = $user->join('contact.code', ['masterField' => 'code']);
-        $j->addField('contact_phone');
+        /* $j->addField('contact_phone');
 
         $user = $user->createEntity();
         $user->set('name', 'John');
@@ -236,9 +250,8 @@ class JoinArrayTest extends TestCase
             'contact' => [
                 1 => ['id' => 1, 'code' => 'C28', 'contact_phone' => '+123'],
             ],
-        ], $this->getInternalPersistenceData($db));
+        ], $this->getInternalPersistenceData($db)); */
     }
-    */
 
     public function testJoinLoading(): void
     {

--- a/tests/Persistence/Sql/QueryTest.php
+++ b/tests/Persistence/Sql/QueryTest.php
@@ -37,7 +37,7 @@ class QueryTest extends TestCase
             }
         };
 
-        if (!(new \ReflectionProperty($query, 'connection'))->isInitialized($query)) {
+        if (($query->connection ?? null) === null) {
             $query->connection = \Closure::bind(static function () use ($query) {
                 $connection = new Persistence\Sql\Sqlite\Connection();
                 $connection->expressionClass = \Closure::bind(static fn () => $query->expressionClass, null, Query::class)();

--- a/tests/RandomTest.php
+++ b/tests/RandomTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Atk4\Data\Tests;
 
-use Atk4\Core\Exception as CoreException;
 use Atk4\Data\Exception;
 use Atk4\Data\Field;
 use Atk4\Data\Model;
@@ -355,12 +354,12 @@ class RandomTest extends TestCase
         $m->delete();
     }
 
-    public function testAddFieldDuplicateNameException(): void
+    public function testAddTitleDuplicateNameException(): void
     {
         $m = new Model_Item($this->db);
 
-        $this->expectException(CoreException::class);
-        $this->expectExceptionMessage('already exist');
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage('Field with such name already exists');
         $m->hasOne('foo', ['model' => [Model_Item::class]])->addTitle();
     }
 

--- a/tests/RandomTest.php
+++ b/tests/RandomTest.php
@@ -355,7 +355,7 @@ class RandomTest extends TestCase
         $m->delete();
     }
 
-    public function testIssue220(): void
+    public function testAddFieldDuplicateNameException(): void
     {
         $m = new Model_Item($this->db);
 

--- a/tests/ReferenceSqlTest.php
+++ b/tests/ReferenceSqlTest.php
@@ -68,10 +68,7 @@ class ReferenceSqlTest extends TestCase
         );
     }
 
-    /**
-     * Tests to make sure refLink properly generates field links.
-     */
-    public function testLink(): void
+    public function testRefLink(): void
     {
         $u = new Model($this->db, ['table' => 'user']);
         $u->addField('name');
@@ -85,6 +82,24 @@ class ReferenceSqlTest extends TestCase
         $this->assertSameSql(
             'select `id`, `amount`, `user_id` from `order` `_O_7442e29d7d53` where `user_id` = `user`.`id`',
             $u->refLink('Orders')->action('select')->render()[0]
+        );
+    }
+
+    public function testRefLink2(): void
+    {
+        $u = new Model($this->db, ['table' => 'user']);
+        $u->addField('name');
+        $u->addField('currency_code');
+
+        $c = new Model($this->db, ['table' => 'currency']);
+        $c->addField('code');
+        $c->addField('name');
+
+        $u->hasMany('cur', ['model' => $c, 'ourField' => 'currency_code', 'theirField' => 'code']);
+
+        $this->assertSameSql(
+            'select `id`, `code`, `name` from `currency` `_c_b5fddf1ef601` where `code` = `user`.`currency_code`',
+            $u->refLink('cur')->action('select')->render()[0]
         );
     }
 
@@ -121,24 +136,6 @@ class ReferenceSqlTest extends TestCase
 
         $cc = $u->load(2)->ref('cur');
         self::assertSame('Pound', $cc->get('name'));
-    }
-
-    public function testLink2(): void
-    {
-        $u = new Model($this->db, ['table' => 'user']);
-        $u->addField('name');
-        $u->addField('currency_code');
-
-        $c = new Model($this->db, ['table' => 'currency']);
-        $c->addField('code');
-        $c->addField('name');
-
-        $u->hasMany('cur', ['model' => $c, 'ourField' => 'currency_code', 'theirField' => 'code']);
-
-        $this->assertSameSql(
-            'select `id`, `code`, `name` from `currency` `_c_b5fddf1ef601` where `code` = `user`.`currency_code`',
-            $u->refLink('cur')->action('select')->render()[0]
-        );
     }
 
     /**

--- a/tests/ReferenceTest.php
+++ b/tests/ReferenceTest.php
@@ -79,7 +79,17 @@ class ReferenceTest extends TestCase
         self::assertSame('order', $o->getModel()->table);
     }
 
-    public function testRefName1(): void
+    public function testRefLinkEntityException(): void
+    {
+        $user = new Model($this->db, ['table' => 'user']);
+        $user = $user->createEntity();
+
+        $this->expectException(\TypeError::class);
+        $this->expectExceptionMessage('Expected model, but instance is an entity');
+        $user->refLink('order');
+    }
+
+    public function testHasManyDuplicateNameException(): void
     {
         $user = new Model(null, ['table' => 'user']);
         $order = new Model();
@@ -88,10 +98,11 @@ class ReferenceTest extends TestCase
         $user->hasMany('Orders', ['model' => $order]);
 
         $this->expectException(Exception::class);
+        $this->expectExceptionMessage('Reference with such name already exists');
         $user->hasMany('Orders', ['model' => $order]);
     }
 
-    public function testRefName2(): void
+    public function testHasOneDuplicateNameException(): void
     {
         $order = new Model(null, ['table' => 'order']);
         $user = new Model(null, ['table' => 'user']);
@@ -99,6 +110,7 @@ class ReferenceTest extends TestCase
         $user->hasOne('user_id', ['model' => $user]);
 
         $this->expectException(Exception::class);
+        $this->expectExceptionMessage('Reference with such name already exists');
         $user->hasOne('user_id', ['model' => $user]);
     }
 
@@ -157,5 +169,7 @@ class ReferenceTest extends TestCase
         $order->hasOne('placed_by', ['model' => $user, 'ourField' => 'placed_by_user_id', 'checkTheirType' => false]);
 
         self::assertSame('user', $order->ref('placed_by')->table);
+        self::assertSame('string', $order->getField('placed_by_user_id')->type);
+        self::assertSame('integer', $order->ref('placed_by')->getIdField()->type);
     }
 }

--- a/tests/ScopeTest.php
+++ b/tests/ScopeTest.php
@@ -216,7 +216,7 @@ class ScopeTest extends TestCase
         $condition = new Condition('name', 'abc');
 
         $this->expectException(Exception::class);
-        $this->expectExceptionMessage('Condition must be associated with Model to convert to words');
+        $this->expectExceptionMessage('Condition must be associated with model to convert to words');
         $condition->toWords();
     }
 

--- a/tests/UserActionTest.php
+++ b/tests/UserActionTest.php
@@ -159,6 +159,16 @@ class UserActionTest extends TestCase
         self::assertSame('Also Backup UaClient', $client->getUserAction('also_backup')->getDescription());
     }
 
+    public function testAddUserActionDuplicateNameException(): void
+    {
+        $m = new Model();
+        $m->addUserAction('foo', static fn () => 1);
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage('User action with such name already exists');
+        $m->addUserAction('foo', static fn () => 1);
+    }
+
     public function testAppliesToSingleRecordNotEntityException(): void
     {
         $client = new UaClient($this->pers);


### PR DESCRIPTION
`refLink` method does not make sense on entity

when used thru Model method (`Model::refLink()`), no change is needed unless wrongly used on entity