### PR TITLE
Optimize array data mapping to SQL

### DIFF
--- a/src/Persistence/Sql/Mssql/Query.php
+++ b/src/Persistence/Sql/Mssql/Query.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace Atk4\Data\Persistence\Sql\Mssql;
 
 use Atk4\Data\Persistence\Sql\Query as BaseQuery;
+use Atk4\Data\Persistence\Sql\RawExpression;
+use Doctrine\DBAL\Types\Type;
 
 class Query extends BaseQuery
 {
@@ -171,6 +173,41 @@ class Query extends BaseQuery
     public function groupConcat($field, string $separator = ',')
     {
         return $this->expr('string_agg({}, ' . $this->escapeStringLiteral($separator) . ')', [$field]);
+    }
+
+    #[\Override]
+    protected function makeArrayTable(array $rows, array $columnTypes)
+    {
+        $jsonData = [];
+        foreach ($rows as $row) {
+            $jsonRow = [];
+            foreach ($row as $v) {
+                $jsonRow[] = $v;
+            }
+            $jsonData[] = $jsonRow;
+        }
+
+        $json = json_encode($jsonData, \JSON_PRESERVE_ZERO_FRACTION | \JSON_UNESCAPED_UNICODE | \JSON_THROW_ON_ERROR);
+
+        $query = $this->connection->dsql();
+        $i = 0;
+        $defTemplates = [];
+        $defParams = [];
+        foreach ($columnTypes as $k => $type) {
+            $query->field($query->expr('{}', ['c' . $i]), $k);
+
+            $defTemplates[] = '{} ' . Type::getType($type)->getSQLDeclaration([], $this->connection->getDatabasePlatform()) . ' []';
+            $defParams[] = 'c' . $i;
+            $defParams[] = new RawExpression($this->escapeStringLiteral('$[' . $i . ']'));
+
+            ++$i;
+        }
+        $query->table($this->expr(
+            'openjson([]) with (' . implode(', ', $defTemplates) . ')',
+            [$json, ...$defParams]
+        ), 't');
+
+        return $query;
     }
 
     #[\Override]

--- a/src/Persistence/Sql/Mssql/Query.php
+++ b/src/Persistence/Sql/Mssql/Query.php
@@ -178,16 +178,7 @@ class Query extends BaseQuery
     #[\Override]
     protected function makeArrayTable(array $rows, array $columnTypes)
     {
-        $jsonData = [];
-        foreach ($rows as $row) {
-            $jsonRow = [];
-            foreach ($row as $v) {
-                $jsonRow[] = $v;
-            }
-            $jsonData[] = $jsonRow;
-        }
-
-        $json = json_encode($jsonData, \JSON_PRESERVE_ZERO_FRACTION | \JSON_UNESCAPED_UNICODE | \JSON_THROW_ON_ERROR);
+        $json = $this->makeArrayTableMakeJson($rows, array_keys($columnTypes));
 
         $query = $this->connection->dsql();
         $i = 0;

--- a/src/Persistence/Sql/Mysql/Query.php
+++ b/src/Persistence/Sql/Mysql/Query.php
@@ -80,16 +80,7 @@ class Query extends BaseQuery
             return parent::makeArrayTable($rows, $columnTypes);
         }
 
-        $jsonData = [];
-        foreach ($rows as $row) {
-            $jsonRow = [];
-            foreach ($row as $v) {
-                $jsonRow[] = $v;
-            }
-            $jsonData[] = $jsonRow;
-        }
-
-        $json = json_encode($jsonData, \JSON_PRESERVE_ZERO_FRACTION | \JSON_UNESCAPED_UNICODE | \JSON_THROW_ON_ERROR);
+        $json = $this->makeArrayTableMakeJson($rows, array_keys($columnTypes));
 
         $query = $this->connection->dsql();
         $i = 0;

--- a/src/Persistence/Sql/Mysql/Query.php
+++ b/src/Persistence/Sql/Mysql/Query.php
@@ -76,7 +76,7 @@ class Query extends BaseQuery
     #[\Override]
     protected function makeArrayTable(array $rows, array $columnTypes)
     {
-        if ($this->isServerMysql5x()) {
+        if ($this->isServerMysql5x() || (Connection::isServerMariaDb($this->connection) && version_compare($this->connection->getServerVersion(), '10.6') < 0)) {
             return parent::makeArrayTable($rows, $columnTypes);
         }
 

--- a/src/Persistence/Sql/Mysql/Query.php
+++ b/src/Persistence/Sql/Mysql/Query.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace Atk4\Data\Persistence\Sql\Mysql;
 
 use Atk4\Data\Persistence\Sql\Query as BaseQuery;
+use Atk4\Data\Persistence\Sql\RawExpression;
+use Doctrine\DBAL\Types\Type;
 
 class Query extends BaseQuery
 {
@@ -17,13 +19,15 @@ class Query extends BaseQuery
 
     protected string $templateUpdate = 'update [table][join] set [set] [where]';
 
+    private function isServerMysql5x(): bool
+    {
+        return !Connection::isServerMariaDb($this->connection) && version_compare($this->connection->getServerVersion(), '6.0') < 0;
+    }
+
     #[\Override]
     protected function _renderConditionLikeOperator(bool $negated, string $sqlLeft, string $sqlRight): string
     {
-        $isMysql5x = !Connection::isServerMariaDb($this->connection)
-            && version_compare($this->connection->getServerVersion(), '6.0') < 0;
-
-        if ($isMysql5x) {
+        if ($this->isServerMysql5x()) {
             $replaceSqlFx = function (string $sql, string $search, string $replacement) {
                 return 'replace(' . $sql . ', ' . $this->escapeStringLiteral($search) . ', ' . $this->escapeStringLiteral($replacement) . ')';
             };
@@ -56,11 +60,8 @@ class Query extends BaseQuery
     #[\Override]
     protected function _renderConditionRegexpOperator(bool $negated, string $sqlLeft, string $sqlRight, bool $binary = false): string
     {
-        $isMysql5x = !Connection::isServerMariaDb($this->connection)
-            && version_compare($this->connection->getServerVersion(), '6.0') < 0;
-
         return $sqlLeft . ($negated ? ' not' : '') . ' regexp ' . (
-            $isMysql5x
+            $this->isServerMysql5x()
                 ? 'concat(' . $this->escapeStringLiteral('@?') . ', ' . $sqlRight . ')' // https://dbfiddle.uk/diAepf8V
                 : 'concat(' . $this->escapeStringLiteral('(?s)') . ', ' . $sqlRight . ')'
         );
@@ -70,5 +71,51 @@ class Query extends BaseQuery
     public function groupConcat($field, string $separator = ',')
     {
         return $this->expr('group_concat({} separator ' . $this->escapeStringLiteral($separator) . ')', [$field]);
+    }
+
+    #[\Override]
+    protected function makeArrayTable(array $rows, array $columnTypes)
+    {
+        if ($this->isServerMysql5x()) {
+            return parent::makeArrayTable($rows, $columnTypes);
+        }
+
+        $jsonData = [];
+        foreach ($rows as $row) {
+            $jsonRow = [];
+            foreach ($row as $v) {
+                $jsonRow[] = $v;
+            }
+            $jsonData[] = $jsonRow;
+        }
+
+        $json = json_encode($jsonData, \JSON_PRESERVE_ZERO_FRACTION | \JSON_UNESCAPED_UNICODE | \JSON_THROW_ON_ERROR);
+
+        $query = $this->connection->dsql();
+        $i = 0;
+        $defTemplates = [];
+        $defParams = [];
+        foreach ($columnTypes as $k => $type) {
+            $query->field($query->expr('{}', ['c' . $i]), $k);
+
+            $defType = Type::getType($type)->getSQLDeclaration([], $this->connection->getDatabasePlatform());
+            $defCollation = preg_match('~char|text~i', $defType)
+                // https://github.com/atk4/data/blob/6.0.0/src/Schema/Migrator.php#L128
+                // https://github.com/doctrine/dbal/blob/3.10.2/src/Platforms/AbstractMySQLPlatform.php#L597
+                // TODO DBAL 4.0 https://github.com/doctrine/dbal/pull/4644
+                ? 'utf8mb4_unicode_ci'
+                : null;
+            $defTemplates[] = '{} ' . $defType . ($defCollation !== null ? ' COLLATE ' . $this->escapeIdentifier($defCollation) : '') . ' path []';
+            $defParams[] = 'c' . $i;
+            $defParams[] = new RawExpression($this->escapeStringLiteral('$[' . $i . ']'));
+
+            ++$i;
+        }
+        $query->table($this->expr(
+            'json_table([], [] columns (' . implode(', ', $defTemplates) . '))',
+            [$json, new RawExpression($this->escapeStringLiteral('$[*]')), ...$defParams]
+        ), 't');
+
+        return $query;
     }
 }

--- a/src/Persistence/Sql/Oracle/Query.php
+++ b/src/Persistence/Sql/Oracle/Query.php
@@ -213,8 +213,10 @@ class Query extends BaseQuery
         foreach ($columnTypes as $k => $type) {
             $query->field($query->expr('{}', ['c' . $i]), $k);
 
-            // https://web.archive.org/web/20250615224942/https://docs.oracle.com/en/database/oracle/oracle-database/23/sqlrf/JSON_VALUE.html#GUID-C7F19D36-1E75-4CB2-AE67-ADFBAD23CBC2__CJABCIJE
-            $defTemplates[] = '{} ' . (['boolean' => 'NUMBER(1)', 'bigint' => 'NUMBER(20)', 'float' => 'NUMBER'][$type] ?? 'VARCHAR2') . ' path []';
+            $defTemplates[] = '{} '
+                . (['boolean' => 'NUMBER(1)', 'bigint' => 'NUMBER(20)', 'float' => 'NUMBER'][$type] ?? 'VARCHAR2')
+                . ' path []'
+                . ($type === 'boolean' && version_compare($this->connection->getServerVersion(), '21.0') >= 0 ? ' ALLOW BOOLEAN TO NUMBER' : '');
             $defParams[] = 'c' . $i;
             $defParams[] = new RawExpression($this->escapeStringLiteral('$[' . $i . ']'));
 

--- a/src/Persistence/Sql/Oracle/Query.php
+++ b/src/Persistence/Sql/Oracle/Query.php
@@ -8,6 +8,7 @@ use Atk4\Data\Exception;
 use Atk4\Data\Field;
 use Atk4\Data\Persistence\Sql\ExecuteException;
 use Atk4\Data\Persistence\Sql\Query as BaseQuery;
+use Atk4\Data\Persistence\Sql\RawExpression;
 use Doctrine\DBAL\Connection as DbalConnection;
 use Doctrine\DBAL\Exception\DatabaseObjectNotFoundException;
 
@@ -189,6 +190,42 @@ class Query extends BaseQuery
     public function groupConcat($field, string $separator = ',')
     {
         return $this->expr('listagg({field}, []) within group (order by {field})', ['field' => $field, $separator]);
+    }
+
+    #[\Override]
+    protected function makeArrayTable(array $rows, array $columnTypes)
+    {
+        $jsonData = [];
+        foreach ($rows as $row) {
+            $jsonRow = [];
+            foreach ($row as $v) {
+                $jsonRow[] = $v;
+            }
+            $jsonData[] = $jsonRow;
+        }
+
+        $json = json_encode($jsonData, \JSON_PRESERVE_ZERO_FRACTION | \JSON_UNESCAPED_UNICODE | \JSON_THROW_ON_ERROR);
+
+        $query = $this->connection->dsql();
+        $i = 0;
+        $defTemplates = [];
+        $defParams = [];
+        foreach ($columnTypes as $k => $type) {
+            $query->field($query->expr('{}', ['c' . $i]), $k);
+
+            // https://web.archive.org/web/20250615224942/https://docs.oracle.com/en/database/oracle/oracle-database/23/sqlrf/JSON_VALUE.html#GUID-C7F19D36-1E75-4CB2-AE67-ADFBAD23CBC2__CJABCIJE
+            $defTemplates[] = '{} ' . (['boolean' => 'NUMBER(1)', 'bigint' => 'NUMBER(20)', 'float' => 'NUMBER'][$type] ?? 'VARCHAR2') . ' path []';
+            $defParams[] = 'c' . $i;
+            $defParams[] = new RawExpression($this->escapeStringLiteral('$[' . $i . ']'));
+
+            ++$i;
+        }
+        $query->table($this->expr(
+            'json_table([], [] columns (' . implode(', ', $defTemplates) . '))',
+            [$json, new RawExpression($this->escapeStringLiteral('$[*]')), ...$defParams]
+        ), 't');
+
+        return $query;
     }
 
     #[\Override]

--- a/src/Persistence/Sql/Oracle/Query.php
+++ b/src/Persistence/Sql/Oracle/Query.php
@@ -195,16 +195,7 @@ class Query extends BaseQuery
     #[\Override]
     protected function makeArrayTable(array $rows, array $columnTypes)
     {
-        $jsonData = [];
-        foreach ($rows as $row) {
-            $jsonRow = [];
-            foreach ($row as $v) {
-                $jsonRow[] = $v;
-            }
-            $jsonData[] = $jsonRow;
-        }
-
-        $json = json_encode($jsonData, \JSON_PRESERVE_ZERO_FRACTION | \JSON_UNESCAPED_UNICODE | \JSON_THROW_ON_ERROR);
+        $json = $this->makeArrayTableMakeJson($rows, array_keys($columnTypes));
 
         $query = $this->connection->dsql();
         $i = 0;

--- a/src/Persistence/Sql/Postgresql/Query.php
+++ b/src/Persistence/Sql/Postgresql/Query.php
@@ -6,6 +6,8 @@ namespace Atk4\Data\Persistence\Sql\Postgresql;
 
 use Atk4\Data\Persistence\Sql\Expression as BaseExpression;
 use Atk4\Data\Persistence\Sql\Query as BaseQuery;
+use Atk4\Data\Persistence\Sql\RawExpression;
+use Doctrine\DBAL\Types\Type;
 
 class Query extends BaseQuery
 {
@@ -116,5 +118,44 @@ class Query extends BaseQuery
     public function groupConcat($field, string $separator = ','): BaseExpression
     {
         return $this->expr('string_agg({}, [])', [$field, $separator]);
+    }
+
+    #[\Override]
+    protected function makeArrayTable(array $rows, array $columnTypes)
+    {
+        if (version_compare($this->connection->getServerVersion(), '17.0') < 0) {
+            return parent::makeArrayTable($rows, $columnTypes);
+        }
+
+        $jsonData = [];
+        foreach ($rows as $row) {
+            $jsonRow = [];
+            foreach ($row as $v) {
+                $jsonRow[] = $v;
+            }
+            $jsonData[] = $jsonRow;
+        }
+
+        $json = json_encode($jsonData, \JSON_PRESERVE_ZERO_FRACTION | \JSON_UNESCAPED_UNICODE | \JSON_THROW_ON_ERROR);
+
+        $query = $this->connection->dsql();
+        $i = 0;
+        $defTemplates = [];
+        $defParams = [];
+        foreach ($columnTypes as $k => $type) {
+            $query->field($query->expr('{}', ['c' . $i]), $k);
+
+            $defTemplates[] = '{} ' . Type::getType($type)->getSQLDeclaration([], $this->connection->getDatabasePlatform()) . ' path []';
+            $defParams[] = 'c' . $i;
+            $defParams[] = new RawExpression($this->escapeStringLiteral('$[' . $i . ']'));
+
+            ++$i;
+        }
+        $query->table($this->expr(
+            'json_table([], [] columns (' . implode(', ', $defTemplates) . '))',
+            [$json, new RawExpression($this->escapeStringLiteral('$[*]')), ...$defParams]
+        ), 't');
+
+        return $query;
     }
 }

--- a/src/Persistence/Sql/Postgresql/Query.php
+++ b/src/Persistence/Sql/Postgresql/Query.php
@@ -120,13 +120,35 @@ class Query extends BaseQuery
         return $this->expr('string_agg({}, [])', [$field, $separator]);
     }
 
+    private function jsonTableToXml(string $json): string
+    {
+        $rows = json_decode($json, true, 512, \JSON_BIGINT_AS_STRING | \JSON_THROW_ON_ERROR);
+
+        return '<t>'
+            . implode('', array_map(function ($row) {
+                assert($row === array_values($row));
+
+                $parts = [];
+                foreach ($row as $i => $v) {
+                    if ($v === null) {
+                        continue;
+                    }
+
+                    $vStr = \Closure::bind(fn () => $this->castGetValue($v), $this, BaseExpression::class)();
+
+                    $parts[] = ' c' . $i . '="'
+                        . preg_replace_callback('~[\x00-\x1f"&<\x7f]~', static fn ($matches) => '&#x' . dechex(ord($matches[0])) . ';', $vStr)
+                        . '"';
+                }
+
+                return '<r' . implode('', $parts) . '/>';
+            }, $rows))
+            . '</t>';
+    }
+
     #[\Override]
     protected function makeArrayTable(array $rows, array $columnTypes)
     {
-        if (version_compare($this->connection->getServerVersion(), '17.0') < 0) {
-            return parent::makeArrayTable($rows, $columnTypes);
-        }
-
         $jsonData = [];
         foreach ($rows as $row) {
             $jsonRow = [];
@@ -138,6 +160,8 @@ class Query extends BaseQuery
 
         $json = json_encode($jsonData, \JSON_PRESERVE_ZERO_FRACTION | \JSON_UNESCAPED_UNICODE | \JSON_THROW_ON_ERROR);
 
+        $asXml = version_compare($this->connection->getServerVersion(), '17.0') < 0;
+
         $query = $this->connection->dsql();
         $i = 0;
         $defTemplates = [];
@@ -147,14 +171,24 @@ class Query extends BaseQuery
 
             $defTemplates[] = '{} ' . Type::getType($type)->getSQLDeclaration([], $this->connection->getDatabasePlatform()) . ' path []';
             $defParams[] = 'c' . $i;
-            $defParams[] = new RawExpression($this->escapeStringLiteral('$[' . $i . ']'));
+            $defParams[] = new RawExpression($this->escapeStringLiteral($asXml ? '@c' . $i : '$[' . $i . ']'));
 
             ++$i;
         }
-        $query->table($this->expr(
-            'json_table([], [] columns (' . implode(', ', $defTemplates) . '))',
-            [$json, new RawExpression($this->escapeStringLiteral('$[*]')), ...$defParams]
-        ), 't');
+
+        if ($asXml) {
+            $xml = $this->jsonTableToXml($json);
+
+            $query->table($this->expr(
+                'xmltable([] passing xmlparse(document []) columns ' . implode(', ', $defTemplates) . ')',
+                [new RawExpression($this->escapeStringLiteral('/t/r')), $xml, ...$defParams]
+            ), 't');
+        } else {
+            $query->table($this->expr(
+                'json_table([], [] columns (' . implode(', ', $defTemplates) . '))',
+                [$json, new RawExpression($this->escapeStringLiteral('$[*]')), ...$defParams]
+            ), 't');
+        }
 
         return $query;
     }

--- a/src/Persistence/Sql/Postgresql/Query.php
+++ b/src/Persistence/Sql/Postgresql/Query.php
@@ -149,16 +149,7 @@ class Query extends BaseQuery
     #[\Override]
     protected function makeArrayTable(array $rows, array $columnTypes)
     {
-        $jsonData = [];
-        foreach ($rows as $row) {
-            $jsonRow = [];
-            foreach ($row as $v) {
-                $jsonRow[] = $v;
-            }
-            $jsonData[] = $jsonRow;
-        }
-
-        $json = json_encode($jsonData, \JSON_PRESERVE_ZERO_FRACTION | \JSON_UNESCAPED_UNICODE | \JSON_THROW_ON_ERROR);
+        $json = $this->makeArrayTableMakeJson($rows, array_keys($columnTypes));
 
         $asXml = version_compare($this->connection->getServerVersion(), '17.0') < 0;
 

--- a/src/Persistence/Sql/Query.php
+++ b/src/Persistence/Sql/Query.php
@@ -1194,6 +1194,10 @@ abstract class Query extends Expression
             return $query;
         }
 
+        // this fallback approach is resource intensive, limit the maximum row count
+        // as it is limited by maximum unioned queries and maximum bound variables anyway
+        assert(count($rows) <= 5_000);
+
         // TODO simplify once https://github.com/atk4/data/pull/677 is merged
         $queries = [];
         $isFirst = true;

--- a/src/Persistence/Sql/Query.php
+++ b/src/Persistence/Sql/Query.php
@@ -1161,6 +1161,22 @@ abstract class Query extends Expression
     }
 
     /**
+     * @param list<array<string, scalar|null>> $rows
+     * @param list<string>                     $columnNames
+     */
+    protected function makeArrayTableMakeJson(array $rows, array $columnNames): string
+    {
+        $jsonData = [];
+        foreach ($rows as $row) {
+            assert(array_keys($row) === $columnNames);
+
+            $jsonData[] = array_values($row);
+        }
+
+        return json_encode($jsonData, \JSON_PRESERVE_ZERO_FRACTION | \JSON_UNESCAPED_UNICODE | \JSON_THROW_ON_ERROR);
+    }
+
+    /**
      * @param list<array<string, scalar|null>>                   $rows
      * @param array<string, 'boolean'|'bigint'|'float'|'string'> $columnTypes
      *

--- a/src/Persistence/Sql/Sqlite/Query.php
+++ b/src/Persistence/Sql/Sqlite/Query.php
@@ -6,6 +6,7 @@ namespace Atk4\Data\Persistence\Sql\Sqlite;
 
 use Atk4\Data\Persistence\Sql\ExecuteException;
 use Atk4\Data\Persistence\Sql\Query as BaseQuery;
+use Atk4\Data\Persistence\Sql\RawExpression;
 use Doctrine\DBAL\Connection as DbalConnection;
 use Doctrine\DBAL\Exception\TableNotFoundException;
 
@@ -160,6 +161,34 @@ class Query extends BaseQuery
     public function groupConcat($field, string $separator = ',')
     {
         return $this->expr('group_concat({}, [])', [$field, $separator]);
+    }
+
+    #[\Override]
+    protected function makeArrayTable(array $rows, array $columnTypes)
+    {
+        $jsonData = [];
+        foreach ($rows as $row) {
+            $jsonRow = [];
+            foreach ($row as $v) {
+                $jsonRow[] = $v;
+            }
+            $jsonData[] = $jsonRow;
+        }
+
+        $json = json_encode($jsonData, \JSON_PRESERVE_ZERO_FRACTION | \JSON_UNESCAPED_UNICODE | \JSON_THROW_ON_ERROR);
+
+        $query = $this->connection->dsql();
+        $i = 0;
+        foreach ($columnTypes as $k => $type) {
+            $query->field($query->expr('json_extract(value, [])', [
+                new RawExpression($this->escapeStringLiteral('$[' . $i . ']')),
+            ]), $k);
+
+            ++$i;
+        }
+        $query->table($this->expr('json_each([])', [$json]));
+
+        return $query;
     }
 
     #[\Override]

--- a/src/Persistence/Sql/Sqlite/Query.php
+++ b/src/Persistence/Sql/Sqlite/Query.php
@@ -166,16 +166,7 @@ class Query extends BaseQuery
     #[\Override]
     protected function makeArrayTable(array $rows, array $columnTypes)
     {
-        $jsonData = [];
-        foreach ($rows as $row) {
-            $jsonRow = [];
-            foreach ($row as $v) {
-                $jsonRow[] = $v;
-            }
-            $jsonData[] = $jsonRow;
-        }
-
-        $json = json_encode($jsonData, \JSON_PRESERVE_ZERO_FRACTION | \JSON_UNESCAPED_UNICODE | \JSON_THROW_ON_ERROR);
+        $json = $this->makeArrayTableMakeJson($rows, array_keys($columnTypes));
 
         $query = $this->connection->dsql();
         $i = 0;

--- a/tests/Persistence/Sql/MaterializedArrayActionTest.php
+++ b/tests/Persistence/Sql/MaterializedArrayActionTest.php
@@ -56,14 +56,14 @@ class MaterializedArrayActionTest extends TestCase
             self::assertSame([':a' => '[]'], $render[1]);
         } elseif ($this->getDatabasePlatform() instanceof MySQLPlatform && !$this->isServerMysql5x()) {
             self::assertSame([':a' => '[]'], $render[1]);
-        } elseif ($this->getDatabasePlatform() instanceof PostgreSQLPlatform && !$this->isServerPostgreSQL16OrLower()) {
-            self::assertSame([':a' => '[]'], $render[1]);
+        } elseif ($this->getDatabasePlatform() instanceof PostgreSQLPlatform) {
+            self::assertSame($this->isServerPostgreSQL16OrLower() ? [':a' => '<t></t>'] : [':a' => '[]'], $render[1]);
         } elseif ($this->getDatabasePlatform() instanceof SQLServerPlatform) {
             self::assertSame([':a' => '[]'], $render[1]);
         } elseif ($this->getDatabasePlatform() instanceof OraclePlatform) {
             self::assertSame([':xxaaaa' => '[]'], $render[1]);
         } else {
-            self::assertSameSql('select :a `bool`, :b `int`, :c `float`, :d `string` limit ' . ($this->getDatabasePlatform() instanceof PostgreSQLPlatform ? '0 offset 0' : '0, 0'), $render[0]);
+            self::assertSameSql('select :a `bool`, :b `int`, :c `float`, :d `string` limit 0, 0', $render[0]);
             self::assertSame([':a' => null, ':b' => null, ':c' => null, ':d' => null], $render[1]);
         }
 
@@ -82,8 +82,8 @@ class MaterializedArrayActionTest extends TestCase
             self::assertSame([':a' => '[[false,0,0.0,"Mark"]]'], $render[1]);
         } elseif ($this->getDatabasePlatform() instanceof MySQLPlatform && !$this->isServerMysql5x()) {
             self::assertSame([':a' => '[[false,0,0.0,"Mark"]]'], $render[1]);
-        } elseif ($this->getDatabasePlatform() instanceof PostgreSQLPlatform && !$this->isServerPostgreSQL16OrLower()) {
-            self::assertSame([':a' => '[[false,0,0.0,"Mark"]]'], $render[1]);
+        } elseif ($this->getDatabasePlatform() instanceof PostgreSQLPlatform) {
+            self::assertSame($this->isServerPostgreSQL16OrLower() ? [':a' => '<t><r c0="0" c1="0" c2="0" c3="Mark"/></t>'] : [':a' => '[[false,0,0.0,"Mark"]]'], $render[1]);
         } elseif ($this->getDatabasePlatform() instanceof SQLServerPlatform) {
             self::assertSame([':a' => '[[false,0,0.0,"Mark"]]'], $render[1]);
         } elseif ($this->getDatabasePlatform() instanceof OraclePlatform) {
@@ -102,34 +102,39 @@ class MaterializedArrayActionTest extends TestCase
     {
         $action = new ArrayAction([
             ['bool' => true, 'int' => \PHP_INT_MIN, 'float' => -1e-20, 'string' => ''],
-            ['bool' => null, 'int' => \PHP_INT_MAX, 'float' => 1.0123456789123e50, 'string' => ' foo' . "\n"],
+            ['bool' => null, 'int' => \PHP_INT_MAX, 'float' => 1.0123456789123e50, 'string' => ' <foo>&"\'🔥' . "\n"],
         ], ['bool', 'int', 'float', 'string']);
         $query = new MaterializedArrayAction($action);
 
         $render = $this->renderQuery($query);
         if ($this->getDatabasePlatform() instanceof SQLitePlatform) {
             self::assertSameSql('select json_extract(value, \'$[0]\') `bool`, json_extract(value, \'$[1]\') `int`, json_extract(value, \'$[2]\') `float`, json_extract(value, \'$[3]\') `string` from json_each(:a)', $render[0]);
-            self::assertSame([':a' => '[[true,-9223372036854775808,-1.0e-20,""],[null,9223372036854775807,1.0123456789123e+50," foo\n"]]'], $render[1]);
+            self::assertSame([':a' => '[[true,-9223372036854775808,-1.0e-20,""],[null,9223372036854775807,1.0123456789123e+50," <foo>&\"\'🔥\n"]]'], $render[1]);
         } elseif ($this->getDatabasePlatform() instanceof MySQLPlatform && !$this->isServerMysql5x()) {
             self::assertSameSql('select `c0` `bool`, `c1` `int`, `c2` `float`, `c3` `string` from json_table(:a, \'$[*]\' columns (`c0` TINYINT(1) path \'$[0]\', `c1` BIGINT path \'$[1]\', `c2` DOUBLE PRECISION path \'$[2]\', `c3` VARCHAR(255) COLLATE `utf8mb4_unicode_ci` path \'$[3]\')) `t`', $render[0]);
-            self::assertSame([':a' => '[[true,-9223372036854775808,-1.0e-20,""],[null,9223372036854775807,1.0123456789123e+50," foo\n"]]'], $render[1]);
-        } elseif ($this->getDatabasePlatform() instanceof PostgreSQLPlatform && !$this->isServerPostgreSQL16OrLower()) {
-            self::assertSameSql('select `c0` `bool`, `c1` `int`, `c2` `float`, `c3` `string` from json_table(:a, \'$[*]\' columns (`c0` BOOLEAN path \'$[0]\', `c1` BIGINT path \'$[1]\', `c2` DOUBLE PRECISION path \'$[2]\', `c3` ATK4__CIVARCHAR path \'$[3]\')) `t`', $render[0]);
-            self::assertSame([':a' => '[[true,-9223372036854775808,-1.0e-20,""],[null,9223372036854775807,1.0123456789123e+50," foo\n"]]'], $render[1]);
+            self::assertSame([':a' => '[[true,-9223372036854775808,-1.0e-20,""],[null,9223372036854775807,1.0123456789123e+50," <foo>&\"\'🔥\n"]]'], $render[1]);
+        } elseif ($this->getDatabasePlatform() instanceof PostgreSQLPlatform) {
+            if ($this->isServerPostgreSQL16OrLower()) {
+                self::assertSameSql('select `c0` `bool`, `c1` `int`, `c2` `float`, `c3` `string` from xmltable(\'/t/r\' passing xmlparse(document :a) columns `c0` BOOLEAN path \'@c0\', `c1` BIGINT path \'@c1\', `c2` DOUBLE PRECISION path \'@c2\', `c3` ATK4__CIVARCHAR path \'@c3\') `t`', $render[0]);
+                self::assertSame([':a' => '<t><r c0="1" c1="-9223372036854775808" c2="-1.0E-20" c3=""/><r c1="9223372036854775807" c2="1.0123456789123E+50" c3=" &#x3c;foo>&#x26;&#x22;\'🔥&#xa;"/></t>'], $render[1]);
+            } else {
+                self::assertSameSql('select `c0` `bool`, `c1` `int`, `c2` `float`, `c3` `string` from json_table(:a, \'$[*]\' columns (`c0` BOOLEAN path \'$[0]\', `c1` BIGINT path \'$[1]\', `c2` DOUBLE PRECISION path \'$[2]\', `c3` ATK4__CIVARCHAR path \'$[3]\')) `t`', $render[0]);
+                self::assertSame([':a' => '[[true,-9223372036854775808,-1.0e-20,""],[null,9223372036854775807,1.0123456789123e+50," <foo>&\"\'🔥\n"]]'], $render[1]);
+            }
         } elseif ($this->getDatabasePlatform() instanceof SQLServerPlatform) {
             self::assertSameSql('select `c0` `bool`, `c1` `int`, `c2` `float`, `c3` `string` from openjson(:a) with (`c0` BIT \'$[0]\', `c1` BIGINT \'$[1]\', `c2` DOUBLE PRECISION \'$[2]\', `c3` NVARCHAR(1020) \'$[3]\') `t`', $render[0]);
-            self::assertSame([':a' => '[[true,-9223372036854775808,-1.0e-20,""],[null,9223372036854775807,1.0123456789123e+50," foo\n"]]'], $render[1]);
+            self::assertSame([':a' => '[[true,-9223372036854775808,-1.0e-20,""],[null,9223372036854775807,1.0123456789123e+50," <foo>&\"\'🔥\n"]]'], $render[1]);
         } elseif ($this->getDatabasePlatform() instanceof OraclePlatform) {
             self::assertSameSql('select `c0` `bool`, `c1` `int`, `c2` `float`, `c3` `string` from json_table(:a, \'$[*]\' columns (`c0` NUMBER(1) path \'$[0]\', `c1` NUMBER(20) path \'$[1]\', `c2` NUMBER path \'$[2]\', `c3` VARCHAR2 path \'$[3]\')) `t`', $render[0]);
-            self::assertSame([':xxaaaa' => '[[true,-9223372036854775808,-1.0e-20,""],[null,9223372036854775807,1.0123456789123e+50," foo\n"]]'], $render[1]);
+            self::assertSame([':xxaaaa' => '[[true,-9223372036854775808,-1.0e-20,""],[null,9223372036854775807,1.0123456789123e+50," <foo>&\"\'🔥\n"]]'], $render[1]);
         } else {
             self::assertSameSql('select :a `bool`, :b `int`, :c `float`, :d `string` union all select :e, :f, :g, :h', $render[0]);
-            self::assertSame([':a' => true, ':b' => \PHP_INT_MIN, ':c' => -1e-20, ':d' => '', ':e' => null, ':f' => \PHP_INT_MAX, ':g' => 1.0123456789123e50, ':h' => ' foo' . "\n"], $render[1]);
+            self::assertSame([':a' => true, ':b' => \PHP_INT_MIN, ':c' => -1e-20, ':d' => '', ':e' => null, ':f' => \PHP_INT_MAX, ':g' => 1.0123456789123e50, ':h' => ' <foo>&"\'🔥' . "\n"], $render[1]);
         }
 
         self::{'assertEquals'}([
             ['bool' => '1', 'int' => \PHP_INT_MIN, 'float' => -1e-20, 'string' => ''],
-            ['bool' => null, 'int' => \PHP_INT_MAX, 'float' => 1.0123456789123e50, 'string' => ' foo' . "\n"],
+            ['bool' => null, 'int' => \PHP_INT_MAX, 'float' => 1.0123456789123e50, 'string' => ' <foo>&"\'🔥' . "\n"],
         ], $query->getDsqlExpression($this->getConnection()->expr())->getRows());
     }
 

--- a/tests/Persistence/Sql/MaterializedArrayActionTest.php
+++ b/tests/Persistence/Sql/MaterializedArrayActionTest.php
@@ -54,8 +54,7 @@ class MaterializedArrayActionTest extends TestCase
             self::assertSameSql('select :a `bool`, :b `int`, :c `float`, :d `string` limit 0 offset 0', $render[0]);
             self::assertSame([':a' => null, ':b' => null, ':c' => null, ':d' => null], $render[1]);
         } elseif ($this->getDatabasePlatform() instanceof SQLServerPlatform) {
-            self::assertSameSql('select :a `bool`, :b `int`, :c `float`, :d `string` order by (select null) offset 9223372036854775807 rows fetch next 1 rows only', $render[0]);
-            self::assertSame([':a' => null, ':b' => null, ':c' => null, ':d' => null], $render[1]);
+            self::assertSame([':a' => '[]'], $render[1]);
         } elseif ($this->getDatabasePlatform() instanceof OraclePlatform) {
             self::assertSameSql('select :a `bool`, :b `int`, :c `float`, :d `string` from "DUAL" fetch next 0 rows only', $render[0]);
             self::assertSame([':xxaaaa' => null, ':xxaaab' => null, ':xxaaac' => null, ':xxaaad' => null], $render[1]);
@@ -83,8 +82,7 @@ class MaterializedArrayActionTest extends TestCase
             self::assertSameSql('select :a `bool`, :b `int`, :c `float`, :d `string`', $render[0]);
             self::assertSame([':a' => false, ':b' => 0, ':c' => 0.0, ':d' => 'Mark'], $render[1]);
         } elseif ($this->getDatabasePlatform() instanceof SQLServerPlatform) {
-            self::assertSameSql('select :a `bool`, :b `int`, :c `float`, :d `string`', $render[0]);
-            self::assertSame([':a' => false, ':b' => 0, ':c' => 0.0, ':d' => 'Mark'], $render[1]);
+            self::assertSame([':a' => '[[false,0,0.0,"Mark"]]'], $render[1]);
         } elseif ($this->getDatabasePlatform() instanceof OraclePlatform) {
             self::assertSameSql('select :a `bool`, :b `int`, :c `float`, :d `string` from "DUAL"', $render[0]);
             self::assertSame([':xxaaaa' => false, ':xxaaab' => 0, ':xxaaac' => 0.0, ':xxaaad' => 'Mark'], $render[1]);
@@ -117,8 +115,8 @@ class MaterializedArrayActionTest extends TestCase
             self::assertSameSql('select :a `bool`, :b `int`, :c `float`, :d `string` union all select :e, :f, :g, :h', $render[0]);
             self::assertSame([':a' => true, ':b' => \PHP_INT_MIN, ':c' => -1e-20, ':d' => '', ':e' => null, ':f' => \PHP_INT_MAX, ':g' => 1.0123456789123e50, ':h' => ' foo' . "\n"], $render[1]);
         } elseif ($this->getDatabasePlatform() instanceof SQLServerPlatform) {
-            self::assertSameSql('select :a `bool`, :b `int`, :c `float`, :d `string` union all select :e, :f, :g, :h', $render[0]);
-            self::assertSame([':a' => true, ':b' => \PHP_INT_MIN, ':c' => -1e-20, ':d' => '', ':e' => null, ':f' => \PHP_INT_MAX, ':g' => 1.0123456789123e50, ':h' => ' foo' . "\n"], $render[1]);
+            self::assertSameSql('select `c0` `bool`, `c1` `int`, `c2` `float`, `c3` `string` from openjson(:a) with (`c0` BIT \'$[0]\', `c1` BIGINT \'$[1]\', `c2` DOUBLE PRECISION \'$[2]\', `c3` NVARCHAR(1020) \'$[3]\') `t`', $render[0]);
+            self::assertSame([':a' => '[[true,-9223372036854775808,-1.0e-20,""],[null,9223372036854775807,1.0123456789123e+50," foo\n"]]'], $render[1]);
         } elseif ($this->getDatabasePlatform() instanceof OraclePlatform) {
             self::assertSameSql('select :a `bool`, :b `int`, :c `float`, :d `string` from "DUAL" union all select :e, :f, :g, :h from "DUAL"', $render[0]);
             self::assertSame([':xxaaaa' => true, ':xxaaab' => \PHP_INT_MIN, ':xxaaac' => -1e-20, ':xxaaad' => '', ':xxaaae' => null, ':xxaaaf' => \PHP_INT_MAX, ':xxaaag' => 1.0123456789123e50, ':xxaaah' => ' foo' . "\n"], $render[1]);

--- a/tests/Persistence/Sql/MaterializedArrayActionTest.php
+++ b/tests/Persistence/Sql/MaterializedArrayActionTest.php
@@ -56,8 +56,7 @@ class MaterializedArrayActionTest extends TestCase
         } elseif ($this->getDatabasePlatform() instanceof SQLServerPlatform) {
             self::assertSame([':a' => '[]'], $render[1]);
         } elseif ($this->getDatabasePlatform() instanceof OraclePlatform) {
-            self::assertSameSql('select :a `bool`, :b `int`, :c `float`, :d `string` from "DUAL" fetch next 0 rows only', $render[0]);
-            self::assertSame([':xxaaaa' => null, ':xxaaab' => null, ':xxaaac' => null, ':xxaaad' => null], $render[1]);
+            self::assertSame([':xxaaaa' => '[]'], $render[1]);
         } else {
             self::assertSameSql('select :a `bool`, :b `int`, :c `float`, :d `string` limit 0, 0', $render[0]);
             self::assertSame([':a' => null, ':b' => null, ':c' => null, ':d' => null], $render[1]);
@@ -84,8 +83,7 @@ class MaterializedArrayActionTest extends TestCase
         } elseif ($this->getDatabasePlatform() instanceof SQLServerPlatform) {
             self::assertSame([':a' => '[[false,0,0.0,"Mark"]]'], $render[1]);
         } elseif ($this->getDatabasePlatform() instanceof OraclePlatform) {
-            self::assertSameSql('select :a `bool`, :b `int`, :c `float`, :d `string` from "DUAL"', $render[0]);
-            self::assertSame([':xxaaaa' => false, ':xxaaab' => 0, ':xxaaac' => 0.0, ':xxaaad' => 'Mark'], $render[1]);
+            self::assertSame([':xxaaaa' => '[[false,0,0.0,"Mark"]]'], $render[1]);
         } else {
             self::assertSameSql('select :a `bool`, :b `int`, :c `float`, :d `string`', $render[0]);
             self::assertSame([':a' => false, ':b' => 0, ':c' => 0.0, ':d' => 'Mark'], $render[1]);
@@ -118,15 +116,11 @@ class MaterializedArrayActionTest extends TestCase
             self::assertSameSql('select `c0` `bool`, `c1` `int`, `c2` `float`, `c3` `string` from openjson(:a) with (`c0` BIT \'$[0]\', `c1` BIGINT \'$[1]\', `c2` DOUBLE PRECISION \'$[2]\', `c3` NVARCHAR(1020) \'$[3]\') `t`', $render[0]);
             self::assertSame([':a' => '[[true,-9223372036854775808,-1.0e-20,""],[null,9223372036854775807,1.0123456789123e+50," foo\n"]]'], $render[1]);
         } elseif ($this->getDatabasePlatform() instanceof OraclePlatform) {
-            self::assertSameSql('select :a `bool`, :b `int`, :c `float`, :d `string` from "DUAL" union all select :e, :f, :g, :h from "DUAL"', $render[0]);
-            self::assertSame([':xxaaaa' => true, ':xxaaab' => \PHP_INT_MIN, ':xxaaac' => -1e-20, ':xxaaad' => '', ':xxaaae' => null, ':xxaaaf' => \PHP_INT_MAX, ':xxaaag' => 1.0123456789123e50, ':xxaaah' => ' foo' . "\n"], $render[1]);
+            self::assertSameSql('select `c0` `bool`, `c1` `int`, `c2` `float`, `c3` `string` from json_table(:a, \'$[*]\' columns (`c0` NUMBER(1) path \'$[0]\', `c1` NUMBER(20) path \'$[1]\', `c2` NUMBER path \'$[2]\', `c3` VARCHAR2 path \'$[3]\')) `t`', $render[0]);
+            self::assertSame([':xxaaaa' => '[[true,-9223372036854775808,-1.0e-20,""],[null,9223372036854775807,1.0123456789123e+50," foo\n"]]'], $render[1]);
         } else {
             self::assertSameSql('select :a `bool`, :b `int`, :c `float`, :d `string` union all select :e, :f, :g, :h', $render[0]);
             self::assertSame([':a' => true, ':b' => \PHP_INT_MIN, ':c' => -1e-20, ':d' => '', ':e' => null, ':f' => \PHP_INT_MAX, ':g' => 1.0123456789123e50, ':h' => ' foo' . "\n"], $render[1]);
-        }
-
-        if ($this->getDatabasePlatform() instanceof OraclePlatform) {
-            self::markTestIncomplete('TODO Oracle remove once JSON_TABLE() is used');
         }
 
         self::{'assertEquals'}([
@@ -156,10 +150,6 @@ class MaterializedArrayActionTest extends TestCase
         self::assertSame([
             ['foo' => '1', 'bar' => 'u'],
         ], $query->getDsqlExpression($this->getConnection()->expr())->getRows());
-
-        if ($this->getDatabasePlatform() instanceof OraclePlatform) {
-            self::markTestIncomplete('TODO Oracle remove once JSON_TABLE() is used');
-        }
 
         $action->generator = new \ArrayIterator([['foo' => 1, 'bar' => 'u'], ['foo' => null, 'bar' => 'v']]);
         self::assertSame([

--- a/tests/Persistence/Sql/MaterializedArrayActionTest.php
+++ b/tests/Persistence/Sql/MaterializedArrayActionTest.php
@@ -40,6 +40,12 @@ class MaterializedArrayActionTest extends TestCase
             && version_compare($this->getConnection()->getServerVersion(), '6.0') < 0;
     }
 
+    private function isServerPostgreSQL16OrLower(): bool
+    {
+        return $this->getDatabasePlatform() instanceof PostgreSQLPlatform
+            && version_compare($this->getConnection()->getServerVersion(), '17.0') < 0;
+    }
+
     public function testRenderZeroRows(): void
     {
         $action = new ArrayAction([], ['bool', 'int', 'float', 'string']);
@@ -50,15 +56,14 @@ class MaterializedArrayActionTest extends TestCase
             self::assertSame([':a' => '[]'], $render[1]);
         } elseif ($this->getDatabasePlatform() instanceof MySQLPlatform && !$this->isServerMysql5x()) {
             self::assertSame([':a' => '[]'], $render[1]);
-        } elseif ($this->getDatabasePlatform() instanceof PostgreSQLPlatform) {
-            self::assertSameSql('select :a `bool`, :b `int`, :c `float`, :d `string` limit 0 offset 0', $render[0]);
-            self::assertSame([':a' => null, ':b' => null, ':c' => null, ':d' => null], $render[1]);
+        } elseif ($this->getDatabasePlatform() instanceof PostgreSQLPlatform && !$this->isServerPostgreSQL16OrLower()) {
+            self::assertSame([':a' => '[]'], $render[1]);
         } elseif ($this->getDatabasePlatform() instanceof SQLServerPlatform) {
             self::assertSame([':a' => '[]'], $render[1]);
         } elseif ($this->getDatabasePlatform() instanceof OraclePlatform) {
             self::assertSame([':xxaaaa' => '[]'], $render[1]);
         } else {
-            self::assertSameSql('select :a `bool`, :b `int`, :c `float`, :d `string` limit 0, 0', $render[0]);
+            self::assertSameSql('select :a `bool`, :b `int`, :c `float`, :d `string` limit ' . ($this->getDatabasePlatform() instanceof PostgreSQLPlatform ? '0 offset 0' : '0, 0'), $render[0]);
             self::assertSame([':a' => null, ':b' => null, ':c' => null, ':d' => null], $render[1]);
         }
 
@@ -77,9 +82,8 @@ class MaterializedArrayActionTest extends TestCase
             self::assertSame([':a' => '[[false,0,0.0,"Mark"]]'], $render[1]);
         } elseif ($this->getDatabasePlatform() instanceof MySQLPlatform && !$this->isServerMysql5x()) {
             self::assertSame([':a' => '[[false,0,0.0,"Mark"]]'], $render[1]);
-        } elseif ($this->getDatabasePlatform() instanceof PostgreSQLPlatform) {
-            self::assertSameSql('select :a `bool`, :b `int`, :c `float`, :d `string`', $render[0]);
-            self::assertSame([':a' => false, ':b' => 0, ':c' => 0.0, ':d' => 'Mark'], $render[1]);
+        } elseif ($this->getDatabasePlatform() instanceof PostgreSQLPlatform && !$this->isServerPostgreSQL16OrLower()) {
+            self::assertSame([':a' => '[[false,0,0.0,"Mark"]]'], $render[1]);
         } elseif ($this->getDatabasePlatform() instanceof SQLServerPlatform) {
             self::assertSame([':a' => '[[false,0,0.0,"Mark"]]'], $render[1]);
         } elseif ($this->getDatabasePlatform() instanceof OraclePlatform) {
@@ -109,9 +113,9 @@ class MaterializedArrayActionTest extends TestCase
         } elseif ($this->getDatabasePlatform() instanceof MySQLPlatform && !$this->isServerMysql5x()) {
             self::assertSameSql('select `c0` `bool`, `c1` `int`, `c2` `float`, `c3` `string` from json_table(:a, \'$[*]\' columns (`c0` TINYINT(1) path \'$[0]\', `c1` BIGINT path \'$[1]\', `c2` DOUBLE PRECISION path \'$[2]\', `c3` VARCHAR(255) COLLATE `utf8mb4_unicode_ci` path \'$[3]\')) `t`', $render[0]);
             self::assertSame([':a' => '[[true,-9223372036854775808,-1.0e-20,""],[null,9223372036854775807,1.0123456789123e+50," foo\n"]]'], $render[1]);
-        } elseif ($this->getDatabasePlatform() instanceof PostgreSQLPlatform) {
-            self::assertSameSql('select :a `bool`, :b `int`, :c `float`, :d `string` union all select :e, :f, :g, :h', $render[0]);
-            self::assertSame([':a' => true, ':b' => \PHP_INT_MIN, ':c' => -1e-20, ':d' => '', ':e' => null, ':f' => \PHP_INT_MAX, ':g' => 1.0123456789123e50, ':h' => ' foo' . "\n"], $render[1]);
+        } elseif ($this->getDatabasePlatform() instanceof PostgreSQLPlatform && !$this->isServerPostgreSQL16OrLower()) {
+            self::assertSameSql('select `c0` `bool`, `c1` `int`, `c2` `float`, `c3` `string` from json_table(:a, \'$[*]\' columns (`c0` BOOLEAN path \'$[0]\', `c1` BIGINT path \'$[1]\', `c2` DOUBLE PRECISION path \'$[2]\', `c3` ATK4__CIVARCHAR path \'$[3]\')) `t`', $render[0]);
+            self::assertSame([':a' => '[[true,-9223372036854775808,-1.0e-20,""],[null,9223372036854775807,1.0123456789123e+50," foo\n"]]'], $render[1]);
         } elseif ($this->getDatabasePlatform() instanceof SQLServerPlatform) {
             self::assertSameSql('select `c0` `bool`, `c1` `int`, `c2` `float`, `c3` `string` from openjson(:a) with (`c0` BIT \'$[0]\', `c1` BIGINT \'$[1]\', `c2` DOUBLE PRECISION \'$[2]\', `c3` NVARCHAR(1020) \'$[3]\') `t`', $render[0]);
             self::assertSame([':a' => '[[true,-9223372036854775808,-1.0e-20,""],[null,9223372036854775807,1.0123456789123e+50," foo\n"]]'], $render[1]);

--- a/tests/Persistence/Sql/MaterializedArrayActionTest.php
+++ b/tests/Persistence/Sql/MaterializedArrayActionTest.php
@@ -132,7 +132,7 @@ class MaterializedArrayActionTest extends TestCase
             self::assertSameSql('select `c0` `bool`, `c1` `int`, `c2` `float`, `c3` `string` from openjson(:a) with (`c0` BIT \'$[0]\', `c1` BIGINT \'$[1]\', `c2` DOUBLE PRECISION \'$[2]\', `c3` NVARCHAR(1020) \'$[3]\') `t`', $render[0]);
             self::assertSame([':a' => '[[true,-9223372036854775808,-1.0e-20,""],[null,9223372036854775807,1.0123456789123e+50," <foo>&\"\'🔥\n"]]'], $render[1]);
         } elseif ($this->getDatabasePlatform() instanceof OraclePlatform) {
-            self::assertSameSql('select `c0` `bool`, `c1` `int`, `c2` `float`, `c3` `string` from json_table(:a, \'$[*]\' columns (`c0` NUMBER(1) path \'$[0]\', `c1` NUMBER(20) path \'$[1]\', `c2` NUMBER path \'$[2]\', `c3` VARCHAR2 path \'$[3]\')) `t`', $render[0]);
+            self::assertSameSql('select `c0` `bool`, `c1` `int`, `c2` `float`, `c3` `string` from json_table(:a, \'$[*]\' columns (`c0` NUMBER(1) path \'$[0]\'' . (version_compare($this->getConnection()->getServerVersion(), '21.0') >= 0 ? ' ALLOW BOOLEAN TO NUMBER' : '') . ', `c1` NUMBER(20) path \'$[1]\', `c2` NUMBER path \'$[2]\', `c3` VARCHAR2 path \'$[3]\')) `t`', $render[0]);
             self::assertSame([':xxaaaa' => '[[true,-9223372036854775808,-1.0e-20,""],[null,9223372036854775807,1.0123456789123e+50," <foo>&\"\'🔥\n"]]'], $render[1]);
         } else {
             self::assertSameSql('select :a `bool`, :b `int`, :c `float`, :d `string` union all select :e, :f, :g, :h', $render[0]);

--- a/tests/Persistence/Sql/MaterializedArrayActionTest.php
+++ b/tests/Persistence/Sql/MaterializedArrayActionTest.php
@@ -39,8 +39,7 @@ class MaterializedArrayActionTest extends TestCase
 
         $render = $this->renderQuery($query);
         if ($this->getDatabasePlatform() instanceof SQLitePlatform) {
-            self::assertSameSql('select :a `bool`, :b `int`, :c `float`, :d `string` limit 0, 0', $render[0]);
-            self::assertSame([':a' => null, ':b' => null, ':c' => null, ':d' => null], $render[1]);
+            self::assertSame([':a' => '[]'], $render[1]);
         } elseif ($this->getDatabasePlatform() instanceof MySQLPlatform) {
             self::assertSameSql('select :a `bool`, :b `int`, :c `float`, :d `string` limit 0, 0', $render[0]);
             self::assertSame([':a' => null, ':b' => null, ':c' => null, ':d' => null], $render[1]);
@@ -70,8 +69,7 @@ class MaterializedArrayActionTest extends TestCase
 
         $render = $this->renderQuery($query);
         if ($this->getDatabasePlatform() instanceof SQLitePlatform) {
-            self::assertSameSql('select :a `bool`, :b `int`, :c `float`, :d `string`', $render[0]);
-            self::assertSame([':a' => false, ':b' => 0, ':c' => 0.0, ':d' => 'Mark'], $render[1]);
+            self::assertSame([':a' => '[[false,0,0.0,"Mark"]]'], $render[1]);
         } elseif ($this->getDatabasePlatform() instanceof MySQLPlatform) {
             self::assertSameSql('select :a `bool`, :b `int`, :c `float`, :d `string`', $render[0]);
             self::assertSame([':a' => false, ':b' => 0, ':c' => 0.0, ':d' => 'Mark'], $render[1]);
@@ -104,8 +102,8 @@ class MaterializedArrayActionTest extends TestCase
 
         $render = $this->renderQuery($query);
         if ($this->getDatabasePlatform() instanceof SQLitePlatform) {
-            self::assertSameSql('select :a `bool`, :b `int`, :c `float`, :d `string` union all select :e, :f, :g, :h', $render[0]);
-            self::assertSame([':a' => true, ':b' => \PHP_INT_MIN, ':c' => -1e-20, ':d' => '', ':e' => null, ':f' => \PHP_INT_MAX, ':g' => 1.0123456789123e50, ':h' => ' foo' . "\n"], $render[1]);
+            self::assertSameSql('select json_extract(value, \'$[0]\') `bool`, json_extract(value, \'$[1]\') `int`, json_extract(value, \'$[2]\') `float`, json_extract(value, \'$[3]\') `string` from json_each(:a)', $render[0]);
+            self::assertSame([':a' => '[[true,-9223372036854775808,-1.0e-20,""],[null,9223372036854775807,1.0123456789123e+50," foo\n"]]'], $render[1]);
         } elseif ($this->getDatabasePlatform() instanceof MySQLPlatform) {
             self::assertSameSql('select :a `bool`, :b `int`, :c `float`, :d `string` union all select :e, :f, :g, :h', $render[0]);
             self::assertSame([':a' => true, ':b' => \PHP_INT_MIN, ':c' => -1e-20, ':d' => '', ':e' => null, ':f' => \PHP_INT_MAX, ':g' => 1.0123456789123e50, ':h' => ' foo' . "\n"], $render[1]);

--- a/tests/Persistence/Sql/MaterializedArrayActionTest.php
+++ b/tests/Persistence/Sql/MaterializedArrayActionTest.php
@@ -8,6 +8,7 @@ use Atk4\Data\Persistence\Array_\Action as ArrayAction;
 use Atk4\Data\Persistence\Sql\Exception;
 use Atk4\Data\Persistence\Sql\Expressionable;
 use Atk4\Data\Persistence\Sql\MaterializedArrayAction;
+use Atk4\Data\Persistence\Sql\Mysql\Connection as MysqlConnection;
 use Atk4\Data\Schema\TestCase;
 use Doctrine\DBAL\Platforms\MySQLPlatform;
 use Doctrine\DBAL\Platforms\OraclePlatform;
@@ -32,6 +33,13 @@ class MaterializedArrayActionTest extends TestCase
         return $render;
     }
 
+    private function isServerMysql5x(): bool
+    {
+        return $this->getDatabasePlatform() instanceof MySQLPlatform
+            && !MysqlConnection::isServerMariaDb($this->getConnection())
+            && version_compare($this->getConnection()->getServerVersion(), '6.0') < 0;
+    }
+
     public function testRenderZeroRows(): void
     {
         $action = new ArrayAction([], ['bool', 'int', 'float', 'string']);
@@ -40,9 +48,8 @@ class MaterializedArrayActionTest extends TestCase
         $render = $this->renderQuery($query);
         if ($this->getDatabasePlatform() instanceof SQLitePlatform) {
             self::assertSame([':a' => '[]'], $render[1]);
-        } elseif ($this->getDatabasePlatform() instanceof MySQLPlatform) {
-            self::assertSameSql('select :a `bool`, :b `int`, :c `float`, :d `string` limit 0, 0', $render[0]);
-            self::assertSame([':a' => null, ':b' => null, ':c' => null, ':d' => null], $render[1]);
+        } elseif ($this->getDatabasePlatform() instanceof MySQLPlatform && !$this->isServerMysql5x()) {
+            self::assertSame([':a' => '[]'], $render[1]);
         } elseif ($this->getDatabasePlatform() instanceof PostgreSQLPlatform) {
             self::assertSameSql('select :a `bool`, :b `int`, :c `float`, :d `string` limit 0 offset 0', $render[0]);
             self::assertSame([':a' => null, ':b' => null, ':c' => null, ':d' => null], $render[1]);
@@ -70,9 +77,8 @@ class MaterializedArrayActionTest extends TestCase
         $render = $this->renderQuery($query);
         if ($this->getDatabasePlatform() instanceof SQLitePlatform) {
             self::assertSame([':a' => '[[false,0,0.0,"Mark"]]'], $render[1]);
-        } elseif ($this->getDatabasePlatform() instanceof MySQLPlatform) {
-            self::assertSameSql('select :a `bool`, :b `int`, :c `float`, :d `string`', $render[0]);
-            self::assertSame([':a' => false, ':b' => 0, ':c' => 0.0, ':d' => 'Mark'], $render[1]);
+        } elseif ($this->getDatabasePlatform() instanceof MySQLPlatform && !$this->isServerMysql5x()) {
+            self::assertSame([':a' => '[[false,0,0.0,"Mark"]]'], $render[1]);
         } elseif ($this->getDatabasePlatform() instanceof PostgreSQLPlatform) {
             self::assertSameSql('select :a `bool`, :b `int`, :c `float`, :d `string`', $render[0]);
             self::assertSame([':a' => false, ':b' => 0, ':c' => 0.0, ':d' => 'Mark'], $render[1]);
@@ -104,9 +110,9 @@ class MaterializedArrayActionTest extends TestCase
         if ($this->getDatabasePlatform() instanceof SQLitePlatform) {
             self::assertSameSql('select json_extract(value, \'$[0]\') `bool`, json_extract(value, \'$[1]\') `int`, json_extract(value, \'$[2]\') `float`, json_extract(value, \'$[3]\') `string` from json_each(:a)', $render[0]);
             self::assertSame([':a' => '[[true,-9223372036854775808,-1.0e-20,""],[null,9223372036854775807,1.0123456789123e+50," foo\n"]]'], $render[1]);
-        } elseif ($this->getDatabasePlatform() instanceof MySQLPlatform) {
-            self::assertSameSql('select :a `bool`, :b `int`, :c `float`, :d `string` union all select :e, :f, :g, :h', $render[0]);
-            self::assertSame([':a' => true, ':b' => \PHP_INT_MIN, ':c' => -1e-20, ':d' => '', ':e' => null, ':f' => \PHP_INT_MAX, ':g' => 1.0123456789123e50, ':h' => ' foo' . "\n"], $render[1]);
+        } elseif ($this->getDatabasePlatform() instanceof MySQLPlatform && !$this->isServerMysql5x()) {
+            self::assertSameSql('select `c0` `bool`, `c1` `int`, `c2` `float`, `c3` `string` from json_table(:a, \'$[*]\' columns (`c0` TINYINT(1) path \'$[0]\', `c1` BIGINT path \'$[1]\', `c2` DOUBLE PRECISION path \'$[2]\', `c3` VARCHAR(255) COLLATE `utf8mb4_unicode_ci` path \'$[3]\')) `t`', $render[0]);
+            self::assertSame([':a' => '[[true,-9223372036854775808,-1.0e-20,""],[null,9223372036854775807,1.0123456789123e+50," foo\n"]]'], $render[1]);
         } elseif ($this->getDatabasePlatform() instanceof PostgreSQLPlatform) {
             self::assertSameSql('select :a `bool`, :b `int`, :c `float`, :d `string` union all select :e, :f, :g, :h', $render[0]);
             self::assertSame([':a' => true, ':b' => \PHP_INT_MIN, ':c' => -1e-20, ':d' => '', ':e' => null, ':f' => \PHP_INT_MAX, ':g' => 1.0123456789123e50, ':h' => ' foo' . "\n"], $render[1]);

--- a/tests/Persistence/Sql/MaterializedArrayActionTest.php
+++ b/tests/Persistence/Sql/MaterializedArrayActionTest.php
@@ -40,6 +40,13 @@ class MaterializedArrayActionTest extends TestCase
             && version_compare($this->getConnection()->getServerVersion(), '6.0') < 0;
     }
 
+    private function isServerMariadb105OrLower(): bool
+    {
+        return $this->getDatabasePlatform() instanceof MySQLPlatform
+            && MysqlConnection::isServerMariaDb($this->getConnection())
+            && version_compare($this->getConnection()->getServerVersion(), '10.6') < 0;
+    }
+
     private function isServerPostgreSQL16OrLower(): bool
     {
         return $this->getDatabasePlatform() instanceof PostgreSQLPlatform
@@ -54,7 +61,7 @@ class MaterializedArrayActionTest extends TestCase
         $render = $this->renderQuery($query);
         if ($this->getDatabasePlatform() instanceof SQLitePlatform) {
             self::assertSame([':a' => '[]'], $render[1]);
-        } elseif ($this->getDatabasePlatform() instanceof MySQLPlatform && !$this->isServerMysql5x()) {
+        } elseif ($this->getDatabasePlatform() instanceof MySQLPlatform && !$this->isServerMysql5x() && !$this->isServerMariadb105OrLower()) {
             self::assertSame([':a' => '[]'], $render[1]);
         } elseif ($this->getDatabasePlatform() instanceof PostgreSQLPlatform) {
             self::assertSame($this->isServerPostgreSQL16OrLower() ? [':a' => '<t></t>'] : [':a' => '[]'], $render[1]);
@@ -80,7 +87,7 @@ class MaterializedArrayActionTest extends TestCase
         $render = $this->renderQuery($query);
         if ($this->getDatabasePlatform() instanceof SQLitePlatform) {
             self::assertSame([':a' => '[[false,0,0.0,"Mark"]]'], $render[1]);
-        } elseif ($this->getDatabasePlatform() instanceof MySQLPlatform && !$this->isServerMysql5x()) {
+        } elseif ($this->getDatabasePlatform() instanceof MySQLPlatform && !$this->isServerMysql5x() && !$this->isServerMariadb105OrLower()) {
             self::assertSame([':a' => '[[false,0,0.0,"Mark"]]'], $render[1]);
         } elseif ($this->getDatabasePlatform() instanceof PostgreSQLPlatform) {
             self::assertSame($this->isServerPostgreSQL16OrLower() ? [':a' => '<t><r c0="0" c1="0" c2="0" c3="Mark"/></t>'] : [':a' => '[[false,0,0.0,"Mark"]]'], $render[1]);
@@ -110,7 +117,7 @@ class MaterializedArrayActionTest extends TestCase
         if ($this->getDatabasePlatform() instanceof SQLitePlatform) {
             self::assertSameSql('select json_extract(value, \'$[0]\') `bool`, json_extract(value, \'$[1]\') `int`, json_extract(value, \'$[2]\') `float`, json_extract(value, \'$[3]\') `string` from json_each(:a)', $render[0]);
             self::assertSame([':a' => '[[true,-9223372036854775808,-1.0e-20,""],[null,9223372036854775807,1.0123456789123e+50," <foo>&\"\'🔥\n"]]'], $render[1]);
-        } elseif ($this->getDatabasePlatform() instanceof MySQLPlatform && !$this->isServerMysql5x()) {
+        } elseif ($this->getDatabasePlatform() instanceof MySQLPlatform && !$this->isServerMysql5x() && !$this->isServerMariadb105OrLower()) {
             self::assertSameSql('select `c0` `bool`, `c1` `int`, `c2` `float`, `c3` `string` from json_table(:a, \'$[*]\' columns (`c0` TINYINT(1) path \'$[0]\', `c1` BIGINT path \'$[1]\', `c2` DOUBLE PRECISION path \'$[2]\', `c3` VARCHAR(255) COLLATE `utf8mb4_unicode_ci` path \'$[3]\')) `t`', $render[0]);
             self::assertSame([':a' => '[[true,-9223372036854775808,-1.0e-20,""],[null,9223372036854775807,1.0123456789123e+50," <foo>&\"\'🔥\n"]]'], $render[1]);
         } elseif ($this->getDatabasePlatform() instanceof PostgreSQLPlatform) {


### PR DESCRIPTION
improves #1251

SQLite tested with 500k rows, time needed ~1 second.

MySQL (pdo_mysql, mysqli) tested with 200k rows, time needed ~1 second.