### PR TITLE
Add noChanges parameter in AfterSave hook

### DIFF
--- a/src/Model.php
+++ b/src/Model.php
@@ -1616,7 +1616,7 @@ class Model implements \IteratorAggregate
                 $this->reload();
             }
 
-            $this->hook(self::HOOK_AFTER_SAVE, [$isUpdate]);
+            $this->hook(self::HOOK_AFTER_SAVE, [$isUpdate, $noChanges]);
 
             if ($this->idField) {
                 $this->validateEntityScope();

--- a/tests/ModelNestedArrayTest.php
+++ b/tests/ModelNestedArrayTest.php
@@ -143,7 +143,7 @@ class ModelNestedArrayTest extends TestCase
             ['main', Model::HOOK_AFTER_UNLOAD, []],
             ['main', Model::HOOK_BEFORE_LOAD, [\DateTime::class]],
             ['main', Model::HOOK_AFTER_LOAD, []],
-            ['main', Model::HOOK_AFTER_SAVE, [false]],
+            ['main', Model::HOOK_AFTER_SAVE, [false, false]],
             ['main', '<<<'],
         ], $this->hookLogs);
 
@@ -172,7 +172,7 @@ class ModelNestedArrayTest extends TestCase
             ['main', '>>>'],
             ['main', Model::HOOK_VALIDATE, ['save']],
             ['main', Model::HOOK_BEFORE_SAVE, [true]],
-            ['main', Model::HOOK_AFTER_SAVE, [true]],
+            ['main', Model::HOOK_AFTER_SAVE, [true, true]],
             ['main', '<<<'],
 
             ['main', '>>>'],
@@ -186,7 +186,7 @@ class ModelNestedArrayTest extends TestCase
             ['inner', Model::HOOK_BEFORE_SAVE, [true]],
             ['inner', Model::HOOK_BEFORE_UPDATE, [['name' => 'Susan']]],
             ['inner', Model::HOOK_AFTER_UPDATE, [['name' => 'Susan']]],
-            ['inner', Model::HOOK_AFTER_SAVE, [true]],
+            ['inner', Model::HOOK_AFTER_SAVE, [true, false]],
             ['inner', '<<<'],
             ['inner', Model::HOOK_BEFORE_UNLOAD, []],
             ['inner', Model::HOOK_AFTER_UNLOAD, []],
@@ -197,7 +197,7 @@ class ModelNestedArrayTest extends TestCase
             ['main', Model::HOOK_BEFORE_LOAD, [\DateTime::class]],
             ['main', Model::HOOK_AFTER_LOAD, []],
 
-            ['main', Model::HOOK_AFTER_SAVE, [true]],
+            ['main', Model::HOOK_AFTER_SAVE, [true, false]],
             ['main', '<<<'],
         ], $this->hookLogs);
 

--- a/tests/ModelNestedArrayTest.php
+++ b/tests/ModelNestedArrayTest.php
@@ -136,7 +136,7 @@ class ModelNestedArrayTest extends TestCase
             ['inner', Model::HOOK_BEFORE_SAVE, [false]],
             ['inner', Model::HOOK_BEFORE_INSERT, [['uid' => null, 'name' => 'Karl', 'y' => \DateTime::class]]],
             ['inner', Model::HOOK_AFTER_INSERT, []],
-            ['inner', Model::HOOK_AFTER_SAVE, [false]],
+            ['inner', Model::HOOK_AFTER_SAVE, [false, false]],
             ['inner', '<<<'],
             ['main', Model::HOOK_AFTER_INSERT, []],
             ['main', Model::HOOK_BEFORE_UNLOAD, []],

--- a/tests/ModelNestedSqlTest.php
+++ b/tests/ModelNestedSqlTest.php
@@ -175,7 +175,7 @@ class ModelNestedSqlTest extends TestCase
             ['inner', Persistence\Sql::HOOK_BEFORE_INSERT_QUERY, [Query::class]],
             ['inner', Persistence\Sql::HOOK_AFTER_INSERT_QUERY, [Query::class]],
             ['inner', Model::HOOK_AFTER_INSERT, []],
-            ['inner', Model::HOOK_AFTER_SAVE, [false]],
+            ['inner', Model::HOOK_AFTER_SAVE, [false, false]],
             ['inner', Persistence\Sql::HOOK_INIT_SELECT_QUERY, [Query::class, 'select']],
             ['inner', '<<<'],
             ['main', Model::HOOK_AFTER_INSERT, []],
@@ -185,7 +185,7 @@ class ModelNestedSqlTest extends TestCase
             ['inner', Persistence\Sql::HOOK_INIT_SELECT_QUERY, [Query::class, 'select']],
             ['main', Persistence\Sql::HOOK_INIT_SELECT_QUERY, [Query::class, 'select']],
             ['main', Model::HOOK_AFTER_LOAD, []],
-            ['main', Model::HOOK_AFTER_SAVE, [false]],
+            ['main', Model::HOOK_AFTER_SAVE, [false, false]],
             ['main', '<<<'],
         ], $this->hookLogs);
 
@@ -216,7 +216,7 @@ class ModelNestedSqlTest extends TestCase
             ['main', '>>>'],
             ['main', Model::HOOK_VALIDATE, ['save']],
             ['main', Model::HOOK_BEFORE_SAVE, [true]],
-            ['main', Model::HOOK_AFTER_SAVE, [true]],
+            ['main', Model::HOOK_AFTER_SAVE, [true, true]],
             ['main', '<<<'],
 
             ['main', '>>>'],
@@ -234,7 +234,7 @@ class ModelNestedSqlTest extends TestCase
             ['inner', Persistence\Sql::HOOK_BEFORE_UPDATE_QUERY, [Query::class]],
             ['inner', Persistence\Sql::HOOK_AFTER_UPDATE_QUERY, [Query::class]],
             ['inner', Model::HOOK_AFTER_UPDATE, [['name' => 'Susan']]],
-            ['inner', Model::HOOK_AFTER_SAVE, [true]],
+            ['inner', Model::HOOK_AFTER_SAVE, [true, false]],
             ['inner', Persistence\Sql::HOOK_INIT_SELECT_QUERY, [Query::class, 'select']],
             ['inner', '<<<'],
             ['inner', Model::HOOK_BEFORE_UNLOAD, []],
@@ -248,7 +248,7 @@ class ModelNestedSqlTest extends TestCase
             ['main', Persistence\Sql::HOOK_INIT_SELECT_QUERY, [Query::class, 'select']],
             ['main', Model::HOOK_AFTER_LOAD, []],
 
-            ['main', Model::HOOK_AFTER_SAVE, [true]],
+            ['main', Model::HOOK_AFTER_SAVE, [true, false]],
             ['main', '<<<'],
         ], $this->hookLogs);
 


### PR DESCRIPTION
In AfterSave hook there is no way to tell if any data fields were changed (updated) or not as in such case AfterUpdate hook is not fired at all.
So I think that it would be useful to pass $noChanges value, which is already calculated before, as parameter to AfterSave hook.
I've at least one use-case for it already :)
