### PR TITLE
Use Doctrine SQL formatter

### DIFF
--- a/.github/workflows/test-unit.yml
+++ b/.github/workflows/test-unit.yml
@@ -47,7 +47,7 @@ jobs:
       - name: Install PHP dependencies
         run: |
           if [ "${{ matrix.type }}" != "Phpunit" ] && [ "${{ matrix.type }}" != "StaticAnalysis" ]; then composer remove --no-interaction --no-update phpunit/phpunit ergebnis/phpunit-slow-test-detector --dev; fi
-          if [ "${{ matrix.type }}" != "CodingStyle" ]; then composer remove --no-interaction --no-update friendsofphp/php-cs-fixer ergebnis/composer-normalize --dev && composer --no-interaction --no-update require jdorn/sql-formatter; fi
+          if [ "${{ matrix.type }}" != "CodingStyle" ]; then composer remove --no-interaction --no-update friendsofphp/php-cs-fixer ergebnis/composer-normalize --dev; fi
           if [ "${{ matrix.type }}" != "StaticAnalysis" ]; then composer remove --no-interaction --no-update phpstan/\* --dev; fi
           composer update --ansi --prefer-dist --no-interaction --no-progress --optimize-autoloader
 
@@ -141,7 +141,7 @@ jobs:
       - name: Install PHP dependencies
         run: |
           if [ "${{ matrix.type }}" != "Phpunit" ] && [ "${{ matrix.type }}" != "Phpunit Lowest" ] && [ "${{ matrix.type }}" != "Phpunit Burn" ]; then composer remove --no-interaction --no-update phpunit/phpunit ergebnis/phpunit-slow-test-detector --dev; fi
-          if [ "${{ matrix.type }}" != "CodingStyle" ]; then composer remove --no-interaction --no-update friendsofphp/php-cs-fixer ergebnis/composer-normalize --dev && composer --no-update --ansi --prefer-dist --no-interaction --no-progress require jdorn/sql-formatter; fi
+          if [ "${{ matrix.type }}" != "CodingStyle" ]; then composer remove --no-interaction --no-update friendsofphp/php-cs-fixer ergebnis/composer-normalize --dev; fi
           if [ "${{ matrix.type }}" != "StaticAnalysis" ]; then composer remove --no-interaction --no-update phpstan/\* --dev; fi
           if [ -n "$LOG_COVERAGE" ]; then composer require --no-interaction --no-install phpunit/phpcov; fi
           composer update --ansi --prefer-dist --no-interaction --no-progress --optimize-autoloader

--- a/composer.json
+++ b/composer.json
@@ -45,6 +45,7 @@
         "mvorisek/atk4-hintable": "~1.9.0"
     },
     "require-dev": {
+        "doctrine/sql-formatter": "dev-1-5-php74 as 1.5.99",
         "ergebnis/composer-normalize": "^2.13",
         "ergebnis/phpunit-slow-test-detector": "^2.9",
         "friendsofphp/php-cs-fixer": "^3.0",
@@ -55,11 +56,18 @@
         "phpunit/phpunit": "^9.5.25 || ^10.0 || ^11.0"
     },
     "conflict": {
-        "jdorn/sql-formatter": "<1.2.16"
+        "doctrine/sql-formatter": "<1.5 || >=2.0"
     },
     "suggest": {
-        "jdorn/sql-formatter": "*"
+        "doctrine/sql-formatter": "*"
     },
+    "repositories": [
+        {
+            "type": "git",
+            "url": "https://github.com/atk4/doctrine-sql-formatter.git",
+            "name": "doctrine/sql-formatter"
+        }
+    ],
     "minimum-stability": "dev",
     "prefer-stable": true,
     "autoload": {

--- a/docs/persistence/sql/expressions.md
+++ b/docs/persistence/sql/expressions.md
@@ -265,10 +265,10 @@ This method will use HTML formatting if argument is passed.
 :::
 
 In order for HTML parsing to work and to make your debug queries better
-formatted, install `sql-formatter`:
+formatted, install `doctrine/sql-formatter`:
 
 ```
-composer require jdorn/sql-formatter
+composer require doctrine/sql-formatter
 ```
 
 ## Escaping Methods

--- a/src/Persistence/Sql/Expression.php
+++ b/src/Persistence/Sql/Expression.php
@@ -14,6 +14,8 @@ use Doctrine\DBAL\Platforms\PostgreSQLPlatform;
 use Doctrine\DBAL\Platforms\SQLServerPlatform;
 use Doctrine\DBAL\Result as DbalResult;
 use Doctrine\DBAL\Statement;
+use Doctrine\SqlFormatter\NullHighlighter;
+use Doctrine\SqlFormatter\SqlFormatter;
 
 /**
  * @phpstan-implements \ArrayAccess<int|string, mixed>
@@ -414,17 +416,9 @@ abstract class Expression implements Expressionable, \ArrayAccess
             $sql
         );
 
-        if (class_exists(\SqlFormatter::class)) { // requires optional "jdorn/sql-formatter" package
-            \Closure::bind(static function () {
-                // fix latest/1.2.17 release from 2014-01-12
-                if (end(\SqlFormatter::$reserved_toplevel) === 'INTERSECT') {
-                    \SqlFormatter::$reserved_toplevel[] = 'OFFSET';
-                    \SqlFormatter::$reserved_toplevel[] = 'FETCH';
-                }
-            }, null, \SqlFormatter::class)();
-
-            // fix string literal tokenize
-            // https://github.com/jdorn/sql-formatter/blob/v1.2.17/lib/SqlFormatter.php#L339
+        if (class_exists(SqlFormatter::class)) { // requires optional "doctrine/sql-formatter" package
+            // fix string literal tokenize 1/2
+            // https://github.com/doctrine/sql-formatter/blob/1.4.0/src/Tokenizer.php#L974
             $origStringTokens = [];
             $sql = preg_replace_callback('~' . self::QUOTED_TOKEN_REGEX . '~', static function ($matches) use (&$origStringTokens) {
                 $firstChar = substr($matches[0], 0, 1);
@@ -434,14 +428,17 @@ abstract class Expression implements Expressionable, \ArrayAccess
 
                 $k = $firstChar
                     . 'atk4' . "\xff" . str_pad((string) count($origStringTokens), 5, '0', \STR_PAD_LEFT)
-                    . $firstChar;
+                    . ($firstChar === '[' ? ']' : $firstChar);
                 $origStringTokens[$k] = $matches[0];
 
                 return $k;
             }, $sql);
 
-            $sql = str_replace(array_keys($origStringTokens), $origStringTokens, \SqlFormatter::format($sql, false));
-            $sql = preg_replace('~' . self::QUOTED_TOKEN_REGEX . '\K| +(?=\n)|(?<=:) (?=\w)~', '', $sql);
+            $sqlFormatter = new SqlFormatter(new NullHighlighter());
+            $sql = $sqlFormatter->format($sql);
+
+            // fix string literal tokenize 2/2
+            $sql = str_replace(array_keys($origStringTokens), $origStringTokens, $sqlFormatter->format($sql));
         }
 
         return $sql;


### PR DESCRIPTION
To have SQL queries formatted add `doctrine/sql-formatter` dependency to your projects.

If you have added `jdorn/sql-formatter` dependency in the past, you can remove it, atk4/* projects no longer need it.

Example composer.json change:
```diff
     "require-dev": {
-        "jdorn/sql-formatter": "^1.2.17"
+        "doctrine/sql-formatter": "dev-1-5-php74 as 1.5.99"
     },
     "repositories": [
+        {
+            "type": "git",
+            "url": "https://github.com/atk4/doctrine-sql-formatter.git",
+            "name": "doctrine/sql-formatter"
+        }
     ]
```