### PR TITLE
Prevent rendering SQL from a different connection

### DIFF
--- a/src/Persistence/Sql/Connection.php
+++ b/src/Persistence/Sql/Connection.php
@@ -432,11 +432,6 @@ abstract class Connection
     {
         if (($this->serverVersionRaw ?? null) === null) {
             $this->serverVersionRaw = $this->getConnection()->getWrappedConnection()->getServerVersion(); // @phpstan-ignore method.deprecated, method.notFound
-
-            // https://github.com/php/php-src/issues/7972
-            if (\PHP_VERSION_ID < 8_01_03) {
-                $this->serverVersionRaw = preg_replace('~^5\.5\.5-(?=\d+\.\d+\.\d+.*-MariaDB-)~', '', $this->serverVersionRaw);
-            }
         }
 
         assert(preg_match('~(\d+)\.(\d+)(?:\.(\d+))?~', $this->serverVersionRaw, $matches) === 1);

--- a/src/Persistence/Sql/Expression.php
+++ b/src/Persistence/Sql/Expression.php
@@ -192,6 +192,12 @@ abstract class Expression implements Expressionable, \ArrayAccess
 
         $expr = $expr->getDsqlExpression($this);
 
+        $thisConnection = $this->connection ?? null;
+        $exprConnection = $expr->connection ?? null;
+        if ($thisConnection !== null && $exprConnection !== null && $exprConnection !== $thisConnection) {
+            throw new Exception('Connection instance does not match');
+        }
+
         // render given expression into params of the current expression
         $expressionParamBaseBackup = $expr->paramBase;
         try {
@@ -390,7 +396,7 @@ abstract class Expression implements Expressionable, \ArrayAccess
     public function render(): array
     {
         if ($this->template === null) {
-            throw new Exception('Template is not defined for Expression');
+            throw new Exception('Template is not defined');
         }
 
         try {

--- a/src/Persistence/Sql/Mysql/Connection.php
+++ b/src/Persistence/Sql/Mysql/Connection.php
@@ -18,4 +18,17 @@ class Connection extends BaseConnection
 
         return preg_match('~(?<!\w)MariaDB(?!\w)~i', $connection->getServerVersion(true)) === 1;
     }
+
+    #[\Override]
+    public function getServerVersion(bool $raw = false): string
+    {
+        // https://github.com/php/php-src/issues/7972
+        if (\PHP_VERSION_ID < 8_01_03 && parent::getServerVersion() === '5.5.5') {
+            \Closure::bind(function () {
+                $this->serverVersionRaw = preg_replace('~^5\.5\.5-(?=\d+\.\d+\.\d+.*-MariaDB-)~', '', $this->serverVersionRaw);
+            }, $this, parent::class)();
+        }
+
+        return parent::getServerVersion($raw);
+    }
 }

--- a/tests/Persistence/Sql/ExpressionTest.php
+++ b/tests/Persistence/Sql/ExpressionTest.php
@@ -47,6 +47,7 @@ class ExpressionTest extends TestCase
     public function testConstructorNoTemplateException(): void
     {
         $this->expectException(Exception::class);
+        $this->expectExceptionMessage('Template is not defined');
         $this->e()->render();
     }
 
@@ -366,6 +367,7 @@ class ExpressionTest extends TestCase
     public function testConsumeUnsupportedEscapeModeException(): void
     {
         $this->expectException(Exception::class);
+        $this->expectExceptionMessage('Unexpected escape mode');
         $this->callProtected($this->e(), 'consume', 123, 'blahblah');
     }
 
@@ -373,6 +375,18 @@ class ExpressionTest extends TestCase
     {
         $this->expectException(\Error::class);
         $this->callProtected($this->e(), 'consume', new \stdClass());
+    }
+
+    public function testConsumeDifferentConnectionException(): void
+    {
+        $c1 = Connection::connect('sqlite::memory:');
+        $c2 = Connection::connect('sqlite::memory:');
+
+        $c1->expr('[]', [$c1->expr('foo')])->render();
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage('Connection instance does not match');
+        $c1->expr('[]', [$c2->expr('foo')])->render();
     }
 
     public function testRenderNoTagException(): void

--- a/tests/Persistence/Sql/QueryTest.php
+++ b/tests/Persistence/Sql/QueryTest.php
@@ -917,15 +917,16 @@ class QueryTest extends TestCase
                         EOF,
                 $this->createMysqlQuery($serverVersion, '[where]')->where('name', 'like', 'foo')->render()[0]
             );
+            $mysqlQuery = $this->createMysqlQuery($serverVersion, '[where]');
             self::assertSame(
                 $serverVersion === '5.7.0'
                     ? <<<'EOF'
-                        where sum("a") not like replace(replace(replace(replace(replace(replace(replace(replace(sum("b"), '\\\\', '\\\\*'), '\\_', '\\_*'), '\\%', '\\%*'), '\\', '\\\\'), '\\\\_*', '\\_'), '\\\\%*', '\\%'), '\\\\\\\\*', '\\\\'), '%\\', '%\\\\') escape '\\'
+                        where sum(`a`) not like replace(replace(replace(replace(replace(replace(replace(replace(sum(`b`), '\\\\', '\\\\*'), '\\_', '\\_*'), '\\%', '\\%*'), '\\', '\\\\'), '\\\\_*', '\\_'), '\\\\%*', '\\%'), '\\\\\\\\*', '\\\\'), '%\\', '%\\\\') escape '\\'
                         EOF
                     : <<<'EOF'
-                        where sum("a") not like regexp_replace(sum("b"), '\\\\\\\\|\\\\(?![_%])', '\\\\\\\\') escape '\\'
+                        where sum(`a`) not like regexp_replace(sum(`b`), '\\\\\\\\|\\\\(?![_%])', '\\\\\\\\') escape '\\'
                         EOF,
-                $this->createMysqlQuery($serverVersion, '[where]')->where($this->e('sum({})', ['a']), 'not like', $this->e('sum({})', ['b']))->render()[0]
+                $mysqlQuery->where($mysqlQuery->expr('sum({})', ['a']), 'not like', $mysqlQuery->expr('sum({})', ['b']))->render()[0]
             );
         }
 
@@ -1005,11 +1006,12 @@ class QueryTest extends TestCase
                     : 'where `name` regexp concat(\'(?s)\', :a)',
                 $this->createMysqlQuery($serverVersion, '[where]')->where('name', 'regexp', 'foo')->render()[0]
             );
+            $mysqlQuery = $this->createMysqlQuery($serverVersion, '[where]');
             self::assertSame(
                 $serverVersion === '5.7.0'
-                    ? 'where sum("a") not regexp concat(\'@?\', sum("b"))'
-                    : 'where sum("a") not regexp concat(\'(?s)\', sum("b"))',
-                $this->createMysqlQuery($serverVersion, '[where]')->where($this->e('sum({})', ['a']), 'not regexp', $this->e('sum({})', ['b']))->render()[0]
+                    ? 'where sum(`a`) not regexp concat(\'@?\', sum(`b`))'
+                    : 'where sum(`a`) not regexp concat(\'(?s)\', sum(`b`))',
+                $mysqlQuery->where($mysqlQuery->expr('sum({})', ['a']), 'not regexp', $mysqlQuery->expr('sum({})', ['b']))->render()[0]
             );
         }
 

--- a/tests/Persistence/Sql/QueryTest.php
+++ b/tests/Persistence/Sql/QueryTest.php
@@ -25,7 +25,7 @@ use PHPUnit\Framework\Attributes\DoesNotPerformAssertions;
 
 class QueryTest extends TestCase
 {
-    private SqliteConnection $dummyConnection;
+    private ?SqliteConnection $dummyConnection = null;
 
     /**
      * @param string|array<string, mixed> $template
@@ -63,7 +63,7 @@ class QueryTest extends TestCase
         };
 
         if (($query->connection ?? null) === null) {
-            if (($this->dummyConnection ?? null) === null) {
+            if ($this->dummyConnection === null) {
                 $this->dummyConnection = \Closure::bind(static function () use ($query) {
                     $connection = new SqliteConnection();
                     $connection->expressionClass = \Closure::bind(static fn () => $query->expressionClass, null, Query::class)();

--- a/tests/Persistence/Sql/QueryTest.php
+++ b/tests/Persistence/Sql/QueryTest.php
@@ -25,6 +25,8 @@ use PHPUnit\Framework\Attributes\DoesNotPerformAssertions;
 
 class QueryTest extends TestCase
 {
+    private SqliteConnection $dummyConnection;
+
     /**
      * @param string|array<string, mixed> $template
      * @param array<int|string, mixed>    $arguments
@@ -61,13 +63,17 @@ class QueryTest extends TestCase
         };
 
         if (($query->connection ?? null) === null) {
-            $query->connection = \Closure::bind(static function () use ($query) {
-                $connection = new SqliteConnection();
-                $connection->expressionClass = \Closure::bind(static fn () => $query->expressionClass, null, Query::class)();
-                $connection->queryClass = get_class($query);
+            if (($this->dummyConnection ?? null) === null) {
+                $this->dummyConnection = \Closure::bind(static function () use ($query) {
+                    $connection = new SqliteConnection();
+                    $connection->expressionClass = \Closure::bind(static fn () => $query->expressionClass, null, Query::class)();
+                    $connection->queryClass = get_class($query);
 
-                return $connection;
-            }, null, Connection::class)();
+                    return $connection;
+                }, null, Connection::class)();
+            }
+
+            $query->connection = $this->dummyConnection;
         }
 
         return $query;


### PR DESCRIPTION
With normal usage there should be no BC-break.