### PR TITLE
Impl. binary (case sensitive) LIKE/REGEXP for SQLite

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -53,7 +53,7 @@ parameters:
         -
             message: '~^Class Doctrine\\DBAL\\(Platforms\\SqlitePlatform|Schema\\SqliteSchemaManager) referenced with incorrect case: Doctrine\\DBAL\\(Platforms\\SQLitePlatform|Schema\\SQLiteSchemaManager)\.$~'
             path: '*'
-            count: 22
+            count: 20
 
         # TODO these rules are generated, this ignores should be fixed in the code
         # for src/Schema/TestCase.php

--- a/src/Persistence.php
+++ b/src/Persistence.php
@@ -303,14 +303,14 @@ abstract class Persistence
      */
     public function typecastSaveRow(Model $model, array $row): array
     {
-        $result = [];
+        $res = [];
         foreach ($row as $fieldName => $value) {
             $field = $model->getField($fieldName);
 
-            $result[$field->getPersistenceName()] = $this->typecastSaveField($field, $value);
+            $res[$field->getPersistenceName()] = $this->typecastSaveField($field, $value);
         }
 
-        return $result;
+        return $res;
     }
 
     /**
@@ -327,14 +327,14 @@ abstract class Persistence
      */
     public function typecastLoadRow(Model $model, array $row): array
     {
-        $result = [];
+        $res = [];
         foreach ($row as $fieldName => $value) {
             $field = $model->getField($fieldName);
 
-            $result[$fieldName] = $this->typecastLoadField($field, $value);
+            $res[$fieldName] = $this->typecastLoadField($field, $value);
         }
 
-        return $result;
+        return $res;
     }
 
     /**

--- a/src/Persistence/Array_/Action.php
+++ b/src/Persistence/Array_/Action.php
@@ -67,12 +67,12 @@ class Action
      */
     public function aggregate(string $fx, string $field, bool $coalesce = false)
     {
-        $result = 0;
+        $res = 0;
         $column = array_column($this->getRows(), $field);
 
         switch (strtoupper($fx)) {
             case 'SUM':
-                $result = array_sum($column);
+                $res = array_sum($column);
 
                 break;
             case 'AVG':
@@ -80,15 +80,15 @@ class Action
                     $column = array_filter($column, static fn ($v) => $v !== null);
                 }
 
-                $result = array_sum($column) / count($column);
+                $res = array_sum($column) / count($column);
 
                 break;
             case 'MAX':
-                $result = max($column);
+                $res = max($column);
 
                 break;
             case 'MIN':
-                $result = min($column);
+                $res = min($column);
 
                 break;
             default:
@@ -96,7 +96,7 @@ class Action
                     ->addMoreInfo('action', $fx);
         }
 
-        $this->generator = new \ArrayIterator([['v' => $result]]);
+        $this->generator = new \ArrayIterator([['v' => $res]]);
 
         return $this;
     }
@@ -167,34 +167,34 @@ class Action
 
         switch (strtoupper($operator)) {
             case '=':
-                $result = is_array($v2) ? $this->evaluateIf($v1, 'IN', $v2) : $v1 === $v2;
+                $res = is_array($v2) ? $this->evaluateIf($v1, 'IN', $v2) : $v1 === $v2;
 
                 break;
             case '>':
-                $result = $v1 > $v2;
+                $res = $v1 > $v2;
 
                 break;
             case '>=':
-                $result = $v1 >= $v2;
+                $res = $v1 >= $v2;
 
                 break;
             case '<':
-                $result = $v1 < $v2;
+                $res = $v1 < $v2;
 
                 break;
             case '<=':
-                $result = $v1 <= $v2;
+                $res = $v1 <= $v2;
 
                 break;
             case '!=':
-                $result = !$this->evaluateIf($v1, '=', $v2);
+                $res = !$this->evaluateIf($v1, '=', $v2);
 
                 break;
             case 'IN':
-                $result = false;
+                $res = false;
                 foreach ($v2 as $v2Item) { // TODO flatten rows, this looses column names!
                     if ($this->evaluateIf($v1, '=', $v2Item)) {
-                        $result = true;
+                        $res = true;
 
                         break;
                     }
@@ -202,27 +202,27 @@ class Action
 
                 break;
             case 'NOT IN':
-                $result = !$this->evaluateIf($v1, 'IN', $v2);
+                $res = !$this->evaluateIf($v1, 'IN', $v2);
 
                 break;
             case 'LIKE':
                 $pattern = str_replace('_', '(.)', str_replace('%', '(.*)', preg_quote($v2, '~')));
 
-                $result = preg_match('~^' . $pattern . '$~is', (string) $v1) === 1;
+                $res = preg_match('~^' . $pattern . '$~is', (string) $v1) === 1;
 
                 break;
             case 'NOT LIKE':
-                $result = !$this->evaluateIf($v1, 'LIKE', $v2);
+                $res = !$this->evaluateIf($v1, 'LIKE', $v2);
 
                 break;
             case 'REGEXP':
                 $pattern = preg_replace('~(?<!\\\)(?:\\\\\\\)*+\K\~~', '\\\~', $v2);
 
-                $result = preg_match('~' . $pattern . '~is', $v1) === 1;
+                $res = preg_match('~' . $pattern . '~is', $v1) === 1;
 
                 break;
             case 'NOT REGEXP':
-                $result = !$this->evaluateIf($v1, 'REGEXP', $v2);
+                $res = !$this->evaluateIf($v1, 'REGEXP', $v2);
 
                 break;
             default:
@@ -230,7 +230,7 @@ class Action
                     ->addMoreInfo('operator', $operator);
         }
 
-        return $result;
+        return $res;
     }
 
     /**

--- a/src/Persistence/Sql/Mysql/Query.php
+++ b/src/Persistence/Sql/Mysql/Query.php
@@ -54,7 +54,7 @@ class Query extends BaseQuery
     }
 
     #[\Override]
-    protected function _renderConditionRegexpOperator(bool $negated, string $sqlLeft, string $sqlRight): string
+    protected function _renderConditionRegexpOperator(bool $negated, string $sqlLeft, string $sqlRight, bool $binary = false): string
     {
         $serverVersion = $this->connection->getConnection()->getWrappedConnection()->getServerVersion(); // @phpstan-ignore-line
         $isMysql5x = str_starts_with($serverVersion, '5.') && !str_contains($serverVersion, 'MariaDB');

--- a/src/Persistence/Sql/Oracle/Query.php
+++ b/src/Persistence/Sql/Oracle/Query.php
@@ -18,10 +18,10 @@ class Query extends BaseQuery
     protected string $expressionClass = Expression::class;
 
     #[\Override]
-    protected function _renderConditionRegexpOperator(bool $negated, string $sqlLeft, string $sqlRight): string
+    protected function _renderConditionRegexpOperator(bool $negated, string $sqlLeft, string $sqlRight, bool $binary = false): string
     {
         return ($negated ? 'not ' : '') . 'regexp_like(' . $sqlLeft . ', ' . $sqlRight
-            . ', ' . $this->escapeStringLiteral('in') . ')';
+            . ', ' . $this->escapeStringLiteral(($binary ? '' : 'i') . 'n') . ')';
     }
 
     #[\Override]

--- a/src/Persistence/Sql/Oracle/Query.php
+++ b/src/Persistence/Sql/Oracle/Query.php
@@ -21,7 +21,7 @@ class Query extends BaseQuery
     protected function _renderConditionRegexpOperator(bool $negated, string $sqlLeft, string $sqlRight, bool $binary = false): string
     {
         return ($negated ? 'not ' : '') . 'regexp_like(' . $sqlLeft . ', ' . $sqlRight
-            . ', ' . $this->escapeStringLiteral(($binary ? '' : 'i') . 'n') . ')';
+            . ', ' . $this->escapeStringLiteral(($binary ? 'c' : 'i') . 'n') . ')';
     }
 
     #[\Override]

--- a/src/Persistence/Sql/Postgresql/Query.php
+++ b/src/Persistence/Sql/Postgresql/Query.php
@@ -33,9 +33,9 @@ class Query extends BaseQuery
 
     // needed for PostgreSQL v14 and lower
     #[\Override]
-    protected function _renderConditionRegexpOperator(bool $negated, string $sqlLeft, string $sqlRight): string
+    protected function _renderConditionRegexpOperator(bool $negated, string $sqlLeft, string $sqlRight, bool $binary = false): string
     {
-        return $sqlLeft . ' ' . ($negated ? '!' : '') . '~* ' . $sqlRight;
+        return $sqlLeft . ' ' . ($negated ? '!' : '') . '~' . ($binary ? '' : '*') . ' ' . $sqlRight;
     }
 
     #[\Override]

--- a/src/Persistence/Sql/Query.php
+++ b/src/Persistence/Sql/Query.php
@@ -501,6 +501,50 @@ abstract class Query extends Expression
     }
 
     /**
+     * @param \Closure(string, string): string $makeSqlFx
+     */
+    protected function _renderConditionBinaryReuse(
+        string $sqlLeft,
+        string $sqlRight,
+        \Closure $makeSqlFx,
+        bool $allowReuseLeft = true,
+        bool $allowReuseRight = true,
+        string $internalIdentifier = 'reuse'
+    ): string {
+        $nonTrivialSqlRegex = '~\s|\(~';
+        $subqueryLeftColumnSql = $allowReuseLeft && preg_match($nonTrivialSqlRegex, $sqlLeft)
+            ? $this->escapeIdentifier('__atk4_' . $internalIdentifier . '_left__')
+            : null;
+        $subqueryRightColumnSql = $allowReuseRight && preg_match($nonTrivialSqlRegex, $sqlRight)
+            ? $this->escapeIdentifier('__atk4_' . $internalIdentifier . '_right__')
+            : null;
+
+        $subqueryFromSql = null;
+        if ($subqueryLeftColumnSql !== null || $subqueryRightColumnSql !== null) {
+            $subqueryFromSql = 'select ';
+            if ($subqueryLeftColumnSql !== null) {
+                $subqueryFromSql .= $sqlLeft . ' ' . $subqueryLeftColumnSql;
+                $sqlLeft = $subqueryLeftColumnSql;
+            }
+            if ($subqueryRightColumnSql !== null) {
+                if ($subqueryLeftColumnSql !== null) {
+                    $subqueryFromSql .= ', ';
+                }
+                $subqueryFromSql .= $sqlRight . ' ' . $subqueryRightColumnSql;
+                $sqlRight = $subqueryRightColumnSql;
+            }
+        }
+
+        $res = $makeSqlFx($sqlLeft, $sqlRight);
+
+        if ($subqueryFromSql !== null) {
+            $res = '(select ' . $res . ' from (' . $subqueryFromSql . ') ' . $this->escapeIdentifier('__atk4_' . $internalIdentifier . '_tmp__') . ')';
+        }
+
+        return $res;
+    }
+
+    /**
      * Override to fix numeric affinity for SQLite.
      */
     protected function _renderConditionBinary(string $operator, string $sqlLeft, string $sqlRight): string

--- a/src/Persistence/Sql/Query.php
+++ b/src/Persistence/Sql/Query.php
@@ -572,10 +572,10 @@ abstract class Query extends Expression
             . ' escape ' . $this->escapeStringLiteral('\\');
     }
 
-    protected function _renderConditionRegexpOperator(bool $negated, string $sqlLeft, string $sqlRight): string
+    protected function _renderConditionRegexpOperator(bool $negated, string $sqlLeft, string $sqlRight, bool $binary = false): string
     {
         return ($negated ? 'not ' : '') . 'regexp_like(' . $sqlLeft . ', ' . $sqlRight
-            . ', ' . $this->escapeStringLiteral('is') . ')';
+            . ', ' . $this->escapeStringLiteral(($binary ? '' : 'i') . 's') . ')';
     }
 
     /**

--- a/src/Persistence/Sql/Sqlite/Query.php
+++ b/src/Persistence/Sql/Sqlite/Query.php
@@ -100,7 +100,7 @@ class Query extends BaseQuery
                     return 'regexp_replace(' . $sql . ', ' . $this->escapeStringLiteral($search) . ', ' . $this->escapeStringLiteral($replacement) . ')';
                 };
 
-                $res = '('
+                return '('
                     . parent::_renderConditionLikeOperator(false, $sqlLeft, $sqlRight)
                     . ' and ((' . $sqlLeft . ' = lower(' . $sqlLeft . ') and ' . $sqlLeft . ' = upper(' . $sqlLeft . '))'
                     . ' or ' . $this->_renderConditionRegexpOperator(
@@ -121,8 +121,6 @@ class Query extends BaseQuery
                         ) . ', ' . $this->escapeStringLiteral('$') . ')',
                         true
                     ) . '))';
-
-                return $res;
             }
         );
     }
@@ -138,12 +136,10 @@ class Query extends BaseQuery
             $sqlLeft,
             $sqlRight,
             function ($sqlLeft, $sqlRight) {
-                $res = 'case when ' . $sqlLeft . ' = lower(' . $sqlLeft . ') and ' . $sqlLeft . ' = upper(' . $sqlLeft . ')'
+                return 'case when ' . $sqlLeft . ' = lower(' . $sqlLeft . ') and ' . $sqlLeft . ' = upper(' . $sqlLeft . ')'
                     . ' then ' . parent::_renderConditionRegexpOperator(false, $sqlLeft, $sqlRight)
                     . ' else ' . parent::_renderConditionRegexpOperator(false, $sqlLeft, $sqlRight, true)
                     . ' end';
-
-                return $res;
             }
         );
     }

--- a/src/Persistence/Sql/Sqlite/Query.php
+++ b/src/Persistence/Sql/Sqlite/Query.php
@@ -15,6 +15,31 @@ class Query extends BaseQuery
 
     protected string $templateTruncate = 'delete [from] [tableNoalias]';
 
+    #[\Override]
+    protected function _renderConditionBinaryReuse(
+        string $sqlLeft,
+        string $sqlRight,
+        \Closure $makeSqlFx,
+        bool $allowReuseLeft = true,
+        bool $allowReuseRight = true,
+        string $internalIdentifier = 'reuse'
+    ): string {
+        // https://sqlite.org/forum/info/c9970a37edf11cd1
+        if (version_compare(Connection::getDriverVersion(), '3.45') < 0) {
+            $allowReuseLeft = false;
+            $allowReuseRight = false;
+        }
+
+        return parent::_renderConditionBinaryReuse(
+            $sqlLeft,
+            $sqlRight,
+            $makeSqlFx,
+            $allowReuseLeft,
+            $allowReuseRight,
+            $internalIdentifier
+        );
+    }
+
     private function _renderConditionBinaryCheckNumericSql(string $sql): string
     {
         return 'typeof(' . $sql . ') in (' . $this->escapeStringLiteral('integer')
@@ -28,72 +53,40 @@ class Query extends BaseQuery
     #[\Override]
     protected function _renderConditionBinary(string $operator, string $sqlLeft, string $sqlRight): string
     {
-        /** @var bool */
-        $allowCastLeft = true;
         $allowCastRight = !in_array($operator, ['in', 'not in'], true);
 
-        // https://sqlite.org/forum/info/c9970a37edf11cd1
-        $subqueryFromSql = null;
-        if (version_compare(Connection::getDriverVersion(), '3.45') >= 0) {
-            $nonTrivialSqlRegex = '~\s|\(~';
-            $subqueryLeftColumnSql = $allowCastLeft && preg_match($nonTrivialSqlRegex, $sqlLeft)
-                ? $this->escapeIdentifier('__atk4_affinity_left__')
-                : null;
-            $subqueryRightColumnSql = $allowCastRight && preg_match($nonTrivialSqlRegex, $sqlRight)
-                ? $this->escapeIdentifier('__atk4_affinity_right__')
-                : null;
-
-            if ($subqueryLeftColumnSql !== null || $subqueryRightColumnSql !== null) {
-                $subqueryFromSql = 'select ';
-                if ($subqueryLeftColumnSql !== null) {
-                    $subqueryFromSql .= $sqlLeft . ' ' . $subqueryLeftColumnSql;
-                    $sqlLeft = $subqueryLeftColumnSql;
+        return $this->_renderConditionBinaryReuse(
+            $sqlLeft,
+            $sqlRight,
+            function ($sqlLeft, $sqlRight) use ($operator, $allowCastRight) {
+                $res = 'case when ' . $this->_renderConditionBinaryCheckNumericSql($sqlLeft)
+                    . ' then ' . parent::_renderConditionBinary($operator, 'cast(' . $sqlLeft . ' as numeric)', $sqlRight)
+                    . ' else ';
+                if ($allowCastRight) {
+                    $res .= 'case when ' . $this->_renderConditionBinaryCheckNumericSql($sqlRight)
+                        . ' then ' . parent::_renderConditionBinary($operator, $sqlLeft, 'cast(' . $sqlRight . ' as numeric)')
+                        . ' else ';
                 }
-                if ($subqueryRightColumnSql !== null) {
-                    if ($subqueryLeftColumnSql !== null) {
-                        $subqueryFromSql .= ', ';
-                    }
-                    $subqueryFromSql .= $sqlRight . ' ' . $subqueryRightColumnSql;
-                    $sqlRight = $subqueryRightColumnSql;
+                $res .= parent::_renderConditionBinary($operator, $sqlLeft, $sqlRight);
+                if ($allowCastRight) {
+                    $res .= ' end';
                 }
-            }
-        }
+                $res .= ' end';
 
-        $res = '';
-        if ($allowCastLeft) {
-            $res .= 'case when ' . $this->_renderConditionBinaryCheckNumericSql($sqlLeft)
-                . ' then ' . parent::_renderConditionBinary($operator, 'cast(' . $sqlLeft . ' as numeric)', $sqlRight)
-                . ' else ';
-        }
-        if ($allowCastRight) {
-            $res .= 'case when ' . $this->_renderConditionBinaryCheckNumericSql($sqlRight)
-                . ' then ' . parent::_renderConditionBinary($operator, $sqlLeft, 'cast(' . $sqlRight . ' as numeric)')
-                . ' else ';
-        }
-        $res .= parent::_renderConditionBinary($operator, $sqlLeft, $sqlRight);
-        if ($allowCastRight) {
-            $res .= ' end';
-        }
-        if ($allowCastLeft) {
-            $res .= ' end';
-        }
-
-        if ($subqueryFromSql !== null) {
-            $res = '(select ' . $res . ' from (' . $subqueryFromSql . ') ' . $this->escapeIdentifier('__atk4_affinity_tmp__') . ')';
-        }
-
-        return $res;
+                return $res;
+            },
+            true,
+            $allowCastRight,
+            'affinity'
+        );
     }
 
     #[\Override]
     protected function _renderConditionInOperator(bool $negated, string $sqlLeft, array $sqlValues): string
     {
-        $res = '(' . implode(' or ', array_map(fn ($v) => $this->_renderConditionBinary('=', $sqlLeft, $v), $sqlValues)) . ')';
-        if ($negated) {
-            $res = 'not' . $res;
-        }
-
-        return $res;
+        return ($negated ? ' not' : '') . '('
+            . implode(' or ', array_map(fn ($v) => $this->_renderConditionBinary('=', $sqlLeft, $v), $sqlValues))
+            . ')';
     }
 
     #[\Override]

--- a/src/Persistence/Sql/Sqlite/Query.php
+++ b/src/Persistence/Sql/Sqlite/Query.php
@@ -90,6 +90,43 @@ class Query extends BaseQuery
     }
 
     #[\Override]
+    protected function _renderConditionLikeOperator(bool $negated, string $sqlLeft, string $sqlRight): string
+    {
+        return ($negated ? 'not ' : '') . $this->_renderConditionBinaryReuse(
+            $sqlLeft,
+            $sqlRight,
+            function ($sqlLeft, $sqlRight) {
+                $regexReplaceSqlFx = function (string $sql, string $search, string $replacement) {
+                    return 'regexp_replace(' . $sql . ', ' . $this->escapeStringLiteral($search) . ', ' . $this->escapeStringLiteral($replacement) . ')';
+                };
+
+                $res = '('
+                    . parent::_renderConditionLikeOperator(false, $sqlLeft, $sqlRight)
+                    . ' and ((' . $sqlLeft . ' = lower(' . $sqlLeft . ') and ' . $sqlLeft . ' = upper(' . $sqlLeft . '))'
+                    . ' or ' . preg_replace('~(?<=\')i(?=s\'\)$)~', '', $this->_renderConditionRegexpOperator(
+                        false,
+                        $sqlLeft,
+                        'concat(' . $this->escapeStringLiteral('^') . ',' . $regexReplaceSqlFx(
+                            $regexReplaceSqlFx(
+                                $regexReplaceSqlFx(
+                                    $regexReplaceSqlFx($sqlRight, '\\\(?:(?=[_%])|\K\\\)|(?=[.\\\+*?[^\]$(){}|])', '\\'),
+                                    '(?<!\\\)(\\\\\\\)*\K_',
+                                    '.'
+                                ),
+                                '(?<!\\\)(\\\\\\\)*\K%',
+                                '.*'
+                            ),
+                            '(?<!\\\)(\\\\\\\)*\K\\\(?=[_%])',
+                            ''
+                        ) . ', ' . $this->escapeStringLiteral('$') . ')'
+                    )) . '))';
+
+                return $res;
+            }
+        );
+    }
+
+    #[\Override]
     public function groupConcat($field, string $separator = ',')
     {
         return $this->expr('group_concat({}, [])', [$field, $separator]);

--- a/src/Persistence/Sql/Sqlite/Query.php
+++ b/src/Persistence/Sql/Sqlite/Query.php
@@ -128,6 +128,27 @@ class Query extends BaseQuery
     }
 
     #[\Override]
+    protected function _renderConditionRegexpOperator(bool $negated, string $sqlLeft, string $sqlRight, bool $binary = false): string
+    {
+        if ($binary) {
+            return parent::_renderConditionRegexpOperator($negated, $sqlLeft, $sqlRight, $binary);
+        }
+
+        return ($negated ? 'not ' : '') . $this->_renderConditionBinaryReuse(
+            $sqlLeft,
+            $sqlRight,
+            function ($sqlLeft, $sqlRight) {
+                $res = 'case when ' . $sqlLeft . ' = lower(' . $sqlLeft . ') and ' . $sqlLeft . ' = upper(' . $sqlLeft . ')'
+                    . ' then ' . parent::_renderConditionRegexpOperator(false, $sqlLeft, $sqlRight)
+                    . ' else ' . parent::_renderConditionRegexpOperator(false, $sqlLeft, $sqlRight, true)
+                    . ' end';
+
+                return $res;
+            }
+        );
+    }
+
+    #[\Override]
     public function groupConcat($field, string $separator = ',')
     {
         return $this->expr('group_concat({}, [])', [$field, $separator]);

--- a/src/Persistence/Sql/Sqlite/Query.php
+++ b/src/Persistence/Sql/Sqlite/Query.php
@@ -103,7 +103,7 @@ class Query extends BaseQuery
                 $res = '('
                     . parent::_renderConditionLikeOperator(false, $sqlLeft, $sqlRight)
                     . ' and ((' . $sqlLeft . ' = lower(' . $sqlLeft . ') and ' . $sqlLeft . ' = upper(' . $sqlLeft . '))'
-                    . ' or ' . preg_replace('~(?<=\')i(?=s\'\)$)~', '', $this->_renderConditionRegexpOperator(
+                    . ' or ' . $this->_renderConditionRegexpOperator(
                         false,
                         $sqlLeft,
                         'concat(' . $this->escapeStringLiteral('^') . ',' . $regexReplaceSqlFx(
@@ -118,8 +118,9 @@ class Query extends BaseQuery
                             ),
                             '(?<!\\\)(\\\\\\\)*\K\\\(?=[_%])',
                             ''
-                        ) . ', ' . $this->escapeStringLiteral('$') . ')'
-                    )) . '))';
+                        ) . ', ' . $this->escapeStringLiteral('$') . ')',
+                        true
+                    ) . '))';
 
                 return $res;
             }

--- a/src/Util/DeepCopy.php
+++ b/src/Util/DeepCopy.php
@@ -161,16 +161,16 @@ class DeepCopy
      */
     protected function extractKeys(array $array): array
     {
-        $result = [];
+        $res = [];
         foreach ($array as $key => $val) {
             if (is_int($key)) {
-                $result[$val] = [];
+                $res[$val] = [];
             } else {
-                $result[$key] = $val;
+                $res[$key] = $val;
             }
         }
 
-        return $result;
+        return $res;
     }
 
     /**

--- a/tests/ConditionSqlTest.php
+++ b/tests/ConditionSqlTest.php
@@ -713,9 +713,9 @@ class ConditionSqlTest extends TestCase
         }
 
         self::assertSame([1], $findIdsRegexFx('name', 'John'));
-        self::assertSame(/* $isBinary ? [] : */ [1], $findIdsRegexFx('name', 'john'));
+        self::assertSame($isBinary ? [] : [1], $findIdsRegexFx('name', 'john'));
         self::assertSame([13], $findIdsRegexFx('name', 'heiß'));
-        self::assertSame(/* $isBinary ? [] : */ [13], $findIdsRegexFx('name', 'Heiß'));
+        self::assertSame($isBinary ? [] : [13], $findIdsRegexFx('name', 'Heiß'));
         self::assertSame([1], $findIdsRegexFx('name', 'Joh'));
         self::assertSame([1], $findIdsRegexFx('name', 'ohn'));
         self::assertSame([1, 2, 3, ...($this->getDatabasePlatform() instanceof OraclePlatform ? [] : [4]), 13], $findIdsRegexFx('name', 'a', true));
@@ -752,7 +752,7 @@ class ConditionSqlTest extends TestCase
         self::assertSame([5, 6, 7, 8, 9, 11, 12], $findIdsRegexFx('name', 'Sa.ra'));
         self::assertSame([2, 3, 13], $findIdsRegexFx('name', '[e]'));
         self::assertSame([1, 2, 3, 13], $findIdsRegexFx('name', '[eo]'));
-        self::assertSame([1, 2, 3, .../* ($isBinary ? [] : */ [13] /* ) */], $findIdsRegexFx('name', '[A-P][aeo]'));
+        self::assertSame([1, 2, 3, ...($isBinary ? [] : [13])], $findIdsRegexFx('name', '[A-P][aeo]'));
         self::assertSame([3], $findIdsRegexFx('name', 'o[^h]'));
         self::assertSame([5, 6, 7, 8, 9, 10, 11, 12], $findIdsRegexFx('name', '^Sa'));
         self::assertSame([], $findIdsRegexFx('name', '^ra'));

--- a/tests/ConditionSqlTest.php
+++ b/tests/ConditionSqlTest.php
@@ -12,7 +12,6 @@ use Atk4\Data\ValidationException;
 use Doctrine\DBAL\Platforms\MySQLPlatform;
 use Doctrine\DBAL\Platforms\OraclePlatform;
 use Doctrine\DBAL\Platforms\PostgreSQLPlatform;
-use Doctrine\DBAL\Platforms\SQLitePlatform;
 use Doctrine\DBAL\Platforms\SQLServerPlatform;
 use PHPUnit\Framework\Attributes\DataProviderExternal;
 
@@ -544,12 +543,6 @@ class ConditionSqlTest extends TestCase
 
             return $res;
         };
-
-        if ($this->getDatabasePlatform() instanceof SQLitePlatform && ($type === 'binary' || $type === 'blob')) {
-            self::assertTrue(true); // @phpstan-ignore-line
-
-            return; // TODO
-        }
 
         if ($this->getDatabasePlatform() instanceof PostgreSQLPlatform && ($type === 'binary' || $type === 'blob')) {
             self::assertTrue(true); // @phpstan-ignore-line

--- a/tests/LookupSqlTest.php
+++ b/tests/LookupSqlTest.php
@@ -155,8 +155,6 @@ class LookupSqlTest extends TestCase
     {
         $c = new LCountry($this->db);
 
-        $results = [];
-
         // should be OK, will set country name, rest of fields will be null
         $c->createEntity()->saveAndUnload(['name' => 'Canada']);
 

--- a/tests/Persistence/ArrayTest.php
+++ b/tests/Persistence/ArrayTest.php
@@ -442,7 +442,6 @@ class ArrayTest extends TestCase
             $dbDataCountries[8],
             $dbDataCountries[9],
         ], $m->action('select')->getRows());
-        $result = $m->action('select')->getRows();
 
         $m->scope()->clear();
         $m->addCondition('code', '<', 12);

--- a/tests/Persistence/Sql/QueryTest.php
+++ b/tests/Persistence/Sql/QueryTest.php
@@ -887,11 +887,13 @@ class QueryTest extends TestCase
             $this->q('[where]')->where('name', 'not regexp', 'foo')->render()[0]
         );
         self::assertSame(
-            'where regexp_like(`name`, :a, \'is\')',
+            'where case when `name` = lower(`name`) and `name` = upper(`name`) then regexp_like(`name`, :a, \'is\') else regexp_like(`name`, :a, \'s\') end',
             (new SqliteQuery('[where]'))->where('name', 'regexp', 'foo')->render()[0]
         );
         self::assertSame(
-            'where regexp_like(`name`, sum("b"), \'is\')',
+            version_compare(SqliteConnection::getDriverVersion(), '3.45') < 0
+                ? 'where case when `name` = lower(`name`) and `name` = upper(`name`) then regexp_like(`name`, sum("b"), \'is\') else regexp_like(`name`, sum("b"), \'s\') end'
+                : 'where (select case when `name` = lower(`name`) and `name` = upper(`name`) then regexp_like(`name`, `__atk4_reuse_right__`, \'is\') else regexp_like(`name`, `__atk4_reuse_right__`, \'s\') end from (select sum("b") `__atk4_reuse_right__`) `__atk4_reuse_tmp__`)',
             (new SqliteQuery('[where]'))->where('name', 'regexp', $this->e('sum({})', ['b']))->render()[0]
         );
         foreach (['8.0', 'MariaDB-11.0'] as $serverVersion) {

--- a/tests/Persistence/Sql/QueryTest.php
+++ b/tests/Persistence/Sql/QueryTest.php
@@ -649,12 +649,6 @@ class QueryTest extends TestCase
             'where "id" in (select * from "user")',
             $this->q('[where]')->where('id', $this->q()->table('user'))->render()[0]
         );
-        self::assertSame(
-            version_compare(SqliteConnection::getDriverVersion(), '3.45') < 0
-                ? 'where case when typeof(`id`) in (\'integer\', \'real\') then cast(`id` as numeric) != (select * from "user") else case when typeof((select * from "user")) in (\'integer\', \'real\') then `id` != cast((select * from "user") as numeric) else `id` != (select * from "user") end end'
-                : 'where (select case when typeof(`id`) in (\'integer\', \'real\') then cast(`id` as numeric) != `__atk4_affinity_right__` else case when typeof(`__atk4_affinity_right__`) in (\'integer\', \'real\') then `id` != cast(`__atk4_affinity_right__` as numeric) else `id` != `__atk4_affinity_right__` end end from (select (select * from "user") `__atk4_affinity_right__`) `__atk4_affinity_tmp__`)',
-            (new SqliteQuery('[where]'))->where('id', '!=', $this->q()->table('user'))->render()[0]
-        );
 
         // field name with special symbols - not escape
         self::assertSame(
@@ -860,14 +854,18 @@ class QueryTest extends TestCase
         );
         self::assertSame(
             <<<'EOF'
-                where `name` like regexp_replace(:a, '(\\[\\_%])|(\\)', '\1\2\2') escape '\'
+                where (`name` like regexp_replace(:a, '(\\[\\_%])|(\\)', '\1\2\2') escape '\' and ((`name` = lower(`name`) and `name` = upper(`name`)) or regexp_like(`name`, concat('^',regexp_replace(regexp_replace(regexp_replace(regexp_replace(:a, '\\(?:(?=[_%])|\K\\)|(?=[.\\+*?[^\]$(){}|])', '\'), '(?<!\\)(\\\\)*\K_', '.'), '(?<!\\)(\\\\)*\K%', '.*'), '(?<!\\)(\\\\)*\K\\(?=[_%])', ''), '$'), 's')))
                 EOF,
             (new SqliteQuery('[where]'))->where('name', 'like', 'foo')->render()[0]
         );
         self::assertSame(
-            <<<'EOF'
-                where `name` like regexp_replace(sum("b"), '(\\[\\_%])|(\\)', '\1\2\2') escape '\'
-                EOF,
+            version_compare(SqliteConnection::getDriverVersion(), '3.45') < 0
+                ? <<<'EOF'
+                    where (`name` like regexp_replace(sum("b"), '(\\[\\_%])|(\\)', '\1\2\2') escape '\' and ((`name` = lower(`name`) and `name` = upper(`name`)) or regexp_like(`name`, concat('^',regexp_replace(regexp_replace(regexp_replace(regexp_replace(sum("b"), '\\(?:(?=[_%])|\K\\)|(?=[.\\+*?[^\]$(){}|])', '\'), '(?<!\\)(\\\\)*\K_', '.'), '(?<!\\)(\\\\)*\K%', '.*'), '(?<!\\)(\\\\)*\K\\(?=[_%])', ''), '$'), 's')))
+                    EOF
+                : <<<'EOF'
+                    where (select (`name` like regexp_replace(`__atk4_reuse_right__`, '(\\[\\_%])|(\\)', '\1\2\2') escape '\' and ((`name` = lower(`name`) and `name` = upper(`name`)) or regexp_like(`name`, concat('^',regexp_replace(regexp_replace(regexp_replace(regexp_replace(`__atk4_reuse_right__`, '\\(?:(?=[_%])|\K\\)|(?=[.\\+*?[^\]$(){}|])', '\'), '(?<!\\)(\\\\)*\K_', '.'), '(?<!\\)(\\\\)*\K%', '.*'), '(?<!\\)(\\\\)*\K\\(?=[_%])', ''), '$'), 's'))) from (select sum("b") `__atk4_reuse_right__`) `__atk4_reuse_tmp__`)
+                    EOF,
             (new SqliteQuery('[where]'))->where('name', 'like', $this->e('sum({})', ['b']))->render()[0]
         );
         foreach (['8.0', 'MariaDB-11.0'] as $serverVersion) {

--- a/tests/Schema/MigratorTest.php
+++ b/tests/Schema/MigratorTest.php
@@ -119,19 +119,20 @@ class MigratorTest extends TestCase
             $model->addCondition('v', 'in', ['MixedCase', 'foo']);
             self::assertSameExportUnordered($expectedExport, $model->export(['id']));
 
-            // TODO
-            // $model->scope()->clear();
-            // $model->addCondition('v', 'like', 'MixedCase');
-            // self::assertSameExportUnordered($expectedExport, $model->export(['id']));
-            //
-            // $model->scope()->clear();
-            // $model->addCondition('v', 'like', '%ix%Case');
-            // self::assertSameExportUnordered($expectedExport, $model->export(['id']));
+            if (!$this->getDatabasePlatform() instanceof PostgreSQLPlatform && !$this->getDatabasePlatform() instanceof SQLServerPlatform && !$this->getDatabasePlatform() instanceof OraclePlatform) {
+                $model->scope()->clear();
+                $model->addCondition('v', 'like', 'MixedCase');
+                self::assertSameExportUnordered($expectedExport, $model->export(['id']));
 
-            // TODO
-            // $model->scope()->clear();
-            // $model->addCondition('v', 'regexp', 'ix.+Case');
-            // self::assertSameExportUnordered($expectedExport, $model->export(['id']));
+                $model->scope()->clear();
+                $model->addCondition('v', 'like', '%ix%Case');
+                self::assertSameExportUnordered($expectedExport, $model->export(['id']));
+
+                // TODO
+                // $model->scope()->clear();
+                // $model->addCondition('v', 'regexp', 'ix.+Case');
+                // self::assertSameExportUnordered($expectedExport, $model->export(['id']));
+            }
         }
     }
 

--- a/tests/Schema/MigratorTest.php
+++ b/tests/Schema/MigratorTest.php
@@ -128,10 +128,9 @@ class MigratorTest extends TestCase
                 $model->addCondition('v', 'like', '%ix%Case');
                 self::assertSameExportUnordered($expectedExport, $model->export(['id']));
 
-                // TODO
-                // $model->scope()->clear();
-                // $model->addCondition('v', 'regexp', 'ix.+Case');
-                // self::assertSameExportUnordered($expectedExport, $model->export(['id']));
+                $model->scope()->clear();
+                $model->addCondition('v', 'regexp', 'ix.+Case');
+                self::assertSameExportUnordered($expectedExport, $model->export(['id']));
             }
         }
     }


### PR DESCRIPTION
for binary/blob columns (all SQLite columns /wo COLLATION NOCASE)

the main motivation is to align the behaviour with MySQL