### PR TITLE
Allow array/object type as condition value for json DBAL type

### DIFF
--- a/src/Field.php
+++ b/src/Field.php
@@ -399,9 +399,16 @@ class Field implements Expressionable
         if ($value instanceof Persistence\Array_\Action) {
             $v = $value;
         } elseif (is_array($value)) {
-            $v = array_map(static fn ($value) => $value === null ? null : $typecastField->typecastSaveField($value), $value);
+            $v = array_map(
+                static fn ($value) => $value === null
+                    ? null
+                    : $typecastField->typecastSaveField($value),
+                $value
+            );
         } else {
-            $v = $value === null ? null : $typecastField->typecastSaveField($value);
+            $v = $value === null
+                ? null
+                : $typecastField->typecastSaveField($value);
         }
 
         return [$this, $operator, $v];

--- a/src/Field.php
+++ b/src/Field.php
@@ -398,7 +398,7 @@ class Field implements Expressionable
 
         if ($value instanceof Persistence\Array_\Action) {
             $v = $value;
-        } elseif (is_array($value)) {
+        } elseif (is_array($value) && in_array($operator, [Scope\Condition::OPERATOR_IN, Scope\Condition::OPERATOR_NOT_IN], true)) {
             $v = array_map(
                 static fn ($value) => $value === null
                     ? null

--- a/src/Model/Scope/Condition.php
+++ b/src/Model/Scope/Condition.php
@@ -143,7 +143,7 @@ class Condition extends AbstractScope
                 $field = $model->getField($field);
             }
 
-            if ($field instanceof Field && in_array($field->type, ['string', 'integer', 'bigint'], true)) {
+            if ($field instanceof Field && in_array($field->type, ['string', 'text', 'boolean', 'smallint', 'integer', 'bigint', 'float', 'decimal', 'atk4_money'], true)) { // common scalar DBAL types
                 foreach ($this->value as $v) {
                     if (is_array($v)) {
                         throw (new Exception('Multi-dimensional array as condition value is not supported'))

--- a/src/Model/Scope/Condition.php
+++ b/src/Model/Scope/Condition.php
@@ -369,7 +369,7 @@ class Condition extends AbstractScope
                 : '';
         }
 
-        if (is_array($value)) {
+        if (is_array($value) && in_array($this->operator, [self::OPERATOR_IN, self::OPERATOR_NOT_IN], true)) {
             $res = [];
             foreach ($value as $v) {
                 $res[] = $this->valueToWords($model, $v);
@@ -386,8 +386,6 @@ class Condition extends AbstractScope
             if ($value instanceof Expressionable) {
                 return 'expression \'' . $value->getDsqlExpression(new SqliteExpression())->getDebugQuery() . '\'';
             }
-
-            return 'object ' . print_r($value, true);
         }
 
         // handling of scope on references

--- a/src/Model/Scope/Condition.php
+++ b/src/Model/Scope/Condition.php
@@ -372,7 +372,9 @@ class Condition extends AbstractScope
         if (is_array($value) && in_array($this->operator, [self::OPERATOR_IN, self::OPERATOR_NOT_IN], true)) {
             $res = [];
             foreach ($value as $v) {
-                $res[] = $this->valueToWords($model, $v);
+                $thisCloned = $this;
+                $thisCloned->operator = self::OPERATOR_EQUALS;
+                $res[] = $thisCloned->valueToWords($model, $v);
             }
 
             return implode(' or ', $res);
@@ -426,8 +428,11 @@ class Condition extends AbstractScope
             $valueStr = (string) $value;
         } elseif (is_float($value)) {
             $valueStr = Expression::castFloatToString($value);
+        } elseif (is_string($value)) {
+            $valueStr = '\'' . $value . '\'';
         } else {
-            $valueStr = '\'' . (string) $value . '\'';
+            $genericPersistence = new class extends Persistence {};
+            $valueStr = $genericPersistence->typecastSaveField($field, $value); // @phpstan-ignore argument.type
         }
 
         return $valueStr . ($title !== null ? ' (\'' . $title . '\')' : '');

--- a/src/Model/Scope/Condition.php
+++ b/src/Model/Scope/Condition.php
@@ -372,7 +372,7 @@ class Condition extends AbstractScope
         if (is_array($value) && in_array($this->operator, [self::OPERATOR_IN, self::OPERATOR_NOT_IN], true)) {
             $res = [];
             foreach ($value as $v) {
-                $thisCloned = $this;
+                $thisCloned = clone $this;
                 $thisCloned->operator = self::OPERATOR_EQUALS;
                 $res[] = $thisCloned->valueToWords($model, $v);
             }

--- a/src/Model/Scope/Condition.php
+++ b/src/Model/Scope/Condition.php
@@ -147,29 +147,31 @@ class Condition extends AbstractScope
     protected function onChangeModel(): void
     {
         $model = $this->getModel();
-        if ($model !== null) {
-            // if we have a definitive equal condition set the value as default value for field
-            // new records will automatically get this value assigned for the field
-            // TODO: fix when condition is part of OR scope
-            if ($this->operator === self::OPERATOR_EQUALS && !is_array($this->value)
-                && !$this->value instanceof Expressionable
-                && !$this->value instanceof Persistence\Array_\Action // needed to pass hintable tests
-            ) {
-                // field containing '/' means chained references and it is handled in toQueryArguments method
-                $field = $this->field;
-                if (is_string($field) && !str_contains($field, '/')) {
-                    $field = $model->getField($field);
-                }
+        if ($model === null) {
+            return;
+        }
 
-                // TODO Model/field should not be mutated, see:
-                // https://github.com/atk4/data/issues/662
-                // for now, do not set default at least for PK/ID
-                if ($field instanceof Field && $field->shortName !== $field->getOwner()->idField) {
-                    $field->system = true;
-                    $fakePersistence = new Persistence\Array_();
-                    $valueCloned = $fakePersistence->typecastLoadField($field, $fakePersistence->typecastSaveField($field, $this->value));
-                    $field->default = $valueCloned;
-                }
+        // if we have a definitive equal condition set the value as default value for field
+        // new records will automatically get this value assigned for the field
+        // TODO: fix when condition is part of OR scope
+        if ($this->operator === self::OPERATOR_EQUALS && !is_array($this->value)
+            && !$this->value instanceof Expressionable
+            && !$this->value instanceof Persistence\Array_\Action // needed to pass hintable tests
+        ) {
+            // field containing '/' means chained references and it is handled in toQueryArguments method
+            $field = $this->field;
+            if (is_string($field) && !str_contains($field, '/')) {
+                $field = $model->getField($field);
+            }
+
+            // TODO Model/field should not be mutated, see:
+            // https://github.com/atk4/data/issues/662
+            // for now, do not set default at least for PK/ID
+            if ($field instanceof Field && $field->shortName !== $field->getOwner()->idField) {
+                $field->system = true;
+                $fakePersistence = new Persistence\Array_();
+                $valueCloned = $fakePersistence->typecastLoadField($field, $fakePersistence->typecastSaveField($field, $this->value));
+                $field->default = $valueCloned;
             }
         }
     }

--- a/src/Model/Scope/Condition.php
+++ b/src/Model/Scope/Condition.php
@@ -126,21 +126,6 @@ class Condition extends AbstractScope
                     ->addMoreInfo('operator', $operator);
             }
         }
-
-        if (is_array($value)) {
-            foreach ($value as $v) {
-                if (is_array($v)) {
-                    throw (new Exception('Multi-dimensional array as condition value is not supported'))
-                        ->addMoreInfo('value', $value);
-                }
-            }
-
-            if (!in_array($this->operator, [self::OPERATOR_IN, self::OPERATOR_NOT_IN], true)) {
-                throw (new Exception('Operator is not supported for array condition value'))
-                    ->addMoreInfo('operator', $operator)
-                    ->addMoreInfo('value', $value);
-            }
-        }
     }
 
     #[\Override]
@@ -151,10 +136,33 @@ class Condition extends AbstractScope
             return;
         }
 
+        if (is_array($this->value)) {
+            // field containing '/' means chained references and it is handled in toQueryArguments method
+            $field = $this->field;
+            if (is_string($field) && !str_contains($field, '/')) {
+                $field = $model->getField($field);
+            }
+
+            if ($field instanceof Field && in_array($field->type, ['string', 'integer', 'bigint'], true)) {
+                foreach ($this->value as $v) {
+                    if (is_array($v)) {
+                        throw (new Exception('Multi-dimensional array as condition value is not supported'))
+                            ->addMoreInfo('value', $this->value);
+                    }
+                }
+
+                if (!in_array($this->operator, [self::OPERATOR_IN, self::OPERATOR_NOT_IN], true)) {
+                    throw (new Exception('Operator is not supported for array condition value'))
+                        ->addMoreInfo('operator', $this->operator)
+                        ->addMoreInfo('value', $this->value);
+                }
+            }
+        }
+
         // if we have a definitive equal condition set the value as default value for field
         // new records will automatically get this value assigned for the field
         // TODO: fix when condition is part of OR scope
-        if ($this->operator === self::OPERATOR_EQUALS && !is_array($this->value)
+        if ($this->operator === self::OPERATOR_EQUALS
             && !$this->value instanceof Expressionable
             && !$this->value instanceof Persistence\Array_\Action // needed to pass hintable tests
         ) {

--- a/tests/ScopeTest.php
+++ b/tests/ScopeTest.php
@@ -10,7 +10,9 @@ use Atk4\Data\Model\Scope;
 use Atk4\Data\Model\Scope\Condition;
 use Atk4\Data\Schema\TestCase;
 use Doctrine\DBAL\Platforms\MySQLPlatform;
+use Doctrine\DBAL\Platforms\PostgreSQLPlatform;
 use Doctrine\DBAL\Platforms\SQLitePlatform;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class SCountry extends Model
 {
@@ -542,5 +544,48 @@ class ScopeTest extends TestCase
 
         self::assertTrue($scope->isEmpty());
         self::assertEmpty($scope->toWords($user));
+    }
+
+    /**
+     * @param array<mixed> $value
+     *
+     * @dataProvider provideJsonArrayCases
+     */
+    #[DataProvider('provideJsonArrayCases')]
+    public function testJsonArray(array $value, string $expectedToWords): void
+    {
+        $this->setupTables();
+
+        $country = new SCountry($this->db);
+        $country->getField('name')->type = 'json';
+
+        $entity = $country->createEntity()->save(['name' => $value]);
+
+        if ($this->getDatabasePlatform() instanceof PostgreSQLPlatform) {
+            // TODO setup table with native JSON type column
+            self::markTestIncomplete('PostgreSQL: operator does not exist: atk4__civarchar = json');
+        }
+
+        $countryEqual = clone $country;
+        $countryEqual->addCondition('name', $value);
+        self::assertSame($entity->getId(), $countryEqual->loadOne()->getId());
+
+        $countryIn = clone $country;
+        $countryIn->addCondition('name', 'IN', [$value]);
+        self::assertSame($entity->getId(), $countryEqual->loadOne()->getId());
+
+        self::assertSame('', $country->scope()->toWords());
+        self::assertSame($expectedToWords, $countryEqual->scope()->toWords());
+        self::assertSame(str_replace(' equal to ', ' one of ', $expectedToWords), $countryIn->scope()->toWords());
+    }
+
+    /**
+     * @return iterable<list<mixed>>
+     */
+    public static function provideJsonArrayCases(): iterable
+    {
+        yield [['list', 'v2'], 'Name is equal to ["list","v2"]'];
+        yield [['assoc' => 'v', 'v2'], 'Name is equal to {"assoc":"v","0":"v2"}'];
+        yield [['assoc' => 'v', ['nested' => 'v2']], 'Name is equal to {"assoc":"v","0":{"nested":"v2"}}'];
     }
 }

--- a/tests/ScopeTest.php
+++ b/tests/ScopeTest.php
@@ -608,9 +608,8 @@ class ScopeTest extends TestCase
             && !MysqlConnection::isServerMariaDb($this->getConnection())
             && MysqlConnection::getServerMinorVersion($this->getConnection()) >= 800
         ) {
-            // Atk4\Data\Exception: No record was found
-            // TODO investigate and workaround
-            self::markTestIncomplete('MySQL 8.x has broken JSON = JSON support');
+            // https://dbfiddle.uk/XbGfYE1F
+            self::markTestIncomplete('MySQL 8.x does not support native JSON = string JSON comparison');
         } elseif ($this->getDatabasePlatform() instanceof OraclePlatform) {
             // inconsistent datatypes: expected - got CLOB
         } elseif ($this->getDatabasePlatform() instanceof PostgreSQLPlatform) {

--- a/tests/ScopeTest.php
+++ b/tests/ScopeTest.php
@@ -8,6 +8,7 @@ use Atk4\Data\Exception;
 use Atk4\Data\Model;
 use Atk4\Data\Model\Scope;
 use Atk4\Data\Model\Scope\Condition;
+use Atk4\Data\Persistence\Sql\Mysql\Connection as MysqlConnection;
 use Atk4\Data\Schema\TestCase;
 use Doctrine\DBAL\Platforms\MySQLPlatform;
 use Doctrine\DBAL\Platforms\OraclePlatform;
@@ -603,7 +604,14 @@ class ScopeTest extends TestCase
         $countryIn = clone $country;
         $countryIn->addCondition('name', 'IN', [$value]);
 
-        if ($this->getDatabasePlatform() instanceof OraclePlatform) {
+        if ($this->getDatabasePlatform() instanceof MySQLPlatform
+            && !MysqlConnection::isServerMariaDb($this->getConnection())
+            && MysqlConnection::getServerMinorVersion($this->getConnection()) >= 800
+        ) {
+            // Atk4\Data\Exception: No record was found
+            // TODO investigate and workaround
+            self::markTestIncomplete('MySQL 8.x has broken JSON = JSON support');
+        } elseif ($this->getDatabasePlatform() instanceof OraclePlatform) {
             // inconsistent datatypes: expected - got CLOB
         } elseif ($this->getDatabasePlatform() instanceof PostgreSQLPlatform) {
             // operator does not exist: json = json

--- a/tests/ScopeTest.php
+++ b/tests/ScopeTest.php
@@ -10,7 +10,6 @@ use Atk4\Data\Model\Scope;
 use Atk4\Data\Model\Scope\Condition;
 use Atk4\Data\Schema\TestCase;
 use Doctrine\DBAL\Platforms\MySQLPlatform;
-use Doctrine\DBAL\Platforms\PostgreSQLPlatform;
 use Doctrine\DBAL\Platforms\SQLitePlatform;
 use PHPUnit\Framework\Attributes\DataProvider;
 
@@ -548,19 +547,18 @@ class ScopeTest extends TestCase
 
     public function testDatetimeObject(): void
     {
-        $this->setupTables();
+        $country = new Model($this->db, ['table' => 't']);
+        $country->addField('name', ['type' => 'datetime']);
 
-        $country = new SCountry($this->db);
-        $country->getField('name')->type = 'datetime';
+        $this->createMigrator($country)->create();
+        $country->import([
+            ['name' => null],
+            ['name' => new \DateTime()],
+        ]);
 
         $value = new \DateTime('2024-02-20 10:20:40 UTC');
 
         $entity = $country->createEntity()->save(['name' => $value]);
-
-        if ($this->getDatabasePlatform() instanceof PostgreSQLPlatform) {
-            // TODO setup table with native TIMESTAMP type column
-            self::markTestIncomplete('PostgreSQL: operator does not exist: atk4__civarchar = timestamp without time zone');
-        }
 
         $countryEqual = clone $country;
         $countryEqual->addCondition('name', $value);
@@ -583,17 +581,19 @@ class ScopeTest extends TestCase
     #[DataProvider('provideJsonArrayCases')]
     public function testJsonArray(array $value, string $expectedToWords): void
     {
-        $this->setupTables();
+        $country = new Model($this->db, ['table' => 't']);
+        $country->addField('name', ['type' => 'json']);
 
-        $country = new SCountry($this->db);
-        $country->getField('name')->type = 'json';
+        $this->createMigrator($country)->create();
+        $country->import([
+            ['name' => null],
+            ['name' => []],
+            ['name' => ['']],
+            ['name' => [1]],
+            ['name' => ['foo']],
+        ]);
 
         $entity = $country->createEntity()->save(['name' => $value]);
-
-        if ($this->getDatabasePlatform() instanceof PostgreSQLPlatform) {
-            // TODO setup table with native JSON type column
-            self::markTestIncomplete('PostgreSQL: operator does not exist: atk4__civarchar = json');
-        }
 
         $countryEqual = clone $country;
         $countryEqual->addCondition('name', $value);

--- a/tests/ScopeTest.php
+++ b/tests/ScopeTest.php
@@ -231,16 +231,20 @@ class ScopeTest extends TestCase
 
     public function testConditionUnsupportedOperatorWithArrayValueException(): void
     {
+        $country = new SCountry($this->db);
+
         $this->expectException(Exception::class);
         $this->expectExceptionMessage('Operator is not supported for array condition value');
-        new Condition('name', '>', ['a', 'b']);
+        $country->addCondition('name', '>', ['a', 'b']);
     }
 
     public function testConditionMultiDimensionalArrayException(): void
     {
+        $country = new SCountry($this->db);
+
         $this->expectException(Exception::class);
         $this->expectExceptionMessage('Multi-dimensional array as condition value is not supported');
-        new Condition('name', ['a', 'b' => ['c']]);
+        $country->addCondition('name', ['a', 'b' => ['c']]);
     }
 
     public function testConditionNestedException(): void

--- a/tests/ScopeTest.php
+++ b/tests/ScopeTest.php
@@ -10,6 +10,8 @@ use Atk4\Data\Model\Scope;
 use Atk4\Data\Model\Scope\Condition;
 use Atk4\Data\Schema\TestCase;
 use Doctrine\DBAL\Platforms\MySQLPlatform;
+use Doctrine\DBAL\Platforms\OraclePlatform;
+use Doctrine\DBAL\Platforms\PostgreSQLPlatform;
 use Doctrine\DBAL\Platforms\SQLitePlatform;
 use PHPUnit\Framework\Attributes\DataProvider;
 
@@ -566,7 +568,7 @@ class ScopeTest extends TestCase
 
         $countryIn = clone $country;
         $countryIn->addCondition('name', 'IN', [$value]);
-        self::assertSame($entity->getId(), $countryEqual->loadOne()->getId());
+        self::assertSame($entity->getId(), $countryIn->loadOne()->getId());
 
         self::assertSame('', $country->scope()->toWords());
         self::assertSame('Name is equal to 2024-02-20 10:20:40.000000', $countryEqual->scope()->toWords());
@@ -597,11 +599,19 @@ class ScopeTest extends TestCase
 
         $countryEqual = clone $country;
         $countryEqual->addCondition('name', $value);
-        self::assertSame($entity->getId(), $countryEqual->loadOne()->getId());
 
         $countryIn = clone $country;
         $countryIn->addCondition('name', 'IN', [$value]);
-        self::assertSame($entity->getId(), $countryEqual->loadOne()->getId());
+
+        if ($this->getDatabasePlatform() instanceof OraclePlatform) {
+            // inconsistent datatypes: expected - got CLOB
+        } elseif ($this->getDatabasePlatform() instanceof PostgreSQLPlatform) {
+            // operator does not exist: json = json
+        } else {
+            self::assertSame($entity->getId(), $countryEqual->loadOne()->getId());
+
+            self::assertSame($entity->getId(), $countryIn->loadOne()->getId());
+        }
 
         self::assertSame('', $country->scope()->toWords());
         self::assertSame($expectedToWords, $countryEqual->scope()->toWords());

--- a/tests/ScopeTest.php
+++ b/tests/ScopeTest.php
@@ -550,30 +550,30 @@ class ScopeTest extends TestCase
 
     public function testDatetimeObject(): void
     {
-        $country = new Model($this->db, ['table' => 't']);
-        $country->addField('name', ['type' => 'datetime']);
+        $model = new Model($this->db, ['table' => 't']);
+        $model->addField('name', ['type' => 'datetime']);
 
-        $this->createMigrator($country)->create();
-        $country->import([
+        $this->createMigrator($model)->create();
+        $model->import([
             ['name' => null],
             ['name' => new \DateTime()],
         ]);
 
         $value = new \DateTime('2024-02-20 10:20:40 UTC');
 
-        $entity = $country->createEntity()->save(['name' => $value]);
+        $entity = $model->createEntity()->save(['name' => $value]);
 
-        $countryEqual = clone $country;
-        $countryEqual->addCondition('name', $value);
-        self::assertSame($entity->getId(), $countryEqual->loadOne()->getId());
+        $modelEqual = clone $model;
+        $modelEqual->addCondition('name', $value);
+        self::assertSame($entity->getId(), $modelEqual->loadOne()->getId());
 
-        $countryIn = clone $country;
-        $countryIn->addCondition('name', 'IN', [$value]);
-        self::assertSame($entity->getId(), $countryIn->loadOne()->getId());
+        $modelIn = clone $model;
+        $modelIn->addCondition('name', 'IN', [$value]);
+        self::assertSame($entity->getId(), $modelIn->loadOne()->getId());
 
-        self::assertSame('', $country->scope()->toWords());
-        self::assertSame('Name is equal to 2024-02-20 10:20:40.000000', $countryEqual->scope()->toWords());
-        self::assertSame('Name is one of 2024-02-20 10:20:40.000000', $countryIn->scope()->toWords());
+        self::assertSame('', $model->scope()->toWords());
+        self::assertSame('Name is equal to 2024-02-20 10:20:40.000000', $modelEqual->scope()->toWords());
+        self::assertSame('Name is one of 2024-02-20 10:20:40.000000', $modelIn->scope()->toWords());
     }
 
     /**
@@ -584,11 +584,11 @@ class ScopeTest extends TestCase
     #[DataProvider('provideJsonArrayCases')]
     public function testJsonArray(array $value, string $expectedToWords): void
     {
-        $country = new Model($this->db, ['table' => 't']);
-        $country->addField('name', ['type' => 'json']);
+        $model = new Model($this->db, ['table' => 't']);
+        $model->addField('name', ['type' => 'json']);
 
-        $this->createMigrator($country)->create();
-        $country->import([
+        $this->createMigrator($model)->create();
+        $model->import([
             ['name' => null],
             ['name' => []],
             ['name' => ['']],
@@ -596,13 +596,13 @@ class ScopeTest extends TestCase
             ['name' => ['foo']],
         ]);
 
-        $entity = $country->createEntity()->save(['name' => $value]);
+        $entity = $model->createEntity()->save(['name' => $value]);
 
-        $countryEqual = clone $country;
-        $countryEqual->addCondition('name', $value);
+        $modelEqual = clone $model;
+        $modelEqual->addCondition('name', $value);
 
-        $countryIn = clone $country;
-        $countryIn->addCondition('name', 'IN', [$value]);
+        $modelIn = clone $model;
+        $modelIn->addCondition('name', 'IN', [$value]);
 
         if ($this->getDatabasePlatform() instanceof MySQLPlatform
             && !MysqlConnection::isServerMariaDb($this->getConnection())
@@ -615,14 +615,14 @@ class ScopeTest extends TestCase
         } elseif ($this->getDatabasePlatform() instanceof PostgreSQLPlatform) {
             // operator does not exist: json = json
         } else {
-            self::assertSame($entity->getId(), $countryEqual->loadOne()->getId());
+            self::assertSame($entity->getId(), $modelEqual->loadOne()->getId());
 
-            self::assertSame($entity->getId(), $countryIn->loadOne()->getId());
+            self::assertSame($entity->getId(), $modelIn->loadOne()->getId());
         }
 
-        self::assertSame('', $country->scope()->toWords());
-        self::assertSame($expectedToWords, $countryEqual->scope()->toWords());
-        self::assertSame(str_replace(' equal to ', ' one of ', $expectedToWords), $countryIn->scope()->toWords());
+        self::assertSame('', $model->scope()->toWords());
+        self::assertSame($expectedToWords, $modelEqual->scope()->toWords());
+        self::assertSame(str_replace(' equal to ', ' one of ', $expectedToWords), $modelIn->scope()->toWords());
     }
 
     /**

--- a/tests/ScopeTest.php
+++ b/tests/ScopeTest.php
@@ -546,6 +546,35 @@ class ScopeTest extends TestCase
         self::assertEmpty($scope->toWords($user));
     }
 
+    public function testDatetimeObject(): void
+    {
+        $this->setupTables();
+
+        $country = new SCountry($this->db);
+        $country->getField('name')->type = 'datetime';
+
+        $value = new \DateTime('2024-02-20 10:20:40 UTC');
+
+        $entity = $country->createEntity()->save(['name' => $value]);
+
+        if ($this->getDatabasePlatform() instanceof PostgreSQLPlatform) {
+            // TODO setup table with native TIMESTAMP type column
+            self::markTestIncomplete('PostgreSQL: operator does not exist: atk4__civarchar = timestamp without time zone');
+        }
+
+        $countryEqual = clone $country;
+        $countryEqual->addCondition('name', $value);
+        self::assertSame($entity->getId(), $countryEqual->loadOne()->getId());
+
+        $countryIn = clone $country;
+        $countryIn->addCondition('name', 'IN', [$value]);
+        self::assertSame($entity->getId(), $countryEqual->loadOne()->getId());
+
+        self::assertSame('', $country->scope()->toWords());
+        self::assertSame('Name is equal to 2024-02-20 10:20:40.000000', $countryEqual->scope()->toWords());
+        self::assertSame('Name is one of 2024-02-20 10:20:40.000000', $countryIn->scope()->toWords());
+    }
+
     /**
      * @param array<mixed> $value
      *


### PR DESCRIPTION
related with #1092

Not only strictly for `json` DBAL type.