### PR TITLE
Remove Model::dsql() and Model::exprNow() methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -663,7 +663,7 @@ $salary
     ->table('salary')
     ->field(['emp_no', 'max_salary' => $eMs, 'months' => $eDf])
     ->group('emp_no')
-    ->order('-max_salary')
+    ->order('-max_salary');
 
 // define sub-query for employee "id" with certain birth-date
 $employees = $salary->dsql()

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -125,10 +125,6 @@ parameters:
         -
             identifier: method.notFound
             message: '~^Call to an undefined method Atk4\\Data\\Persistence::exprNow\(\)\.$~'
-        # for src/Reference/HasMany.php
-        -
-            identifier: method.notFound
-            message: '~^Call to an undefined method Atk4\\Data\\Model::dsql\(\)\.$~'
         # for tests/FieldTest.php
         -
             identifier: method.notFound

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -118,13 +118,6 @@ parameters:
         -
             identifier: method.notFound
             message: '~^Call to an undefined method Atk4\\Data\\Reference::refLink\(\)\.$~'
-        # for src/Persistence/Sql.php
-        -
-            identifier: method.notFound
-            message: '~^Call to an undefined method Atk4\\Data\\Persistence::expr\(\)\.$~'
-        -
-            identifier: method.notFound
-            message: '~^Call to an undefined method Atk4\\Data\\Persistence::exprNow\(\)\.$~'
         # for tests/FieldTest.php
         -
             identifier: method.notFound

--- a/src/Persistence/Sql.php
+++ b/src/Persistence/Sql.php
@@ -129,7 +129,7 @@ class Sql extends Persistence
     protected function initPersistence(Model $model): void
     {
         $model->addMethod('expr', static function (Model $m, ...$args) {
-            return $m->getPersistence()->expr($m, ...$args);
+            return self::assertInstanceOf($m->getPersistence())->expr($m, ...$args);
         });
     }
 

--- a/src/Persistence/Sql.php
+++ b/src/Persistence/Sql.php
@@ -131,9 +131,6 @@ class Sql extends Persistence
         $model->addMethod('expr', static function (Model $m, ...$args) {
             return $m->getPersistence()->expr($m, ...$args);
         });
-        $model->addMethod('dsql', static function (Model $m, ...$args) {
-            return $m->getPersistence()->dsql($m, ...$args);
-        });
         $model->addMethod('exprNow', static function (Model $m, ...$args) {
             return $m->getPersistence()->exprNow($m, ...$args);
         });

--- a/src/Persistence/Sql.php
+++ b/src/Persistence/Sql.php
@@ -131,9 +131,6 @@ class Sql extends Persistence
         $model->addMethod('expr', static function (Model $m, ...$args) {
             return $m->getPersistence()->expr($m, ...$args);
         });
-        $model->addMethod('exprNow', static function (Model $m, ...$args) {
-            return $m->getPersistence()->exprNow($m, ...$args);
-        });
     }
 
     /**

--- a/tests/ConditionSqlTest.php
+++ b/tests/ConditionSqlTest.php
@@ -547,7 +547,7 @@ class ConditionSqlTest extends TestCase
             $t = (clone $u)->addCondition($field, ($negated ? 'not ' : '') . 'like', $value);
             $res = array_keys($t->export(null, 'id'));
 
-            $t = (clone $u)->addCondition($field, ($negated ? 'not ' : '') . 'like', $u->dsql()->field($u->expr('[]', [$value])));
+            $t = (clone $u)->addCondition($field, ($negated ? 'not ' : '') . 'like', $u->getPersistence()->dsql()->field($u->expr('[]', [$value])));
             if (!$this->getConnection()->getConnection()->getNativeConnection() instanceof \mysqli // https://bugs.mysql.com/bug.php?id=114659
                 && (!$this->getDatabasePlatform() instanceof SQLServerPlatform || !$isBinary) // string encoding of bound variable is UTF-16
             ) {
@@ -681,7 +681,7 @@ class ConditionSqlTest extends TestCase
             $t = (clone $u)->addCondition($field, ($negated ? 'not ' : '') . 'regexp', $value);
             $res = array_keys($t->export(null, 'id'));
 
-            $t = (clone $u)->addCondition($field, ($negated ? 'not ' : '') . 'regexp', $u->dsql()->field($u->expr('[]', [$value])));
+            $t = (clone $u)->addCondition($field, ($negated ? 'not ' : '') . 'regexp', $u->getPersistence()->dsql()->field($u->expr('[]', [$value])));
             if (!$this->getConnection()->getConnection()->getNativeConnection() instanceof \mysqli) { // https://bugs.mysql.com/bug.php?id=114659
                 self::assertSame(array_keys($t->export(null, 'id')), $res);
             }

--- a/tests/FolderTest.php
+++ b/tests/FolderTest.php
@@ -19,7 +19,7 @@ class Folder extends Model
         $this->addField('name');
 
         $this->hasMany('SubFolder', ['model' => [self::class], 'theirField' => 'parent_id'])
-            ->addField('count', ['aggregate' => 'count', 'field' => $this->getPersistence()->expr($this, '*')]);
+            ->addField('count', ['aggregate' => 'count', 'field' => $this->getPersistence()->expr($this, '*')]); // @phpstan-ignore method.notFound
 
         $this->hasOne('parent_id', ['model' => [self::class]])
             ->addTitle();

--- a/tests/ReferenceSqlTest.php
+++ b/tests/ReferenceSqlTest.php
@@ -534,7 +534,7 @@ class ReferenceSqlTest extends TestCase
                 'items_code' => ['aggregate' => 'count', 'field' => 'code', 'type' => 'integer'], // counts only not-null values
                 'items_star' => ['aggregate' => 'count', 'type' => 'integer'], // no field set, counts all rows with count(*)
                 'items_c:' => ['concat' => '::', 'field' => 'name'],
-                'items_c-' => ['aggregate' => $i->dsql()->groupConcat($i->expr('[name]'), '-')],
+                'items_c-' => ['aggregate' => $i->getPersistence()->dsql()->groupConcat($i->expr('[name]'), '-')],
                 'len' => ['aggregate' => $i->expr('SUM(' . $makeLengthSqlFx('[name]') . ')'), 'type' => 'integer'],
                 'len2' => ['expr' => 'SUM(' . $makeLengthSqlFx('[name]') . ')', 'type' => 'integer'],
                 'chicken5' => ['expr' => 'SUM([])', 'args' => [5], 'type' => 'integer'],


### PR DESCRIPTION
Use `$m->getPersistence()->dsql()` (`$m->getPersistence()->exprNow()`) instead if needed.