### PR TITLE
Workaround MySQL/MariaDB bind long string cropped

### DIFF
--- a/src/Persistence/Sql/Mysql/ExpressionTrait.php
+++ b/src/Persistence/Sql/Mysql/ExpressionTrait.php
@@ -46,7 +46,7 @@ trait ExpressionTrait
 
         $sql = preg_replace_callback(
             '~' . self::QUOTED_TOKEN_REGEX . '\K|:\w+~',
-            static function ($matches) use ($params) {
+            function ($matches) use ($params) {
                 if ($matches[0] === '') {
                     return '';
                 }
@@ -58,6 +58,13 @@ trait ExpressionTrait
                 // TODO open php-src feature request
                 if (is_float($value)) {
                     $sql = '(' . $sql . ' + 0e0)';
+                }
+
+                // workaround bind long string param silently cropped
+                // https://bugs.mysql.com/bug.php?id=119444
+                // https://jira.mariadb.org/browse/MDEV-38153
+                if (is_string($value) && strlen($value) >= 64 * 1024) {
+                    $sql = 'replace(' . $sql . ', ' . $this->escapeStringLiteral('') . ', ' . $this->escapeStringLiteral('mysql-119444') . ')';
                 }
 
                 return $sql;

--- a/tests/Persistence/Sql/WithDb/SelectTest.php
+++ b/tests/Persistence/Sql/WithDb/SelectTest.php
@@ -145,6 +145,33 @@ class SelectTest extends TestCase
         }
     }
 
+    public function testSelectUnionLongString(): void
+    {
+        $str = str_repeat('x', 256 * 1024);
+        $str2 = 'y' . $str;
+
+        $tableExpr = $this->e(
+            implode(' union all ', array_fill(0, 2, '[]')),
+            array_map(function ($v) {
+                $q = $this->q()->field($this->e('[]', [$v]), 'v');
+                $q->wrapInParentheses = false;
+
+                return $q;
+            }, [$str, $str2])
+        );
+        $tableExpr->wrapInParentheses = true;
+
+        $res = $this->q()
+            ->field('v')
+            ->table($tableExpr, 't')
+            ->getRows();
+
+        self::assertSame([
+            ['v' => $str],
+            ['v' => $str2],
+        ], $res);
+    }
+
     public function testOtherQueries(): void
     {
         $this->setupTables();


### PR DESCRIPTION
We trick the server optimizer to not use the wrongly estimated maximum string length.

further improved in #1268 - and tested againts all released MySQL/MariaDB versions