### PR TITLE
Make LIKE operator escapable

### DIFF
--- a/src/Persistence/Sql/Expression.php
+++ b/src/Persistence/Sql/Expression.php
@@ -387,7 +387,7 @@ abstract class Expression implements Expressionable, \ArrayAccess
         $i = 0;
         $sql = preg_replace_callback(
             '~' . self::QUOTED_TOKEN_REGEX . '\K|(?:\?|:\w+)~',
-            static function ($matches) use ($params, &$i) {
+            function ($matches) use ($params, &$i) {
                 if ($matches[0] === '') {
                     return '';
                 }
@@ -411,7 +411,7 @@ abstract class Expression implements Expressionable, \ArrayAccess
                     return '*long string* (length: ' . strlen($v) . ' bytes, sha256: ' . hash('sha256', $v) . ')';
                 }
 
-                return '\'' . str_replace('\'', '\'\'', $v) . '\'';
+                return $this->escapeStringLiteral($v);
             },
             $sql
         );

--- a/src/Persistence/Sql/Mssql/Query.php
+++ b/src/Persistence/Sql/Mssql/Query.php
@@ -36,6 +36,15 @@ class Query extends BaseQuery
         EOF;
 
     #[\Override]
+    protected function _renderConditionLikeOperator(bool $negated, string $sqlLeft, string $sqlRight): string
+    {
+        $sqlRightEscaped = $sqlRight;
+
+        return $sqlLeft . ($negated ? ' not' : '') . ' like ' . $sqlRightEscaped
+            . ' escape ' . $this->escapeStringLiteral('\\');
+    }
+
+    #[\Override]
     protected function deduplicateRenderOrder(array $sqls): array
     {
         $res = [];

--- a/src/Persistence/Sql/Mssql/Query.php
+++ b/src/Persistence/Sql/Mssql/Query.php
@@ -46,11 +46,11 @@ class Query extends BaseQuery
         // https://devblogs.microsoft.com/azure-sql/introducing-regular-expression-regex-support-in-azure-sql-db/
         $sqlRightEscaped = $sqlRight;
         foreach (['\\', '_', '%'] as $v) {
-            $sqlRightEscaped = $replaceSqlFx($sqlRightEscaped, '\\' . $v, '\\' . "\x01" . $v);
+            $sqlRightEscaped = $replaceSqlFx($sqlRightEscaped, '\\' . $v, '\\' . $v . '*');
         }
         $sqlRightEscaped = $replaceSqlFx($sqlRightEscaped, '\\', '\\\\');
-        foreach (['\\', '_', '%'] as $v) {
-            $sqlRightEscaped = $replaceSqlFx($sqlRightEscaped, '\\\\' . "\x01" . str_replace('\\', '\\\\', $v), '\\' . $v);
+        foreach (['_', '%', '\\'] as $v) {
+            $sqlRightEscaped = $replaceSqlFx($sqlRightEscaped, '\\\\' . str_replace('\\', '\\\\', $v) . '*', '\\' . $v);
         }
 
         return $sqlLeft . ($negated ? ' not' : '') . ' like ' . $sqlRightEscaped

--- a/src/Persistence/Sql/Mssql/Query.php
+++ b/src/Persistence/Sql/Mssql/Query.php
@@ -38,7 +38,20 @@ class Query extends BaseQuery
     #[\Override]
     protected function _renderConditionLikeOperator(bool $negated, string $sqlLeft, string $sqlRight): string
     {
+        $replaceSqlFx = function (string $sql, string $search, string $replacement) {
+            return 'replace(' . $sql . ', ' . $this->escapeStringLiteral($search) . ', ' . $this->escapeStringLiteral($replacement) . ')';
+        };
+
+        // workaround missing regexp_replace() function
+        // https://devblogs.microsoft.com/azure-sql/introducing-regular-expression-regex-support-in-azure-sql-db/
         $sqlRightEscaped = $sqlRight;
+        foreach (['\\', '_', '%'] as $v) {
+            $sqlRightEscaped = $replaceSqlFx($sqlRightEscaped, '\\' . $v, '\\' . "\x01" . $v);
+        }
+        $sqlRightEscaped = $replaceSqlFx($sqlRightEscaped, '\\', '\\\\');
+        foreach (['\\', '_', '%'] as $v) {
+            $sqlRightEscaped = $replaceSqlFx($sqlRightEscaped, '\\\\' . "\x01" . str_replace('\\', '\\\\', $v), '\\' . $v);
+        }
 
         return $sqlLeft . ($negated ? ' not' : '') . ' like ' . $sqlRightEscaped
             . ' escape ' . $this->escapeStringLiteral('\\');

--- a/src/Persistence/Sql/Mysql/Query.php
+++ b/src/Persistence/Sql/Mysql/Query.php
@@ -29,7 +29,6 @@ class Query extends BaseQuery
             };
 
             // workaround missing regexp_replace() function
-            // https://devblogs.microsoft.com/azure-sql/introducing-regular-expression-regex-support-in-azure-sql-db/
             $sqlRightEscaped = $sqlRight;
             foreach (['\\', '_', '%'] as $v) {
                 $sqlRightEscaped = $replaceSqlFx($sqlRightEscaped, '\\' . $v, '\\' . $v . '*');

--- a/src/Persistence/Sql/Mysql/Query.php
+++ b/src/Persistence/Sql/Mysql/Query.php
@@ -21,7 +21,12 @@ class Query extends BaseQuery
     protected function _renderConditionLikeOperator(bool $negated, string $sqlLeft, string $sqlRight): string
     {
         $serverVersion = $this->connection->getConnection()->getWrappedConnection()->getServerVersion(); // @phpstan-ignore-line
-        $isMysql5x = str_starts_with($serverVersion, '5.') && !str_contains($serverVersion, 'MariaDB');
+        $isMariaDb = str_contains($serverVersion, 'MariaDB');
+        $isMysql5x = str_starts_with($serverVersion, '5.') && !$isMariaDb;
+
+        if ($isMariaDb) {
+            return parent::_renderConditionLikeOperator($negated, $sqlLeft, $sqlRight);
+        }
 
         $sqlRightEscaped = $isMysql5x
             ? $sqlRight

--- a/src/Persistence/Sql/Mysql/Query.php
+++ b/src/Persistence/Sql/Mysql/Query.php
@@ -21,18 +21,13 @@ class Query extends BaseQuery
     protected function _renderConditionLikeOperator(bool $negated, string $sqlLeft, string $sqlRight): string
     {
         $serverVersion = $this->connection->getConnection()->getWrappedConnection()->getServerVersion(); // @phpstan-ignore-line
-        $isMariaDb = str_contains($serverVersion, 'MariaDB');
-        $isMysql5x = str_starts_with($serverVersion, '5.') && !$isMariaDb;
-
-        if ($isMariaDb) {
-            return parent::_renderConditionLikeOperator($negated, $sqlLeft, $sqlRight);
-        }
+        $isMysql5x = str_starts_with($serverVersion, '5.') && !str_contains($serverVersion, 'MariaDB');
 
         $sqlRightEscaped = $isMysql5x
             ? $sqlRight
             : 'regexp_replace(' . $sqlRight . ', '
-                . $this->escapeStringLiteral('(\\\[\\\_%])|(\\\)') . ', '
-                . $this->escapeStringLiteral('$1$2$2') . ')';
+                . $this->escapeStringLiteral('\\\\\\\|\\\(?![_%])') . ', '
+                . $this->escapeStringLiteral('\\\\\\\\') . ')';
 
         return $sqlLeft . ($negated ? ' not' : '') . ' like ' . $sqlRightEscaped
             . ' escape ' . $this->escapeStringLiteral('\\');

--- a/src/Persistence/Sql/Mysql/Query.php
+++ b/src/Persistence/Sql/Mysql/Query.php
@@ -23,14 +23,11 @@ class Query extends BaseQuery
         $serverVersion = $this->connection->getConnection()->getWrappedConnection()->getServerVersion(); // @phpstan-ignore-line
         $isMysql5x = str_starts_with($serverVersion, '5.') && !str_contains($serverVersion, 'MariaDB');
 
-        if ($isMysql5x) {
-            return $sqlLeft . ($negated ? ' not' : '') . ' like ' . $sqlRight
-                . ' escape ' . $this->escapeStringLiteral('\\');
-        }
-
-        $sqlRightEscaped = 'regexp_replace(' . $sqlRight . ', '
-            . $this->escapeStringLiteral('((\\\\\\\)*)(([^\\\]|\\\[\\\_%])|(\\\))') . ', '
-            . $this->escapeStringLiteral('$1$4$5$5') . ')';
+        $sqlRightEscaped = $isMysql5x
+            ? $sqlRight
+            : 'regexp_replace(' . $sqlRight . ', '
+                . $this->escapeStringLiteral('((\\\\\\\)*)(([^\\\]|\\\[\\\_%])|(\\\))') . ', '
+                . $this->escapeStringLiteral('$1$4$5$5') . ')';
 
         return $sqlLeft . ($negated ? ' not' : '') . ' like ' . $sqlRightEscaped
             . ' escape ' . $this->escapeStringLiteral('\\');

--- a/src/Persistence/Sql/Mysql/Query.php
+++ b/src/Persistence/Sql/Mysql/Query.php
@@ -38,6 +38,12 @@ class Query extends BaseQuery
             foreach (['_', '%', '\\'] as $v) {
                 $sqlRightEscaped = $replaceSqlFx($sqlRightEscaped, '\\\\' . str_replace('\\', '\\\\', $v) . '*', '\\' . $v);
             }
+
+            // workaround https://bugs.mysql.com/bug.php?id=84118
+            // https://bugs.mysql.com/bug.php?id=63829
+            // https://bugs.mysql.com/bug.php?id=68901
+            // https://www.db-fiddle.com/f/argVwuJuqjFAALqfUSTEJb/0
+            $sqlRightEscaped = $replaceSqlFx($sqlRightEscaped, '%\\', '%\\\\');
         } else {
             $sqlRightEscaped = 'regexp_replace(' . $sqlRight . ', '
                 . $this->escapeStringLiteral('\\\\\\\|\\\(?![_%])') . ', '

--- a/src/Persistence/Sql/Mysql/Query.php
+++ b/src/Persistence/Sql/Mysql/Query.php
@@ -32,11 +32,11 @@ class Query extends BaseQuery
             // https://devblogs.microsoft.com/azure-sql/introducing-regular-expression-regex-support-in-azure-sql-db/
             $sqlRightEscaped = $sqlRight;
             foreach (['\\', '_', '%'] as $v) {
-                $sqlRightEscaped = $replaceSqlFx($sqlRightEscaped, '\\' . $v, '\\' . "\x01" . $v);
+                $sqlRightEscaped = $replaceSqlFx($sqlRightEscaped, '\\' . $v, '\\' . $v . '*');
             }
             $sqlRightEscaped = $replaceSqlFx($sqlRightEscaped, '\\', '\\\\');
-            foreach (['\\', '_', '%'] as $v) {
-                $sqlRightEscaped = $replaceSqlFx($sqlRightEscaped, '\\\\' . "\x01" . str_replace('\\', '\\\\', $v), '\\' . $v);
+            foreach (['_', '%', '\\'] as $v) {
+                $sqlRightEscaped = $replaceSqlFx($sqlRightEscaped, '\\\\' . str_replace('\\', '\\\\', $v) . '*', '\\' . $v);
             }
         } else {
             $sqlRightEscaped = 'regexp_replace(' . $sqlRight . ', '

--- a/src/Persistence/Sql/Mysql/Query.php
+++ b/src/Persistence/Sql/Mysql/Query.php
@@ -23,11 +23,26 @@ class Query extends BaseQuery
         $serverVersion = $this->connection->getConnection()->getWrappedConnection()->getServerVersion(); // @phpstan-ignore-line
         $isMysql5x = str_starts_with($serverVersion, '5.') && !str_contains($serverVersion, 'MariaDB');
 
-        $sqlRightEscaped = $isMysql5x
-            ? $sqlRight
-            : 'regexp_replace(' . $sqlRight . ', '
+        if ($isMysql5x) {
+            $replaceSqlFx = function (string $sql, string $search, string $replacement) {
+                return 'replace(' . $sql . ', ' . $this->escapeStringLiteral($search) . ', ' . $this->escapeStringLiteral($replacement) . ')';
+            };
+
+            // workaround missing regexp_replace() function
+            // https://devblogs.microsoft.com/azure-sql/introducing-regular-expression-regex-support-in-azure-sql-db/
+            $sqlRightEscaped = $sqlRight;
+            foreach (['\\', '_', '%'] as $v) {
+                $sqlRightEscaped = $replaceSqlFx($sqlRightEscaped, '\\' . $v, '\\' . "\x01" . $v);
+            }
+            $sqlRightEscaped = $replaceSqlFx($sqlRightEscaped, '\\', '\\\\');
+            foreach (['\\', '_', '%'] as $v) {
+                $sqlRightEscaped = $replaceSqlFx($sqlRightEscaped, '\\\\' . "\x01" . str_replace('\\', '\\\\', $v), '\\' . $v);
+            }
+        } else {
+            $sqlRightEscaped = 'regexp_replace(' . $sqlRight . ', '
                 . $this->escapeStringLiteral('\\\\\\\|\\\(?![_%])') . ', '
                 . $this->escapeStringLiteral('\\\\\\\\') . ')';
+        }
 
         return $sqlLeft . ($negated ? ' not' : '') . ' like ' . $sqlRightEscaped
             . ' escape ' . $this->escapeStringLiteral('\\');

--- a/src/Persistence/Sql/Mysql/Query.php
+++ b/src/Persistence/Sql/Mysql/Query.php
@@ -31,8 +31,8 @@ class Query extends BaseQuery
         $sqlRightEscaped = $isMysql5x
             ? $sqlRight
             : 'regexp_replace(' . $sqlRight . ', '
-                . $this->escapeStringLiteral('((\\\\\\\)*)(([^\\\]|\\\[\\\_%])|(\\\))') . ', '
-                . $this->escapeStringLiteral('$1$4$5$5') . ')';
+                . $this->escapeStringLiteral('(\\\[\\\_%])|(\\\)') . ', '
+                . $this->escapeStringLiteral('$1$2$2') . ')';
 
         return $sqlLeft . ($negated ? ' not' : '') . ' like ' . $sqlRightEscaped
             . ' escape ' . $this->escapeStringLiteral('\\');

--- a/src/Persistence/Sql/Mysql/Query.php
+++ b/src/Persistence/Sql/Mysql/Query.php
@@ -18,6 +18,25 @@ class Query extends BaseQuery
     protected string $templateUpdate = 'update [table][join] set [set] [where]';
 
     #[\Override]
+    protected function _renderConditionLikeOperator(bool $negated, string $sqlLeft, string $sqlRight): string
+    {
+        $serverVersion = $this->connection->getConnection()->getWrappedConnection()->getServerVersion(); // @phpstan-ignore-line
+        $isMysql5x = str_starts_with($serverVersion, '5.') && !str_contains($serverVersion, 'MariaDB');
+
+        if ($isMysql5x) {
+            return $sqlLeft . ($negated ? ' not' : '') . ' like ' . $sqlRight
+                . ' escape ' . $this->escapeStringLiteral('\\');
+        }
+
+        $sqlRightEscaped = 'regexp_replace(' . $sqlRight . ', '
+            . $this->escapeStringLiteral('((\\\\\\\)*)(([^\\\]|\\\[\\\_%])|(\\\))') . ', '
+            . $this->escapeStringLiteral('$1$4$5$5') . ')';
+
+        return $sqlLeft . ($negated ? ' not' : '') . ' like ' . $sqlRightEscaped
+            . ' escape ' . $this->escapeStringLiteral('\\');
+    }
+
+    #[\Override]
     protected function _renderConditionRegexpOperator(bool $negated, string $sqlLeft, string $sqlRight): string
     {
         $serverVersion = $this->connection->getConnection()->getWrappedConnection()->getServerVersion(); // @phpstan-ignore-line

--- a/src/Persistence/Sql/Oracle/Query.php
+++ b/src/Persistence/Sql/Oracle/Query.php
@@ -18,18 +18,6 @@ class Query extends BaseQuery
     protected string $expressionClass = Expression::class;
 
     #[\Override]
-    protected function _renderConditionLikeOperator(bool $negated, string $sqlLeft, string $sqlRight): string
-    {
-        $sqlRight = 'regexp_replace(regexp_replace(' . $sqlRight
-            . ', ' . $this->escapeStringLiteral('((\\\\\\\)*)(\\\([^_%]))?')
-            . ', ' . $this->escapeStringLiteral('\1\4')
-            . '), ' . $this->escapeStringLiteral('((^|[^\\\])(\\\\\\\)*\\\)$')
-            . ', ' . $this->escapeStringLiteral('\1\\\\') . ')';
-
-        return parent::_renderConditionLikeOperator($negated, $sqlLeft, $sqlRight);
-    }
-
-    #[\Override]
     protected function _renderConditionRegexpOperator(bool $negated, string $sqlLeft, string $sqlRight): string
     {
         return ($negated ? 'not ' : '') . 'regexp_like(' . $sqlLeft . ', ' . $sqlRight

--- a/src/Persistence/Sql/Postgresql/Query.php
+++ b/src/Persistence/Sql/Postgresql/Query.php
@@ -21,8 +21,8 @@ class Query extends BaseQuery
     protected function _renderConditionLikeOperator(bool $negated, string $sqlLeft, string $sqlRight): string
     {
         $sqlRightEscaped = 'regexp_replace(' . $sqlRight . ', '
-            . $this->escapeStringLiteral('((\\\\\\\)*)(([^\\\]|\\\[\\\_%])|(\\\))') . ', '
-            . $this->escapeStringLiteral('\1\4\5\5') . ', '
+            . $this->escapeStringLiteral('(\\\[\\\_%])|(\\\)') . ', '
+            . $this->escapeStringLiteral('\1\2\2') . ', '
             . $this->escapeStringLiteral('g') . ')';
 
         return $sqlLeft . ($negated ? ' not' : '') . ' like ' . $sqlRightEscaped

--- a/src/Persistence/Sql/Postgresql/Query.php
+++ b/src/Persistence/Sql/Postgresql/Query.php
@@ -16,13 +16,14 @@ class Query extends BaseQuery
 
     protected string $templateUpdate = 'update [table][join] set [set] [where]';
     protected string $templateReplace;
-    
+
     #[\Override]
     protected function _renderConditionLikeOperator(bool $negated, string $sqlLeft, string $sqlRight): string
     {
         $sqlRightEscaped = 'regexp_replace(' . $sqlRight . ', '
             . $this->escapeStringLiteral('((\\\\\\\)*)(([^\\\]|\\\[\\\_%])|(\\\))') . ', '
-            . $this->escapeStringLiteral('\1\4\5\5') . ', 1, 0)';
+            . $this->escapeStringLiteral('\1\4\5\5') . ', '
+            . $this->escapeStringLiteral('g') . ')';
 
         return $sqlLeft . ($negated ? ' not' : '') . ' like ' . $sqlRightEscaped
             . ' escape ' . $this->escapeStringLiteral('\\');

--- a/src/Persistence/Sql/Postgresql/Query.php
+++ b/src/Persistence/Sql/Postgresql/Query.php
@@ -16,6 +16,17 @@ class Query extends BaseQuery
 
     protected string $templateUpdate = 'update [table][join] set [set] [where]';
     protected string $templateReplace;
+    
+    #[\Override]
+    protected function _renderConditionLikeOperator(bool $negated, string $sqlLeft, string $sqlRight): string
+    {
+        $sqlRightEscaped = 'regexp_replace(' . $sqlRight . ', '
+            . $this->escapeStringLiteral('((\\\\\\\)*)(([^\\\]|\\\[\\\_%])|(\\\))') . ', '
+            . $this->escapeStringLiteral('\1\4\5\5') . ', 1, 0)';
+
+        return $sqlLeft . ($negated ? ' not' : '') . ' like ' . $sqlRightEscaped
+            . ' escape ' . $this->escapeStringLiteral('\\');
+    }
 
     // needed for PostgreSQL v14 and lower
     #[\Override]

--- a/src/Persistence/Sql/Query.php
+++ b/src/Persistence/Sql/Query.php
@@ -521,8 +521,8 @@ abstract class Query extends Expression
     protected function _renderConditionLikeOperator(bool $negated, string $sqlLeft, string $sqlRight): string
     {
         $sqlRightEscaped = 'regexp_replace(' . $sqlRight . ', '
-            . $this->escapeStringLiteral('((\\\\\\\)*)(([^\\\]|\\\[\\\_%])|(\\\))') . ', '
-            . $this->escapeStringLiteral('\1\4\5\5') . ')';
+            . $this->escapeStringLiteral('(\\\[\\\_%])|(\\\)') . ', '
+            . $this->escapeStringLiteral('\1\2\2') . ')';
 
         return $sqlLeft . ($negated ? ' not' : '') . ' like ' . $sqlRightEscaped
             . ' escape ' . $this->escapeStringLiteral('\\');

--- a/src/Persistence/Sql/Query.php
+++ b/src/Persistence/Sql/Query.php
@@ -520,7 +520,11 @@ abstract class Query extends Expression
 
     protected function _renderConditionLikeOperator(bool $negated, string $sqlLeft, string $sqlRight): string
     {
-        return $sqlLeft . ($negated ? ' not' : '') . ' like ' . $sqlRight
+        $sqlRightEscaped = 'regexp_replace(' . $sqlRight . ', '
+            . $this->escapeStringLiteral('((\\\\\\\)*)(([^\\\]|\\\[\\\_%])|(\\\))') . ', '
+            . $this->escapeStringLiteral('\1\4\5\5') . ')';
+
+        return $sqlLeft . ($negated ? ' not' : '') . ' like ' . $sqlRightEscaped
             . ' escape ' . $this->escapeStringLiteral('\\');
     }
 

--- a/src/Persistence/Sql/Sqlite/Connection.php
+++ b/src/Persistence/Sql/Sqlite/Connection.php
@@ -26,6 +26,7 @@ class Connection extends BaseConnection
             new EnableForeignKeys(),
             new PreserveAutoincrementOnRollbackMiddleware(),
             new CreateRegexpLikeFunctionMiddleware(),
+            new CreateRegexpReplaceFunctionMiddleware(),
         ]);
 
         return $configuration;

--- a/src/Persistence/Sql/Sqlite/CreateRegexpReplaceFunctionMiddleware.php
+++ b/src/Persistence/Sql/Sqlite/CreateRegexpReplaceFunctionMiddleware.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Atk4\Data\Persistence\Sql\Sqlite;
+
+use Doctrine\DBAL\Driver;
+use Doctrine\DBAL\Driver\Connection;
+use Doctrine\DBAL\Driver\Middleware;
+use Doctrine\DBAL\Driver\Middleware\AbstractDriverMiddleware;
+
+class CreateRegexpReplaceFunctionMiddleware implements Middleware
+{
+    #[\Override]
+    public function wrap(Driver $driver): Driver
+    {
+        return new class($driver) extends AbstractDriverMiddleware {
+            #[\Override]
+            public function connect(
+                #[\SensitiveParameter]
+                array $params
+            ): Connection {
+                $connection = parent::connect($params);
+
+                $nativeConnection = $connection->getNativeConnection();
+                assert($nativeConnection instanceof \PDO);
+
+                $nativeConnection->sqliteCreateFunction('regexp_replace', static function ($value, string $pattern, string $replacement, string $flags = ''): ?string {
+                    if ($value === null) {
+                        return null;
+                    }
+
+                    if (is_int($value)) {
+                        $value = (string) $value;
+                    } elseif (is_float($value)) {
+                        $value = Expression::castFloatToString($value);
+                    }
+
+                    $isValidUtf8Value = \PHP_VERSION_ID < 80200
+                        ? preg_match('~~u', $value) === 1 // much faster in PHP 8.1 and lower
+                        : mb_check_encoding($value, 'UTF-8');
+
+                    $pregPattern = '~' . preg_replace('~(?<!\\\)(?:\\\\\\\)*+\K\~~', '\\\~', $pattern) . '~'
+                        . $flags . ($isValidUtf8Value ? 'u' : '');
+
+                    return preg_replace($pregPattern, $replacement, $value);
+                }, -1, \PDO::SQLITE_DETERMINISTIC);
+
+                return $connection;
+            }
+        };
+    }
+}

--- a/src/Schema/Migrator.php
+++ b/src/Schema/Migrator.php
@@ -114,6 +114,16 @@ class Migrator
         $table = $this->fixAbstractAssetName(new Table('0.0'), $tableName);
         if ($this->getDatabasePlatform() instanceof MySQLPlatform) {
             $table->addOption('charset', 'utf8mb4');
+
+            // https://bugs.mysql.com/bug.php?id=84118
+            // https://bugs.mysql.com/bug.php?id=63829
+            // https://bugs.mysql.com/bug.php?id=68901
+            // https://www.db-fiddle.com/f/aGa9atFZzWLha6Hu5J6zsi/0
+            $serverVersion = $this->getConnection()->getConnection()->getWrappedConnection()->getServerVersion(); // @phpstan-ignore-line
+            $isMysql5x = str_starts_with($serverVersion, '5.') && !str_contains($serverVersion, 'MariaDB');
+            if ($isMysql5x) {
+                $table->addOption('collation', 'utf8mb4_general_ci');
+            }
         }
 
         $this->table = $table;

--- a/src/Schema/Migrator.php
+++ b/src/Schema/Migrator.php
@@ -114,16 +114,6 @@ class Migrator
         $table = $this->fixAbstractAssetName(new Table('0.0'), $tableName);
         if ($this->getDatabasePlatform() instanceof MySQLPlatform) {
             $table->addOption('charset', 'utf8mb4');
-
-            // https://bugs.mysql.com/bug.php?id=84118
-            // https://bugs.mysql.com/bug.php?id=63829
-            // https://bugs.mysql.com/bug.php?id=68901
-            // https://www.db-fiddle.com/f/aGa9atFZzWLha6Hu5J6zsi/0
-            $serverVersion = $this->getConnection()->getConnection()->getWrappedConnection()->getServerVersion(); // @phpstan-ignore-line
-            $isMysql5x = str_starts_with($serverVersion, '5.') && !str_contains($serverVersion, 'MariaDB');
-            if ($isMysql5x) {
-                $table->addOption('collation', 'utf8mb4_general_ci');
-            }
         }
 
         $this->table = $table;

--- a/tests/ConditionSqlTest.php
+++ b/tests/ConditionSqlTest.php
@@ -556,12 +556,12 @@ class ConditionSqlTest extends TestCase
         self::assertSame([4, 5], $findIdsLikeFx('name', '%ro_li%'));
         self::assertSame([4], $findIdsLikeFx('name', '%ro\_li%'));
 
-        self::assertSame([], $findIdsLikeFx('name', '%li\ne%'));
+        self::assertSame([4], $findIdsLikeFx('name', '%li\ne%'));
         self::assertSame([4, 5], $findIdsLikeFx('name', '%li%\ne%'));
         self::assertSame([4], $findIdsLikeFx('name', '%li\\\ne%'));
-        self::assertSame([4], $findIdsLikeFx('name', '%li\\\\\ne%'));
+        self::assertSame([5], $findIdsLikeFx('name', '%li\\\\\ne%'));
         self::assertSame([5], $findIdsLikeFx('name', '%li\\\\\\\ne%'));
-        self::assertSame([5], $findIdsLikeFx('name', '%li\\\\\\\\\ne%'));
+        self::assertSame([], $findIdsLikeFx('name', '%li\\\\\\\\\ne%'));
         self::assertSame([], $findIdsLikeFx('name', '%li\\\\\\\\\\\ne%'));
         self::assertSame([5], $findIdsLikeFx('name', '%.li%ne'));
         self::assertSame([], $findIdsLikeFx('name', '%.li%ne\\'));
@@ -570,7 +570,7 @@ class ConditionSqlTest extends TestCase
 
         self::assertStringStartsWith("Ca\nro", $u->load(5)->get('name'));
         self::assertSame([5], $findIdsLikeFx('name', "Ca\n%"));
-        self::assertSame([5], $findIdsLikeFx('name', "Ca\\\n%"));
+        self::assertSame([], $findIdsLikeFx('name', "Ca\\\n%"));
         self::assertSame([], $findIdsLikeFx('name', 'Ca\\n%'));
         self::assertSame([], $findIdsLikeFx('name', 'Ca %'));
     }

--- a/tests/ConditionSqlTest.php
+++ b/tests/ConditionSqlTest.php
@@ -591,7 +591,7 @@ class ConditionSqlTest extends TestCase
         self::assertStringStartsWith("Ca\nro", $u->load(5)->get('name'));
         self::assertSame([5], $findIdsLikeFx('name', "Ca\n%"));
         self::assertSame([], $findIdsLikeFx('name', "Ca\\\n%"));
-        self::assertSame([], $findIdsLikeFx('name', 'Ca\\n%'));
+        self::assertSame([], $findIdsLikeFx('name', 'Ca\n%'));
         self::assertSame([], $findIdsLikeFx('name', 'Ca %'));
     }
 

--- a/tests/ConditionSqlTest.php
+++ b/tests/ConditionSqlTest.php
@@ -513,7 +513,7 @@ class ConditionSqlTest extends TestCase
                 1 => ['id' => 1, 'name' => 'John', 'c' => 1],
                 ['id' => 2, 'name' => 'Peter', 'c' => 2000],
                 ['id' => 3, 'name' => 'Joe', 'c' => 50],
-                ['id' => 4, 'name' => 'Ca%ro_li\ne'],
+                ['id' => 4, 'name' => 'Ca_ro%li\ne'],
                 ['id' => 5, 'name' => "Ca\nro.li\\\\ne"],
             ],
         ]);
@@ -550,21 +550,39 @@ class ConditionSqlTest extends TestCase
         self::assertSame([2, 3], $findIdsLikeFx('c', '%0%'));
         self::assertSame([1], $findIdsLikeFx('c', '%0%', true));
 
-        self::assertSame([4, 5], $findIdsLikeFx('name', '%Ca%ro%'));
-        self::assertSame([4], $findIdsLikeFx('name', '%Ca\%ro%'));
+        self::assertSame([4, 5], $findIdsLikeFx('name', '%Ca_ro%'));
+        self::assertSame([4], $findIdsLikeFx('name', '%Ca\_ro%'));
+        self::assertSame([4, 5], $findIdsLikeFx('name', '%ro%li%'));
+        self::assertSame([4], $findIdsLikeFx('name', '%ro\%li%'));
 
-        self::assertSame([4, 5], $findIdsLikeFx('name', '%ro_li%'));
-        self::assertSame([4], $findIdsLikeFx('name', '%ro\_li%'));
-
+        self::assertSame([], $findIdsLikeFx('name', '%line%'));
         self::assertSame([4], $findIdsLikeFx('name', '%li\ne%'));
-        self::assertSame([4], $findIdsLikeFx('name', '%l_\ne%'));
-        self::assertSame([5], $findIdsLikeFx('name', '%l__\ne%'));
-        self::assertSame([4, 5], $findIdsLikeFx('name', '%li%\ne%'));
         self::assertSame([4], $findIdsLikeFx('name', '%li\\\ne%'));
         self::assertSame([5], $findIdsLikeFx('name', '%li\\\\\ne%'));
         self::assertSame([5], $findIdsLikeFx('name', '%li\\\\\\\ne%'));
         self::assertSame([], $findIdsLikeFx('name', '%li\\\\\\\\\ne%'));
         self::assertSame([], $findIdsLikeFx('name', '%li\\\\\\\\\\\ne%'));
+        self::assertSame([4, 5], $findIdsLikeFx('name', '%li%ne%'));
+        self::assertSame([4, 5], $findIdsLikeFx('name', '%li%\ne%'));
+        self::assertSame([4, 5], $findIdsLikeFx('name', '%li%\\\ne%'));
+        self::assertSame([5], $findIdsLikeFx('name', '%li%\\\\\ne%'));
+        self::assertSame([5], $findIdsLikeFx('name', '%li%\\\\\\\ne%'));
+        self::assertSame([], $findIdsLikeFx('name', '%li%\\\\\\\\\ne%'));
+        self::assertSame([], $findIdsLikeFx('name', '%li%\\\\\\\\\\\ne%'));
+        self::assertSame([], $findIdsLikeFx('name', '%li\%ne%'));
+        self::assertSame([4, 5], $findIdsLikeFx('name', '%li\\\%ne%'));
+        self::assertSame([], $findIdsLikeFx('name', '%li\\\\\%ne%'));
+        self::assertSame([5], $findIdsLikeFx('name', '%li\\\\\\\%ne%'));
+        self::assertSame([], $findIdsLikeFx('name', '%li\\\\\\\\\%ne%'));
+        self::assertSame([], $findIdsLikeFx('name', '%li\%e%'));
+        self::assertSame([4, 5], $findIdsLikeFx('name', '%li\\\%e%'));
+        self::assertSame([], $findIdsLikeFx('name', '%li\\\\\%e%'));
+        self::assertSame([5], $findIdsLikeFx('name', '%li\\\\\\\%e%'));
+        self::assertSame([], $findIdsLikeFx('name', '%li\\\\\\\\\%e%'));
+
+        self::assertSame([4], $findIdsLikeFx('name', '%l_\ne%'));
+        self::assertSame([5], $findIdsLikeFx('name', '%l__\ne%'));
+        self::assertSame([4, 5], $findIdsLikeFx('name', '%li%%\ne%'));
         self::assertSame([5], $findIdsLikeFx('name', '%.li%ne'));
         self::assertSame([], $findIdsLikeFx('name', '%.li%ne\\'));
         self::assertSame([], $findIdsLikeFx('name', '%.li%ne\\\\'));

--- a/tests/ConditionSqlTest.php
+++ b/tests/ConditionSqlTest.php
@@ -556,22 +556,10 @@ class ConditionSqlTest extends TestCase
         self::assertSame([4, 5], $findIdsLikeFx('name', '%ro_li%'));
         self::assertSame([4], $findIdsLikeFx('name', '%ro\_li%'));
 
-        // https://bugs.mysql.com/bug.php?id=84118
-        // https://bugs.mysql.com/bug.php?id=63829
-        // https://bugs.mysql.com/bug.php?id=68901
-        $isMysqlMariadb = $this->getDatabasePlatform() instanceof MySQLPlatform
-            ? str_contains($this->getConnection()->getConnection()->getWrappedConnection()->getServerVersion(), 'MariaDB') // @phpstan-ignore-line
-            : false;
-        $isMysql5x = $this->getDatabasePlatform() instanceof MySQLPlatform && !$isMysqlMariadb
-            ? str_starts_with($this->getConnection()->getConnection()->getWrappedConnection()->getServerVersion(), '5.') // @phpstan-ignore-line
-            : false;
-
         self::assertSame([4], $findIdsLikeFx('name', '%li\ne%'));
         self::assertSame([4], $findIdsLikeFx('name', '%l_\ne%'));
         self::assertSame([5], $findIdsLikeFx('name', '%l__\ne%'));
-        if (!$isMysql5x) {
-            self::assertSame([4, 5], $findIdsLikeFx('name', '%li%\ne%'));
-        }
+        self::assertSame([4, 5], $findIdsLikeFx('name', '%li%\ne%'));
         self::assertSame([4], $findIdsLikeFx('name', '%li\\\ne%'));
         self::assertSame([5], $findIdsLikeFx('name', '%li\\\\\ne%'));
         self::assertSame([5], $findIdsLikeFx('name', '%li\\\\\\\ne%'));

--- a/tests/ConditionSqlTest.php
+++ b/tests/ConditionSqlTest.php
@@ -556,8 +556,22 @@ class ConditionSqlTest extends TestCase
         self::assertSame([4, 5], $findIdsLikeFx('name', '%ro_li%'));
         self::assertSame([4], $findIdsLikeFx('name', '%ro\_li%'));
 
+        // https://bugs.mysql.com/bug.php?id=84118
+        // https://bugs.mysql.com/bug.php?id=63829
+        // https://bugs.mysql.com/bug.php?id=68901
+        $isMysqlMariadb = $this->getDatabasePlatform() instanceof MySQLPlatform
+            ? str_contains($this->getConnection()->getConnection()->getWrappedConnection()->getServerVersion(), 'MariaDB') // @phpstan-ignore-line
+            : false;
+        $isMysql5x = $this->getDatabasePlatform() instanceof MySQLPlatform && !$isMysqlMariadb
+            ? str_starts_with($this->getConnection()->getConnection()->getWrappedConnection()->getServerVersion(), '5.') // @phpstan-ignore-line
+            : false;
+
         self::assertSame([4], $findIdsLikeFx('name', '%li\ne%'));
-        self::assertSame([4, 5], $findIdsLikeFx('name', '%li%\ne%'));
+        self::assertSame([4], $findIdsLikeFx('name', '%l_\ne%'));
+        self::assertSame([5], $findIdsLikeFx('name', '%l__\ne%'));
+        if (!$isMysql5x) {
+            self::assertSame([4, 5], $findIdsLikeFx('name', '%li%\ne%'));
+        }
         self::assertSame([4], $findIdsLikeFx('name', '%li\\\ne%'));
         self::assertSame([5], $findIdsLikeFx('name', '%li\\\\\ne%'));
         self::assertSame([5], $findIdsLikeFx('name', '%li\\\\\\\ne%'));

--- a/tests/Persistence/Sql/QueryTest.php
+++ b/tests/Persistence/Sql/QueryTest.php
@@ -11,7 +11,6 @@ use Atk4\Data\Persistence\Sql\Expression;
 use Atk4\Data\Persistence\Sql\Mysql\Connection as MysqlConnection;
 use Atk4\Data\Persistence\Sql\Mysql\Expression as MysqlExpression;
 use Atk4\Data\Persistence\Sql\Mysql\Query as MysqlQuery;
-use Atk4\Data\Persistence\Sql\Oracle\Query as OracleQuery;
 use Atk4\Data\Persistence\Sql\Query;
 use Atk4\Data\Persistence\Sql\Sqlite\Connection as SqliteConnection;
 use PHPUnit\Framework\Attributes\DataProvider;
@@ -784,12 +783,7 @@ class QueryTest extends TestCase
                 EOF,
             $this->q('[where]')->where('name', 'not like', 'foo')->render()[0]
         );
-        self::assertSame(
-            <<<'EOF'
-                where "name" like regexp_replace(regexp_replace(regexp_replace(:xxaaaa, '((\\\\)*)(\\([^_%]))?', '\1\4'), '((^|[^\\])(\\\\)*\\)$', concat('\1', rpad(chr(92), 2, chr(92)))), '((\\\\)*)(([^\\]|\\[\\_%])|(\\))', '\1\4\5\5') escape chr(92)
-                EOF,
-            (new OracleQuery('[where]'))->where('name', 'like', 'foo')->render()[0]
-        );
+        // TODO add MysqlQuery test once MySQL 5.x support is dropped
 
         // regexp | not regexp
         self::assertSame(

--- a/tests/Persistence/Sql/QueryTest.php
+++ b/tests/Persistence/Sql/QueryTest.php
@@ -773,16 +773,20 @@ class QueryTest extends TestCase
 
         // like | not like
         self::assertSame(
-            'where "name" like :a escape \'\\\'',
+            <<<'EOF'
+                where "name" like regexp_replace(:a, '((\\\\)*)(([^\\]|\\[\\_%])|(\\))', '\1\4\5\5') escape '\'
+                EOF,
             $this->q('[where]')->where('name', 'like', 'foo')->render()[0]
         );
         self::assertSame(
-            'where "name" not like :a escape \'\\\'',
+            <<<'EOF'
+                where "name" not like regexp_replace(:a, '((\\\\)*)(([^\\]|\\[\\_%])|(\\))', '\1\4\5\5') escape '\'
+                EOF,
             $this->q('[where]')->where('name', 'not like', 'foo')->render()[0]
         );
         self::assertSame(
             <<<'EOF'
-                where "name" like regexp_replace(regexp_replace(:xxaaaa, '((\\\\)*)(\\([^_%]))?', '\1\4'), '((^|[^\\])(\\\\)*\\)$', concat('\1', rpad(chr(92), 2, chr(92)))) escape chr(92)
+                where "name" like regexp_replace(regexp_replace(regexp_replace(:xxaaaa, '((\\\\)*)(\\([^_%]))?', '\1\4'), '((^|[^\\])(\\\\)*\\)$', concat('\1', rpad(chr(92), 2, chr(92)))), '((\\\\)*)(([^\\]|\\[\\_%])|(\\))', '\1\4\5\5') escape chr(92)
                 EOF,
             (new OracleQuery('[where]'))->where('name', 'like', 'foo')->render()[0]
         );
@@ -1346,7 +1350,9 @@ class QueryTest extends TestCase
             ->caseWhen(['status', 'like', '%Used%'], 't2.expose_used')
             ->caseElse(null)
             ->render()[0];
-        self::assertSame('case when "status" = :a then :b when "status" like :c escape \'\\\' then :d else :e end', $s);
+        self::assertSame(<<<'EOF'
+            case when "status" = :a then :b when "status" like regexp_replace(:c, '((\\\\)*)(([^\\]|\\[\\_%])|(\\))', '\1\4\5\5') escape '\' then :d else :e end
+            EOF, $s);
 
         // with subqueries
         $age = $this->e('year(now()) - year(birth_date)');

--- a/tests/Persistence/Sql/QueryTest.php
+++ b/tests/Persistence/Sql/QueryTest.php
@@ -773,13 +773,13 @@ class QueryTest extends TestCase
         // like | not like
         self::assertSame(
             <<<'EOF'
-                where "name" like regexp_replace(:a, '((\\\\)*)(([^\\]|\\[\\_%])|(\\))', '\1\4\5\5') escape '\'
+                where "name" like regexp_replace(:a, '(\\[\\_%])|(\\)', '\1\2\2') escape '\'
                 EOF,
             $this->q('[where]')->where('name', 'like', 'foo')->render()[0]
         );
         self::assertSame(
             <<<'EOF'
-                where "name" not like regexp_replace(:a, '((\\\\)*)(([^\\]|\\[\\_%])|(\\))', '\1\4\5\5') escape '\'
+                where "name" not like regexp_replace(:a, '(\\[\\_%])|(\\)', '\1\2\2') escape '\'
                 EOF,
             $this->q('[where]')->where('name', 'not like', 'foo')->render()[0]
         );
@@ -1345,7 +1345,7 @@ class QueryTest extends TestCase
             ->caseElse(null)
             ->render()[0];
         self::assertSame(<<<'EOF'
-            case when "status" = :a then :b when "status" like regexp_replace(:c, '((\\\\)*)(([^\\]|\\[\\_%])|(\\))', '\1\4\5\5') escape '\' then :d else :e end
+            case when "status" = :a then :b when "status" like regexp_replace(:c, '(\\[\\_%])|(\\)', '\1\2\2') escape '\' then :d else :e end
             EOF, $s);
 
         // with subqueries


### PR DESCRIPTION
rework #1194, require `\` to be escaped only before `\`, `_` and `%`