### PR TITLE
Fix LIKE/REGEXP with binary input for MySQL

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -53,7 +53,7 @@ parameters:
         -
             message: '~^Class Doctrine\\DBAL\\(Platforms\\SqlitePlatform|Schema\\SqliteSchemaManager) referenced with incorrect case: Doctrine\\DBAL\\(Platforms\\SQLitePlatform|Schema\\SQLiteSchemaManager)\.$~'
             path: '*'
-            count: 22
+            count: 20
 
         # TODO these rules are generated, this ignores should be fixed in the code
         # for src/Schema/TestCase.php

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -53,7 +53,7 @@ parameters:
         -
             message: '~^Class Doctrine\\DBAL\\(Platforms\\SqlitePlatform|Schema\\SqliteSchemaManager) referenced with incorrect case: Doctrine\\DBAL\\(Platforms\\SQLitePlatform|Schema\\SQLiteSchemaManager)\.$~'
             path: '*'
-            count: 20
+            count: 22
 
         # TODO these rules are generated, this ignores should be fixed in the code
         # for src/Schema/TestCase.php

--- a/src/Persistence/Sql/Mysql/Connection.php
+++ b/src/Persistence/Sql/Mysql/Connection.php
@@ -5,9 +5,23 @@ declare(strict_types=1);
 namespace Atk4\Data\Persistence\Sql\Mysql;
 
 use Atk4\Data\Persistence\Sql\Connection as BaseConnection;
+use Doctrine\DBAL\Configuration;
 
 class Connection extends BaseConnection
 {
     protected string $expressionClass = Expression::class;
     protected string $queryClass = Query::class;
+
+    #[\Override]
+    protected static function createDbalConfiguration(): Configuration
+    {
+        $configuration = parent::createDbalConfiguration();
+
+        $configuration->setMiddlewares([
+            ...$configuration->getMiddlewares(),
+            new DisableEmulatePrepareForPdoRegexpMiddleware(),
+        ]);
+
+        return $configuration;
+    }
 }

--- a/src/Persistence/Sql/Mysql/DisableEmulatePrepareForPdoRegexpConnectionMiddleware.php
+++ b/src/Persistence/Sql/Mysql/DisableEmulatePrepareForPdoRegexpConnectionMiddleware.php
@@ -18,7 +18,7 @@ class DisableEmulatePrepareForPdoRegexpConnectionMiddleware extends AbstractConn
         // https://dbfiddle.uk/9SA-omyF
         $pdo = $this->getNativeConnection();
         if ($pdo instanceof \PDO && $pdo->getAttribute(\PDO::ATTR_EMULATE_PREPARES)
-            && preg_match('~\sregexp\s|(?<!\w)regexp_[a-z]+\(~i', preg_replace('~' . Expression::QUOTED_TOKEN_REGEX . '~', '', $sql))
+            && preg_match('~\sregexp\s|(?<!\w)regexp_[a-z]+\s*\(~i', preg_replace('~' . Expression::QUOTED_TOKEN_REGEX . '~', '', $sql))
         ) {
             $pdo->setAttribute(\PDO::ATTR_EMULATE_PREPARES, false);
             try {

--- a/src/Persistence/Sql/Mysql/DisableEmulatePrepareForPdoRegexpConnectionMiddleware.php
+++ b/src/Persistence/Sql/Mysql/DisableEmulatePrepareForPdoRegexpConnectionMiddleware.php
@@ -12,13 +12,13 @@ class DisableEmulatePrepareForPdoRegexpConnectionMiddleware extends AbstractConn
     #[\Override]
     public function prepare(string $sql): Statement
     {
-        // workaround SQLSTATE[HY000]: General error: 3995 Character set 'binary' cannot be used
-        // in conjunction with 'utf8mb4_0900_ai_ci' in call to regexp_like.
+        // workaround MySQL v8.0.22 and higher SQLSTATE[HY000]: General error: 3995 Character set 'binary'
+        // cannot be used in conjunction with 'utf8mb4_0900_ai_ci' in call to regexp_like.
         // https://github.com/mysql/mysql-server/blob/72136a6d15/sql/item_regexp_func.cc#L115-L120
         // https://dbfiddle.uk/9SA-omyF
         $pdo = $this->getNativeConnection();
         if ($pdo instanceof \PDO && $pdo->getAttribute(\PDO::ATTR_EMULATE_PREPARES)
-            && preg_match('~ regexp ~i', preg_replace('~' . Expression::QUOTED_TOKEN_REGEX . '~', '', $sql))
+            && preg_match('~\sregexp\s|(?<!\w)regexp_[a-z]+\(~i', preg_replace('~' . Expression::QUOTED_TOKEN_REGEX . '~', '', $sql))
         ) {
             $pdo->setAttribute(\PDO::ATTR_EMULATE_PREPARES, false);
             try {

--- a/src/Persistence/Sql/Mysql/DisableEmulatePrepareForPdoRegexpConnectionMiddleware.php
+++ b/src/Persistence/Sql/Mysql/DisableEmulatePrepareForPdoRegexpConnectionMiddleware.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Atk4\Data\Persistence\Sql\Mysql;
+
+use Doctrine\DBAL\Driver\Middleware\AbstractConnectionMiddleware;
+use Doctrine\DBAL\Driver\Statement;
+
+class DisableEmulatePrepareForPdoRegexpConnectionMiddleware extends AbstractConnectionMiddleware
+{
+    #[\Override]
+    public function prepare(string $sql): Statement
+    {
+        // workaround SQLSTATE[HY000]: General error: 3995 Character set 'binary' cannot be used
+        // in conjunction with 'utf8mb4_0900_ai_ci' in call to regexp_like.
+        // https://github.com/mysql/mysql-server/blob/72136a6d15/sql/item_regexp_func.cc#L115-L120
+        // https://dbfiddle.uk/9SA-omyF
+        $pdo = $this->getNativeConnection();
+        if ($pdo instanceof \PDO && $pdo->getAttribute(\PDO::ATTR_EMULATE_PREPARES)
+            && preg_match('~ regexp ~i', preg_replace('~' . Expression::QUOTED_TOKEN_REGEX . '~', '', $sql))
+        ) {
+            $pdo->setAttribute(\PDO::ATTR_EMULATE_PREPARES, false);
+            try {
+                return parent::prepare($sql);
+            } finally {
+                $pdo->setAttribute(\PDO::ATTR_EMULATE_PREPARES, true);
+            }
+        }
+
+        return parent::prepare($sql);
+    }
+}

--- a/src/Persistence/Sql/Mysql/DisableEmulatePrepareForPdoRegexpMiddleware.php
+++ b/src/Persistence/Sql/Mysql/DisableEmulatePrepareForPdoRegexpMiddleware.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Atk4\Data\Persistence\Sql\Mysql;
+
+use Doctrine\DBAL\Driver;
+use Doctrine\DBAL\Driver\Connection;
+use Doctrine\DBAL\Driver\Middleware;
+use Doctrine\DBAL\Driver\Middleware\AbstractDriverMiddleware;
+
+class DisableEmulatePrepareForPdoRegexpMiddleware implements Middleware
+{
+    #[\Override]
+    public function wrap(Driver $driver): Driver
+    {
+        return new class($driver) extends AbstractDriverMiddleware {
+            #[\Override]
+            public function connect(
+                #[\SensitiveParameter]
+                array $params
+            ): Connection {
+                return new DisableEmulatePrepareForPdoRegexpConnectionMiddleware(parent::connect($params));
+            }
+        };
+    }
+}

--- a/src/Persistence/Sql/Sqlite/Connection.php
+++ b/src/Persistence/Sql/Sqlite/Connection.php
@@ -25,6 +25,11 @@ class Connection extends BaseConnection
             ...$configuration->getMiddlewares(),
             new EnableForeignKeys(),
             new PreserveAutoincrementOnRollbackMiddleware(),
+            ...(
+                version_compare(self::getDriverVersion(), '3.44') < 0
+                    ? [new CreateConcatFunctionMiddleware()]
+                    : []
+            ),
             new CreateRegexpLikeFunctionMiddleware(),
             new CreateRegexpReplaceFunctionMiddleware(),
         ]);

--- a/src/Persistence/Sql/Sqlite/CreateConcatFunctionMiddleware.php
+++ b/src/Persistence/Sql/Sqlite/CreateConcatFunctionMiddleware.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Atk4\Data\Persistence\Sql\Sqlite;
+
+use Doctrine\DBAL\Driver;
+use Doctrine\DBAL\Driver\Connection;
+use Doctrine\DBAL\Driver\Middleware;
+use Doctrine\DBAL\Driver\Middleware\AbstractDriverMiddleware;
+
+/**
+ * Remove once SQLite v3.43 support is dropped.
+ */
+class CreateConcatFunctionMiddleware implements Middleware
+{
+    #[\Override]
+    public function wrap(Driver $driver): Driver
+    {
+        return new class($driver) extends AbstractDriverMiddleware {
+            #[\Override]
+            public function connect(
+                #[\SensitiveParameter]
+                array $params
+            ): Connection {
+                $connection = parent::connect($params);
+
+                $nativeConnection = $connection->getNativeConnection();
+                assert($nativeConnection instanceof \PDO);
+
+                $nativeConnection->sqliteCreateFunction('concat', static function ($value, ...$values): string {
+                    $res = '';
+                    foreach ([$value, ...$values] as $v) {
+                        if (is_int($v)) {
+                            $v = (string) $v;
+                        } elseif (is_float($v)) {
+                            $v = Expression::castFloatToString($v);
+                        }
+
+                        $res .= $v;
+                    }
+
+                    return $res;
+                }, -1, \PDO::SQLITE_DETERMINISTIC);
+
+                return $connection;
+            }
+        };
+    }
+}

--- a/src/Persistence/Sql/Sqlite/CreateConcatFunctionMiddleware.php
+++ b/src/Persistence/Sql/Sqlite/CreateConcatFunctionMiddleware.php
@@ -29,8 +29,8 @@ class CreateConcatFunctionMiddleware implements Middleware
                 assert($nativeConnection instanceof \PDO);
 
                 $nativeConnection->sqliteCreateFunction('concat', static function ($value, ...$values): string {
-                    $res = '';
-                    foreach ([$value, ...$values] as $v) {
+                    $res = CreateRegexpLikeFunctionMiddleware::castScalarToString($value) ?? '';
+                    foreach ($values as $v) {
                         $res .= CreateRegexpLikeFunctionMiddleware::castScalarToString($v);
                     }
 

--- a/src/Persistence/Sql/Sqlite/CreateConcatFunctionMiddleware.php
+++ b/src/Persistence/Sql/Sqlite/CreateConcatFunctionMiddleware.php
@@ -31,13 +31,7 @@ class CreateConcatFunctionMiddleware implements Middleware
                 $nativeConnection->sqliteCreateFunction('concat', static function ($value, ...$values): string {
                     $res = '';
                     foreach ([$value, ...$values] as $v) {
-                        if (is_int($v)) {
-                            $v = (string) $v;
-                        } elseif (is_float($v)) {
-                            $v = Expression::castFloatToString($v);
-                        }
-
-                        $res .= $v;
+                        $res .= CreateRegexpLikeFunctionMiddleware::castScalarToString($v);
                     }
 
                     return $res;

--- a/src/Persistence/Sql/Sqlite/CreateRegexpLikeFunctionMiddleware.php
+++ b/src/Persistence/Sql/Sqlite/CreateRegexpLikeFunctionMiddleware.php
@@ -32,8 +32,11 @@ class CreateRegexpLikeFunctionMiddleware implements Middleware
 
                     $value = CreateRegexpLikeFunctionMiddleware::castScalarToString($value);
 
-                    $binary = !mb_check_encoding($pattern, 'UTF-8')
-                        || !mb_check_encoding($value, 'UTF-8');
+                    $binary = \PHP_VERSION_ID < 80200
+                        ? preg_match('~~u', $pattern) !== 1 // much faster in PHP 8.1 and lower
+                            || preg_match('~~u', $value) !== 1
+                        : !mb_check_encoding($pattern, 'UTF-8')
+                            || !mb_check_encoding($value, 'UTF-8');
 
                     $pregPattern = '~' . preg_replace('~(?<!\\\)(?:\\\\\\\)*+\K\~~', '\\\~', $pattern) . '~'
                         . $flags . ($binary ? '' : 'u');

--- a/src/Persistence/Sql/Sqlite/CreateRegexpLikeFunctionMiddleware.php
+++ b/src/Persistence/Sql/Sqlite/CreateRegexpLikeFunctionMiddleware.php
@@ -30,11 +30,7 @@ class CreateRegexpLikeFunctionMiddleware implements Middleware
                         return null;
                     }
 
-                    if (is_int($value)) {
-                        $value = (string) $value;
-                    } elseif (is_float($value)) {
-                        $value = Expression::castFloatToString($value);
-                    }
+                    $value = CreateRegexpLikeFunctionMiddleware::castScalarToString($value);
 
                     $isValidUtf8Value = \PHP_VERSION_ID < 80200
                         ? preg_match('~~u', $value) === 1 // much faster in PHP 8.1 and lower
@@ -49,5 +45,20 @@ class CreateRegexpLikeFunctionMiddleware implements Middleware
                 return $connection;
             }
         };
+    }
+
+    /**
+     * @param string|int|float|null $value
+     */
+    public static function castScalarToString($value): ?string
+    {
+        if (is_int($value)) {
+            return (string) $value;
+        }
+        if (is_float($value)) {
+            return Expression::castFloatToString($value);
+        }
+
+        return $value;
     }
 }

--- a/src/Persistence/Sql/Sqlite/CreateRegexpLikeFunctionMiddleware.php
+++ b/src/Persistence/Sql/Sqlite/CreateRegexpLikeFunctionMiddleware.php
@@ -32,12 +32,11 @@ class CreateRegexpLikeFunctionMiddleware implements Middleware
 
                     $value = CreateRegexpLikeFunctionMiddleware::castScalarToString($value);
 
-                    $isValidUtf8Value = \PHP_VERSION_ID < 80200
-                        ? preg_match('~~u', $value) === 1 // much faster in PHP 8.1 and lower
-                        : mb_check_encoding($value, 'UTF-8');
+                    $binary = !mb_check_encoding($pattern, 'UTF-8')
+                        || !mb_check_encoding($value, 'UTF-8');
 
                     $pregPattern = '~' . preg_replace('~(?<!\\\)(?:\\\\\\\)*+\K\~~', '\\\~', $pattern) . '~'
-                        . $flags . ($isValidUtf8Value ? 'u' : '');
+                        . $flags . ($binary ? '' : 'u');
 
                     return preg_match($pregPattern, $value) === 1;
                 }, -1, \PDO::SQLITE_DETERMINISTIC);

--- a/src/Persistence/Sql/Sqlite/CreateRegexpLikeFunctionMiddleware.php
+++ b/src/Persistence/Sql/Sqlite/CreateRegexpLikeFunctionMiddleware.php
@@ -49,7 +49,7 @@ class CreateRegexpLikeFunctionMiddleware implements Middleware
     /**
      * @param string|int|float|null $value
      */
-    public static function castScalarToString($value): ?string
+    final public static function castScalarToString($value): ?string
     {
         if (is_int($value)) {
             return (string) $value;

--- a/src/Persistence/Sql/Sqlite/CreateRegexpReplaceFunctionMiddleware.php
+++ b/src/Persistence/Sql/Sqlite/CreateRegexpReplaceFunctionMiddleware.php
@@ -32,12 +32,12 @@ class CreateRegexpReplaceFunctionMiddleware implements Middleware
 
                     $value = CreateRegexpLikeFunctionMiddleware::castScalarToString($value);
 
-                    $isValidUtf8Value = \PHP_VERSION_ID < 80200
-                        ? preg_match('~~u', $value) === 1 // much faster in PHP 8.1 and lower
-                        : mb_check_encoding($value, 'UTF-8');
+                    $binary = !mb_check_encoding($pattern, 'UTF-8')
+                        || !mb_check_encoding($value, 'UTF-8')
+                        || !mb_check_encoding($replacement, 'UTF-8');
 
                     $pregPattern = '~' . preg_replace('~(?<!\\\)(?:\\\\\\\)*+\K\~~', '\\\~', $pattern) . '~'
-                        . $flags . ($isValidUtf8Value ? 'u' : '');
+                        . $flags . ($binary ? '' : 'u');
 
                     return preg_replace($pregPattern, $replacement, $value);
                 }, -1, \PDO::SQLITE_DETERMINISTIC);

--- a/src/Persistence/Sql/Sqlite/CreateRegexpReplaceFunctionMiddleware.php
+++ b/src/Persistence/Sql/Sqlite/CreateRegexpReplaceFunctionMiddleware.php
@@ -32,9 +32,13 @@ class CreateRegexpReplaceFunctionMiddleware implements Middleware
 
                     $value = CreateRegexpLikeFunctionMiddleware::castScalarToString($value);
 
-                    $binary = !mb_check_encoding($pattern, 'UTF-8')
-                        || !mb_check_encoding($value, 'UTF-8')
-                        || !mb_check_encoding($replacement, 'UTF-8');
+                    $binary = \PHP_VERSION_ID < 80200
+                        ? preg_match('~~u', $pattern) !== 1 // much faster in PHP 8.1 and lower
+                            || preg_match('~~u', $value) !== 1
+                            || preg_match('~~u', $replacement) !== 1
+                        : !mb_check_encoding($pattern, 'UTF-8')
+                            || !mb_check_encoding($value, 'UTF-8')
+                            || !mb_check_encoding($replacement, 'UTF-8');
 
                     $pregPattern = '~' . preg_replace('~(?<!\\\)(?:\\\\\\\)*+\K\~~', '\\\~', $pattern) . '~'
                         . $flags . ($binary ? '' : 'u');

--- a/src/Persistence/Sql/Sqlite/CreateRegexpReplaceFunctionMiddleware.php
+++ b/src/Persistence/Sql/Sqlite/CreateRegexpReplaceFunctionMiddleware.php
@@ -30,11 +30,7 @@ class CreateRegexpReplaceFunctionMiddleware implements Middleware
                         return null;
                     }
 
-                    if (is_int($value)) {
-                        $value = (string) $value;
-                    } elseif (is_float($value)) {
-                        $value = Expression::castFloatToString($value);
-                    }
+                    $value = CreateRegexpLikeFunctionMiddleware::castScalarToString($value);
 
                     $isValidUtf8Value = \PHP_VERSION_ID < 80200
                         ? preg_match('~~u', $value) === 1 // much faster in PHP 8.1 and lower

--- a/src/Persistence/Sql/Sqlite/ExpressionTrait.php
+++ b/src/Persistence/Sql/Sqlite/ExpressionTrait.php
@@ -23,7 +23,7 @@ trait ExpressionTrait
                 $partsLeft = array_slice($parts, 0, intdiv(count($parts), 2));
                 $partsRight = array_slice($parts, count($partsLeft));
 
-                return '(' . $buildConcatSqlFx($partsLeft) . ' || ' . $buildConcatSqlFx($partsRight) . ')';
+                return 'concat(' . $buildConcatSqlFx($partsLeft) . ', ' . $buildConcatSqlFx($partsRight) . ')';
             }
 
             return reset($parts);

--- a/src/Persistence/Sql/Sqlite/Query.php
+++ b/src/Persistence/Sql/Sqlite/Query.php
@@ -17,7 +17,8 @@ class Query extends BaseQuery
 
     private function _renderConditionBinaryCheckNumericSql(string $sql): string
     {
-        return 'typeof(' . $sql . ') in (\'integer\', \'real\')';
+        return 'typeof(' . $sql . ') in (' . $this->escapeStringLiteral('integer')
+            . ', ' . $this->escapeStringLiteral('real') . ')';
     }
 
     /**

--- a/tests/ConditionSqlTest.php
+++ b/tests/ConditionSqlTest.php
@@ -12,6 +12,7 @@ use Atk4\Data\ValidationException;
 use Doctrine\DBAL\Platforms\MySQLPlatform;
 use Doctrine\DBAL\Platforms\OraclePlatform;
 use Doctrine\DBAL\Platforms\PostgreSQLPlatform;
+use Doctrine\DBAL\Platforms\SQLitePlatform;
 use Doctrine\DBAL\Platforms\SQLServerPlatform;
 use PHPUnit\Framework\Attributes\DataProviderExternal;
 
@@ -529,6 +530,7 @@ class ConditionSqlTest extends TestCase
             ['name' => 'Ca*ro^li$ne'],
             ['name' => 'Ja[n]e'],
             ['name' => 'Ja\[^n]e'],
+            ['name' => 'heiß'],
         ]);
 
         $findIdsLikeFx = function (string $field, string $value, bool $negated = false) use ($u) {
@@ -543,11 +545,42 @@ class ConditionSqlTest extends TestCase
             return $res;
         };
 
+        if ($this->getDatabasePlatform() instanceof SQLitePlatform && ($type === 'binary' || $type === 'blob')) {
+            self::assertTrue(true); // @phpstan-ignore-line
+
+            return; // TODO
+        }
+
+        if ($this->getDatabasePlatform() instanceof PostgreSQLPlatform && ($type === 'binary' || $type === 'blob')) {
+            self::assertTrue(true); // @phpstan-ignore-line
+
+            return; // TODO
+        }
+
+        if ($this->getDatabasePlatform() instanceof SQLServerPlatform && ($type === 'binary' || $type === 'blob')) {
+            self::assertTrue(true); // @phpstan-ignore-line
+
+            return; // TODO
+        }
+
+        if ($this->getDatabasePlatform() instanceof OraclePlatform && ($type === 'text' || $type === 'blob')) {
+            $this->expectException(Exception::class);
+            $this->expectExceptionMessage('Unsupported CLOB/BLOB field operator');
+        }
+
+        if ($this->getDatabasePlatform() instanceof OraclePlatform && $type === 'binary') {
+            self::assertTrue(true); // @phpstan-ignore-line
+
+            return; // TODO
+        }
+
         self::assertSame([1], $findIdsLikeFx('name', 'John'));
         self::assertSame($isBinary ? [] : [1], $findIdsLikeFx('name', 'john'));
+        self::assertSame([9], $findIdsLikeFx('name', 'heiß'));
+        self::assertSame($isBinary ? [] : [9], $findIdsLikeFx('name', 'Heiß'));
         self::assertSame([], $findIdsLikeFx('name', 'Joh'));
         self::assertSame([1, 3], $findIdsLikeFx('name', 'Jo%'));
-        self::assertSame(array_values(array_diff(range(1, 8), [1, 3])), $findIdsLikeFx('name', 'Jo%', true));
+        self::assertSame(array_values(array_diff(range(1, 9), [1, 3])), $findIdsLikeFx('name', 'Jo%', true));
         self::assertSame([1], $findIdsLikeFx('name', '%John%'));
         self::assertSame([1], $findIdsLikeFx('name', 'Jo%n'));
         self::assertSame([1], $findIdsLikeFx('name', 'J%n'));
@@ -663,13 +696,39 @@ class ConditionSqlTest extends TestCase
             return $res;
         };
 
-        self::assertSame([1], $findIdsRegexFx('name', 'John'));
-        if ($isBinary) {
+        if ($this->getDatabasePlatform() instanceof MySQLPlatform && $type === 'binary' && $this->getConnection()->getConnection()->getNativeConnection() instanceof \PDO) {
+            self::assertTrue(true); // @phpstan-ignore-line
+
+            return; // TODO SQLSTATE[HY000]: General error: 3995 Character set 'binary' cannot be used in conjunction with 'utf8mb4_general_ci' in call to regexp_like.
+        }
+
+        if ($this->getDatabasePlatform() instanceof MySQLPlatform && ($type === 'binary' || $type === 'blob')) {
+            self::assertTrue(true); // @phpstan-ignore-line
+
             return; // TODO
         }
-        self::assertSame([1], $findIdsRegexFx('name', 'john'));
+
+        if ($this->getDatabasePlatform() instanceof PostgreSQLPlatform && ($type === 'binary' || $type === 'blob')) {
+            self::assertTrue(true); // @phpstan-ignore-line
+
+            return; // TODO
+        }
+
+        if ($this->getDatabasePlatform() instanceof OraclePlatform && ($type === 'text' || $type === 'blob')) {
+            $this->expectException(Exception::class);
+            $this->expectExceptionMessage('Unsupported CLOB/BLOB field operator');
+        }
+
+        if ($this->getDatabasePlatform() instanceof OraclePlatform && $type === 'binary') {
+            self::assertTrue(true); // @phpstan-ignore-line
+
+            return; // TODO
+        }
+
+        self::assertSame([1], $findIdsRegexFx('name', 'John'));
+        self::assertSame(/* $isBinary ? [] : */ [1], $findIdsRegexFx('name', 'john'));
         self::assertSame([13], $findIdsRegexFx('name', 'heiß'));
-        self::assertSame([13], $findIdsRegexFx('name', 'Heiß'));
+        self::assertSame(/* $isBinary ? [] : */ [13], $findIdsRegexFx('name', 'Heiß'));
         self::assertSame([1], $findIdsRegexFx('name', 'Joh'));
         self::assertSame([1], $findIdsRegexFx('name', 'ohn'));
         self::assertSame([1, 2, 3, ...($this->getDatabasePlatform() instanceof OraclePlatform ? [] : [4]), 13], $findIdsRegexFx('name', 'a', true));
@@ -706,7 +765,7 @@ class ConditionSqlTest extends TestCase
         self::assertSame([5, 6, 7, 8, 9, 11, 12], $findIdsRegexFx('name', 'Sa.ra'));
         self::assertSame([2, 3, 13], $findIdsRegexFx('name', '[e]'));
         self::assertSame([1, 2, 3, 13], $findIdsRegexFx('name', '[eo]'));
-        self::assertSame([1, 2, 3, 13], $findIdsRegexFx('name', '[A-P][aeo]'));
+        self::assertSame([1, 2, 3, .../* ($isBinary ? [] : */ [13] /* ) */], $findIdsRegexFx('name', '[A-P][aeo]'));
         self::assertSame([3], $findIdsRegexFx('name', 'o[^h]'));
         self::assertSame([5, 6, 7, 8, 9, 10, 11, 12], $findIdsRegexFx('name', '^Sa'));
         self::assertSame([], $findIdsRegexFx('name', '^ra'));

--- a/tests/ConditionSqlTest.php
+++ b/tests/ConditionSqlTest.php
@@ -696,12 +696,6 @@ class ConditionSqlTest extends TestCase
             return $res;
         };
 
-        if ($this->getDatabasePlatform() instanceof MySQLPlatform && $type === 'binary' && $this->getConnection()->getConnection()->getNativeConnection() instanceof \PDO) {
-            self::assertTrue(true); // @phpstan-ignore-line
-
-            return; // TODO SQLSTATE[HY000]: General error: 3995 Character set 'binary' cannot be used in conjunction with 'utf8mb4_general_ci' in call to regexp_like.
-        }
-
         if ($this->getDatabasePlatform() instanceof MySQLPlatform && ($type === 'binary' || $type === 'blob')) {
             self::assertTrue(true); // @phpstan-ignore-line
 

--- a/tests/ConditionSqlTest.php
+++ b/tests/ConditionSqlTest.php
@@ -7,11 +7,13 @@ namespace Atk4\Data\Tests;
 use Atk4\Data\Exception;
 use Atk4\Data\Model;
 use Atk4\Data\Schema\TestCase;
+use Atk4\Data\Tests\Schema\MigratorTest;
 use Atk4\Data\ValidationException;
 use Doctrine\DBAL\Platforms\MySQLPlatform;
 use Doctrine\DBAL\Platforms\OraclePlatform;
 use Doctrine\DBAL\Platforms\PostgreSQLPlatform;
 use Doctrine\DBAL\Platforms\SQLServerPlatform;
+use PHPUnit\Framework\Attributes\DataProviderExternal;
 
 class ConditionSqlTest extends TestCase
 {
@@ -506,24 +508,28 @@ class ConditionSqlTest extends TestCase
         self::assertNull($u->getField('name')->default); // should not set field default value
     }
 
-    public function testLikeCondition(): void
+    /**
+     * @dataProvider \Atk4\Data\Tests\Schema\MigratorTest::provideCharacterTypeFieldCaseSensitivityCases
+     */
+    #[DataProviderExternal(MigratorTest::class, 'provideCharacterTypeFieldCaseSensitivityCases')]
+    public function testLikeCondition(string $type, bool $isBinary): void
     {
-        $this->setDb([
-            'user' => [
-                1 => ['id' => 1, 'name' => 'John', 'c' => 1],
-                ['id' => 2, 'name' => 'Peter', 'c' => 2000],
-                ['id' => 3, 'name' => 'Joe', 'c' => 50],
-                ['id' => 4, 'name' => 'Ca_ro%li\ne'],
-                ['id' => 5, 'name' => "Ca\nro.li\\\\ne"],
-                ['id' => 6, 'name' => 'Ca*ro^li$ne'],
-                ['id' => 7, 'name' => 'Ja[n]e'],
-                ['id' => 8, 'name' => 'Ja\[^n]e'],
-            ],
-        ]);
-
         $u = new Model($this->db, ['table' => 'user']);
-        $u->addField('name', ['type' => 'string']);
+        $u->addField('name', ['type' => $type]);
         $u->addField('c', ['type' => 'integer']);
+
+        $this->createMigrator($u)->create();
+
+        $u->import([
+            ['name' => 'John', 'c' => 1],
+            ['name' => 'Peter', 'c' => 2000],
+            ['name' => 'Joe', 'c' => 50],
+            ['name' => 'Ca_ro%li\ne'],
+            ['name' => "Ca\nro.li\\\\ne"],
+            ['name' => 'Ca*ro^li$ne'],
+            ['name' => 'Ja[n]e'],
+            ['name' => 'Ja\[^n]e'],
+        ]);
 
         $findIdsLikeFx = function (string $field, string $value, bool $negated = false) use ($u) {
             $t = (clone $u)->addCondition($field, ($negated ? 'not ' : '') . 'like', $value);
@@ -538,7 +544,7 @@ class ConditionSqlTest extends TestCase
         };
 
         self::assertSame([1], $findIdsLikeFx('name', 'John'));
-        self::assertSame([1], $findIdsLikeFx('name', 'john'));
+        self::assertSame($isBinary ? [] : [1], $findIdsLikeFx('name', 'john'));
         self::assertSame([], $findIdsLikeFx('name', 'Joh'));
         self::assertSame([1, 3], $findIdsLikeFx('name', 'Jo%'));
         self::assertSame(array_values(array_diff(range(1, 8), [1, 3])), $findIdsLikeFx('name', 'Jo%', true));
@@ -603,37 +609,42 @@ class ConditionSqlTest extends TestCase
         self::assertSame([8], $findIdsLikeFx('name', '%^n%'));
         self::assertSame([8], $findIdsLikeFx('name', '%[^n]%'));
 
-        self::assertStringStartsWith("Ca\nro", $u->load(5)->get('name'));
-        self::assertSame([5], $findIdsLikeFx('name', "Ca\n%"));
-        self::assertSame([], $findIdsLikeFx('name', "Ca\\\n%"));
-        self::assertSame([], $findIdsLikeFx('name', 'Ca\n%'));
-        self::assertSame([], $findIdsLikeFx('name', 'Ca %'));
+        if ($type !== 'string') {
+            self::assertStringStartsWith("Ca\nro", $u->load(5)->get('name'));
+            self::assertSame([5], $findIdsLikeFx('name', "Ca\n%"));
+            self::assertSame([], $findIdsLikeFx('name', "Ca\\\n%"));
+            self::assertSame([], $findIdsLikeFx('name', 'Ca %'));
+        }
     }
 
-    public function testRegexpCondition(): void
+    /**
+     * @dataProvider \Atk4\Data\Tests\Schema\MigratorTest::provideCharacterTypeFieldCaseSensitivityCases
+     */
+    #[DataProviderExternal(MigratorTest::class, 'provideCharacterTypeFieldCaseSensitivityCases')]
+    public function testRegexpCondition(string $type, bool $isBinary): void
     {
-        $this->setDb([
-            'user' => [
-                1 => ['id' => 1, 'name' => 'John', 'c' => 1, 'rating' => 1.5],
-                ['id' => 2, 'name' => 'Peter', 'c' => 2000, 'rating' => 2.5],
-                ['id' => 3, 'name' => 'Joe', 'c' => 50],
-                ['id' => 4, 'name' => ''],
-                ['id' => 5, 'name' => 'Sa ra'],
-                ['id' => 6, 'name' => "Sa\nra"],
-                ['id' => 7, 'name' => 'Sa.ra'],
-                ['id' => 8, 'name' => 'Sa/ra'],
-                ['id' => 9, 'name' => 'Sa\ra'],
-                ['id' => 10, 'name' => 'Sa\\\ra'],
-                ['id' => 11, 'name' => 'Sa~ra'],
-                ['id' => 12, 'name' => 'Sa$ra'],
-                ['id' => 13, 'name' => 'heiß'],
-            ],
-        ]);
-
         $u = new Model($this->db, ['table' => 'user']);
-        $u->addField('name', ['type' => 'string']);
+        $u->addField('name', ['type' => $type]);
         $u->addField('c', ['type' => 'integer']);
         $u->addField('rating', ['type' => 'float']);
+
+        $this->createMigrator($u)->create();
+
+        $u->import([
+            ['name' => 'John', 'c' => 1, 'rating' => 1.5],
+            ['name' => 'Peter', 'c' => 2000, 'rating' => 2.5],
+            ['name' => 'Joe', 'c' => 50],
+            ['name' => ''],
+            ['name' => 'Sa ra'],
+            ['name' => "Sa\nra"],
+            ['name' => 'Sa.ra'],
+            ['name' => 'Sa/ra'],
+            ['name' => 'Sa\ra'],
+            ['name' => 'Sa\\\ra'],
+            ['name' => 'Sa~ra'],
+            ['name' => 'Sa$ra'],
+            ['name' => 'heiß'],
+        ]);
 
         if ($this->getDatabasePlatform() instanceof SQLServerPlatform) {
             // https://devblogs.microsoft.com/azure-sql/introducing-regular-expression-regex-support-in-azure-sql-db/
@@ -653,6 +664,9 @@ class ConditionSqlTest extends TestCase
         };
 
         self::assertSame([1], $findIdsRegexFx('name', 'John'));
+        if ($isBinary) {
+            return; // TODO
+        }
         self::assertSame([1], $findIdsRegexFx('name', 'john'));
         self::assertSame([13], $findIdsRegexFx('name', 'heiß'));
         self::assertSame([13], $findIdsRegexFx('name', 'Heiß'));
@@ -676,14 +690,16 @@ class ConditionSqlTest extends TestCase
         self::assertSame([8], $findIdsRegexFx('name', '\/ra'));
         self::assertSame([11], $findIdsRegexFx('name', '~ra'));
         self::assertSame([11], $findIdsRegexFx('name', '\~ra'));
-        self::assertSame([5], $findIdsRegexFx('name', ' ra'));
-        self::assertSame([5], $findIdsRegexFx('name', '\ ra'));
-        self::assertSame([6], $findIdsRegexFx('name', "\nra"));
-        self::assertSame([6], $findIdsRegexFx('name', "\\\nra"));
 
-        self::assertSame("Sa\nra", $u->load(6)->get('name'));
-        self::assertSame([6], $findIdsRegexFx('name', "Sa\nra"));
-        self::assertSame([6], $findIdsRegexFx('name', "Sa\\\nra"));
+        if ($type !== 'string') {
+            self::assertSame("Sa\nra", $u->load(6)->get('name'));
+            self::assertSame([6], $findIdsRegexFx('name', "Sa\nra"));
+            self::assertSame([6], $findIdsRegexFx('name', "Sa\\\nra"));
+            self::assertSame([6], $findIdsRegexFx('name', "\nra"));
+            self::assertSame([6], $findIdsRegexFx('name', "\\\nra"));
+            self::assertSame([5], $findIdsRegexFx('name', ' ra'));
+            self::assertSame([5], $findIdsRegexFx('name', '\ ra'));
+        }
 
         self::assertSame([2, 3, 13], $findIdsRegexFx('name', '.e'));
         self::assertSame(array_values(array_diff(range(1, 13), [4])), $findIdsRegexFx('name', '.'));
@@ -699,7 +715,7 @@ class ConditionSqlTest extends TestCase
 
         self::assertSame([1, 3], $findIdsRegexFx('name', 'John|e$'));
         self::assertSame([1], $findIdsRegexFx('name', '((John))()'));
-        self::assertSame([1, 3, 5], $findIdsRegexFx('name', '(J|Sa ra)'));
+        self::assertSame([1, 3, 11], $findIdsRegexFx('name', '(J|Sa~ra)'));
 
         self::assertSame([1], $findIdsRegexFx('name', 'J.+n'));
         self::assertSame([], $findIdsRegexFx('name', 'John.+'));
@@ -734,7 +750,7 @@ class ConditionSqlTest extends TestCase
             self::assertSame([1, 3], $findIdsRegexFx('name', '\wo'));
             self::assertSame([13], $findIdsRegexFx('name', 'hei\w$'));
             self::assertSame([10], $findIdsRegexFx('name', '\W\\\\'));
-            if (!$this->getDatabasePlatform() instanceof OraclePlatform) {
+            if ($type !== 'string' && !$this->getDatabasePlatform() instanceof OraclePlatform) {
                 self::assertSame([5], $findIdsRegexFx('name', '\x20'));
                 self::assertSame([6], $findIdsRegexFx('name', '\n'));
                 self::assertSame([], $findIdsRegexFx('name', '\r'));

--- a/tests/ExpressionSqlTest.php
+++ b/tests/ExpressionSqlTest.php
@@ -7,7 +7,6 @@ namespace Atk4\Data\Tests;
 use Atk4\Data\Model;
 use Atk4\Data\Schema\TestCase;
 use Doctrine\DBAL\Platforms\OraclePlatform;
-use Doctrine\DBAL\Platforms\SQLitePlatform;
 
 class ExpressionSqlTest extends TestCase
 {
@@ -133,9 +132,7 @@ class ExpressionSqlTest extends TestCase
         $m->addField('surname');
         $m->addField('cached_name');
 
-        if ($this->getDatabasePlatform() instanceof SQLitePlatform) {
-            $concatExpr = '[name] || \' \' || [surname]';
-        } elseif ($this->getDatabasePlatform() instanceof OraclePlatform) { // needed for Oracle 21 and lower
+        if ($this->getDatabasePlatform() instanceof OraclePlatform) { // needed for Oracle 21 and lower
             $concatExpr = 'CONCAT(CONCAT([name], \' \'), [surname])';
         } else {
             $concatExpr = 'CONCAT([name], \' \', [surname])';

--- a/tests/Persistence/Sql/ExpressionTest.php
+++ b/tests/Persistence/Sql/ExpressionTest.php
@@ -254,16 +254,16 @@ class ExpressionTest extends TestCase
 
         self::assertSame('\'\'', $escapeStringLiteralFx(''));
         self::assertSame('\'foo\'', $escapeStringLiteralFx('foo'));
-        self::assertSame('(\'\' || x\'00\')', $escapeStringLiteralFx("\0"));
-        self::assertSame('(\'a\' || x\'0000\')', $escapeStringLiteralFx("a\0\0"));
-        self::assertSame('(\'a\' || x\'' . str_repeat('00', 10_000) . '\')', $escapeStringLiteralFx('a' . str_repeat("\0", 10_000)));
-        self::assertSame('(\'a\' || (x\'006200\' || \'c\'))', $escapeStringLiteralFx("a\0b\0c"));
+        self::assertSame('concat(\'\', x\'00\')', $escapeStringLiteralFx("\0"));
+        self::assertSame('concat(\'a\', x\'0000\')', $escapeStringLiteralFx("a\0\0"));
+        self::assertSame('concat(\'a\', x\'' . str_repeat('00', 10_000) . '\')', $escapeStringLiteralFx('a' . str_repeat("\0", 10_000)));
+        self::assertSame('concat(\'a\', concat(x\'006200\', \'c\'))', $escapeStringLiteralFx("a\0b\0c"));
         self::assertSame(
-            '(\'a\' || (x\'00' . str_repeat('62', 100) . '00\' || \'c\'))',
+            'concat(\'a\', concat(x\'00' . str_repeat('62', 100) . '00\', \'c\'))',
             $escapeStringLiteralFx("a\0" . str_repeat('b', 100) . "\0c")
         );
         self::assertSame(
-            '((\'a\' || x\'00\') || (\'' . str_repeat('b', 101) . '\' || (x\'00\' || \'c\')))',
+            'concat(concat(\'a\', x\'00\'), concat(\'' . str_repeat('b', 101) . '\', concat(x\'00\', \'c\')))',
             $escapeStringLiteralFx("a\0" . str_repeat('b', 101) . "\0c")
         );
 

--- a/tests/Persistence/Sql/QueryTest.php
+++ b/tests/Persistence/Sql/QueryTest.php
@@ -837,6 +837,14 @@ class QueryTest extends TestCase
             'where not regexp_like("name", :a, \'is\')',
             $this->q('[where]')->where('name', 'not regexp', '^foo')->render()[0]
         );
+        self::assertSame(
+            'where regexp_like(`name`, :a, \'is\')',
+            (new SqliteQuery('[where]'))->where('name', 'regexp', 'foo')->render()[0]
+        );
+        self::assertSame(
+            'where regexp_like(`name`, sum("b"), \'is\')',
+            (new SqliteQuery('[where]'))->where('name', 'regexp', $this->e('sum({})', ['b']))->render()[0]
+        );
         // TODO add MysqlQuery test once MySQL 5.x support is dropped
     }
 

--- a/tests/Persistence/Sql/QueryTest.php
+++ b/tests/Persistence/Sql/QueryTest.php
@@ -14,6 +14,8 @@ use Atk4\Data\Persistence\Sql\Mysql\Query as MysqlQuery;
 use Atk4\Data\Persistence\Sql\Query;
 use Atk4\Data\Persistence\Sql\Sqlite\Connection as SqliteConnection;
 use Atk4\Data\Persistence\Sql\Sqlite\Query as SqliteQuery;
+use Doctrine\DBAL\Connection as DbalConnection;
+use Doctrine\DBAL\Driver\Middleware\AbstractConnectionMiddleware;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\DoesNotPerformAssertions;
 
@@ -762,6 +764,48 @@ class QueryTest extends TestCase
         yield ['in', null];
     }
 
+    /**
+     * @param string|array<string, mixed> $template
+     */
+    private function createMysqlQuery(string $serverVersion, $template = []): MysqlQuery
+    {
+        $dbalConnection = new class($serverVersion) extends DbalConnection {
+            private string $serverVersion;
+
+            public function __construct(string $serverVersion) // @phpstan-ignore-line
+            {
+                $this->serverVersion = $serverVersion;
+            }
+
+            #[\Override]
+            public function getWrappedConnection()
+            {
+                return new class($this->serverVersion) extends AbstractConnectionMiddleware {
+                    private string $serverVersion;
+
+                    public function __construct(string $serverVersion) // @phpstan-ignore-line
+                    {
+                        $this->serverVersion = $serverVersion;
+                    }
+
+                    #[\Override]
+                    public function getServerVersion()
+                    {
+                        return $this->serverVersion;
+                    }
+                };
+            }
+        };
+
+        $connection = \Closure::bind(static fn () => new MysqlConnection(), null, Connection::class)();
+        \Closure::bind(static fn () => $connection->_connection = $dbalConnection, null, Connection::class)();
+
+        $q = new MysqlQuery($template);
+        $q->connection = $connection;
+
+        return $q;
+    }
+
     public function testWhereSpecialValues(): void
     {
         // in | not in
@@ -826,16 +870,23 @@ class QueryTest extends TestCase
                 EOF,
             (new SqliteQuery('[where]'))->where('name', 'like', $this->e('sum({})', ['b']))->render()[0]
         );
-        // TODO add MysqlQuery test once MySQL 5.x support is dropped
+        foreach (['8.0', 'MariaDB-11.0'] as $serverVersion) {
+            self::assertSame(
+                <<<'EOF'
+                    where `name` like regexp_replace(:a, '\\\\\\\\|\\\\(?![_%])', '\\\\\\\\') escape '\\'
+                    EOF,
+                $this->createMysqlQuery($serverVersion, '[where]')->where('name', 'like', 'foo')->render()[0]
+            );
+        }
 
         // regexp | not regexp
         self::assertSame(
             'where regexp_like("name", :a, \'is\')',
-            $this->q('[where]')->where('name', 'regexp', '^foo')->render()[0]
+            $this->q('[where]')->where('name', 'regexp', 'foo')->render()[0]
         );
         self::assertSame(
             'where not regexp_like("name", :a, \'is\')',
-            $this->q('[where]')->where('name', 'not regexp', '^foo')->render()[0]
+            $this->q('[where]')->where('name', 'not regexp', 'foo')->render()[0]
         );
         self::assertSame(
             'where regexp_like(`name`, :a, \'is\')',
@@ -845,7 +896,14 @@ class QueryTest extends TestCase
             'where regexp_like(`name`, sum("b"), \'is\')',
             (new SqliteQuery('[where]'))->where('name', 'regexp', $this->e('sum({})', ['b']))->render()[0]
         );
-        // TODO add MysqlQuery test once MySQL 5.x support is dropped
+        foreach (['8.0', 'MariaDB-11.0'] as $serverVersion) {
+            self::assertSame(
+                <<<'EOF'
+                    where `name` regexp concat('(?s)', :a)
+                    EOF,
+                $this->createMysqlQuery($serverVersion, '[where]')->where('name', 'regexp', 'foo')->render()[0]
+            );
+        }
     }
 
     public function testWhereInWithNullException(): void

--- a/tests/Persistence/Sql/QueryTest.php
+++ b/tests/Persistence/Sql/QueryTest.php
@@ -13,6 +13,7 @@ use Atk4\Data\Persistence\Sql\Mysql\Expression as MysqlExpression;
 use Atk4\Data\Persistence\Sql\Mysql\Query as MysqlQuery;
 use Atk4\Data\Persistence\Sql\Query;
 use Atk4\Data\Persistence\Sql\Sqlite\Connection as SqliteConnection;
+use Atk4\Data\Persistence\Sql\Sqlite\Query as SqliteQuery;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\DoesNotPerformAssertions;
 
@@ -620,6 +621,10 @@ class QueryTest extends TestCase
             'where "id" is not null',
             $this->q('[where]')->where('id', '!=', null)->render()[0]
         );
+        self::assertSame(
+            'where case when typeof(`id`) in (\'integer\', \'real\') then cast(`id` as numeric) = :a else case when typeof(:a) in (\'integer\', \'real\') then `id` = cast(:a as numeric) else `id` = :a end end',
+            (new SqliteQuery('[where]'))->where('id', 1)->render()[0]
+        );
 
         // three parameters - field, condition, value
         self::assertSame(
@@ -642,6 +647,12 @@ class QueryTest extends TestCase
             'where "id" in (select * from "user")',
             $this->q('[where]')->where('id', $this->q()->table('user'))->render()[0]
         );
+        self::assertSame(
+            version_compare(SqliteConnection::getDriverVersion(), '3.45') < 0
+                ? 'where case when typeof(`id`) in (\'integer\', \'real\') then cast(`id` as numeric) != (select * from "user") else case when typeof((select * from "user")) in (\'integer\', \'real\') then `id` != cast((select * from "user") as numeric) else `id` != (select * from "user") end end'
+                : 'where (select case when typeof(`id`) in (\'integer\', \'real\') then cast(`id` as numeric) != `__atk4_affinity_right__` else case when typeof(`__atk4_affinity_right__`) in (\'integer\', \'real\') then `id` != cast(`__atk4_affinity_right__` as numeric) else `id` != `__atk4_affinity_right__` end end from (select (select * from "user") `__atk4_affinity_right__`) `__atk4_affinity_tmp__`)',
+            (new SqliteQuery('[where]'))->where('id', '!=', $this->q()->table('user'))->render()[0]
+        );
 
         // field name with special symbols - not escape
         self::assertSame(
@@ -653,6 +664,18 @@ class QueryTest extends TestCase
         self::assertSame(
             'where now = :a',
             $this->q('[where]')->where($this->e('now'), 1)->render()[0]
+        );
+        self::assertSame(
+            version_compare(SqliteConnection::getDriverVersion(), '3.45') < 0
+                ? 'where case when typeof(sum("id")) in (\'integer\', \'real\') then cast(sum("id") as numeric) = :a else case when typeof(:a) in (\'integer\', \'real\') then sum("id") = cast(:a as numeric) else sum("id") = :a end end'
+                : 'where (select case when typeof(`__atk4_affinity_left__`) in (\'integer\', \'real\') then cast(`__atk4_affinity_left__` as numeric) = :a else case when typeof(:a) in (\'integer\', \'real\') then `__atk4_affinity_left__` = cast(:a as numeric) else `__atk4_affinity_left__` = :a end end from (select sum("id") `__atk4_affinity_left__`) `__atk4_affinity_tmp__`)',
+            (new SqliteQuery('[where]'))->where($this->e('sum({})', ['id']), 1)->render()[0]
+        );
+        self::assertSame(
+            version_compare(SqliteConnection::getDriverVersion(), '3.45') < 0
+                ? 'where case when typeof(sum("id")) in (\'integer\', \'real\') then cast(sum("id") as numeric) = sum("b") else case when typeof(sum("b")) in (\'integer\', \'real\') then sum("id") = cast(sum("b") as numeric) else sum("id") = sum("b") end end'
+                : 'where (select case when typeof(`__atk4_affinity_left__`) in (\'integer\', \'real\') then cast(`__atk4_affinity_left__` as numeric) = `__atk4_affinity_right__` else case when typeof(`__atk4_affinity_right__`) in (\'integer\', \'real\') then `__atk4_affinity_left__` = cast(`__atk4_affinity_right__` as numeric) else `__atk4_affinity_left__` = `__atk4_affinity_right__` end end from (select sum("id") `__atk4_affinity_left__`, sum("b") `__atk4_affinity_right__`) `__atk4_affinity_tmp__`)',
+            (new SqliteQuery('[where]'))->where($this->e('sum({})', ['id']), $this->e('sum({})', ['b']))->render()[0]
         );
 
         // more than one where condition - join with AND keyword
@@ -749,6 +772,14 @@ class QueryTest extends TestCase
         self::assertSame(
             'where "id" not in (:a, :b)',
             $this->q('[where]')->where('id', 'not in', [1, 2])->render()[0]
+        );
+        self::assertSame(
+            'where ('
+                . 'case when typeof(`id`) in (\'integer\', \'real\') then cast(`id` as numeric) = :a else case when typeof(:a) in (\'integer\', \'real\') then `id` = cast(:a as numeric) else `id` = :a end end'
+                . ' or '
+                . 'case when typeof(`id`) in (\'integer\', \'real\') then cast(`id` as numeric) = :b else case when typeof(:b) in (\'integer\', \'real\') then `id` = cast(:b as numeric) else `id` = :b end end'
+                . ')',
+            (new SqliteQuery('[where]'))->where('id', 'in', [1, 2])->render()[0]
         );
         // special treatment for empty array values
         self::assertSame(

--- a/tests/Persistence/Sql/QueryTest.php
+++ b/tests/Persistence/Sql/QueryTest.php
@@ -814,6 +814,18 @@ class QueryTest extends TestCase
                 EOF,
             $this->q('[where]')->where('name', 'not like', 'foo')->render()[0]
         );
+        self::assertSame(
+            <<<'EOF'
+                where `name` like regexp_replace(:a, '(\\[\\_%])|(\\)', '\1\2\2') escape '\'
+                EOF,
+            (new SqliteQuery('[where]'))->where('name', 'like', 'foo')->render()[0]
+        );
+        self::assertSame(
+            <<<'EOF'
+                where `name` like regexp_replace(sum("b"), '(\\[\\_%])|(\\)', '\1\2\2') escape '\'
+                EOF,
+            (new SqliteQuery('[where]'))->where('name', 'like', $this->e('sum({})', ['b']))->render()[0]
+        );
         // TODO add MysqlQuery test once MySQL 5.x support is dropped
 
         // regexp | not regexp

--- a/tests/Schema/MigratorTest.php
+++ b/tests/Schema/MigratorTest.php
@@ -103,15 +103,36 @@ class MigratorTest extends TestCase
             ['v' => 'MixedCase'],
         ]);
 
-        $model->addCondition('v', 'MixedCase');
-        $model->setOrder($this->getDatabasePlatform() instanceof OraclePlatform && in_array($type, ['text', 'blob'], true) ? 'id' : 'v');
+        if (!$this->getDatabasePlatform() instanceof OraclePlatform || !in_array($type, ['text', 'blob'], true)) {
+            $model->setOrder('v');
+        }
 
-        self::assertSameExportUnordered(
-            $isBinary
-                ? [['id' => 3]]
-                : [['id' => 1], ['id' => 2], ['id' => 3]],
-            $model->export(['id'])
-        );
+        $expectedExport = $isBinary
+            ? [['id' => 3]]
+            : [['id' => 1], ['id' => 2], ['id' => 3]];
+
+        $model->addCondition('v', 'MixedCase');
+        self::assertSameExportUnordered($expectedExport, $model->export(['id']));
+
+        if (!$this->getDatabasePlatform() instanceof OraclePlatform || !in_array($type, ['text', 'blob'], true)) {
+            $model->scope()->clear();
+            $model->addCondition('v', 'in', ['MixedCase', 'foo']);
+            self::assertSameExportUnordered($expectedExport, $model->export(['id']));
+
+            // TODO
+            // $model->scope()->clear();
+            // $model->addCondition('v', 'like', 'MixedCase');
+            // self::assertSameExportUnordered($expectedExport, $model->export(['id']));
+            //
+            // $model->scope()->clear();
+            // $model->addCondition('v', 'like', '%ix%Case');
+            // self::assertSameExportUnordered($expectedExport, $model->export(['id']));
+
+            // TODO
+            // $model->scope()->clear();
+            // $model->addCondition('v', 'regexp', 'ix.+Case');
+            // self::assertSameExportUnordered($expectedExport, $model->export(['id']));
+        }
     }
 
     /**

--- a/tests/Schema/MigratorTest.php
+++ b/tests/Schema/MigratorTest.php
@@ -97,7 +97,11 @@ class MigratorTest extends TestCase
 
         $this->createMigrator($model)->create();
 
-        $model->import([['v' => 'mixedcase'], ['v' => 'MIXEDCASE'], ['v' => 'MixedCase']]);
+        $model->import([
+            ['v' => 'mixedcase'],
+            ['v' => 'MIXEDCASE'],
+            ['v' => 'MixedCase'],
+        ]);
 
         $model->addCondition('v', 'MixedCase');
         $model->setOrder($this->getDatabasePlatform() instanceof OraclePlatform && in_array($type, ['text', 'blob'], true) ? 'id' : 'v');
@@ -177,12 +181,14 @@ class MigratorTest extends TestCase
 
         $this->createMigrator($model)->create();
 
-        $model->import([['v' => $str . (
-            // MSSQL database ignores trailing \0 characters even with binary comparison
-            // https://dba.stackexchange.com/questions/48660/comparing-binary-0x-and-0x00-turns-out-to-be-equal-on-sql-server
-            $isBinary ? ($this->getDatabasePlatform() instanceof SQLServerPlatform ? ' ' : "\0") : '.'
-        )]]);
-        $model->import([['v' => $str]]);
+        $model->import([
+            ['v' => $str . (
+                // MSSQL database ignores trailing \0 characters even with binary comparison
+                // https://dba.stackexchange.com/questions/48660/comparing-binary-0x-and-0x00-turns-out-to-be-equal-on-sql-server
+                $isBinary ? ($this->getDatabasePlatform() instanceof SQLServerPlatform ? ' ' : "\0") : '.'
+            )],
+            ['v' => $str],
+        ]);
 
         $model->addCondition('v', $str);
         $rows = $model->export();


### PR DESCRIPTION
extracted from #1202

UPDATE: reverted in #1206 as MySQL 8.0.22+ LIKE with mixed string + binary is simply broken