### PR TITLE
Make LIKE operator escapable

### DIFF
--- a/src/Persistence/Sql/Oracle/Query.php
+++ b/src/Persistence/Sql/Oracle/Query.php
@@ -18,6 +18,18 @@ class Query extends BaseQuery
     protected string $expressionClass = Expression::class;
 
     #[\Override]
+    protected function _renderConditionLikeOperator(bool $negated, string $sqlLeft, string $sqlRight): string
+    {
+        $sqlRight = 'regexp_replace(regexp_replace(' . $sqlRight
+            . ', ' . $this->escapeStringLiteral('((\\\\\\\)*)(\\\([^_%]))?')
+            . ', ' . $this->escapeStringLiteral('\1\4')
+            . '), ' . $this->escapeStringLiteral('((^|[^\\\])(\\\\\\\)*\\\)$')
+            . ', ' . $this->escapeStringLiteral('\1\\\\') . ')';
+
+        return parent::_renderConditionLikeOperator($negated, $sqlLeft, $sqlRight);
+    }
+
+    #[\Override]
     public function render(): array
     {
         if ($this->mode === 'select' && count($this->args['table'] ?? []) === 0) {

--- a/src/Persistence/Sql/Query.php
+++ b/src/Persistence/Sql/Query.php
@@ -518,6 +518,12 @@ abstract class Query extends Expression
         return $sqlLeft . ($negated ? ' not' : '') . ' in (' . implode(', ', $sqlValues) . ')';
     }
 
+    protected function _renderConditionLikeOperator(bool $negated, string $sqlLeft, string $sqlRight): string
+    {
+        return $sqlLeft . ($negated ? ' not' : '') . ' like ' . $sqlRight
+            . ' escape ' . $this->escapeStringLiteral('\\');
+    }
+
     /**
      * @param array{mixed}|array{mixed, string|null, mixed} $row
      */
@@ -604,6 +610,10 @@ abstract class Query extends Expression
         // if value is object, then it should be Expression or Query itself
         // otherwise just escape value
         $value = $this->consume($value, self::ESCAPE_PARAM);
+
+        if (in_array($operator, ['like', 'not like'], true)) {
+            return $this->_renderConditionLikeOperator($operator === 'not like', $field, $value);
+        }
 
         return $this->_renderConditionBinary($operator, $field, $value);
     }

--- a/tests/ConditionSqlTest.php
+++ b/tests/ConditionSqlTest.php
@@ -510,7 +510,7 @@ class ConditionSqlTest extends TestCase
                 ['id' => 2, 'name' => 'Peter', 'c' => 2000],
                 ['id' => 3, 'name' => 'Joe', 'c' => 50],
                 ['id' => 4, 'name' => 'Ca%ro_li\ne', 'c' => null],
-                ['id' => 5, 'name' => 'Ca.ro.li.ne', 'c' => null],
+                ['id' => 5, 'name' => 'Ca.ro.li\\\ne', 'c' => null],
             ],
         ]);
 
@@ -541,8 +541,21 @@ class ConditionSqlTest extends TestCase
         self::assertSame([1], $findIdsLikeFx('c', '%0%', true));
 
         self::assertSame([4, 5], $findIdsLikeFx('name', '%Ca%ro%'));
+        self::assertSame([4], $findIdsLikeFx('name', '%Ca\%ro%'));
+
         self::assertSame([4, 5], $findIdsLikeFx('name', '%ro_li%'));
-        // self::assertSame([4, 5], $findIdsLikeFx('name', '%li_\ne%'));
-        // self::assertSame([4], $findIdsLikeFx('name', '%li\\ne%'));
+        self::assertSame([4], $findIdsLikeFx('name', '%ro\_li%'));
+
+        self::assertSame([], $findIdsLikeFx('name', '%li\ne%'));
+        self::assertSame([4, 5], $findIdsLikeFx('name', '%li%\ne%'));
+        self::assertSame([4], $findIdsLikeFx('name', '%li\\\ne%'));
+        self::assertSame([4], $findIdsLikeFx('name', '%li\\\\\ne%'));
+        self::assertSame([5], $findIdsLikeFx('name', '%li\\\\\\\ne%'));
+        self::assertSame([5], $findIdsLikeFx('name', '%li\\\\\\\\\ne%'));
+        self::assertSame([], $findIdsLikeFx('name', '%li\\\\\\\\\\\ne%'));
+        self::assertSame([5], $findIdsLikeFx('name', '%.li%ne'));
+        self::assertSame([], $findIdsLikeFx('name', '%.li%ne\\'));
+        self::assertSame([], $findIdsLikeFx('name', '%.li%ne\\\\'));
+        self::assertSame([], $findIdsLikeFx('name', '%*li%ne'));
     }
 }

--- a/tests/Persistence/Sql/QueryTest.php
+++ b/tests/Persistence/Sql/QueryTest.php
@@ -11,6 +11,7 @@ use Atk4\Data\Persistence\Sql\Expression;
 use Atk4\Data\Persistence\Sql\Mysql\Connection as MysqlConnection;
 use Atk4\Data\Persistence\Sql\Mysql\Expression as MysqlExpression;
 use Atk4\Data\Persistence\Sql\Mysql\Query as MysqlQuery;
+use Atk4\Data\Persistence\Sql\Oracle\Query as OracleQuery;
 use Atk4\Data\Persistence\Sql\Query;
 use Atk4\Data\Persistence\Sql\Sqlite\Connection as SqliteConnection;
 use PHPUnit\Framework\Attributes\DataProvider;
@@ -49,6 +50,10 @@ class QueryTest extends TestCase
             #[\Override]
             protected function escapeStringLiteral(string $value): string
             {
+                if ($value === '\\') {
+                    return '\'\\\'';
+                }
+
                 return null; // @phpstan-ignore-line
             }
         };
@@ -772,12 +777,18 @@ class QueryTest extends TestCase
 
         // like | not like
         self::assertSame(
-            'where "name" like :a',
+            'where "name" like :a escape \'\\\'',
             $this->q('[where]')->where('name', 'like', 'foo')->render()[0]
         );
         self::assertSame(
-            'where "name" not like :a',
+            'where "name" not like :a escape \'\\\'',
             $this->q('[where]')->where('name', 'not like', 'foo')->render()[0]
+        );
+        self::assertSame(
+            <<<'EOF'
+                where "name" like regexp_replace(regexp_replace(:xxaaaa, '((\\\\)*)(\\([^_%]))?', '\1\4'), '((^|[^\\])(\\\\)*\\)$', concat('\1', rpad(chr(92), 2, chr(92)))) escape chr(92)
+                EOF,
+            (new OracleQuery('[where]'))->where('name', 'like', 'foo')->render()[0]
         );
     }
 
@@ -1328,7 +1339,7 @@ class QueryTest extends TestCase
             ->caseWhen(['status', 'like', '%Used%'], 't2.expose_used')
             ->caseElse(null)
             ->render()[0];
-        self::assertSame('case when "status" = :a then :b when "status" like :c then :d else :e end', $s);
+        self::assertSame('case when "status" = :a then :b when "status" like :c escape \'\\\' then :d else :e end', $s);
 
         // with subqueries
         $age = $this->e('year(now()) - year(birth_date)');


### PR DESCRIPTION
unify LIKE behaviour across all DB vendors (was default on MySQL, BC break on SQLite)

UPDATE: was reworked in #1198