### PR TITLE
Impl. hash index for array persistence

### DIFF
--- a/src/Model/Join.php
+++ b/src/Model/Join.php
@@ -311,7 +311,6 @@ abstract class Join
             $foreignModel = $this->getForeignModel();
 
             $ourField = $this->getOwner()->getField($this->masterField);
-            $ourField = $this->getMasterField();
             $theirField = $foreignModel->getField($this->foreignField);
 
             if ($theirField->type !== $ourField->type) {

--- a/src/Model/Join.php
+++ b/src/Model/Join.php
@@ -270,7 +270,7 @@ abstract class Join
         $this->getForeignModel(); // assert valid foreignTable
 
         if ($this->reverse && $this->masterField !== $idField) { // TODO not implemented yet, see https://github.com/atk4/data/issues/803
-            throw (new Exception('Joining tables on non-id fields is not implemented yet'))
+            throw (new Exception('Reverse join with non-ID master field is not implemented yet'))
                 ->addMoreInfo('masterField', $this->masterField)
                 ->addMoreInfo('idField', $idField);
         }

--- a/src/Persistence.php
+++ b/src/Persistence.php
@@ -29,7 +29,7 @@ abstract class Persistence
     public const ID_LOAD_ANY = self::class . '@idLoadAny-qZ5TJwMVJ4LzVhuN';
 
     /** @internal prevent recursion */
-    private bool $typecastSaveSkipNormalize = false;
+    private bool $typecastSaveSkipNormalize = false; // @phpstan-ignore property.tooWideBool
 
     /**
      * Connects database.

--- a/src/Persistence/Array_.php
+++ b/src/Persistence/Array_.php
@@ -62,7 +62,7 @@ class Array_ extends Persistence
 
         if (($this->seedData[$tableName] ?? []) === []) {
             // initialize with at least 1 column
-            $this->data[$tableName]->addColumnName($model->getIdField()->getPersistenceName());
+            $this->data[$tableName]->addColumn($model->getIdField()->getPersistenceName());
         } else {
             $rows = $this->seedData[$tableName];
             unset($this->seedData[$tableName]);
@@ -158,8 +158,8 @@ class Array_ extends Persistence
         $row = $table->getRowById($model, $id);
         if ($row !== null) {
             foreach (array_keys($rowData) as $columnName) {
-                if (!$table->hasColumnName($columnName)) {
-                    $table->addColumnName($columnName);
+                if (!$table->hasColumn($columnName)) {
+                    $table->addColumn($columnName);
                 }
             }
             $row->updateValues($rowData);

--- a/src/Persistence/Array_/Db/HashIndex.php
+++ b/src/Persistence/Array_/Db/HashIndex.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Atk4\Data\Persistence\Array_\Db;
+
+class HashIndex
+{
+    /** @var array<int|string, array<int, true>> */
+    private array $data = [];
+
+    /**
+     * @param scalar|null $value
+     *
+     * @return int|string
+     */
+    protected function makeIndexKeyFromValue($value)
+    {
+        assert(is_scalar($value) || $value === null); // @phpstan-ignore identical.alwaysTrue, booleanOr.alwaysTrue, function.alreadyNarrowedType
+
+        if (is_float($value)) {
+            $value = $value === (float) (int) $value
+                ? (int) $value
+                : pack('e', $value);
+        }
+
+        return is_int($value)
+            ? $value
+            : (string) $value;
+    }
+
+    /**
+     * @param scalar|null $value
+     */
+    protected function addRow(int $rowIndex, $value): void
+    {
+        $ik = $this->makeIndexKeyFromValue($value);
+
+        $this->data[$ik][$rowIndex] = true;
+    }
+
+    /**
+     * @param scalar|null $value
+     */
+    protected function deleteRow(int $rowIndex, $value): void
+    {
+        $ik = $this->makeIndexKeyFromValue($value);
+
+        if (isset($this->data[$ik])) {
+            unset($this->data[$ik][$rowIndex]);
+            if ($this->data[$ik] === []) {
+                unset($this->data[$ik]);
+            }
+        }
+    }
+
+    /**
+     * @param scalar|null $value
+     *
+     * @return list<int>
+     */
+    public function findPossibleRowIndexes($value): array
+    {
+        $ik = $this->makeIndexKeyFromValue($value);
+
+        return array_keys($this->data[$ik] ?? []);
+    }
+}

--- a/src/Persistence/Array_/Db/HashIndex.php
+++ b/src/Persistence/Array_/Db/HashIndex.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Atk4\Data\Persistence\Array_\Db;
 
+use Atk4\Data\Persistence\Sql\Expression;
+
 class HashIndex
 {
     /** @var array<int|string, array<int, true>> */
@@ -14,19 +16,28 @@ class HashIndex
      *
      * @return int|string
      */
-    protected function makeIndexKeyFromValue($value)
+    protected function makeKeyFromValue($value)
     {
         assert(is_scalar($value) || $value === null); // @phpstan-ignore identical.alwaysTrue, booleanOr.alwaysTrue, function.alreadyNarrowedType
 
         if (is_float($value)) {
-            $value = $value === (float) (int) $value
-                ? (int) $value
-                : pack('e', $value);
+            $value = Expression::castFloatToString($value);
+            if (str_ends_with($value, '.0')) {
+                $value = substr($value, 0, -2);
+            }
+        } elseif ($value === false) {
+            $value = 0;
         }
 
-        return is_int($value)
-            ? $value
-            : (string) $value;
+        if (!is_int($value)) {
+            $value = (string) $value;
+
+            if ($value === (string) (int) $value) {
+                $value = (int) $value;
+            }
+        }
+
+        return $value;
     }
 
     /**
@@ -34,9 +45,9 @@ class HashIndex
      */
     protected function addRow(int $rowIndex, $value): void
     {
-        $ik = $this->makeIndexKeyFromValue($value);
+        $key = $this->makeKeyFromValue($value);
 
-        $this->data[$ik][$rowIndex] = true;
+        $this->data[$key][$rowIndex] = true;
     }
 
     /**
@@ -44,12 +55,12 @@ class HashIndex
      */
     protected function deleteRow(int $rowIndex, $value): void
     {
-        $ik = $this->makeIndexKeyFromValue($value);
+        $key = $this->makeKeyFromValue($value);
 
-        if (isset($this->data[$ik])) {
-            unset($this->data[$ik][$rowIndex]);
-            if ($this->data[$ik] === []) {
-                unset($this->data[$ik]);
+        if (isset($this->data[$key])) {
+            unset($this->data[$key][$rowIndex]);
+            if ($this->data[$key] === []) {
+                unset($this->data[$key]);
             }
         }
     }
@@ -61,8 +72,8 @@ class HashIndex
      */
     public function findPossibleRowIndexes($value): array
     {
-        $ik = $this->makeIndexKeyFromValue($value);
+        $key = $this->makeKeyFromValue($value);
 
-        return array_keys($this->data[$ik] ?? []);
+        return array_keys($this->data[$key] ?? []);
     }
 }

--- a/src/Persistence/Array_/Db/Row.php
+++ b/src/Persistence/Array_/Db/Row.php
@@ -22,7 +22,7 @@ class Row
         $this->rowIndex = self::getNextRowIndex();
     }
 
-    public static function getNextRowIndex(): int
+    protected static function getNextRowIndex(): int
     {
         return ++self::$nextRowIndex;
     }
@@ -84,9 +84,9 @@ class Row
             }
         }
 
-        $that = $this;
-        \Closure::bind(static function () use ($owner, $that, $newData) {
-            $owner->beforeValuesSet($that, $newData);
+        $thisRow = $this;
+        \Closure::bind(static function () use ($owner, $thisRow, $newData) {
+            $owner->beforeValuesSet($thisRow, $newData);
         }, null, $owner)();
 
         foreach ($newData as $columnName => $newValue) {

--- a/src/Persistence/Array_/Db/Row.php
+++ b/src/Persistence/Array_/Db/Row.php
@@ -6,25 +6,21 @@ namespace Atk4\Data\Persistence\Array_\Db;
 
 class Row
 {
-    /** @var int */
-    private static $nextRowIndex = -1;
+    private const DATA_DELETE = [self::class . '@delete'];
 
-    /** @var Table Immutable */
-    private $owner;
-    /** @var int Immutable */
-    private $rowIndex;
+    private static int $lastRowIndex = -1;
+
+    /** @readonly */
+    private ?Table $owner;
+    /** @readonly */
+    private int $rowIndex;
     /** @var array<string, mixed> */
-    private $data = [];
+    private array $data = [];
 
-    public function __construct(Table $owner)
+    protected function __construct(Table $owner)
     {
         $this->owner = $owner;
-        $this->rowIndex = self::getNextRowIndex();
-    }
-
-    protected static function getNextRowIndex(): int
-    {
-        return ++self::$nextRowIndex;
+        $this->rowIndex = ++self::$lastRowIndex;
     }
 
     /**
@@ -64,42 +60,59 @@ class Row
         return $this->data;
     }
 
-    protected function initValue(string $columnName): void
-    {
-        $this->data[$columnName] = null;
-    }
-
     /**
-     * @param array<string, mixed> $data
+     * @param array<string, mixed>|self::DATA_DELETE $data
      */
     public function updateValues(array $data): void
     {
         $owner = $this->getOwner();
 
         $newData = [];
-        foreach ($data as $columnName => $newValue) {
-            $owner->assertHasColumnName($columnName);
-            if ($newValue !== $this->data[$columnName]) {
-                $newData[$columnName] = $newValue;
+        if ($data === self::DATA_DELETE) {
+            $oldData = $this->data;
+        } else {
+            $oldData = [];
+            foreach ($data as $columnName => $newValue) {
+                $oldValue = $this->data[$columnName] ?? -2;
+                $hadColumn = $oldValue !== -2 || array_key_exists($columnName, $this->data);
+                if (!$hadColumn) {
+                    $owner->assertHasColumn($columnName);
+                }
+
+                if ($newValue !== $oldValue) {
+                    if ($hadColumn) {
+                        $oldData[$columnName] = $oldValue;
+                    }
+                    $newData[$columnName] = $newValue;
+                }
+            }
+
+            if ($newData === []) {
+                return;
             }
         }
 
         $thisRow = $this;
         \Closure::bind(static function () use ($owner, $thisRow, $newData) {
-            $owner->beforeValuesSet($thisRow, $newData);
-        }, null, $owner)();
+            $owner->beforeUpdateRow($thisRow, $newData);
+        }, null, Table::class)();
 
-        foreach ($newData as $columnName => $newValue) {
-            $this->data[$columnName] = $newValue;
+        if ($data === self::DATA_DELETE) {
+            $this->data = [];
+        } else {
+            foreach ($newData as $columnName => $newValue) {
+                $this->data[$columnName] = $newValue;
+            }
         }
+
+        \Closure::bind(static function () use ($owner, $thisRow, $oldData) {
+            $owner->afterUpdateRow($thisRow, $oldData);
+        }, null, Table::class)();
     }
 
-    protected function beforeDelete(): void
+    protected function delete(): void
     {
-        $this->updateValues(array_map(static function () {
-            return null;
-        }, $this->data));
-
-        $this->owner = null; // @phpstan-ignore assign.propertyType
+        $this->updateValues(self::DATA_DELETE);
+        $this->owner = null; // @phpstan-ignore property.readOnlyByPhpDocAssignNotInConstructor
     }
 }

--- a/src/Persistence/Array_/Db/Row.php
+++ b/src/Persistence/Array_/Db/Row.php
@@ -73,14 +73,12 @@ class Row
         } else {
             $oldData = [];
             foreach ($data as $columnName => $newValue) {
-                $oldValue = $this->data[$columnName] ?? -2;
-                $hadColumn = $oldValue !== -2 || array_key_exists($columnName, $this->data);
-                if (!$hadColumn) {
-                    $owner->assertHasColumn($columnName);
-                }
-
-                if ($newValue !== $oldValue) {
-                    if ($hadColumn) {
+                $oldValue = $this->data[$columnName] ?? null;
+                $hadColumn = $oldValue !== null || array_key_exists($columnName, $this->data);
+                if (!$hadColumn || $newValue !== $oldValue) {
+                    if (!$hadColumn) {
+                        $owner->assertHasColumn($columnName);
+                    } else {
                         $oldData[$columnName] = $oldValue;
                     }
                     $newData[$columnName] = $newValue;
@@ -105,8 +103,8 @@ class Row
             }
         }
 
-        \Closure::bind(static function () use ($owner, $thisRow, $oldData) {
-            $owner->afterUpdateRow($thisRow, $oldData);
+        \Closure::bind(static function () use ($owner, $thisRow, $oldData, $newData) {
+            $owner->afterUpdateRow($thisRow, $oldData, $newData);
         }, null, Table::class)();
     }
 

--- a/src/Persistence/Array_/Db/Table.php
+++ b/src/Persistence/Array_/Db/Table.php
@@ -131,11 +131,11 @@ class Table
      */
     public function addRow(string $rowClass, array $rowData): Row
     {
-        $that = $this;
+        $thisTable = $this;
         $columnNames = $this->getColumnNames();
-        /** @var Row $row */
-        $row = \Closure::bind(static function () use ($that, $rowClass, $columnNames) {
-            $row = new $rowClass($that);
+
+        $row = \Closure::bind(static function () use ($thisTable, $rowClass, $columnNames) {
+            $row = new $rowClass($thisTable);
             foreach ($columnNames as $columnName) {
                 $row->initValue($columnName);
             }

--- a/src/Persistence/Array_/Db/Table.php
+++ b/src/Persistence/Array_/Db/Table.php
@@ -49,9 +49,11 @@ class Table
      */
     protected function assertValidValue($value): void
     {
-        if ($value instanceof self || $value instanceof Row) {
-            throw new Exception('Value cannot be an ' . get_class($value) . ' object');
-        } elseif (!is_scalar($value) && $value !== null) {
+        if (!is_scalar($value) && $value !== null) {
+            if ($value instanceof self || $value instanceof Row) {
+                throw new Exception('Value cannot be an ' . get_class($value) . ' object');
+            }
+
             throw (new Exception('Value must be scalar'))
                 ->addMoreInfo('value', $value);
         }

--- a/src/Persistence/Array_/Db/Table.php
+++ b/src/Persistence/Array_/Db/Table.php
@@ -189,8 +189,10 @@ class Table
      */
     public function getRowById(Model $model, $idRaw): ?Row
     {
+        $idFieldRaw = $model->getIdField()->getPersistenceName();
+
         foreach ($this->getRows() as $row) {
-            if ($row->getValue($model->getIdField()->getPersistenceName()) === $idRaw) {
+            if ($row->getValue($idFieldRaw) === $idRaw) {
                 return $row;
             }
         }

--- a/src/Persistence/Array_/Db/Table.php
+++ b/src/Persistence/Array_/Db/Table.php
@@ -16,6 +16,9 @@ class Table
     /** @var array<int, Row> */
     private array $rows = [];
 
+    /** @var array<string, HashIndex> */
+    private array $indexes = [];
+
     public function __construct(string $tableName)
     {
         $this->tableName = $tableName;
@@ -50,7 +53,7 @@ class Table
     protected function assertValidValue($value): void
     {
         if (!is_scalar($value) && $value !== null) {
-            throw (new Exception('Value must be scalar'))
+            throw (new Exception('Value must be scalar or null'))
                 ->addMoreInfo('value', $value);
         }
     }
@@ -171,29 +174,97 @@ class Table
 
     /**
      * @param array<string, mixed> $oldData
+     * @param array<string, mixed> $newData
      */
-    protected function afterUpdateRow(Row $row, $oldData): void
+    protected function afterUpdateRow(Row $row, $oldData, $newData): void
     {
-        foreach ($oldData as $columnName => $newValue) {
-            // update index here
+        foreach ($oldData as $columnName => $oldValue) {
+            $index = $this->indexes[$columnName] ?? null;
+            if ($index === null) {
+                continue;
+            }
+
+            \Closure::bind(static function () use ($index, $row, $oldValue) {
+                $index->deleteRow($row->getRowIndex(), $oldValue);
+            }, null, HashIndex::class)();
+        }
+
+        foreach ($newData as $columnName => $newValue) {
+            $index = $this->indexes[$columnName] ?? null;
+            if ($index === null) {
+                continue;
+            }
+
+            \Closure::bind(static function () use ($index, $row, $newValue) {
+                $index->addRow($row->getRowIndex(), $newValue);
+            }, null, HashIndex::class)();
         }
     }
 
+    protected function addIndex(string $columnName): void
+    {
+        assert(!isset($this->indexes[$columnName]));
+
+        $index = new HashIndex();
+
+        foreach ($this->getRows() as $row) {
+            \Closure::bind(static function () use ($index, $row, $columnName) {
+                $index->addRow($row->getRowIndex(), $row->getValue($columnName));
+            }, null, HashIndex::class)();
+        }
+
+        $this->indexes[$columnName] = $index;
+    }
+
     /**
-     * TODO rewrite with hash index support.
+     * @param scalar|null $value
      *
-     * @param scalar $idRaw
+     * @return list<Row>
+     */
+    public function getRowsUsingIndex(string $columnName, $value): array
+    {
+        if (!isset($this->indexes[$columnName])) {
+            $this->addIndex($columnName);
+        }
+
+        $index = $this->indexes[$columnName];
+        $possibleRowIndexes = $index->findPossibleRowIndexes($value);
+
+        $res = [];
+        foreach ($possibleRowIndexes as $rowIndex) {
+            $row = $this->rows[$rowIndex];
+            $rowValue = $row->getValue($columnName);
+            if ($rowValue === $value) {
+                $res[] = $row;
+            }
+        }
+
+        return $res;
+    }
+
+    /**
+     * @param scalar|null $value
+     */
+    public function getRowUsingIndex(string $columnName, $value): ?Row
+    {
+        $rows = $this->getRowsUsingIndex($columnName, $value);
+
+        if ($rows === []) {
+            return null;
+        } elseif (count($rows) === 1) {
+            return $rows[0];
+        }
+
+        throw new Exception('Column is not unique');
+    }
+
+    /**
+     * @param scalar|null $idRaw
      */
     public function getRowById(Model $model, $idRaw): ?Row
     {
         $idFieldRaw = $model->getIdField()->getPersistenceName();
 
-        foreach ($this->getRows() as $row) {
-            if ($row->getValue($idFieldRaw) === $idRaw) {
-                return $row;
-            }
-        }
-
-        return null;
+        return $this->getRowUsingIndex($idFieldRaw, $idRaw);
     }
 }

--- a/src/Persistence/Array_/Db/Table.php
+++ b/src/Persistence/Array_/Db/Table.php
@@ -11,7 +11,7 @@ class Table
 {
     /** @readonly */
     private string $tableName;
-    /** @var array<string, string> */
+    /** @var array<string, true> */
     private array $columnNames = [];
     /** @var array<int, Row> */
     private array $rows = [];
@@ -82,7 +82,7 @@ class Table
      */
     public function getColumnNames(): array
     {
-        return array_values($this->columnNames);
+        return array_keys($this->columnNames);
     }
 
     /**
@@ -98,7 +98,7 @@ class Table
                 ->addMoreInfo('column_name', $columnName);
         }
 
-        $this->columnNames[$columnName] = $columnName;
+        $this->columnNames[$columnName] = true;
 
         foreach ($this->getRows() as $row) {
             $row->updateValues([$columnName => null]);

--- a/src/Persistence/Array_/Db/Table.php
+++ b/src/Persistence/Array_/Db/Table.php
@@ -95,7 +95,7 @@ class Table
         $this->assertValidName($columnName);
 
         if ($this->hasColumn($columnName)) {
-            throw (new Exception('Column name is already present'))
+            throw (new Exception('Column name already exists'))
                 ->addMoreInfo('table_name', $this->getTableName())
                 ->addMoreInfo('column_name', $columnName);
         }
@@ -257,7 +257,7 @@ class Table
             return $rows[0];
         }
 
-        throw new Exception('Column is not unique');
+        throw new Exception('Index is not unique, more than one row was found');
     }
 
     /**

--- a/src/Persistence/Array_/Db/Table.php
+++ b/src/Persistence/Array_/Db/Table.php
@@ -9,12 +9,12 @@ use Atk4\Data\Model;
 
 class Table
 {
-    /** @var string Immutable */
-    private $tableName;
+    /** @readonly */
+    private string $tableName;
     /** @var array<string, string> */
-    private $columnNames = [];
+    private array $columnNames = [];
     /** @var array<int, Row> */
-    private $rows = [];
+    private array $rows = [];
 
     public function __construct(string $tableName)
     {
@@ -29,14 +29,14 @@ class Table
         return [
             'table_name' => $this->getTableName(),
             'column_names' => $this->getColumnNames(),
-            'row_count' => count($this->rows),
+            'row_count' => count($this->getRows()),
         ];
     }
 
     /**
      * @param string $name
      */
-    protected function assertValidIdentifier($name): void
+    protected function assertValidName($name): void
     {
         if (!is_string($name) || $name === '' || is_numeric($name)) { // @phpstan-ignore function.alreadyNarrowedType
             throw (new Exception('Name must be a non-empty non-numeric string'))
@@ -50,10 +50,6 @@ class Table
     protected function assertValidValue($value): void
     {
         if (!is_scalar($value) && $value !== null) {
-            if ($value instanceof self || $value instanceof Row) {
-                throw new Exception('Value cannot be an ' . get_class($value) . ' object');
-            }
-
             throw (new Exception('Value must be scalar'))
                 ->addMoreInfo('value', $value);
         }
@@ -64,41 +60,18 @@ class Table
         return $this->tableName;
     }
 
-    public function hasColumnName(string $columnName): bool
+    public function hasColumn(string $columnName): bool
     {
         return isset($this->columnNames[$columnName]);
     }
 
-    public function assertHasColumnName(string $columnName): void
+    public function assertHasColumn(string $columnName): void
     {
-        if (!isset($this->columnNames[$columnName])) {
+        if (!$this->hasColumn($columnName)) {
             throw (new Exception('Column name does not exist'))
                 ->addMoreInfo('table_name', $this->getTableName())
                 ->addMoreInfo('column_name', $columnName);
         }
-    }
-
-    /**
-     * @return $this
-     */
-    public function addColumnName(string $columnName): self
-    {
-        $this->assertValidIdentifier($columnName);
-        if (isset($this->columnNames[$columnName])) {
-            throw (new Exception('Column name is already present'))
-                ->addMoreInfo('table_name', $this->getTableName())
-                ->addMoreInfo('column_name', $columnName);
-        }
-
-        $this->columnNames[$columnName] = $columnName;
-
-        foreach ($this->getRows() as $row) {
-            \Closure::bind(static function () use ($row, $columnName) {
-                $row->initValue($columnName);
-            }, null, $row)();
-        }
-
-        return $this;
     }
 
     /**
@@ -109,6 +82,28 @@ class Table
         return array_values($this->columnNames);
     }
 
+    /**
+     * @return $this
+     */
+    public function addColumn(string $columnName): self
+    {
+        $this->assertValidName($columnName);
+
+        if ($this->hasColumn($columnName)) {
+            throw (new Exception('Column name is already present'))
+                ->addMoreInfo('table_name', $this->getTableName())
+                ->addMoreInfo('column_name', $columnName);
+        }
+
+        $this->columnNames[$columnName] = $columnName;
+
+        foreach ($this->getRows() as $row) {
+            $row->updateValues([$columnName => null]);
+        }
+
+        return $this;
+    }
+
     public function hasRow(int $rowIndex): bool
     {
         return isset($this->rows[$rowIndex]);
@@ -116,41 +111,41 @@ class Table
 
     public function getRow(int $rowIndex): Row
     {
-        if (!isset($this->rows[$rowIndex])) {
+        $row = $this->rows[$rowIndex] ?? null;
+
+        if ($row === null) {
             throw (new Exception('Row with given index was not found'))
                 ->addMoreInfo('table_name', $this->getTableName())
                 ->addMoreInfo('row_index', $rowIndex);
         }
 
-        return $this->rows[$rowIndex];
+        return $row;
+    }
+
+    /**
+     * @return \Iterator<Row>&\Countable
+     */
+    public function getRows(): \Iterator
+    {
+        return new \ArrayIterator($this->rows);
     }
 
     /**
      * @param class-string<Row>    $rowClass
-     * @param array<string, mixed> $rowData
+     * @param array<string, mixed> $data
      */
-    public function addRow(string $rowClass, array $rowData): Row
+    public function addRow(string $rowClass, array $data): Row
     {
-        $thisTable = $this;
-        $columnNames = $this->getColumnNames();
-
-        $row = \Closure::bind(static function () use ($thisTable, $rowClass, $columnNames) {
-            $row = new $rowClass($thisTable);
-            foreach ($columnNames as $columnName) {
-                $row->initValue($columnName);
-            }
-
-            return $row;
-        }, null, $rowClass)();
-        $this->rows[$row->getRowIndex()] = $row;
-
-        foreach ($rowData as $columnName => $value) {
-            if (!$this->hasColumnName($columnName)) {
-                $this->addColumnName($columnName);
+        foreach ($data as $columnName => $value) {
+            if (!$this->hasColumn($columnName)) {
+                $this->addColumn($columnName);
             }
         }
 
-        $row->updateValues($rowData);
+        $thisTable = $this;
+        $row = \Closure::bind(static fn () => new $rowClass($thisTable), null, Row::class)();
+        $this->rows[$row->getRowIndex()] = $row;
+        $row->updateValues(array_merge(array_fill_keys($this->getColumnNames(), null), $data));
 
         return $row;
     }
@@ -158,28 +153,28 @@ class Table
     public function deleteRow(Row $row): void
     {
         \Closure::bind(static function () use ($row) {
-            $row->beforeDelete();
-        }, null, $row)();
+            $row->delete();
+        }, null, Row::class)();
 
         unset($this->rows[$row->getRowIndex()]);
     }
 
     /**
-     * @return \Traversable<Row>
+     * @param array<string, mixed> $newData
      */
-    public function getRows(): \Traversable
+    protected function beforeUpdateRow(Row $row, $newData): void
     {
-        return new \ArrayIterator($this->rows);
+        foreach ($newData as $columnName => $newValue) {
+            $this->assertValidValue($newValue);
+        }
     }
 
     /**
-     * @param array<string, mixed> $newRowData
+     * @param array<string, mixed> $oldData
      */
-    protected function beforeValuesSet(Row $childRow, $newRowData): void
+    protected function afterUpdateRow(Row $row, $oldData): void
     {
-        foreach ($newRowData as $columnName => $newValue) {
-            $this->assertValidValue($newValue);
-
+        foreach ($oldData as $columnName => $newValue) {
             // update index here
         }
     }

--- a/src/Persistence/Array_/Db/Table.php
+++ b/src/Persistence/Array_/Db/Table.php
@@ -21,6 +21,8 @@ class Table
 
     public function __construct(string $tableName)
     {
+        $this->assertValidName($tableName);
+
         $this->tableName = $tableName;
     }
 
@@ -42,7 +44,7 @@ class Table
     protected function assertValidName($name): void
     {
         if (!is_string($name) || $name === '' || is_numeric($name)) { // @phpstan-ignore function.alreadyNarrowedType
-            throw (new Exception('Name must be a non-empty non-numeric string'))
+            throw (new Exception('Name must be a non-empty and non-numeric'))
                 ->addMoreInfo('name', $name);
         }
     }

--- a/src/Reference/WeakAnalysingMap.php
+++ b/src/Reference/WeakAnalysingMap.php
@@ -229,7 +229,7 @@ class WeakAnalysingMap
 
         foreach ($this->keyByIndexByHash[$hash] ?? [] as $index => $k) {
             if ($this->unboxValue($k->get()) === $key) {
-                throw (new Exception('Analysing key is already present'))
+                throw (new Exception('Analysing key already exists'))
                     ->addMoreInfo('key', $key);
             }
         }

--- a/tests/JoinArrayTest.php
+++ b/tests/JoinArrayTest.php
@@ -175,7 +175,7 @@ class JoinArrayTest extends TestCase
         $user->addField('name');
         $user->addField('code');
         $this->expectException(Exception::class);
-        $this->expectExceptionMessage('Joining tables on non-id fields is not implemented yet');
+        $this->expectExceptionMessage('Reverse join with non-ID master field is not implemented yet');
         $j = $user->join('contact.code', ['masterField' => 'code']);
         /* $j->addField('contact_phone');
 

--- a/tests/JoinSqlTest.php
+++ b/tests/JoinSqlTest.php
@@ -86,20 +86,11 @@ class JoinSqlTest extends TestCase
         self::assertFalse($m->hasJoin('contact8'));
 
         $this->expectException(Exception::class);
-        $this->expectExceptionMessage('Joining tables on non-id fields is not implemented yet'); // https://github.com/atk4/data/issues/803
+        $this->expectExceptionMessage('Reverse join with non-ID master field is not implemented yet');
         $j4 = $m->join('contact4.foo_id', ['masterField' => 'test_id', 'reverse' => true]);
         // self::assertTrue($j4->reverse);
         // self::assertSame('test_id', $this->getProtected($j4, 'masterField'));
         // self::assertSame('foo_id', $this->getProtected($j4, 'foreignField'));
-    }
-
-    public function testDirectionException(): void
-    {
-        $m = new Model($this->db, ['table' => 'user']);
-
-        $this->expectException(Exception::class);
-        $this->expectExceptionMessage('Joining tables on non-id fields is not implemented yet');
-        $m->join('contact.foo_id', ['masterField' => 'test_id']);
     }
 
     public function testJoinSaving1(): void

--- a/tests/JoinTest.php
+++ b/tests/JoinTest.php
@@ -42,7 +42,7 @@ class JoinTest extends TestCase
         self::assertSame('id', $this->getProtected($j, 'foreignField'));
 
         $this->expectException(Exception::class);
-        $this->expectExceptionMessage('Joining tables on non-id fields is not implemented yet');
+        $this->expectExceptionMessage('Reverse join with non-ID master field is not implemented yet');
         $j = $m->join('contact4.foo_id', ['masterField' => 'test_id', 'reverse' => true]);
         // self::assertTrue($j->reverse);
         // self::assertSame('test_id', $this->getProtected($j, 'masterField'));
@@ -51,11 +51,11 @@ class JoinTest extends TestCase
 
     public function testDirectionException(): void
     {
-        $db = new ArrayPersistence(['user' => [], 'contact' => []]);
+        $db = new ArrayPersistence();
         $m = new Model($db, ['table' => 'user']);
 
         $this->expectException(Exception::class);
-        $this->expectExceptionMessage('Joining tables on non-id fields is not implemented yet');
+        $this->expectExceptionMessage('Reverse join with non-ID master field is not implemented yet');
         $m->join('contact.foo_id', ['masterField' => 'test_id']);
     }
 

--- a/tests/ModelMixedPersistenceTest.php
+++ b/tests/ModelMixedPersistenceTest.php
@@ -50,12 +50,13 @@ class ModelMixedPersistenceTest extends TestCase
         ], $m->export());
     }
 
-    public function testArrayWith(): void
+    public function testArrayWithJoinUsingId(): void
     {
         $this->setDb([
             'user' => [
                 10 => ['id' => 10, 'name' => 'John'],
                 20 => ['id' => 20, 'name' => 'Peter'],
+                30 => ['id' => 30, 'name' => 'Maria'],
             ],
         ]);
 
@@ -76,7 +77,7 @@ class ModelMixedPersistenceTest extends TestCase
 
         $m = clone $mUser;
         $m->addCteModel('config', $mArray);
-        $jConfig = $m->join('config.userId'); // TODO join using "name" field once non-ID join is supported
+        $jConfig = $m->join('config.userId');
         $jConfig->addField('path');
         $jConfig->addField('float', ['type' => 'float']);
 
@@ -104,6 +105,62 @@ class ModelMixedPersistenceTest extends TestCase
         self::assertSameExportUnordered([
             ['id' => 10, 'name' => 'John', 'path' => 'new path', 'float' => 0.0],
             ['id' => 20, 'name' => 'Peter', 'path' => '/home/p', 'float' => 2.0],
+        ], $m->export());
+    }
+
+    public function testArrayWithJoinUsingName(): void
+    {
+        $this->setDb([
+            'user' => [
+                10 => ['id' => 10, 'name' => 'John'],
+                20 => ['id' => 20, 'name' => 'Peter'],
+                30 => ['id' => 30, 'name' => 'Maria'],
+            ],
+        ]);
+
+        $mUser = new Model($this->db, ['table' => 'user']);
+        $mUser->addField('name');
+
+        $dbArray = new Persistence\Array_([
+            'config' => [
+                1 => ['id' => 1, 'user_name' => 'John', 'path' => '/home/john'],
+                ['id' => 2, 'user_name' => 'Peter', 'path' => '/home/p'],
+            ],
+        ]);
+
+        $mArray = new Model($dbArray, ['table' => 'config']);
+        $mArray->addField('userName', ['actual' => 'user_name']);
+        $mArray->addField('path');
+
+        $m = clone $mUser;
+        $m->addCteModel('config', $mArray);
+        $jConfig = $m->join('config.userName', ['masterField' => 'name', 'reverse' => false]);
+        $jConfig->addField('path');
+
+        $fromClause = $this->getDatabasePlatform() instanceof OraclePlatform
+            ? ' from "DUAL"'
+            : '';
+
+        $this->assertSameSql(
+            'with `config` as (select :a `id`, :b `userName`, :c `path`' . $fromClause . ' union all select :d, :e, :f' . $fromClause . ')' . "\n"
+                . 'select `user`.`id`, `user`.`name`, `_config`.`path` from `user` inner join `config` `_config` on `_config`.`userName` = `user`.`name`',
+            $m->action('select')->render()[0]
+        );
+
+        self::markTestIncompleteOnMySQL5xPlatformAsWithClauseIsNotSupported();
+
+        self::assertSameExportUnordered([
+            ['id' => 10, 'name' => 'John', 'path' => '/home/john'],
+            ['id' => 20, 'name' => 'Peter', 'path' => '/home/p'],
+        ], $m->export());
+
+        $john = $m->load(10);
+        $john->set('path', 'new path');
+        $john->save();
+
+        self::assertSameExportUnordered([
+            ['id' => 10, 'name' => 'John', 'path' => 'new path'],
+            ['id' => 20, 'name' => 'Peter', 'path' => '/home/p'],
         ], $m->export());
     }
 }

--- a/tests/ModelMixedPersistenceTest.php
+++ b/tests/ModelMixedPersistenceTest.php
@@ -50,6 +50,43 @@ class ModelMixedPersistenceTest extends TestCase
         ], $m->export());
     }
 
+    public function testArrayTableFloatId(): void
+    {
+        $dbArray = new Persistence\Array_([
+            'user' => [
+                '1.0' => ['id' => 1.0, 'name' => 'John'],
+                '1.2' => ['id' => 1.2, 'name' => 'Peter'],
+            ],
+        ]);
+
+        $mArray = new Model(null, ['table' => 'user']);
+        $mArray->addField('id', ['type' => 'float']);
+        $mArray->addField('name');
+        $mArray->setPersistence($dbArray);
+
+        $m = new Model($this->db, ['table' => $mArray]);
+        $m->getIdField()->type = 'float';
+        $m->addField('name');
+
+        self::assertSameExportUnordered([
+            ['id' => 1.0, 'name' => 'John'],
+            ['id' => 1.2, 'name' => 'Peter'],
+        ], $m->export());
+
+        $john = $m->load(1.0);
+        $john->set('name', 'Johny');
+        $john->save();
+
+        self::assertSameExportUnordered([
+            ['id' => 1.0, 'name' => 'Johny'],
+            ['id' => 1.2, 'name' => 'Peter'],
+        ], $m->export());
+
+        self::assertSame('Peter', $m->load(1.2)->get('name'));
+        self::assertNull($m->tryLoad(1.21));
+        self::assertSame('Johny', $m->load(1)->get('name'));
+    }
+
     public function testArrayWithJoinUsingId(): void
     {
         $this->setDb([

--- a/tests/Persistence/Array_/Db/HashIndexTest.php
+++ b/tests/Persistence/Array_/Db/HashIndexTest.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Atk4\Data\Tests\Persistence\Array_\Db;
+
+use Atk4\Core\Phpunit\TestCase;
+use Atk4\Data\Persistence\Array_\Db\HashIndex;
+use PHPUnit\Framework\Attributes\DataProvider;
+
+class HashIndexTest extends TestCase
+{
+    public function testBasic(): void
+    {
+        $index = new HashIndex();
+
+        \Closure::bind(static function () use ($index) {
+            TestCase::assertSame([], $index->data);
+
+            $index->addRow(0, 'foo');
+            TestCase::assertSame(['foo' => [0 => true]], $index->data);
+            TestCase::assertSame([0], $index->findPossibleRowIndexes('foo'));
+
+            $index->addRow(10, 1);
+            $index->addRow(20, '1');
+            TestCase::assertSame(['foo' => [0 => true], 1 => [10 => true, 20 => true]], $index->data);
+            TestCase::assertSame([0], $index->findPossibleRowIndexes('foo'));
+            TestCase::assertSame([10, 20], $index->findPossibleRowIndexes(1));
+
+            $index->deleteRow(10, 1);
+            TestCase::assertSame(['foo' => [0 => true], 1 => [20 => true]], $index->data);
+            TestCase::assertSame([0], $index->findPossibleRowIndexes('foo'));
+            TestCase::assertSame([20], $index->findPossibleRowIndexes(1));
+
+            $index->deleteRow(20, 1);
+            TestCase::assertSame(['foo' => [0 => true]], $index->data);
+            TestCase::assertSame([0], $index->findPossibleRowIndexes('foo'));
+            TestCase::assertSame([], $index->findPossibleRowIndexes(1));
+        }, null, HashIndex::class)();
+    }
+
+    /**
+     * @param scalar|null $value
+     * @param int|string  $expectedKey
+     *
+     * @dataProvider provideMakeKeyFromValueCases
+     */
+    #[DataProvider('provideMakeKeyFromValueCases')]
+    public function testMakeKeyFromValue($value, $expectedKey): void
+    {
+        $index = new HashIndex();
+
+        self::assertSame(
+            $expectedKey,
+            \Closure::bind(static fn () => $index->makeKeyFromValue($value), null, HashIndex::class)()
+        );
+    }
+
+    /**
+     * @return iterable<list<mixed>>
+     */
+    public static function provideMakeKeyFromValueCases(): iterable
+    {
+        yield ['', ''];
+        yield [null, ''];
+        yield ['foo', 'foo'];
+        yield [false, 0];
+        yield [true, 1];
+        yield [0, 0];
+        yield [1, 1];
+        yield [\PHP_INT_MIN, \PHP_INT_MIN];
+        yield [\PHP_INT_MAX, \PHP_INT_MAX];
+        yield ['1', 1];
+        yield [(string) \PHP_INT_MIN, \PHP_INT_MIN];
+        yield [(string) \PHP_INT_MAX, \PHP_INT_MAX];
+        yield [0.0, 0];
+        yield [1.0, 1];
+        yield [0.5, '0.5'];
+        yield [-0.5, '-0.5'];
+        yield [-1e300, '-1.0E+300'];
+        yield [1e300, '1.0E+300'];
+        yield [-\INF, '-INF'];
+        yield [\INF, 'INF'];
+        yield [\NAN, 'NAN'];
+    }
+}

--- a/tests/Persistence/Array_/Db/RowTest.php
+++ b/tests/Persistence/Array_/Db/RowTest.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Atk4\Data\Tests\Persistence\Array_\Db;
+
+use Atk4\Core\Phpunit\TestCase;
+use Atk4\Data\Exception;
+use Atk4\Data\Persistence\Array_\Db\Row;
+use Atk4\Data\Persistence\Array_\Db\Table;
+
+class RowTest extends TestCase
+{
+    public function testUpdateValuesUnknownColumnException(): void
+    {
+        $table = new Table('t');
+        $table->addColumn('foo');
+
+        $row = $table->addRow(Row::class, []);
+        $row->updateValues(['foo' => 1]);
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage('Column name does not exist');
+        $row->updateValues(['bar' => 1]);
+    }
+}

--- a/tests/Persistence/Array_/Db/TableTest.php
+++ b/tests/Persistence/Array_/Db/TableTest.php
@@ -36,6 +36,17 @@ class TableTest extends TestCase
         $table->addColumn('10.0');
     }
 
+    public function testAddColumnDuplicateException(): void
+    {
+        $table = new Table('t');
+
+        $table->addColumn('foo');
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage('Column name already exists');
+        $table->addColumn('foo');
+    }
+
     public function testBeforeAfterUpdateRow(): void
     {
         $table = new class('t') extends Table {
@@ -125,5 +136,41 @@ class TableTest extends TestCase
             ['after', $rowA, ['foo' => 2, 'bar' => null], []],
         ], $table->getAndClearLog());
         self::assertSame([$rowB->getRowIndex() => $rowB], iterator_to_array($table->getRows()));
+    }
+
+    public function testGetRowsUsingIndex(): void
+    {
+        $table = new Table('t');
+        $table->addColumn('foo');
+
+        $rowA = $table->addRow(Row::class, ['foo' => 1]);
+        $rowB = $table->addRow(Row::class, ['foo' => 1]);
+        $rowC = $table->addRow(Row::class, ['foo' => '1']);
+
+        self::assertSame([$rowA, $rowB], $table->getRowsUsingIndex('foo', 1));
+        self::assertSame([$rowC], $table->getRowsUsingIndex('foo', '1'));
+
+        $rowD = $table->addRow(Row::class, ['foo' => null]);
+        $rowE = $table->addRow(Row::class, ['foo' => null]);
+        $rowF = $table->addRow(Row::class, ['foo' => '']);
+
+        self::assertSame([$rowD, $rowE], $table->getRowsUsingIndex('foo', null));
+        self::assertSame([$rowF], $table->getRowsUsingIndex('foo', ''));
+    }
+
+    public function testGetRowUsingIndex(): void
+    {
+        $table = new Table('t');
+        $table->addColumn('foo');
+
+        $table->addRow(Row::class, ['foo' => 1]);
+        $table->addRow(Row::class, ['foo' => 1]);
+        $rowC = $table->addRow(Row::class, ['foo' => '1']);
+
+        self::assertSame($rowC, $table->getRowUsingIndex('foo', '1'));
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage('Index is not unique, more than one row was found');
+        $table->getRowUsingIndex('foo', 1);
     }
 }

--- a/tests/Persistence/Array_/Db/TableTest.php
+++ b/tests/Persistence/Array_/Db/TableTest.php
@@ -1,0 +1,129 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Atk4\Data\Tests\Persistence\Array_\Db;
+
+use Atk4\Core\Phpunit\TestCase;
+use Atk4\Data\Exception;
+use Atk4\Data\Persistence\Array_\Db\Row;
+use Atk4\Data\Persistence\Array_\Db\Table;
+
+class TableTest extends TestCase
+{
+    public function testTableNameNumericException(): void
+    {
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage('Name must be a non-empty and non-numeric');
+        new Table('10');
+    }
+
+    public function testAddColumnNameEmptyException(): void
+    {
+        $table = new Table('t');
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage('Name must be a non-empty and non-numeric');
+        $table->addColumn('');
+    }
+
+    public function testAddColumnNameNumericException(): void
+    {
+        $table = new Table('t');
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage('Name must be a non-empty and non-numeric');
+        $table->addColumn('10.0');
+    }
+
+    public function testBeforeAfterUpdateRow(): void
+    {
+        $table = new class('t') extends Table {
+            /** @var list<array{'before'|'after', Row, array<string, mixed>, 3?: array<string, mixed>}> */
+            private array $log = [];
+
+            #[\Override]
+            protected function beforeUpdateRow(Row $row, $newData): void
+            {
+                parent::beforeUpdateRow($row, $newData);
+
+                $this->log[] = ['before', $row, $newData];
+            }
+
+            #[\Override]
+            protected function afterUpdateRow(Row $row, $oldData, $newData): void
+            {
+                parent::afterUpdateRow($row, $oldData, $newData);
+
+                $this->log[] = ['after', $row, $oldData, $newData];
+            }
+
+            /**
+             * @return list<array{'before'|'after', Row, array<string, mixed>, 3?: array<string, mixed>}>
+             */
+            public function getAndClearLog(): array
+            {
+                $res = $this->log;
+                $this->log = [];
+
+                return $res;
+            }
+        };
+
+        $table->addColumn('foo');
+        self::assertSame([], $table->getAndClearLog());
+
+        $rowA = $table->addRow(Row::class, []);
+        self::assertSame([
+            ['before', $rowA, ['foo' => null]],
+            ['after', $rowA, [], ['foo' => null]],
+        ], $table->getAndClearLog());
+
+        $rowB = $table->addRow(Row::class, ['foo' => 5]);
+        self::assertSame([
+            ['before', $rowB, ['foo' => 5]],
+            ['after', $rowB, [], ['foo' => 5]],
+        ], $table->getAndClearLog());
+
+        $table->addColumn('bar');
+        self::assertSame([
+            ['before', $rowA, ['bar' => null]],
+            ['after', $rowA, [], ['bar' => null]],
+            ['before', $rowB, ['bar' => null]],
+            ['after', $rowB, [], ['bar' => null]],
+        ], $table->getAndClearLog());
+
+        $rowA->updateValues(['foo' => 2]);
+        self::assertSame([
+            ['before', $rowA, ['foo' => 2]],
+            ['after', $rowA, ['foo' => null], ['foo' => 2]],
+        ], $table->getAndClearLog());
+
+        $rowB->updateValues(['foo' => 6]);
+        self::assertSame([
+            ['before', $rowB, ['foo' => 6]],
+            ['after', $rowB, ['foo' => 5], ['foo' => 6]],
+        ], $table->getAndClearLog());
+
+        $rowB->updateValues(['foo' => 7, 'bar' => 8]);
+        self::assertSame([
+            ['before', $rowB, ['foo' => 7, 'bar' => 8]],
+            ['after', $rowB, ['foo' => 6, 'bar' => null], ['foo' => 7, 'bar' => 8]],
+        ], $table->getAndClearLog());
+
+        $rowB->updateValues([]);
+        self::assertSame([], $table->getAndClearLog());
+
+        $rowB->updateValues(['foo' => 7]);
+        self::assertSame([], $table->getAndClearLog());
+
+        self::assertSame([$rowA->getRowIndex() => $rowA, $rowB->getRowIndex() => $rowB], iterator_to_array($table->getRows()));
+
+        $table->deleteRow($rowA);
+        self::assertSame([
+            ['before', $rowA, []],
+            ['after', $rowA, ['foo' => 2, 'bar' => null], []],
+        ], $table->getAndClearLog());
+        self::assertSame([$rowB->getRowIndex() => $rowB], iterator_to_array($table->getRows()));
+    }
+}

--- a/tests/Reference/WeakAnalysingMapTest.php
+++ b/tests/Reference/WeakAnalysingMapTest.php
@@ -131,7 +131,7 @@ class WeakAnalysingMapTest extends TestCase
         self::assertNull($weakOwner->get());
     }
 
-    public function testSetKeyAlreadyPresentException(): void
+    public function testSetKeyDuplicateException(): void
     {
         $map = new WeakAnalysingMap();
 
@@ -153,7 +153,7 @@ class WeakAnalysingMapTest extends TestCase
             $this->forceWeakMapPolyfillHousekeeping($map);
             self::assertNull($map->get($key, $key));
         }
-        self::assertSame('Analysing key is already present', $e);
+        self::assertSame('Analysing key already exists', $e);
     }
 
     public function testGetSetKeyWithHashCollision(): void


### PR DESCRIPTION
Previously, a row lookup performance was O(n), newly it is O(1).

On my local PC 10k rows newly takes about 200 ms to initialize (`Array_::seedData()`).

1M rows tested.